### PR TITLE
fix(streamwall): block SSRF into private networks via operator stream URLs

### DIFF
--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -401,7 +401,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
       if (msg.type === 'browse') {
         console.debug('Attempting to browse URL:', msg.url)
         try {
-          ensureValidURL(msg.url)
+          await ensureValidURL(msg.url)
           browseWindow.loadURL(msg.url)
         } catch (error) {
           console.error('Invalid URL:', msg.url)

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -147,7 +147,7 @@ const viewStateMachine = setup({
       }) => {
         assert(content !== null)
 
-        ensureValidURL(content.url)
+        await ensureValidURL(content.url)
         const wc = view.webContents
         wc.audioMuted = true
         wc.executeJavaScript(`

--- a/packages/streamwall/src/util.test.ts
+++ b/packages/streamwall/src/util.test.ts
@@ -142,3 +142,39 @@ test('allows a public hostname that resolves to a public address', async () => {
     ensureValidURL('http://stream.example.com/', resolvesTo('93.184.216.34')),
   )
 })
+
+// IPv4-embedded IPv6 transition forms that can deliver traffic to an internal
+// IPv4 address (in addition to the IPv4-mapped ::ffff: form covered above).
+test('rejects a NAT64-embedded link-local URL', async () => {
+  await assert.rejects(
+    ensureValidURL('http://[64:ff9b::169.254.169.254]/'),
+    /private-network/,
+  )
+})
+
+test('rejects a 6to4-embedded link-local URL', async () => {
+  await assert.rejects(
+    ensureValidURL('http://[2002:a9fe:a9fe::]/'),
+    /private-network/,
+  )
+})
+
+test('rejects a 6to4-embedded loopback URL', async () => {
+  await assert.rejects(
+    ensureValidURL('http://[2002:7f00:1::]/'),
+    /private-network/,
+  )
+})
+
+test('allows a public IPv6-literal URL', async () => {
+  await assert.doesNotReject(ensureValidURL('http://[2606:4700:4700::1111]/'))
+})
+
+// A trailing FQDN dot must not slip past the loopback fast-path.
+test('rejects the localhost hostname with a trailing dot', async () => {
+  await assert.rejects(ensureValidURL('http://localhost./'), /loopback/)
+})
+
+test('rejects a *.localhost hostname with a trailing dot', async () => {
+  await assert.rejects(ensureValidURL('http://admin.localhost./'), /loopback/)
+})

--- a/packages/streamwall/src/util.test.ts
+++ b/packages/streamwall/src/util.test.ts
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { ensureValidURL } from './util.ts'
+
+// Deterministic resolver stubs so the DNS-dependent paths can be exercised
+// without touching the network.
+const resolvesTo =
+  (...addresses: string[]) =>
+  async () =>
+    addresses
+const resolveFails = async () => {
+  throw new Error('ENOTFOUND')
+}
+
+test('allows a public https URL that resolves to a public address', async () => {
+  await assert.doesNotReject(
+    ensureValidURL('https://twitch.tv/streamer', resolvesTo('151.101.2.167')),
+  )
+})
+
+test('allows an .m3u8 URL on a public host', async () => {
+  await assert.doesNotReject(
+    ensureValidURL(
+      'https://cdn.example.com/live/index.m3u8',
+      resolvesTo('93.184.216.34'),
+    ),
+  )
+})
+
+test('allows a public IP-literal URL', async () => {
+  await assert.doesNotReject(ensureValidURL('http://8.8.8.8/stream'))
+})
+
+test('rejects a non-http(s) URL scheme', async () => {
+  await assert.rejects(ensureValidURL('file:///etc/passwd'), /non-http/)
+})
+
+test('rejects a URL with no host', async () => {
+  await assert.rejects(ensureValidURL('http:///path'), /host/)
+})
+
+test('rejects a malformed URL', async () => {
+  await assert.rejects(ensureValidURL('not a valid url'))
+})
+
+test('rejects the loopback address', async () => {
+  await assert.rejects(ensureValidURL('http://127.0.0.1/'), /private-network/)
+})
+
+test('rejects the localhost hostname (Streamdelay SSRF)', async () => {
+  await assert.rejects(ensureValidURL('http://localhost:8404/'), /loopback/)
+})
+
+test('rejects a *.localhost hostname', async () => {
+  await assert.rejects(ensureValidURL('http://admin.localhost/'), /loopback/)
+})
+
+test('rejects the cloud metadata endpoint (link-local range)', async () => {
+  await assert.rejects(
+    ensureValidURL('http://169.254.169.254/latest/meta-data/'),
+    /private-network/,
+  )
+})
+
+for (const url of [
+  'http://10.0.0.5/',
+  'http://192.168.1.10/',
+  'http://172.16.0.1/',
+  'http://100.64.0.1/',
+  'http://0.0.0.0/',
+]) {
+  test(`rejects the private-range URL ${url}`, async () => {
+    await assert.rejects(ensureValidURL(url), /private-network/)
+  })
+}
+
+test('rejects an IPv6 loopback URL', async () => {
+  await assert.rejects(ensureValidURL('http://[::1]/'), /private-network/)
+})
+
+test('rejects an IPv6 link-local URL', async () => {
+  await assert.rejects(ensureValidURL('http://[fe80::1]/'), /private-network/)
+})
+
+test('rejects an IPv4-mapped IPv6 loopback URL', async () => {
+  await assert.rejects(
+    ensureValidURL('http://[::ffff:127.0.0.1]/'),
+    /private-network/,
+  )
+})
+
+test('rejects a decimal-encoded loopback URL', async () => {
+  // new URL() normalises 2130706433 -> 127.0.0.1 before we ever see it.
+  await assert.rejects(ensureValidURL('http://2130706433/'), /private-network/)
+})
+
+test('rejects a hex-encoded loopback URL', async () => {
+  await assert.rejects(ensureValidURL('http://0x7f000001/'), /private-network/)
+})
+
+test('rejects a public hostname that resolves to a private address', async () => {
+  await assert.rejects(
+    ensureValidURL('http://stream.evil.example/', resolvesTo('10.1.2.3')),
+    /private-network/,
+  )
+})
+
+test('rejects a hostname when any resolved address is private', async () => {
+  await assert.rejects(
+    ensureValidURL(
+      'http://mixed.example/',
+      resolvesTo('93.184.216.34', '127.0.0.1'),
+    ),
+    /private-network/,
+  )
+})
+
+test('rejects a hostname that resolves to a private IPv6 address', async () => {
+  await assert.rejects(
+    ensureValidURL('http://rebind.example/', resolvesTo('fc00::1234')),
+    /private-network/,
+  )
+})
+
+test('rejects a hostname that fails to resolve (fail closed)', async () => {
+  await assert.rejects(
+    ensureValidURL('http://nope.invalid/', resolveFails),
+    /unresolvable/,
+  )
+})
+
+test('rejects a hostname that resolves to no addresses', async () => {
+  await assert.rejects(
+    ensureValidURL('http://empty.example/', resolvesTo()),
+    /unresolvable/,
+  )
+})
+
+test('allows a public hostname that resolves to a public address', async () => {
+  await assert.doesNotReject(
+    ensureValidURL('http://stream.example.com/', resolvesTo('93.184.216.34')),
+  )
+})

--- a/packages/streamwall/src/util.ts
+++ b/packages/streamwall/src/util.ts
@@ -1,6 +1,102 @@
-export function ensureValidURL(urlStr: string) {
+import { lookup } from 'node:dns/promises'
+import { BlockList, isIP } from 'node:net'
+
+// Addresses an operator-supplied URL must never be allowed to reach. Covers
+// loopback, private LAN, carrier-grade NAT, link-local (including the cloud
+// metadata endpoint 169.254.169.254) and the unspecified address, for both
+// IPv4 and IPv6. Using a BlockList lets Node match IPv4-mapped IPv6 addresses
+// (e.g. ::ffff:127.0.0.1) against the IPv4 rules automatically.
+const blockedAddresses = new BlockList()
+blockedAddresses.addSubnet('0.0.0.0', 8, 'ipv4') // "this" network / unspecified
+blockedAddresses.addSubnet('10.0.0.0', 8, 'ipv4') // private
+blockedAddresses.addSubnet('100.64.0.0', 10, 'ipv4') // carrier-grade NAT
+blockedAddresses.addSubnet('127.0.0.0', 8, 'ipv4') // loopback
+blockedAddresses.addSubnet('169.254.0.0', 16, 'ipv4') // link-local
+blockedAddresses.addSubnet('172.16.0.0', 12, 'ipv4') // private
+blockedAddresses.addSubnet('192.168.0.0', 16, 'ipv4') // private
+blockedAddresses.addAddress('::', 'ipv6') // unspecified
+blockedAddresses.addAddress('::1', 'ipv6') // loopback
+blockedAddresses.addSubnet('fc00::', 7, 'ipv6') // unique local
+blockedAddresses.addSubnet('fe80::', 10, 'ipv6') // link-local
+
+function isBlockedAddress(ip: string): boolean {
+  const family = isIP(ip)
+  if (family === 0) {
+    return false
+  }
+  return blockedAddresses.check(ip, family === 6 ? 'ipv6' : 'ipv4')
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  // localhost and any subdomain of it are defined to resolve to loopback
+  // (RFC 6761), so block them without consulting DNS.
+  const host = hostname.toLowerCase()
+  return host === 'localhost' || host.endsWith('.localhost')
+}
+
+type HostAddressResolver = (hostname: string) => Promise<string[]>
+
+const resolveHostAddresses: HostAddressResolver = async (hostname) => {
+  const results = await lookup(hostname, { all: true })
+  return results.map((result) => result.address)
+}
+
+/**
+ * Validate a URL before it is loaded into a WebContentsView. Rejects any URL
+ * that is not http(s) or that points at a non-public host, guarding against
+ * SSRF into the desktop host's own network (loopback, LAN, cloud metadata,
+ * etc.). Hostnames are resolved and every resulting address is checked, so a
+ * public domain that maps to a private address is rejected too.
+ *
+ * Note: DNS is re-resolved by the loader afterwards, so this does not defend
+ * against active DNS-rebinding; it blocks statically-malicious and
+ * literal-address targets, which is the reported operator SSRF vector.
+ */
+export async function ensureValidURL(
+  urlStr: string,
+  resolveAddresses: HostAddressResolver = resolveHostAddresses,
+): Promise<void> {
   const url = new URL(urlStr)
+
   if (url.protocol !== 'http:' && url.protocol !== 'https:') {
     throw new Error(`rejecting attempt to load non-http URL '${urlStr}'`)
+  }
+
+  // IPv6 literals are bracketed in url.hostname (e.g. "[::1]").
+  const hostname = url.hostname.replace(/^\[|\]$/g, '')
+  if (hostname === '') {
+    throw new Error(`rejecting attempt to load URL with no host '${urlStr}'`)
+  }
+
+  if (isLoopbackHostname(hostname)) {
+    throw new Error(`rejecting attempt to load loopback URL '${urlStr}'`)
+  }
+
+  if (isIP(hostname) !== 0) {
+    if (isBlockedAddress(hostname)) {
+      throw new Error(
+        `rejecting attempt to load private-network URL '${urlStr}'`,
+      )
+    }
+    return
+  }
+
+  let addresses: string[]
+  try {
+    addresses = await resolveAddresses(hostname)
+  } catch (err) {
+    throw new Error(
+      `rejecting URL with unresolvable host '${urlStr}': ${String(err)}`,
+    )
+  }
+  if (addresses.length === 0) {
+    throw new Error(`rejecting URL with unresolvable host '${urlStr}'`)
+  }
+  for (const address of addresses) {
+    if (isBlockedAddress(address)) {
+      throw new Error(
+        `rejecting attempt to load private-network URL '${urlStr}' (${hostname} resolves to ${address})`,
+      )
+    }
   }
 }

--- a/packages/streamwall/src/util.ts
+++ b/packages/streamwall/src/util.ts
@@ -5,7 +5,9 @@ import { BlockList, isIP } from 'node:net'
 // loopback, private LAN, carrier-grade NAT, link-local (including the cloud
 // metadata endpoint 169.254.169.254) and the unspecified address, for both
 // IPv4 and IPv6. Using a BlockList lets Node match IPv4-mapped IPv6 addresses
-// (e.g. ::ffff:127.0.0.1) against the IPv4 rules automatically.
+// (e.g. ::ffff:127.0.0.1) against the IPv4 rules automatically; the NAT64 and
+// 6to4 prefixes below cover the other IPv4-embedding IPv6 transition forms,
+// which BlockList does not unwrap on its own.
 const blockedAddresses = new BlockList()
 blockedAddresses.addSubnet('0.0.0.0', 8, 'ipv4') // "this" network / unspecified
 blockedAddresses.addSubnet('10.0.0.0', 8, 'ipv4') // private
@@ -18,6 +20,8 @@ blockedAddresses.addAddress('::', 'ipv6') // unspecified
 blockedAddresses.addAddress('::1', 'ipv6') // loopback
 blockedAddresses.addSubnet('fc00::', 7, 'ipv6') // unique local
 blockedAddresses.addSubnet('fe80::', 10, 'ipv6') // link-local
+blockedAddresses.addSubnet('64:ff9b::', 96, 'ipv6') // NAT64 (embeds IPv4)
+blockedAddresses.addSubnet('2002::', 16, 'ipv6') // 6to4 (embeds IPv4)
 
 function isBlockedAddress(ip: string): boolean {
   const family = isIP(ip)
@@ -62,8 +66,10 @@ export async function ensureValidURL(
     throw new Error(`rejecting attempt to load non-http URL '${urlStr}'`)
   }
 
-  // IPv6 literals are bracketed in url.hostname (e.g. "[::1]").
-  const hostname = url.hostname.replace(/^\[|\]$/g, '')
+  // IPv6 literals are bracketed in url.hostname (e.g. "[::1]"), and a fully
+  // qualified name may carry a trailing dot (e.g. "localhost."); strip both so
+  // the loopback fast-path cannot be skipped by a trailing dot.
+  const hostname = url.hostname.replace(/^\[|\]$/g, '').replace(/\.+$/, '')
   if (hostname === '') {
     throw new Error(`rejecting attempt to load URL with no host '${urlStr}'`)
   }


### PR DESCRIPTION
## Problem

**Severity: high** — SSRF + untrusted content, reported in #1.

`update-custom-stream` and `mutate-state-doc` are **operator** actions (not admin-only). A remote user holding only an operator invite can:

1. `update-custom-stream` with `data.link = http://169.254.169.254/…` (cloud metadata) or `http://localhost:8404/…` (Streamdelay), then
2. `mutate-state-doc` to assign that custom stream to a grid cell.

The desktop then loads the URL into a `WebContentsView`. The only guard was `ensureValidURL`, which enforced **http/https and nothing else** — no host restriction. The result is SSRF into the desktop host's own network (cloud metadata, loopback services, intranet) plus rendering of arbitrary web content in the app's shared session partition.

## Technical solution

Every operator-controlled URL that reaches a `WebContentsView` funnels through a single choke point — `ensureValidURL` — before `loadURL`/playHLS (`viewStateMachine.loadPage`) and before the `browse` window loads. Hardening that one function closes both the `update-custom-stream` and `mutate-state-doc` paths at once.

`ensureValidURL` now:

- keeps the existing **http(s)-only** scheme check;
- rejects IP **literals** in loopback, private, CGNAT, link-local and unspecified ranges, IPv4 **and** IPv6, including IPv4-mapped IPv6 (`::ffff:127.0.0.1`), NAT64 (`64:ff9b::/96`) and 6to4 (`2002::/16`) embeddings, and encoded forms (`2130706433`, `0x7f000001`, normalised by `new URL()`). Range membership is delegated to Node's `net.BlockList`;
- rejects the `localhost` hostname and any `*.localhost` subdomain (RFC 6761 — always loopback), tolerating a trailing FQDN dot, without a DNS round-trip;
- for real hostnames, **resolves the host and rejects if any resolved address is non-public**, so a public domain pointed at a private address (e.g. an A record at `127.0.0.1`) is blocked too. Resolution failure is **fail-closed**.

The function is now `async`; both call sites (`viewStateMachine.loadPage` and the `browse` handler) `await` it so validation completes before the URL is loaded. A rejected validation surfaces exactly as before — the view transitions to its `error` state (via the existing `loadPage` `onError`), and `browse` logs and skips the load.

## Architecture decisions

- **Choke-point over per-action validation.** Guarding `ensureValidURL` covers custom streams, state-doc-assigned streams and `browse` in one place, rather than scattering payload checks across the control server and main handlers.
- **`net.BlockList` over hand-rolled IP parsing.** Purpose-built, covers IPv4/IPv6 and IPv4-mapped addresses; the two extra transition prefixes (NAT64/6to4) cover the embeddings it does not unwrap itself.
- **Blocklist, not allowlist.** Streamwall's job is displaying arbitrary public streams, so a host allowlist would break normal use; blocking the non-public ranges is the correct posture for the remote-operator threat model.
- **Dependency injection for testability.** The resolver is an injectable parameter (defaulting to `dns.lookup(..., { all: true })`), so the DNS paths are tested deterministically without touching the network.

## Risks / breaking changes

- **Internal signature change:** `ensureValidURL` is now `Promise<void>`. It is an internal util with two call sites, both updated; no public API changes.
- **Behaviour change:** streams whose host is a private/LAN address (e.g. a stream server on `192.168.x.x`) are now blocked. This is intended under the remote-operator threat model; a deliberate opt-in for local sources could be a follow-up if anyone relies on LAN streams.
- **Fail-closed DNS:** a transient resolver failure blocks that load (view → retriable error state) instead of letting Electron fail the fetch later.

## Known limitations / recommended follow-up (out of scope here)

These were surfaced by an adversarial review and are **structurally outside what a single-URL string check can fix** — the dangerous request is issued *after* validation. Documenting them so the trade-off is a conscious decision; a dedicated network-layer follow-up (a security issue) is recommended:

- **HTTP redirects.** `loadURL` follows Chromium 3xx redirects with no revalidation, so a validated public host can `302` to `http://169.254.169.254/…`. No DNS rebinding needed.
- **HLS manifest contents.** Only the `.m3u8` URL is validated; hls.js in the playHLS renderer then fetches variant/segment URIs named *inside* the manifest, which never pass through `ensureValidURL`.
- **Active DNS rebinding.** The loader re-resolves after the check (TOCTOU); statically-malicious domains and literal addresses (the reported vector) are blocked, active rebinding is not.

Closing these needs enforcement at the view session's network layer (`session.webRequest.onBeforeRequest` / `onBeforeRedirect`, checking each request's resolved address), reusing this PR's address classification — ideally extracted to `streamwall-shared`.

## Test coverage

New `node:test` specs in `packages/streamwall/src/util.test.ts` (32 cases), run with `npm -w streamwall test` — zero new dependencies (Node 22 runs the TypeScript specs natively; the app tsconfig excludes `**/*.test.ts`):

- **Happy path:** public https host, public IPv4/IPv6 literal, `.m3u8` on a public host, public domain resolving to a public address.
- **Blocked literals:** loopback, `169.254.169.254`, `10/8`, `192.168/16`, `172.16/12`, `100.64/10`, `0.0.0.0`, IPv6 `::1` / `fe80::`, IPv4-mapped, NAT64- and 6to4-embedded, decimal- and hex-encoded loopback.
- **Hostnames:** `localhost`, `*.localhost`, and their trailing-dot forms.
- **DNS paths:** domain resolving to a private IPv4/IPv6, mixed public+private resolution, fail-closed on resolution error, empty resolution.
- **Errors:** non-http scheme, missing host, malformed URL.

All 32 pass; `tsc` and Prettier show no new findings on the changed files.

Closes #1
