### PR TITLE
fix(streamwall): tighten renderer CSP to http(s) stream schemes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17948,7 +17948,8 @@
         "electron": "^42.4.1",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.3",
-        "vite": "^8.0.16"
+        "vite": "^8.0.16",
+        "vitest": "^3.2.6"
       }
     },
     "packages/streamwall-control-client": {

--- a/packages/streamwall/package.json
+++ b/packages/streamwall/package.json
@@ -10,7 +10,9 @@
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.11.2",
@@ -33,7 +35,8 @@
     "electron": "^42.4.1",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "vitest": "^3.2.6"
   },
   "keywords": [],
   "author": "Max Goodhart <c@chromakode.com>",

--- a/packages/streamwall/src/renderer/background.html
+++ b/packages/streamwall/src/renderer/background.html
@@ -5,7 +5,7 @@
     <title>Streamwall Stream Background</title>
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; style-src 'self' 'unsafe-inline'; frame-src *"
+      content="default-src 'self'; style-src 'self' 'unsafe-inline'; frame-src https: http:"
     />
   </head>
   <body>

--- a/packages/streamwall/src/renderer/csp.test.ts
+++ b/packages/streamwall/src/renderer/csp.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Reads the Content-Security-Policy meta tag from a renderer HTML file that
+ * sits next to this test and returns its raw policy string.
+ */
+function readCSP(fileName: string): string {
+  const html = readFileSync(new URL(`./${fileName}`, import.meta.url), 'utf8')
+  const match = html.match(
+    /<meta\s+http-equiv="Content-Security-Policy"\s+content="([^"]*)"/i,
+  )
+  expect(
+    match,
+    `${fileName} must declare a Content-Security-Policy meta tag`,
+  ).not.toBeNull()
+  return match![1]
+}
+
+/**
+ * Parses a CSP string into a map of directive name -> array of source tokens.
+ */
+function parseCSP(csp: string): Map<string, string[]> {
+  const directives = new Map<string, string[]>()
+  for (const part of csp.split(';')) {
+    const tokens = part.trim().split(/\s+/).filter(Boolean)
+    if (tokens.length === 0) {
+      continue
+    }
+    const [name, ...sources] = tokens
+    directives.set(name.toLowerCase(), sources)
+  }
+  return directives
+}
+
+const ALL_RENDERERS = [
+  'background.html',
+  'overlay.html',
+  'playHLS.html',
+  'control.html',
+]
+
+describe('renderer Content-Security-Policy', () => {
+  it('never uses the bare "*" wildcard source', () => {
+    for (const file of ALL_RENDERERS) {
+      const directives = parseCSP(readCSP(file))
+      for (const [name, sources] of directives) {
+        expect(
+          sources,
+          `${file}: directive "${name}" must not use the bare "*" wildcard`,
+        ).not.toContain('*')
+      }
+    }
+  })
+
+  it("keeps scripts locked to 'self' in every renderer", () => {
+    for (const file of ALL_RENDERERS) {
+      const directives = parseCSP(readCSP(file))
+      const scriptSrc =
+        directives.get('script-src') ?? directives.get('default-src')
+      expect(
+        scriptSrc,
+        `${file}: scripts must stay restricted to 'self'`,
+      ).toEqual(["'self'"])
+    }
+  })
+
+  it('restricts overlay/background frame-src to http(s) stream origins', () => {
+    // Streams are embedded from arbitrary user-configured origins, all of
+    // which ensureValidURL constrains to http(s), so both schemes must remain
+    // allowed for the grid to keep working.
+    for (const file of ['background.html', 'overlay.html']) {
+      const frameSrc = parseCSP(readCSP(file)).get('frame-src')
+      expect(frameSrc, `${file}: frame-src must be present`).toBeDefined()
+      expect(new Set(frameSrc)).toEqual(new Set(['https:', 'http:']))
+    }
+  })
+
+  it('restricts playHLS connect-src to self and http(s) origins', () => {
+    // hls.js fetches manifests/segments over http(s); 'self' keeps same-origin
+    // requests (e.g. the Vite dev server) working.
+    const connectSrc = parseCSP(readCSP('playHLS.html')).get('connect-src')
+    expect(
+      connectSrc,
+      'playHLS.html: connect-src must be present',
+    ).toBeDefined()
+    expect(new Set(connectSrc)).toEqual(new Set(["'self'", 'https:', 'http:']))
+  })
+
+  it('keeps playHLS blob media playback without a wildcard', () => {
+    // hls.js plays through a MediaSource blob: URL; http/https cover any direct
+    // source fallback.
+    const mediaSrc = parseCSP(readCSP('playHLS.html')).get('media-src')
+    expect(mediaSrc, 'playHLS.html: media-src must be present').toBeDefined()
+    expect(new Set(mediaSrc)).toEqual(new Set(['blob:', 'https:', 'http:']))
+  })
+})

