### PR TITLE
feat(streamwall): add keyboard shortcut to quit (frameless windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ npm start -- --data.json-url="https://your-site/api/streams.json" --data.toml-fi
 
 ## Hotkeys
 
+**cmd/ctrl+q** quits Streamwall. It works whenever any Streamwall window is focused, and is the only way to exit when the stream window is configured to be frameless (a frameless window has no title bar or close button — see `window.frameless` in `example.config.toml`).
+
 The following hotkeys are available with the "control" webpage focused:
 
 - **alt+[1...9]**: Listen to the numbered stream

--- a/example.config.toml
+++ b/example.config.toml
@@ -6,6 +6,7 @@
 # Position a frameless window (useful for capturing w/ fixed screen positions)
 #x = 0
 #y = 0
+# A frameless window has no title bar or close button; press Cmd/Ctrl+Q to quit.
 #frameless = false
 
 # Set the background color (useful for chroma-keying)

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -1,6 +1,6 @@
 import TOML from '@iarna/toml'
 import * as Sentry from '@sentry/electron/main'
-import { BrowserWindow, app } from 'electron'
+import { BrowserWindow, app, globalShortcut } from 'electron'
 import started from 'electron-squirrel-startup'
 import fs from 'fs'
 import { throttle } from 'lodash-es'
@@ -24,6 +24,7 @@ import {
   watchDataFile,
 } from './data'
 import { BROWSE_PARTITION, hardenSession } from './partitions'
+import { setupQuitShortcut } from './quitShortcut'
 import { loadStorage } from './storage'
 import StreamdelayClient from './StreamdelayClient'
 import StreamWindow from './StreamWindow'
@@ -278,6 +279,14 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   }
   const streamWindow = new StreamWindow(streamWindowConfig)
   const controlWindow = new ControlWindow()
+
+  // Provide a keyboard shortcut to quit. Without it there is no way to exit
+  // when the stream window runs frameless (no title bar / close button).
+  setupQuitShortcut({
+    app,
+    globalShortcut,
+    getFocusedWindow: () => BrowserWindow.getFocusedWindow(),
+  })
 
   let browseWindow: BrowserWindow | null = null
   let streamdelayClient: StreamdelayClient | null = null

