### PR TITLE
fix(security): isolate stream views and browse window into per-view ephemeral partitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "streamwall",
   "scripts": {
     "start:app": "npm -w packages/streamwall start",
-    "start:server": "npm -w packages/streamwall-control-client run build && npm -w packages/streamwall-control-server start"
+    "start:server": "npm -w packages/streamwall-control-client run build && npm -w packages/streamwall-control-server start",
+    "test": "npm run test --workspaces --if-present"
   },
   "workspaces": [
     "packages/streamwall",

--- a/packages/streamwall/package.json
+++ b/packages/streamwall/package.json
@@ -10,7 +10,8 @@
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",
-    "lint": "eslint --ext .ts,.tsx ."
+    "lint": "eslint --ext .ts,.tsx .",
+    "test": "node --experimental-strip-types --disable-warning=ExperimentalWarning --test \"src/**/*.test.ts\""
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.6.0",

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -17,6 +17,7 @@ import {
 } from 'streamwall-shared'
 import { createActor, EventFrom, SnapshotFrom } from 'xstate'
 import { loadHTML } from './loadHTML'
+import { allocateViewPartition, hardenSession } from './partitions'
 import viewStateMachine, { ViewActor } from './viewStateMachine'
 
 function getDisplayOptions(stream: StreamData): ContentDisplayOptions {
@@ -147,15 +148,19 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
     } = this
     assert(win != null, 'Window must be initialized')
     const { backgroundColor } = this.config
+    // Give every view its own unique, ephemeral partition so that streams can
+    // not share cookies/localStorage/cache with each other, the browse window,
+    // or anything persisted to disk.
     const view = new WebContentsView({
       webPreferences: {
         preload: path.join(__dirname, 'mediaPreload.js'),
         nodeIntegration: false,
         contextIsolation: true,
         backgroundThrottling: false,
-        partition: 'persist:session',
+        partition: allocateViewPartition(),
       },
     })
+    hardenSession(view.webContents.session)
     view.setBackgroundColor(backgroundColor)
 
     const viewId = view.webContents.id

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -1,6 +1,6 @@
 import TOML from '@iarna/toml'
 import * as Sentry from '@sentry/electron/main'
-import { BrowserWindow, app, session } from 'electron'
+import { BrowserWindow, app } from 'electron'
 import started from 'electron-squirrel-startup'
 import fs from 'fs'
 import { throttle } from 'lodash-es'
@@ -23,6 +23,7 @@ import {
   pollDataURL,
   watchDataFile,
 } from './data'
+import { BROWSE_PARTITION, hardenSession } from './partitions'
 import { loadStorage } from './storage'
 import StreamdelayClient from './StreamdelayClient'
 import StreamWindow from './StreamWindow'
@@ -248,13 +249,6 @@ function parseArgs(): StreamwallConfig {
 }
 
 async function main(argv: ReturnType<typeof parseArgs>) {
-  // Reject all permission requests from web content.
-  session
-    .fromPartition('persist:session')
-    .setPermissionRequestHandler((webContents, permission, callback) => {
-      callback(false)
-    })
-
   const db = await loadStorage(
     join(app.getPath('userData'), 'streamwall-storage.json'),
   )
@@ -396,10 +390,13 @@ async function main(argv: ReturnType<typeof parseArgs>) {
           webPreferences: {
             nodeIntegration: false,
             contextIsolation: true,
-            partition: 'persist:session',
+            // Keep the operator's browsing isolated from the stream views and
+            // off disk by using a dedicated ephemeral partition.
+            partition: BROWSE_PARTITION,
             sandbox: true,
           },
         })
+        hardenSession(browseWindow.webContents.session)
       }
       if (msg.type === 'browse') {
         console.debug('Attempting to browse URL:', msg.url)

--- a/packages/streamwall/src/main/partitions.test.ts
+++ b/packages/streamwall/src/main/partitions.test.ts
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  allocateViewPartition,
+  BROWSE_PARTITION,
+  createPartitionAllocator,
+  hardenSession,
+} from './partitions.ts'
+
+type PermissionHandler = (
+  webContents: unknown,
+  permission: string,
+  callback: (granted: boolean) => void,
+) => void
+
+function fakeSession() {
+  let handler: PermissionHandler | null = null
+  return {
+    setPermissionRequestHandler(next: PermissionHandler | null) {
+      handler = next
+    },
+    request(permission: string): boolean {
+      assert.ok(handler, 'a permission request handler must be registered')
+      let granted: boolean | undefined
+      handler({}, permission, (value) => {
+        granted = value
+      })
+      assert.notEqual(granted, undefined, 'handler must invoke the callback')
+      return granted!
+    },
+  }
+}
+
+test('createPartitionAllocator yields sequential names with the given prefix', () => {
+  const allocate = createPartitionAllocator('view-')
+  assert.equal(allocate(), 'view-0')
+  assert.equal(allocate(), 'view-1')
+  assert.equal(allocate(), 'view-2')
+})
+
+test('allocated partitions are ephemeral (never persisted to disk)', () => {
+  const allocate = createPartitionAllocator('view-')
+  for (let i = 0; i < 5; i++) {
+    assert.ok(
+      !allocate().startsWith('persist:'),
+      'partition must not use the persistent "persist:" prefix',
+    )
+  }
+})
+
+test('separate allocators maintain independent counters', () => {
+  const a = createPartitionAllocator('a-')
+  const b = createPartitionAllocator('b-')
+  assert.equal(a(), 'a-0')
+  assert.equal(a(), 'a-1')
+  assert.equal(b(), 'b-0')
+})
+
+test('allocateViewPartition returns a unique ephemeral partition on every call', () => {
+  const seen = new Set<string>()
+  for (let i = 0; i < 100; i++) {
+    const partition = allocateViewPartition()
+    assert.ok(partition.startsWith('view-'), 'view partitions are prefixed')
+    assert.ok(!partition.startsWith('persist:'), 'view partitions are ephemeral')
+    assert.ok(!seen.has(partition), `partition ${partition} must be unique`)
+    seen.add(partition)
+  }
+})
+
+test('BROWSE_PARTITION is ephemeral and isolated from stream views', () => {
+  assert.ok(
+    !BROWSE_PARTITION.startsWith('persist:'),
+    'browse partition must be ephemeral',
+  )
+  assert.ok(
+    !BROWSE_PARTITION.startsWith('view-'),
+    'browse partition must not collide with the stream-view namespace',
+  )
+})
+
+test('hardenSession registers a permission request handler', () => {
+  const session = fakeSession()
+  let registered = false
+  const original = session.setPermissionRequestHandler
+  session.setPermissionRequestHandler = (handler) => {
+    registered = true
+    original(handler)
+  }
+  hardenSession(session)
+  assert.ok(registered, 'hardenSession must register a permission handler')
+})
+
+test('hardened session rejects every permission request', () => {
+  const session = fakeSession()
+  hardenSession(session)
+  for (const permission of [
+    'media',
+    'geolocation',
+    'notifications',
+    'midi',
+    'clipboard-read',
+  ]) {
+    assert.equal(
+      session.request(permission),
+      false,
+      `permission "${permission}" must be denied`,
+    )
+  }
+})

