### PR TITLE
fix(control-ui): key custom stream rows by link, not array index

### DIFF
--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -843,12 +843,16 @@ export function ControlUI({
                 <h2>Custom Streams</h2>
                 <div>
                   {/*
-                    Include an empty object at the end to create an extra input for a new custom stream.
-                    We need it to be part of the array (rather than JSX below) for DOM diffing to match the key and retain focus.
+                    Key each row by its stream link (a stable identity) rather
+                    than the array index. The list renders from the shared state
+                    store, which can reorder while an input is focused (e.g.
+                    another operator adds or removes a custom stream). With index
+                    keys, the focused input would rebind to a different stream
+                    and the text being typed would appear to jump rows.
                   */}
-                  {customStreams.map(({ link, label, kind }, idx) => (
+                  {customStreams.map(({ link, label, kind }) => (
                     <CustomStreamInput
-                      key={idx}
+                      key={link}
                       link={link}
                       label={label}
                       kind={kind}


### PR DESCRIPTION
## Problem

Upstream issue [streamwall/streamwall#10](https://github.com/streamwall/streamwall/issues/10): *"custom stream text inputs jump around (autosort?) when typing in them."* A stream's input would lose track of the row it belonged to while the user was editing it.

The originally reported symptom (autosort **while typing**) does **not** reproduce in this v2.0 codebase — the internal store, the render path, and the input component already prevent it:

- Custom streams are stored in `LocalStreamData.dataByURL`, a `Map` with stable insertion order; `update()` writes with `Map.set` on the existing key, so editing a label does not reorder the store.
- `customStreams` is only `filter`ed, never sorted, when rendered (unlike the main `streams` list).
- `LazyChangeInput` keeps the in-progress edit in local state and only commits on blur/Enter, so typing triggers no round-trip.

However, one root-cause remnant of the same defect class remained.

## Root cause

The list rendered each row with the **array index** as its `key`:

```jsx
{customStreams.map(({ link, label, kind }, idx) => (
  <CustomStreamInput key={idx} ... />
))}
```

The list is derived from the shared state store, which **can** reorder while an input is focused — most realistically when **another operator** adds or removes a custom stream in the collaborative control window (the control server multiplexes multiple web clients over Yjs). When the order changes, an index key rebinds the focused `LazyChangeInput` instance — including its locally-held, uncommitted edit — to a *different* stream, so the text being typed appears to jump to another row. This is exactly the "tracks which input by index position … loses track of which stream you're editing" mechanism behind the original report.

## Fix

Key each row by its **stream link** — a stable, unique per-stream identity (custom streams are stored keyed by link in `LocalStreamData`) — so an input keeps tracking the stream it is bound to across reorders. The stale comment describing the removed *"empty object at the end"* input pattern (superseded by the dedicated `CreateCustomStreamInput`) is replaced with one explaining the keying rationale.

Net change: 8 lines in `packages/streamwall-control-ui/src/index.tsx`.

## Scope decisions

- **Not** re-introducing sort-at-display for custom streams: they are currently shown in stable insertion order, which is jump-free; adding a sort would risk re-introducing the very defect without careful keying (now hardened).
- **Not** implementing the reporter's secondary "autofill label from URL" idea: it is a speculative feature the upstream maintainer deliberately did not ship, and it is out of scope for a keying correction.

## Risks / breaking changes

None. `link` is guaranteed present and unique among custom streams (entries without a link are skipped on load, and the store is keyed by link). Keys only need sibling-uniqueness, which holds. No API, storage, or protocol change.

## Verification / test coverage

The project ships **no test harness** (no runner, scripts, or test files), so this change is verified by:

- **Type check** — `tsc --noEmit` on `streamwall-control-ui` reports no new diagnostics (only the two pre-existing `tsconfig` deprecation notices for `baseUrl` / `moduleResolution=node10`).
- **Build** — `streamwall-control-client` (which bundles the control UI via Vite/Rollup) builds green.
- **Formatting** — Prettier reports the file clean.

Adding a Preact/jsdom test framework was judged disproportionate for an 8-line keying correction in a project with no existing test infrastructure; happy to add one in a separate PR if desired.

## Reference

Upstream issue: https://github.com/streamwall/streamwall/issues/10