--- a/packages/streamwall/src/main/quitShortcut.test.ts
+++ b/packages/streamwall/src/main/quitShortcut.test.ts
@@ -1,0 +1,179 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { QUIT_ACCELERATOR, setupQuitShortcut } from './quitShortcut.ts'
+
+type Handler = (...args: unknown[]) => void
+
+function createHarness() {
+  const handlers: Record<string, Handler[]> = {}
+  const registered = new Map<string, () => void>()
+  let quitCalls = 0
+  let registerCalls = 0
+  let unregisterCalls = 0
+  let focused: object | null = null
+
+  const app = {
+    on(event: string, cb: Handler) {
+      ;(handlers[event] ??= []).push(cb)
+      return app
+    },
+    quit() {
+      quitCalls++
+    },
+  }
+
+  const globalShortcut = {
+    register(accelerator: string, cb: () => void) {
+      registerCalls++
+      registered.set(accelerator, cb)
+      return true
+    },
+    unregister(accelerator: string) {
+      unregisterCalls++
+      registered.delete(accelerator)
+    },
+    isRegistered(accelerator: string) {
+      return registered.has(accelerator)
+    },
+  }
+
+  return {
+    app,
+    globalShortcut,
+    registered,
+    emit(event: string, ...args: unknown[]) {
+      for (const h of handlers[event] ?? []) {
+        h(...args)
+      }
+    },
+    setFocused(win: object | null) {
+      focused = win
+    },
+    // Synchronous defer so blur handling is observable immediately in tests.
+    defer(cb: () => void) {
+      cb()
+    },
+    getFocusedWindow: () => focused,
+    get quitCalls() {
+      return quitCalls
+    },
+    get registerCalls() {
+      return registerCalls
+    },
+    get unregisterCalls() {
+      return unregisterCalls
+    },
+  }
+}
+
+function setup(h: ReturnType<typeof createHarness>) {
+  setupQuitShortcut({
+    app: h.app,
+    globalShortcut: h.globalShortcut,
+    getFocusedWindow: h.getFocusedWindow,
+    defer: h.defer,
+  })
+}
+
+test('uses the platform-standard quit accelerator', () => {
+  assert.equal(QUIT_ACCELERATOR, 'CommandOrControl+Q')
+})
+
+test('registers the quit accelerator when a window gains focus', () => {
+  const h = createHarness()
+  setup(h)
+
+  h.setFocused({})
+  h.emit('browser-window-focus')
+
+  assert.ok(h.registered.has(QUIT_ACCELERATOR))
+})
+
+test('the registered accelerator quits the app when triggered', () => {
+  const h = createHarness()
+  setup(h)
+
+  h.setFocused({})
+  h.emit('browser-window-focus')
+  h.registered.get(QUIT_ACCELERATOR)?.()
+
+  assert.equal(h.quitCalls, 1)
+})
+
+test('does not register twice while already focused', () => {
+  const h = createHarness()
+  setup(h)
+
+  h.setFocused({})
+  h.emit('browser-window-focus')
+  h.emit('browser-window-focus')
+
+  assert.equal(h.registerCalls, 1)
+})
+
+test('unregisters when the app loses focus entirely', () => {
+  const h = createHarness()
+  setup(h)
+
+  h.setFocused({})
+  h.emit('browser-window-focus')
+
+  h.setFocused(null)
+  h.emit('browser-window-blur')
+
+  assert.ok(!h.registered.has(QUIT_ACCELERATOR))
+})
+
+test('stays registered while switching between the app own windows', () => {
+  const h = createHarness()
+  setup(h)
+
+  const streamWindow = {}
+  const controlWindow = {}
+
+  h.setFocused(streamWindow)
+  h.emit('browser-window-focus')
+
+  // Switching windows blurs the old one while another app window is focused.
+  h.setFocused(controlWindow)
+  h.emit('browser-window-blur')
+
+  assert.ok(h.registered.has(QUIT_ACCELERATOR))
+})
+
+test('registers immediately if a window is already focused at setup', () => {
+  const h = createHarness()
+  h.setFocused({})
+
+  setup(h)
+
+  assert.ok(h.registered.has(QUIT_ACCELERATOR))
+})
+
+test('does not register at setup when no window is focused', () => {
+  const h = createHarness()
+  setup(h)
+
+  assert.ok(!h.registered.has(QUIT_ACCELERATOR))
+})
+
+test('unregisters on will-quit', () => {
+  const h = createHarness()
+  setup(h)
+
+  h.setFocused({})
+  h.emit('browser-window-focus')
+  h.emit('will-quit')
+
+  assert.ok(!h.registered.has(QUIT_ACCELERATOR))
+})
+
+test('does not attempt to unregister when nothing is registered', () => {
+  const h = createHarness()
+  setup(h)
+
+  h.setFocused(null)
+  h.emit('browser-window-blur')
+
+  assert.equal(h.unregisterCalls, 0)
+})

