### PR TITLE
feat: configurable grid size via grid.count

### DIFF
--- a/example.config.toml
+++ b/example.config.toml
@@ -15,7 +15,13 @@
 #active-color = "#fff"
 
 [grid]
+# Number of columns and rows for a square grid (e.g. 3 = 3x3, 4 = 4x4).
 #count = 3
+
+# For a non-square grid, override the number of columns and/or rows
+# individually. These take precedence over "count".
+#cols = 4
+#rows = 2
 
 [control]
 # Address to serve control server from

--- a/packages/streamwall-shared/package.json
+++ b/packages/streamwall-shared/package.json
@@ -4,6 +4,9 @@
   "version": "0.0.0",
   "type": "module",
   "main": "./src/index.ts",
+  "scripts": {
+    "test": "node --experimental-strip-types --disable-warning=ExperimentalWarning --test \"src/**/*.test.ts\""
+  },
   "dependencies": {
     "color": "^5.0.0",
     "jsondiffpatch": "^0.7.3"

--- a/packages/streamwall-shared/src/geometry.test.ts
+++ b/packages/streamwall-shared/src/geometry.test.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import {
+  boxesFromViewContentMap,
+  idxInBox,
+  idxToCoords,
+  type ViewContent,
+  type ViewContentMap,
+} from './geometry.ts'
+
+const video = (url: string): ViewContent => ({ url, kind: 'video' })
+
+function contentMap(entries: Record<number, ViewContent>): ViewContentMap {
+  return new Map(Object.entries(entries).map(([idx, c]) => [idx, c]))
+}
+
+function assertBox(
+  box: { x: number; y: number; w: number; h: number },
+  expected: { x: number; y: number; w: number; h: number },
+) {
+  assert.equal(box.x, expected.x)
+  assert.equal(box.y, expected.y)
+  assert.equal(box.w, expected.w)
+  assert.equal(box.h, expected.h)
+}
+
+describe('idxToCoords', () => {
+  test('maps indices to coordinates in a 4-wide grid', () => {
+    assert.deepEqual(idxToCoords(4, 0), { x: 0, y: 0 })
+    assert.deepEqual(idxToCoords(4, 3), { x: 3, y: 0 })
+    assert.deepEqual(idxToCoords(4, 6), { x: 2, y: 1 })
+    assert.deepEqual(idxToCoords(4, 15), { x: 3, y: 3 })
+  })
+
+  test('maps indices to coordinates in an 8-wide grid', () => {
+    assert.deepEqual(idxToCoords(8, 15), { x: 7, y: 1 })
+    assert.deepEqual(idxToCoords(8, 63), { x: 7, y: 7 })
+  })
+})
+
+describe('idxInBox', () => {
+  test('detects membership in a rectangular selection of a 4-wide grid', () => {
+    // Selection from idx 0 (0,0) to idx 5 (1,1): the top-left 2x2 block.
+    assert.equal(idxInBox(4, 0, 5, 0), true)
+    assert.equal(idxInBox(4, 0, 5, 1), true)
+    assert.equal(idxInBox(4, 0, 5, 4), true)
+    assert.equal(idxInBox(4, 0, 5, 5), true)
+    // Outside the block:
+    assert.equal(idxInBox(4, 0, 5, 2), false)
+    assert.equal(idxInBox(4, 0, 5, 6), false)
+    assert.equal(idxInBox(4, 0, 5, 8), false)
+  })
+
+  test('is order-independent for start and end', () => {
+    assert.equal(idxInBox(4, 5, 0, 1), true)
+    assert.equal(idxInBox(4, 5, 0, 2), false)
+  })
+})
+
+describe('boxesFromViewContentMap', () => {
+  test('returns no boxes for an empty grid', () => {
+    assert.deepEqual(boxesFromViewContentMap(4, 4, new Map()), [])
+  })
+
+  test('returns a single 1x1 box for one filled cell in a 4x4 grid', () => {
+    const boxes = boxesFromViewContentMap(4, 4, contentMap({ 5: video('a') }))
+    assert.equal(boxes.length, 1)
+    assertBox(boxes[0], { x: 1, y: 1, w: 1, h: 1 })
+    assert.deepEqual(boxes[0].spaces, [5])
+  })
+
+  test('merges adjacent equal content into one 2x2 box in a 4x4 grid', () => {
+    const a = video('a')
+    const boxes = boxesFromViewContentMap(
+      4,
+      4,
+      contentMap({ 0: a, 1: a, 4: a, 5: a }),
+    )
+    assert.equal(boxes.length, 1)
+    assertBox(boxes[0], { x: 0, y: 0, w: 2, h: 2 })
+    assert.deepEqual(boxes[0].spaces, [0, 1, 4, 5])
+  })
+
+  test('keeps distinct content in separate boxes', () => {
+    const boxes = boxesFromViewContentMap(
+      4,
+      4,
+      contentMap({ 0: video('a'), 1: video('b') }),
+    )
+    assert.equal(boxes.length, 2)
+    const urls = boxes.map((b) => b.content?.url).sort()
+    assert.deepEqual(urls, ['a', 'b'])
+  })
+
+  test('merges a fully filled 8x8 grid into a single box', () => {
+    const a = video('a')
+    const full: Record<number, ViewContent> = {}
+    for (let i = 0; i < 64; i++) {
+      full[i] = a
+    }
+    const boxes = boxesFromViewContentMap(8, 8, contentMap(full))
+    assert.equal(boxes.length, 1)
+    assertBox(boxes[0], { x: 0, y: 0, w: 8, h: 8 })
+    assert.equal(boxes[0].spaces.length, 64)
+  })
+
+  test('does not merge across rows when a column differs (non-square 4x2)', () => {
+    const a = video('a')
+    // Fill the entire top row (cols 0..3) of a 4x2 grid.
+    const boxes = boxesFromViewContentMap(
+      4,
+      2,
+      contentMap({ 0: a, 1: a, 2: a, 3: a }),
+    )
+    assert.equal(boxes.length, 1)
+    assertBox(boxes[0], { x: 0, y: 0, w: 4, h: 1 })
+    assert.deepEqual(boxes[0].spaces, [0, 1, 2, 3])
+  })
+})

--- a/packages/streamwall-shared/src/grid.test.ts
+++ b/packages/streamwall-shared/src/grid.test.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import {
+  DEFAULT_GRID_COUNT,
+  type GridDimensionsInput,
+  MAX_GRID_DIMENSION,
+  resolveGridDimensions,
+} from './grid.ts'
+
+describe('resolveGridDimensions', () => {
+  test('defaults to a square grid of DEFAULT_GRID_COUNT when nothing is set', () => {
+    assert.deepEqual(resolveGridDimensions({}), {
+      cols: DEFAULT_GRID_COUNT,
+      rows: DEFAULT_GRID_COUNT,
+    })
+  })
+
+  test('count produces a square grid', () => {
+    assert.deepEqual(resolveGridDimensions({ count: 4 }), { cols: 4, rows: 4 })
+    assert.deepEqual(resolveGridDimensions({ count: 8 }), { cols: 8, rows: 8 })
+  })
+
+  test('supports a minimal 1x1 grid', () => {
+    assert.deepEqual(resolveGridDimensions({ count: 1 }), { cols: 1, rows: 1 })
+  })
+
+  test('explicit cols and rows produce a non-square grid', () => {
+    assert.deepEqual(resolveGridDimensions({ cols: 4, rows: 2 }), {
+      cols: 4,
+      rows: 2,
+    })
+  })
+
+  test('explicit cols overrides count while rows falls back to count', () => {
+    assert.deepEqual(resolveGridDimensions({ count: 4, cols: 6 }), {
+      cols: 6,
+      rows: 4,
+    })
+  })
+
+  test('explicit rows overrides count while cols falls back to count', () => {
+    assert.deepEqual(resolveGridDimensions({ count: 4, rows: 2 }), {
+      cols: 4,
+      rows: 2,
+    })
+  })
+
+  test('a single explicit dimension falls back to the default for the other', () => {
+    assert.deepEqual(resolveGridDimensions({ cols: 5 }), {
+      cols: 5,
+      rows: DEFAULT_GRID_COUNT,
+    })
+    assert.deepEqual(resolveGridDimensions({ rows: 5 }), {
+      cols: DEFAULT_GRID_COUNT,
+      rows: 5,
+    })
+  })
+
+  test('supports the maximum allowed dimension', () => {
+    assert.deepEqual(resolveGridDimensions({ count: MAX_GRID_DIMENSION }), {
+      cols: MAX_GRID_DIMENSION,
+      rows: MAX_GRID_DIMENSION,
+    })
+  })
+
+  describe('validation', () => {
+    const invalidCases: Array<[string, GridDimensionsInput]> = [
+      ['count of zero', { count: 0 }],
+      ['negative count', { count: -1 }],
+      ['zero cols', { cols: 0 }],
+      ['negative rows', { rows: -3 }],
+      ['non-integer cols', { cols: 2.5 }],
+      ['non-integer rows', { rows: 3.1 }],
+      ['NaN count', { count: NaN }],
+      ['Infinity cols', { cols: Infinity }],
+      ['cols above maximum', { cols: MAX_GRID_DIMENSION + 1 }],
+      ['rows above maximum', { rows: MAX_GRID_DIMENSION + 1 }],
+    ]
+    for (const [label, input] of invalidCases) {
+      test(`throws for ${label}`, () => {
+        assert.throws(() => resolveGridDimensions(input))
+      })
+    }
+
+    test('error message names the offending dimension and its value', () => {
+      assert.throws(() => resolveGridDimensions({ cols: 0 }), /cols/)
+      assert.throws(() => resolveGridDimensions({ rows: -2 }), /rows/)
+    })
+  })
+})

--- a/packages/streamwall-shared/src/grid.ts
+++ b/packages/streamwall-shared/src/grid.ts
@@ -1,0 +1,52 @@
+/** Default number of columns and rows when no grid size is configured. */
+export const DEFAULT_GRID_COUNT = 3
+
+/**
+ * Upper bound for a single grid dimension. Guards against absurd
+ * configurations that would spawn thousands of views and exhaust resources.
+ */
+export const MAX_GRID_DIMENSION = 100
+
+export interface GridDimensionsInput {
+  /** Shorthand for a square grid: sets both cols and rows. */
+  count?: number
+  /** Explicit number of columns. Overrides `count`. */
+  cols?: number
+  /** Explicit number of rows. Overrides `count`. */
+  rows?: number
+}
+
+export interface GridDimensions {
+  cols: number
+  rows: number
+}
+
+function validateDimension(name: 'cols' | 'rows', value: number): void {
+  if (!Number.isInteger(value) || value < 1 || value > MAX_GRID_DIMENSION) {
+    throw new Error(
+      `Invalid grid ${name}: ${value}. ` +
+        `Must be an integer between 1 and ${MAX_GRID_DIMENSION}.`,
+    )
+  }
+}
+
+/**
+ * Resolve the effective grid dimensions from configuration input.
+ *
+ * `count` provides a square grid; explicit `cols`/`rows` override it,
+ * allowing non-square grids. Any dimension left unset falls back to
+ * `count`, which itself defaults to {@link DEFAULT_GRID_COUNT}.
+ *
+ * @throws if a resolved dimension is not an integer in
+ *   `[1, MAX_GRID_DIMENSION]`.
+ */
+export function resolveGridDimensions(
+  input: GridDimensionsInput,
+): GridDimensions {
+  const count = input.count ?? DEFAULT_GRID_COUNT
+  const cols = input.cols ?? count
+  const rows = input.rows ?? count
+  validateDimension('cols', cols)
+  validateDimension('rows', rows)
+  return { cols, rows }
+}

--- a/packages/streamwall-shared/src/index.ts
+++ b/packages/streamwall-shared/src/index.ts
@@ -1,5 +1,6 @@
 export * from './colors.ts'
 export * from './geometry.ts'
+export * from './grid.ts'
 export * from './roles.ts'
 export * from './stateDiff.ts'
 export * from './types.ts'

--- a/packages/streamwall-shared/tsconfig.json
+++ b/packages/streamwall-shared/tsconfig.json
@@ -4,5 +4,6 @@
     "@tsconfig/node22/tsconfig",
     "@tsconfig/node-ts/tsconfig"
   ],
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["node_modules", "**/*.test.ts"]
 }

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -8,7 +8,11 @@ import EventEmitter from 'node:events'
 import { join } from 'node:path'
 import ReconnectingWebSocket from 'reconnecting-websocket'
 import 'source-map-support/register'