--- a/packages/streamwall/src/main/partitions.ts
+++ b/packages/streamwall/src/main/partitions.ts
@@ -1,0 +1,62 @@
+/**
+ * Session partition helpers for isolating web content.
+ *
+ * Streamwall loads arbitrary third-party sites as stream views and lets the
+ * operator open a browse window. Electron sessions are keyed by their
+ * `partition` string: contexts that share a partition also share cookies,
+ * localStorage and cache. A partition name beginning with `persist:` is written
+ * to disk and survives across app restarts; any other name lives only in memory
+ * and is discarded when its last web context goes away.
+ *
+ * To prevent cross-site data bleed and persistent tracking, every stream view
+ * gets its own unique, ephemeral partition and the browse window gets a separate
+ * ephemeral partition of its own.
+ *
+ * @see https://www.electronjs.org/docs/latest/api/session
+ */
+
+import type { Session } from 'electron'
+
+const VIEW_PARTITION_PREFIX = 'view-'
+
+/**
+ * Dedicated ephemeral partition for the operator's browse window. It is
+ * isolated from every stream view (which use the `view-` namespace) and is not
+ * persisted to disk.
+ */
+export const BROWSE_PARTITION = 'browse'
+
+/**
+ * Creates a partition-name allocator. Each call to the returned function yields
+ * the next sequential, ephemeral partition name for the given prefix, e.g.
+ * `view-0`, `view-1`, ... The prefix must not begin with `persist:` so the
+ * resulting sessions stay in memory only.
+ */
+export function createPartitionAllocator(prefix: string): () => string {
+  let next = 0
+  return () => `${prefix}${next++}`
+}
+
+/**
+ * App-wide allocator for stream-view partitions. A module-level singleton
+ * guarantees every view created during the process lifetime receives a distinct,
+ * never-reused partition, so no two views can ever share a session.
+ */
+export const allocateViewPartition = createPartitionAllocator(
+  VIEW_PARTITION_PREFIX,
+)
+
+/**
+ * Applies baseline hardening to a session by denying every permission request
+ * (camera, microphone, geolocation, notifications, etc.) from web content.
+ *
+ * Permission handlers are per-session in Electron, so this must be called for
+ * each isolated partition rather than once for a shared one.
+ */
+export function hardenSession(
+  session: Pick<Session, 'setPermissionRequestHandler'>,
+): void {
+  session.setPermissionRequestHandler((_webContents, _permission, callback) => {
+    callback(false)
+  })
+}

