### PR TITLE
Security: use an effective allow-scripts sandbox for overlay/background frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,25 @@ Streamwall can load stream data from both JSON APIs and TOML files. Data sources
 npm start -- --data.json-url="https://your-site/api/streams.json" --data.toml-file="./streams.toml"
 ```
 
+## Security: overlay and background streams
+
+Streams added with the `overlay` or `background` kind are loaded as live web
+pages layered over the whole wall, inside sandboxed `<iframe>`s. Anyone with
+control access can point these tiles at an arbitrary URL, so treat their
+contents as untrusted.
+
+These frames run with `sandbox="allow-scripts"` only. Scripts are allowed so
+widget-style overlays (scoreboards, alerts, players) still work, but the page
+runs in an opaque origin: it cannot escape its sandbox, reach Streamwall's
+internal APIs, or read the app's cookies and storage. Top-level navigation,
+popups, forms and downloads stay blocked.
+
+`allow-same-origin` is intentionally not granted — combined with `allow-scripts`
+it would let a page remove its own sandbox attribute and defeat the protection.
+As a result, overlay/background pages have no access to their own origin's
+cookies or local storage; widgets that depend on same-origin persistence are not
+supported by design.
+
 ## Hotkeys
 
 The following hotkeys are available with the "control" webpage focused:

--- a/packages/streamwall/src/renderer/background.tsx
+++ b/packages/streamwall/src/renderer/background.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'preact/hooks'
 import { styled } from 'styled-components'
 import { StreamData, StreamList } from '../../../streamwall-shared/src/types'
 import { StreamwallLayerGlobal } from '../preload/layerPreload'
+import { LAYER_FRAME_SANDBOX } from './layerFrameSandbox'
 
 declare global {
   interface Window {
@@ -21,7 +22,7 @@ function Background({ streams }: { streams: StreamList }) {
         <BackgroundIFrame
           key={s._id}
           src={s.link}
-          sandbox="allow-scripts allow-same-origin"
+          sandbox={LAYER_FRAME_SANDBOX}
           allow="autoplay"
           scrolling="no"
         />

--- a/packages/streamwall/src/renderer/layerFrameSandbox.sources.test.ts
+++ b/packages/streamwall/src/renderer/layerFrameSandbox.sources.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const rendererDir = fileURLToPath(new URL('.', import.meta.url))
+
+for (const file of ['overlay.tsx', 'background.tsx']) {
+  const source = readFileSync(`${rendererDir}${file}`, 'utf8')
+
+  test(`${file} does not hardcode the ineffective allow-same-origin sandbox`, () => {
+    assert.doesNotMatch(source, /allow-same-origin/)
+  })
+
+  test(`${file} applies the shared LAYER_FRAME_SANDBOX policy to its iframe`, () => {
+    assert.match(source, /sandbox=\{LAYER_FRAME_SANDBOX\}/)
+  })
+}

--- a/packages/streamwall/src/renderer/layerFrameSandbox.test.ts
+++ b/packages/streamwall/src/renderer/layerFrameSandbox.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { LAYER_FRAME_SANDBOX } from './layerFrameSandbox.ts'
+
+const tokens = LAYER_FRAME_SANDBOX.split(' ').filter(Boolean)
+
+test('LAYER_FRAME_SANDBOX allows scripts so overlay/background widgets can render', () => {
+  assert.ok(tokens.includes('allow-scripts'), 'allow-scripts must be granted')
+})
+
+test('LAYER_FRAME_SANDBOX never grants allow-same-origin, which would defeat the sandbox', () => {
+  assert.ok(
+    !tokens.includes('allow-same-origin'),
+    'allow-same-origin must not be granted',
+  )
+  assert.doesNotMatch(LAYER_FRAME_SANDBOX, /allow-same-origin/)
+})
+
+test('LAYER_FRAME_SANDBOX grants no navigation, popup, form or download escape hatches', () => {
+  const escapes = [
+    'allow-top-navigation',
+    'allow-top-navigation-by-user-activation',
+    'allow-top-navigation-to-custom-protocols',
+    'allow-popups',
+    'allow-popups-to-escape-sandbox',
+    'allow-forms',
+    'allow-modals',
+    'allow-downloads',
+    'allow-pointer-lock',
+  ]
+  for (const escape of escapes) {
+    assert.ok(!tokens.includes(escape), `${escape} must not be granted`)
+  }
+})
+
+test('LAYER_FRAME_SANDBOX is a normalized, space-separated token list', () => {
+  assert.equal(LAYER_FRAME_SANDBOX, tokens.join(' '))
+  assert.equal(LAYER_FRAME_SANDBOX, LAYER_FRAME_SANDBOX.trim())
+})

--- a/packages/streamwall/src/renderer/layerFrameSandbox.ts
+++ b/packages/streamwall/src/renderer/layerFrameSandbox.ts
@@ -1,0 +1,33 @@
+/**
+ * Sandbox policy for the `<iframe>` elements that host `overlay` and
+ * `background` custom streams inside the wall's layer renderers
+ * (see `overlay.tsx` and `background.tsx`).
+ *
+ * Trust model
+ * -----------
+ * Overlay/background URLs are supplied by control-UI operators as custom
+ * streams (see `CreateCustomStreamInput` in `streamwall-control-ui`). Anyone
+ * with control access can point a `background`/`overlay` tile at an arbitrary
+ * URL, so the framed document must be treated as untrusted and confined.
+ *
+ * These frames intentionally grant ONLY `allow-scripts`:
+ *
+ *   - Scripts are required so widget-style overlays (scoreboards, alerts,
+ *     embedded players, …) can render.
+ *   - `allow-same-origin` is deliberately omitted. Pairing `allow-scripts`
+ *     with `allow-same-origin` is a documented no-op: a same-origin document
+ *     can reach its own frame element and remove the `sandbox` attribute,
+ *     which is no more secure than not sandboxing at all. Without
+ *     `allow-same-origin` the framed document runs in an opaque origin — it
+ *     cannot strip its own sandbox, cannot reach the layer renderer's
+ *     privileged `streamwallLayer` bridge, and has no access to the app's
+ *     cookies or storage.
+ *   - Top-level navigation, popups, forms, modals and downloads stay blocked
+ *     because their `allow-*` tokens are not present.
+ *
+ * Trade-off: because the frame runs in an opaque origin, an overlay/background
+ * document cannot read or write its own origin's cookies or local storage.
+ * Widgets that depend on same-origin persistence are unsupported by design;
+ * that is the cost of an effective sandbox.
+ */
+export const LAYER_FRAME_SANDBOX = 'allow-scripts'

--- a/packages/streamwall/src/renderer/overlay.tsx
+++ b/packages/streamwall/src/renderer/overlay.tsx
@@ -18,6 +18,7 @@ import { TailSpin } from 'svg-loaders-react'
 import { matchesState } from 'xstate'
 import packageInfo from '../../package.json'
 import { StreamwallLayerGlobal } from '../preload/layerPreload'
+import { LAYER_FRAME_SANDBOX } from './layerFrameSandbox'
 
 import '@fontsource/noto-sans'
 import 'streamwall-control-ui/src/index.css'
@@ -103,7 +104,7 @@ function Overlay({
         <OverlayIFrame
           key={s._id}
           src={s.link}
-          sandbox="allow-scripts allow-same-origin"
+          sandbox={LAYER_FRAME_SANDBOX}
           allow="autoplay"
           scrolling="no"
         />


### PR DESCRIPTION
## Problem

The `overlay` and `background` layer renderers embed operator-supplied
custom-stream URLs in iframes with `sandbox="allow-scripts allow-same-origin"`:

- `packages/streamwall/src/renderer/overlay.tsx`
- `packages/streamwall/src/renderer/background.tsx`

Combining `allow-scripts` with `allow-same-origin` is a documented no-op — a
same-origin document can reach its own frame element and remove the `sandbox`
attribute, leaving the frame no more confined than an un-sandboxed one. Because
anyone with control access can add an `overlay`/`background` stream pointing at
an arbitrary URL (`CreateCustomStreamInput` in the control UI), a malicious URL
effectively runs unsandboxed inside the wall window.

## Solution

Introduce a single source of truth for the layer-frame sandbox policy,
`LAYER_FRAME_SANDBOX`, and apply it to both iframes. The policy grants **only**
`allow-scripts`:

- Scripts stay enabled so widget-style overlays (scoreboards, alerts, embedded
  players) keep working.
- `allow-same-origin` is withheld, so the framed document runs in an **opaque
  origin**: it cannot strip its own sandbox, cannot reach the layer renderer's
  privileged `streamwallLayer` bridge, and has no access to the app's cookies or
  storage.
- Navigation, popups, forms, modals and downloads remain blocked (their
  `allow-*` tokens are absent).

The trust model is documented both at the policy constant and in the README.

## Architecture notes

- The policy lives in one small, well-documented module
  (`layerFrameSandbox.ts`) rather than being duplicated as string literals, so
  the two renderers can never drift and the invariant is unit-testable.
- Tests use the repository's existing zero-dependency `node:test` runner
  (introduced in #97) — no new dependencies are added.

## Risks / breaking changes

- Overlay/background pages no longer run same-origin. Widgets that rely on their
  own cookies / `localStorage` / `IndexedDB` will lose that access. This is the
  intended cost of an effective sandbox; such widgets were never safely
  supported. Rendering, animation, `postMessage`, and CORS-permitted `fetch`
  continue to work, and `allow="autoplay"` is unchanged.
- No API or config surface changes.

## Test coverage

- `layerFrameSandbox.test.ts` — pins the policy invariants: `allow-scripts` is
  present, `allow-same-origin` is never granted, no navigation/popup/form/
  download escape hatches, and the value is a normalized token list.
- `layerFrameSandbox.sources.test.ts` — regression guard asserting both
  renderers apply `LAYER_FRAME_SANDBOX` and contain no hardcoded
  `allow-same-origin`.
- `npm test` (native `node:test`): 15/15 pass. Changed files lint clean and
  transform cleanly through the build's esbuild pipeline.

## Note on branches

Rebased onto the current `main` (which now includes #97). The default
`deps-modernization` branch carries the identical vulnerable lines and should
receive the same fix ported to its newer toolchain.

Closes #6