-import { ControlCommand, StreamwallState } from 'streamwall-shared'
+import {
+  ControlCommand,
+  resolveGridDimensions,
+  StreamwallState,
+} from 'streamwall-shared'
 import { updateElectronApp } from 'update-electron-app'
 import WebSocket from 'ws'
 import yargs from 'yargs'
@@ -35,8 +39,9 @@ const SENTRY_DSN =
 export interface StreamwallConfig {
   help: boolean
   grid: {
-    cols: number
-    rows: number
+    count: number
+    cols?: number
+    rows?: number
   }
   window: {
     x?: number
@@ -99,14 +104,19 @@ function parseArgs(): StreamwallConfig {
       .config('config', (configPath) => {
         return TOML.parse(fs.readFileSync(configPath, 'utf-8'))
       })
-      .group(['grid.cols', 'grid.rows'], 'Grid dimensions')
-      .option('grid.cols', {
+      .group(['grid.count', 'grid.cols', 'grid.rows'], 'Grid dimensions')
+      .option('grid.count', {
+        describe: 'Number of columns and rows for a square grid',
         number: true,
         default: 3,
       })
-      .option('grid.rows', {
+      .option('grid.cols', {
+        describe: 'Number of columns (overrides grid.count)',
         number: true,
-        default: 3,
+      })
+      .option('grid.rows', {
+        describe: 'Number of rows (overrides grid.count)',
+        number: true,
       })
       .group(
         [
@@ -265,9 +275,10 @@ async function main(argv: ReturnType<typeof parseArgs>) {
 
   const overlayStreamData = new LocalStreamData()
 
+  const { cols, rows } = resolveGridDimensions(argv.grid)
   const streamWindowConfig = {
-    cols: argv.grid.cols,
-    rows: argv.grid.rows,
+    cols,
+    rows,
     width: argv.window.width,
     height: argv.window.height,
     x: argv.window.x,
@@ -336,14 +347,23 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     }, 1000),
   )
 
+  const viewCount = cols * rows
   stateDoc.transact(() => {
-    for (let i = 0; i < argv.grid.cols * argv.grid.rows; i++) {
+    for (let i = 0; i < viewCount; i++) {
       if (viewsState.has(String(i))) {
         continue
       }
       const data = new Y.Map<string | undefined>()
       data.set('streamId', undefined)
       viewsState.set(String(i), data)
+    }
+    // Drop view slots outside the current grid (e.g. after the grid has been
+    // made smaller) so stale stream assignments aren't retained or resurfaced
+    // if the grid is later grown again.
+    for (const key of [...viewsState.keys()]) {
+      if (Number(key) >= viewCount) {
+        viewsState.delete(key)
+      }
     }
   })
 


### PR DESCRIPTION
## Problem

[streamwall/streamwall#12](https://github.com/streamwall/streamwall/issues/12) asks for configurable grid sizes (4x4, 8x8, …) instead of a fixed 3x3 wall. The original reporter noted that even after changing the grid constants, *"the control interface shows the 3x3 grid no matter what you set, so there is no way to control the larger grid."*

On this branch the plumbing is actually most of the way there — the main process reads `grid.cols`/`grid.rows`, the synced `StreamwallState.config` carries those dimensions, and the control UI already renders the grid dynamically from `cols`/`rows`. The gaps that made the feature effectively unusable were:

1. **`example.config.toml` documented a non-existent `[grid] count` option** while the code read `grid.cols`/`grid.rows`. A user following the example set `count`, saw no effect, and stayed on the default 3x3 — exactly the reported symptom.
2. **No validation.** A stray `cols = 0` (or negative / non-integer) value divides by zero in the layout math and silently breaks the wall.
3. **Shrinking the grid left stale view slots** in the persisted Yjs state, which could resurface old stream assignments when the grid was later grown again.

## Solution

- **`resolveGridDimensions()`** (new, in `streamwall-shared`): turns `{ count?, cols?, rows? }` into validated `{ cols, rows }`. A single `count` produces a square grid — matching the upstream `--grid.count` resolution — while explicit `cols`/`rows` enable non-square grids and take precedence. Every resolved dimension is validated to be an integer in `[1, MAX_GRID_DIMENSION]`, failing fast with a clear message otherwise.
- **`grid.count` option** added to the main process alongside the existing `grid.cols`/`grid.rows`. Dimensions are now resolved once and reused for both the `StreamWindow` config and the initial view-slot allocation.
- **Shrink handling:** view slots outside the resolved `cols * rows` are pruned on startup.
- **`example.config.toml`** now correctly documents `count` (square) and the `cols`/`rows` overrides (non-square).

## Architecture notes

- The resolver lives in `streamwall-shared` because it is pure, reusable, and trivially unit-testable — the same reasoning as the existing `geometry` helpers it sits next to.
- `count` is intentionally a shorthand rather than the only knob: keeping `cols`/`rows` preserves this fork's existing non-square capability while giving square grids the ergonomic single-number config the issue asks for.
- Precedence (`explicit cols/rows` > `count` > default `3`) is implemented by leaving `grid.cols`/`grid.rows` without yargs defaults, so "unset" is distinguishable from "set to 3".

## Risks / breaking changes

- **No breaking changes.** Default behaviour is unchanged (3x3). Existing configs using `grid.cols`/`grid.rows` keep working.
- Invalid grid values now **fail fast at startup** instead of producing a broken wall. This is intentional and surfaced through the existing top-level error handler.
- Shrink-pruning discards stream assignments for cells that no longer exist — the correct semantics when the grid gets smaller.

## Test coverage

Uses the repo's existing **zero-dependency native Node test runner** (`node:test` with native TypeScript stripping — the same setup introduced in #97), so no test-framework dependency is added. A `test` script is added to `streamwall-shared` and picked up by the workspace-root `npm test` aggregator. 29 tests, all green:

- `resolveGridDimensions`: defaults, `count` squares, non-square overrides, precedence, `1x1` and max boundaries, and validation failures (zero, negative, non-integer, `NaN`, `Infinity`, above-max).
- `geometry` (characterization): `idxToCoords`, `idxInBox`, and `boxesFromViewContentMap` exercised at 4x4, 8x8, and non-square 4x2 — locking in the layout math for arbitrary grid sizes.

Run with `npm test` (root) or `npm -w streamwall-shared test`.

> Rebased onto the current `main` (includes #97). The project's `tsc`/ESLint configs are pre-existingly incompatible with the pinned toolchain (they don't run cleanly on `main` independent of this change), and this worktree has a minimal dependency install, so full app packaging was not exercised here; the new pure logic is fully covered by the native test runner and the new module type-checks cleanly in isolation.

Addresses streamwall/streamwall#12.
