### PR TITLE
fix(control-server): session cookie Max-Age in Sekunden + SameSite (#8)

### DIFF
--- a/packages/streamwall-control-server/package.json
+++ b/packages/streamwall-control-server/package.json
@@ -5,7 +5,8 @@
   "main": "src/index.ts",
   "type": "module",
   "scripts": {
-    "start": "tsx ./src/index.ts"
+    "start": "tsx ./src/index.ts",
+    "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "repository": "github:streamwall/streamwall",
   "author": "Max Goodhart <c@chromakode.com>",

--- a/packages/streamwall-control-server/src/index.test.ts
+++ b/packages/streamwall-control-server/src/index.test.ts
@@ -1,0 +1,99 @@
+import { Low, Memory } from 'lowdb'
+import assert from 'node:assert/strict'
+import { after, describe, test } from 'node:test'
+
+import { initApp, SESSION_COOKIE_NAME } from './index.ts'
+import type { StoredData } from './storage.ts'
+
+const ONE_YEAR_IN_SECONDS = 365 * 24 * 60 * 60
+
+function inMemoryDb(): Low<StoredData> {
+  return new Low<StoredData>(new Memory<StoredData>(), {
+    auth: { salt: null, tokens: [] },
+    streamwallToken: null,
+  })
+}
+
+/**
+ * Build an isolated control-server app backed by in-memory storage, mint a
+ * fresh invite token and redeem it via `GET /invite/:id`. Returns the raw
+ * `Set-Cookie` header produced for the resulting session cookie.
+ */
+async function redeemInvite(baseURL: string) {
+  const { app, auth } = await initApp({
+    baseURL,
+    clientStaticPath: import.meta.dirname,
+    db: inMemoryDb(),
+  })
+  after(() => app.close())
+
+  const { tokenId, secret } = await auth.createToken({
+    kind: 'invite',
+    role: 'admin',
+    name: 'Test invite',
+  })
+
+  const response = await app.inject({
+    method: 'GET',
+    url: `/invite/${tokenId}?token=${secret}`,
+  })
+
+  const rawSetCookie = response.headers['set-cookie']
+  const setCookie = Array.isArray(rawSetCookie)
+    ? rawSetCookie.join('\n')
+    : String(rawSetCookie ?? '')
+
+  return { app, auth, response, setCookie }
+}
+
+describe('session cookie security attributes', () => {
+  test('Max-Age is one year expressed in seconds (not milliseconds)', async () => {
+    const { setCookie } = await redeemInvite('http://localhost:3000')
+
+    const match = setCookie.match(/Max-Age=(\d+)/i)
+    assert.ok(match, 'session cookie should carry a Max-Age attribute')
+    assert.equal(
+      Number(match[1]),
+      ONE_YEAR_IN_SECONDS,
+      'Max-Age must be in seconds; a ms value yields an effectively permanent cookie',
+    )
+  })
+
+  test('SameSite=Strict is set on the session cookie', async () => {
+    const { setCookie } = await redeemInvite('http://localhost:3000')
+    assert.match(setCookie, /SameSite=Strict/i)
+  })
+
+  test('session cookie stays HttpOnly and scoped to /', async () => {
+    const { setCookie } = await redeemInvite('http://localhost:3000')
+    assert.match(setCookie, new RegExp(`^${SESSION_COOKIE_NAME}=`))
+    assert.match(setCookie, /HttpOnly/i)
+    assert.match(setCookie, /Path=\//i)
+  })
+
+  test('session cookie is marked Secure when served over https', async () => {
+    const { setCookie } = await redeemInvite('https://localhost:3000')
+    assert.match(setCookie, /Secure/i)
+    const match = setCookie.match(/Max-Age=(\d+)/i)
+    assert.ok(match)
+    assert.equal(Number(match[1]), ONE_YEAR_IN_SECONDS)
+    assert.match(setCookie, /SameSite=Strict/i)
+  })
+
+  test('an invalid invite token is rejected without setting a cookie', async () => {
+    const { app } = await initApp({
+      baseURL: 'http://localhost:3000',
+      clientStaticPath: import.meta.dirname,
+      db: inMemoryDb(),
+    })
+    after(() => app.close())
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/invite/does-not-exist?token=bogus',
+    })
+
+    assert.equal(response.statusCode, 403)
+    assert.equal(response.headers['set-cookie'], undefined)
+  })
+})

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -21,6 +21,10 @@ import { Auth, StateWrapper, uniqueRand62 } from './auth.ts'
 import { loadStorage, type StorageDB } from './storage.ts'
 
 export const SESSION_COOKIE_NAME = 's'
+// `@fastify/cookie` serializes `maxAge` into the RFC 6265 `Max-Age` attribute,
+// which is measured in SECONDS (not milliseconds). Keep this value in seconds —
+// one year — so sessions stay long-lived while remaining bounded.
+export const SESSION_COOKIE_MAX_AGE_SECONDS = 365 * 24 * 60 * 60
 const STREAMWALL_PING_TIMEOUT_MS = 5 * 1000
 
 interface Client {
@@ -135,7 +139,8 @@ export async function initApp({
           path: '/',
           httpOnly: true,
           secure: isSecure,
-          maxAge: 1 * 365 * 24 * 60 * 60 * 1000,
+          sameSite: 'strict',
+          maxAge: SESSION_COOKIE_MAX_AGE_SECONDS,
         },
       )
 

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -3,6 +3,7 @@ import fastifyStatic from '@fastify/static'
 import fastifyWebsocket from '@fastify/websocket'
 import Fastify from 'fastify'
 import process from 'node:process'
+import { pathToFileURL } from 'node:url'
 import WebSocket from 'ws'
 import * as Y from 'yjs'
 
@@ -82,7 +83,11 @@ function queueWebSocketMessages(ws: WebSocket) {
   return setMessageHandler
 }
 
-async function initApp({ baseURL, clientStaticPath }: AppOptions) {
+export async function initApp({
+  baseURL,
+  clientStaticPath,
+  db: injectedDb,
+}: AppOptions & { db?: StorageDB }) {
   const expectedOrigin = new URL(baseURL).origin
   const clients = new Map<string, Client>()
   const isSecure = baseURL.startsWith('https')
@@ -90,7 +95,7 @@ async function initApp({ baseURL, clientStaticPath }: AppOptions) {
   let currentStreamwallWs: WebSocket | null = null
   let currentStreamwallConn: StreamwallConnection | null = null
 
-  const db = await loadStorage()
+  const db = injectedDb ?? (await loadStorage())
   const auth = new Auth(db.data.auth)
 
   const app = Fastify()
@@ -520,11 +525,16 @@ export default async function runServer({
   return { server: app.server }
 }
 
-runServer({
-  hostname: process.env.STREAMWALL_CONTROL_HOSTNAME,
-  port: process.env.STREAMWALL_CONTROL_PORT,
-  baseURL: process.env.STREAMWALL_CONTROL_URL ?? 'http://localhost:3000',
-  clientStaticPath:
-    process.env.STREAMWALL_CONTROL_STATIC ??
-    path.join(import.meta.dirname, '../../streamwall-control-client/dist'),
-})
+const isMainModule =
+  !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+
+if (isMainModule) {
+  runServer({
+    hostname: process.env.STREAMWALL_CONTROL_HOSTNAME,
+    port: process.env.STREAMWALL_CONTROL_PORT,
+    baseURL: process.env.STREAMWALL_CONTROL_URL ?? 'http://localhost:3000',
+    clientStaticPath:
+      process.env.STREAMWALL_CONTROL_STATIC ??
+      path.join(import.meta.dirname, '../../streamwall-control-client/dist'),
+  })
+}


### PR DESCRIPTION
## Problem

Der Session-Cookie im Control-Server wurde mit einer `maxAge`-Angabe in **Millisekunden** gesetzt:

```ts
maxAge: 1 * 365 * 24 * 60 * 60 * 1000
```

`@fastify/cookie` interpretiert `maxAge` jedoch als **Sekunden** (RFC 6265 `Max-Age`). Der Wert entsprach damit ~1000 Jahren — der Cookie läuft praktisch nie ab, sodass die Sitzungsgültigkeit ausschließlich vom serverseitigen Löschen des Tokens abhängt. Zusätzlich fehlte das `SameSite`-Attribut (fehlende Defense-in-Depth gegen CSRF).

Siehe Issue #8 (Security-Audit).

## Lösung

- `maxAge` wird nun in **Sekunden** ausgedrückt (ein Jahr = `31536000`), gekapselt in der benannten Konstante `SESSION_COOKIE_MAX_AGE_SECONDS` mit erklärendem Kommentar, um ein erneutes `* 1000` zu verhindern.
- `sameSite: 'strict'` wird gesetzt.
- `HttpOnly`, `Path=/` und das transportabhängige `Secure` bleiben unverändert erhalten.

Vorher/Nachher (Live gegen den laufenden Server verifiziert):

```
- set-cookie: s=…; Max-Age=31536000000; Path=/; HttpOnly
+ set-cookie: s=…; Max-Age=31536000; Path=/; HttpOnly; SameSite=Strict
```

## Architekturentscheidungen

Der Control-Server war bisher nicht testbar: `src/index.ts` startete beim Import direkt einen HTTP-Server, und `initApp` war nicht exportiert. Um den Fix per Test am HTTP-Rand abzusichern, wurde ein minimaler, verhaltenserhaltender Test-Seam eingezogen (eigener Commit):

- `initApp` wird exportiert und akzeptiert optional ein Storage-Backend (`db?`), sodass Tests eine In-Memory-`lowdb` injizieren können.
- Der Server-Bootstrap läuft nur noch, wenn das Modul als Einstiegspunkt ausgeführt wird (`import.meta.url`-Guard) — der Import in Tests startet keinen Socket mehr. Der reguläre Start (`npm start` / `tsx src/index.ts`) wurde per Smoke-Test bestätigt.

Für die Tests wird der eingebaute `node:test`-Runner via `tsx` genutzt (keine zusätzliche Test-Dependency im Paket nötig).

## Risiken / Breaking Changes

- **Keine Breaking Changes.** Laufzeitverhalten unverändert außer der Cookie-Lebensdauer und dem neuen `SameSite`.
- Bestehende Sessions mit dem alten (quasi-unbegrenzten) Cookie bleiben gültig; neu ausgestellte Cookies laufen korrekt nach einem Jahr ab.
- `sameSite: 'strict'` ist für diesen Invite-/Session-Flow unkritisch, da der Login serverseitig per Redirect auf denselben Origin erfolgt.

## Testabdeckung

Neu: `packages/streamwall-control-server/src/index.test.ts` (`node:test`, via `npm test -w packages/streamwall-control-server`) — TDD (rot → grün):

1. `Max-Age` ist ein Jahr in **Sekunden** (`31536000`, nicht `…000`).
2. `SameSite=Strict` wird gesetzt.
3. Regression: Cookie bleibt `HttpOnly` und `Path=/`.
4. Über `https` wird zusätzlich `Secure` gesetzt (bei korrektem `Max-Age`/`SameSite`).
5. Ungültiges Invite-Token → `403`, kein Cookie.

Alle 5 Tests grün; Prettier `--check` sauber; die geänderten Dateien typechecken unter der Laufzeitkonfiguration fehlerfrei.

Fixes #8