--- a/packages/streamwall/src/renderer/overlay.html
+++ b/packages/streamwall/src/renderer/overlay.html
@@ -5,7 +5,7 @@
     <title>Streamwall Stream Overlay</title>
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; style-src 'self' 'unsafe-inline'; frame-src *"
+      content="default-src 'self'; style-src 'self' 'unsafe-inline'; frame-src https: http:"
     />
   </head>
   <body>

--- a/packages/streamwall/src/renderer/playHLS.html
+++ b/packages/streamwall/src/renderer/playHLS.html
@@ -5,7 +5,7 @@
     <title>Streamwall HLS Player</title>
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src *; media-src * blob:"
+      content="default-src 'self'; connect-src 'self' https: http:; media-src blob: https: http:"
     />
   </head>
   <body>


### PR DESCRIPTION
## Problem

The `background`, `overlay`, and `playHLS` renderers shipped Content-Security-Policy meta tags with bare `*` wildcards:

- `background.html` / `overlay.html` — `frame-src *`
- `playHLS.html` — `connect-src *; media-src * blob:`

`script-src` stays `'self'`, so exploitability is limited, but the policies were broader than the app actually needs — most notably `connect-src *` let the HLS player open connections over **any** scheme (including `ws:`/`wss:`/`ftp:`), which is a viable exfiltration channel if stream content or a dependency were ever compromised.

Resolves #9.

## Technical solution

Every URL these renderers load is already constrained to `http(s)` by [`ensureValidURL`](../blob/deps-modernization/packages/streamwall/src/util.ts) (grid + HLS `content.url`), and the layer iframes only ever embed user-configured `http(s)` stream pages. So the schemes the app uses are exactly `http:`/`https:` (plus `blob:` for HLS playback). The directives were narrowed to match:

| Renderer | Before | After |
|---|---|---|
| background / overlay | `frame-src *` | `frame-src https: http:` |
| playHLS | `connect-src *` | `connect-src 'self' https: http:` |
| playHLS | `media-src * blob:` | `media-src blob: https: http:` |

Rationale for the specific tokens:
- **`'self'` in `connect-src`** — keeps same-origin requests working, including the Vite dev-server HMR WebSocket in development (same behaviour the other renderers get via `default-src 'self'`).
- **`blob:` retained in `media-src`** — hls.js plays through a `MediaSource` object URL (`blob:`); dropping it would break HLS playback.
- **`http:` kept alongside `https:`** — `ensureValidURL` explicitly permits `http:` streams, so requiring HTTPS-only would be a functional regression for a low-severity finding.

### Why not an explicit origin allowlist?

The issue's remediation suggests restricting to "the specific stream origins actually required." Streamwall's stream origins are **not** a fixed set — they come from arbitrary user-configured data sources (`json-url`, `toml-file`, custom/overlay entries added at runtime via IPC). A static origin allowlist would break the product's core function (displaying arbitrary streams). Scheme restriction is therefore the tightest CSP compatible with the design, and it aligns the renderer policies with the existing `ensureValidURL` security boundary.

## Architecture notes

- No session-level CSP exists; these meta tags are the only CSP for these renderers, so the change is fully contained in the three HTML files.
- `default-src 'self'` (and thus `script-src`) is untouched — scripts remain locked to `'self'`.

## Risks / breaking changes

- **Low.** Only `http(s)` (+ `blob:` media) were ever used by these renderers, so no supported configuration loses capability. The removed schemes (`ws:`/`wss:`/`ftp:` for framing/connect/media) are not used by the layer iframes or hls.js.
- Web Worker creation in hls.js is governed by `worker-src`/`default-src`, which this change does not touch — behaviour there is unchanged from before.

## Test coverage

Adds a vitest regression test (`packages/streamwall/src/renderer/csp.test.ts`) mirroring the existing `streamwall-shared` vitest setup. Developed test-first (red → green). It asserts:

1. No renderer CSP contains a bare `*` wildcard (the core finding).
2. `background`/`overlay` `frame-src` = `{https:, http:}`.
3. playHLS `connect-src` = `{'self', https:, http:}`.
4. playHLS `media-src` = `{blob:, https:, http:}` (blob playback preserved).
5. `script-src` stays `'self'` across all four renderers (regression guard).

```
✓ src/renderer/csp.test.ts (5 tests)
Test Files  1 passed (1)
     Tests  5 passed (5)
```

`streamwall-shared` tests remain green (9 passed).

## Note on linting

`eslint .` currently fails project-wide on `deps-modernization` because ESLint 10 is installed without an `eslint.config.js` (flat-config migration pending). This is a pre-existing condition unrelated to this change and not resolvable here; the new `.ts`/`.html` files introduce no lint-relevant issues. Prettier is clean on all changed files.