--- a/packages/streamwall/src/main/quitShortcut.ts
+++ b/packages/streamwall/src/main/quitShortcut.ts
@@ -1,0 +1,76 @@
+import type { App, BrowserWindow, GlobalShortcut } from 'electron'
+
+/**
+ * Platform-standard quit accelerator (Cmd+Q on macOS, Ctrl+Q elsewhere).
+ */
+export const QUIT_ACCELERATOR = 'CommandOrControl+Q'
+
+export interface QuitShortcutOptions {
+  app: Pick<App, 'on' | 'quit'>
+  globalShortcut: Pick<
+    GlobalShortcut,
+    'register' | 'unregister' | 'isRegistered'
+  >
+  getFocusedWindow: () => BrowserWindow | null
+  /**
+   * Defers a callback to a later tick. Injectable for testing; defaults to
+   * `setImmediate`.
+   */
+  defer?: (cb: () => void) => void
+}
+
+/**
+ * Registers a keyboard shortcut to quit the application while one of its
+ * windows is focused.
+ *
+ * This is the only in-app way to exit when the stream window is configured to
+ * be frameless (`window.frameless = true`): a frameless window has no title bar
+ * or close button, and the menu is removed, so there is otherwise no way to
+ * trigger a quit from within the app.
+ *
+ * The shortcut is scoped to application focus so it does not hijack the
+ * accelerator system-wide: it is registered whenever an app window gains focus
+ * and unregistered once the app loses focus entirely.
+ */
+export function setupQuitShortcut({
+  app,
+  globalShortcut,
+  getFocusedWindow,
+  defer = (cb) => {
+    setImmediate(cb)
+  },
+}: QuitShortcutOptions): void {
+  const register = () => {
+    if (!globalShortcut.isRegistered(QUIT_ACCELERATOR)) {
+      globalShortcut.register(QUIT_ACCELERATOR, () => app.quit())
+    }
+  }
+
+  const unregister = () => {
+    if (globalShortcut.isRegistered(QUIT_ACCELERATOR)) {
+      globalShortcut.unregister(QUIT_ACCELERATOR)
+    }
+  }
+
+  app.on('browser-window-focus', register)
+
+  app.on('browser-window-blur', () => {
+    // Defer so that, when switching between the app's own windows, the focus of
+    // the newly focused window settles before we decide whether the app lost
+    // focus entirely. Otherwise a window switch (blur old, focus new) could
+    // leave the shortcut unregistered while the app is still focused.
+    defer(() => {
+      if (!getFocusedWindow()) {
+        unregister()
+      }
+    })
+  })
+
+  app.on('will-quit', unregister)
+
+  // A window may already be focused by the time this runs (e.g. the stream
+  // window was shown before setup); register eagerly in that case.
+  if (getFocusedWindow()) {
+    register()
+  }
+}


### PR DESCRIPTION
## Problem

[streamwall/streamwall#14](https://github.com/streamwall/streamwall/issues/14) asks for two things: a frameless stream window, and *"a way to trigger `app.quit()` from the UI/keypress events."*

The frameless window is already supported in v2 (`window.frameless`), but the quit part is missing. Today the app only exits when the stream window is closed (`process.exit(0)`), and the control window is created with `closable: false`. When the stream window runs frameless it has no title bar, no close button, and its menu is removed — so there is **no in-app way to quit**. Users are left to force-kill the process or rely on OS-specific tricks (Alt+F4, the macOS app menu).

## Solution

Add a focus-scoped keyboard shortcut (`CommandOrControl+Q`) in the main process that calls `app.quit()`:

- Registered on `browser-window-focus`, unregistered once the app loses focus entirely (checked on `browser-window-blur`, deferred so switching between the app's own windows doesn't drop it), and torn down on `will-quit`.
- Scoping to app focus avoids hijacking Cmd/Ctrl+Q system-wide. Using a **main-process global shortcut** (rather than a renderer hotkey) keeps it working even when a media `WebContentsView` on the wall holds focus — exactly the frameless scenario.

`app.quit()` closes the (closable) stream window, whose existing `close` handler calls `process.exit(0)`, so termination is guaranteed even though the control window is non-closable.

## Architecture notes

- The registration/teardown logic lives in a small, dependency-injected module (`quitShortcut.ts`) that imports Electron only as **types**, so it is unit-testable without an Electron runtime.
- `index.ts` wires it up with the real `app` / `globalShortcut` / `BrowserWindow.getFocusedWindow`.

## Test coverage

Adds a `node:test` runner (run through `esbuild-register`, already a dependency — no new tooling) and **10 tests** covering: accelerator value, registration on focus, quitting on trigger, no double-registration, teardown when focus is lost, staying registered across window switches, eager registration when a window is already focused, and `will-quit` teardown.

```
npm test        # 10 passing
```

## Risks / breaking changes

None. Default behavior is unchanged (a framed window still closes normally); this only adds a keyboard path to quit. No new runtime dependencies.

## Docs

- README hotkeys section documents Cmd/Ctrl+Q.
- `example.config.toml` notes the quit key next to `window.frameless`.

Addresses [streamwall/streamwall#14](https://github.com/streamwall/streamwall/issues/14).