--- a/packages/streamwall/tsconfig.json
+++ b/packages/streamwall/tsconfig.json
@@ -19,5 +19,6 @@
     "outDir": "dist",
     "moduleResolution": "node",
     "resolveJsonModule": true
-  }
+  },
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Problem

Every stream view and the operator's browse window were created on a single shared, persistent Electron session partition (`persist:session`). Because contexts that share a partition also share cookies, `localStorage` and cache, this meant:

- Arbitrary third-party sites loaded as streams shared session state **with each other**.
- Those streams shared session state **with anything the operator browsed**.
- All of it was **written to disk** and survived across restarts, enabling cross-site data bleed and persistent tracking.

Closes #7.

## Solution

Isolate each web context into its own **ephemeral** partition (a partition name that does not begin with `persist:` lives only in memory and is discarded when its last web context goes away):

- **Stream views** now each get a **unique** ephemeral partition (`view-<n>`), so no two views — and nothing on disk — can ever share a session.
- **The browse window** gets its own dedicated ephemeral partition (`browse`), isolated from every stream view.
- The single permission handler that used to guard the shared `persist:session` partition is replaced by **per-session hardening**: every isolated partition denies all permission requests (camera, microphone, geolocation, notifications, …) at creation time. This preserves — and actually tightens — the previous "reject all permissions from web content" behavior.

## Architecture

A small, dependency-free main-process module, `packages/streamwall/src/main/partitions.ts`, encapsulates the two concerns:

- `createPartitionAllocator(prefix)` / `allocateViewPartition` — a module-level singleton allocator that guarantees every view created during the process lifetime receives a distinct, never-reused partition name.
- `BROWSE_PARTITION` — the dedicated ephemeral partition constant for the browse window.
- `hardenSession(session)` — denies all permission requests on a session (permission handlers are per-session in Electron, so this is applied at each partition rather than once for a shared one).

Wiring is a two-line change in `StreamWindow.createView()` and in the browse-window branch of `index.ts`.

## Risks / Breaking changes

- **Sessions are now ephemeral.** Cookies and logins in the browse window no longer persist across app restarts, and stream views no longer inherit session state from the browse window or from one another. This is the intended remediation ("use per-view ephemeral/isolated partitions unless persistence is specifically required"). Stream views load a fixed URL and block navigation, so interactive login inside a view was never a supported flow; the practical impact is that the operator re-authenticates in the browse window per app run.
- No other context used `persist:session` (overlay/background/control render trusted local HTML on the default session), so removing the shared partition and its startup permission handler is safe.

## Test coverage

- **7 unit tests** for the new module (`partitions.test.ts`) covering: sequential/unique allocation, ephemerality (never `persist:`), allocator independence, browse-partition isolation, and that a hardened session denies every permission request.
- Tests run on **Node's built-in test runner with native TypeScript type stripping — no test framework or new dependency added.** Wired up as `npm test` at the repo root and in the `streamwall` package.
- Verified `npm run package` builds and packages the app cleanly, and confirmed `persist:session` no longer appears anywhere in the shipped main-process bundle while the new isolation logic does.
- The production code type-checks cleanly under `tsc`; test files (which use Node-runtime `.ts` import specifiers) are excluded from the production TypeScript project.
