### PR TITLE
fix(streamwall): deny window.open and guard redirects in stream views and the browse window

### DIFF
--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -17,6 +17,7 @@ import {
 } from 'streamwall-shared'
 import { createActor, EventFrom, SnapshotFrom } from 'xstate'
 import { loadHTML } from './loadHTML'
+import { secureStreamView } from './navigationSecurity'
 import { allocateViewPartition, hardenSession } from './partitions'
 import viewStateMachine, { ViewActor } from './viewStateMachine'
 
@@ -165,14 +166,9 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
 
     const viewId = view.webContents.id
 
-    // Prevent view pages from navigating away from the specified URL.
-    view.webContents.on('will-navigate', (ev) => {
-      if (ev.url === view.webContents.getURL()) {
-        console.log('Allowing page to reload:', ev.url)
-        return
-      }
-      ev.preventDefault()
-    })
+    // Lock the view to its stream URL: deny popups and block navigation/redirect
+    // escapes while still allowing the page to reload itself.
+    secureStreamView(view.webContents)
 
     // Hidden window used for loading the BrowserView before it's positioned in the wall
     const offscreenWin = new BrowserWindow({

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -27,6 +27,7 @@ import {
   pollDataURL,
   watchDataFile,
 } from './data'
+import { denyWindowOpen } from './navigationSecurity'
 import { BROWSE_PARTITION, hardenSession } from './partitions'
 import { loadStorage } from './storage'
 import StreamdelayClient from './StreamdelayClient'
@@ -417,6 +418,8 @@ async function main(argv: ReturnType<typeof parseArgs>) {
           },
         })
         hardenSession(browseWindow.webContents.session)
+        // Deny popups; the browse window is meant to show a single URL.
+        denyWindowOpen(browseWindow.webContents)
       }
       if (msg.type === 'browse') {
         console.debug('Attempting to browse URL:', msg.url)

--- a/packages/streamwall/src/main/navigationSecurity.test.ts
+++ b/packages/streamwall/src/main/navigationSecurity.test.ts
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import type { WebContents } from 'electron'
+
+import { denyWindowOpen, secureStreamView } from './navigationSecurity.ts'
+
+interface NavEvent {
+  url: string
+  preventDefault(): void
+}
+
+// A hand-rolled stand-in for Electron's WebContents. The real one can only be
+// instantiated inside a running Electron app, so the guards are written against
+// the narrow surface they use (`on`, `getURL`, `setWindowOpenHandler`) and this
+// double records what they wire up.
+class FakeWebContents {
+  url: string
+  windowOpenHandler: ((details?: unknown) => { action: string }) | null = null
+  navHandlers: Record<string, Array<(event: NavEvent) => void>> = {}
+
+  constructor(url: string) {
+    this.url = url
+  }
+
+  getURL(): string {
+    return this.url
+  }
+
+  on(event: string, listener: (event: NavEvent) => void): this {
+    const handlers = this.navHandlers[event] ?? []
+    handlers.push(listener)
+    this.navHandlers[event] = handlers
+    return this
+  }
+
+  setWindowOpenHandler(
+    handler: (details?: unknown) => { action: string },
+  ): void {
+    this.windowOpenHandler = handler
+  }
+
+  // Dispatch a navigation event to the registered listeners and report whether
+  // any of them called preventDefault().
+  dispatchNavigation(event: string, url: string): boolean {
+    let prevented = false
+    const navEvent: NavEvent = {
+      url,
+      preventDefault: () => {
+        prevented = true
+      },
+    }
+    for (const listener of this.navHandlers[event] ?? []) {
+      listener(navEvent)
+    }
+    return prevented
+  }
+}
+
+const asWebContents = (fake: FakeWebContents) => fake as unknown as WebContents
+
+test('denyWindowOpen installs a handler that denies every popup', () => {
+  const wc = new FakeWebContents('https://example.com/stream')
+  denyWindowOpen(asWebContents(wc))
+
+  assert.ok(wc.windowOpenHandler, 'a window-open handler must be registered')
+  assert.deepEqual(wc.windowOpenHandler({ url: 'https://evil.example/' }), {
+    action: 'deny',
+  })
+})
+
+test('secureStreamView denies window.open popups', () => {
+  const wc = new FakeWebContents('https://example.com/stream')
+  secureStreamView(asWebContents(wc))
+
+  assert.ok(wc.windowOpenHandler, 'a window-open handler must be registered')
+  assert.deepEqual(wc.windowOpenHandler({ url: 'https://evil.example/' }), {
+    action: 'deny',
+  })
+})
+
+test('secureStreamView blocks will-navigate to a different URL', () => {
+  const wc = new FakeWebContents('https://example.com/stream')
+  secureStreamView(asWebContents(wc))
+
+  assert.equal(
+    wc.dispatchNavigation('will-navigate', 'https://evil.example/'),
+    true,
+  )
+})
+
+test('secureStreamView allows will-navigate to the same URL (self reload)', (t) => {
+  // Silence the informational reload log so test output stays clean.
+  t.mock.method(console, 'log', () => undefined)
+  const wc = new FakeWebContents('https://example.com/stream')
+  secureStreamView(asWebContents(wc))
+
+  assert.equal(
+    wc.dispatchNavigation('will-navigate', 'https://example.com/stream'),
+    false,
+  )
+})
+
+test('secureStreamView blocks a redirect away once a page has committed (302 escape)', () => {
+  const wc = new FakeWebContents('https://example.com/stream')
+  secureStreamView(asWebContents(wc))
+
+  assert.equal(
+    wc.dispatchNavigation('will-redirect', 'https://evil.example/'),
+    true,
+  )
+})
+
+test('secureStreamView allows a redirect while the initial load is still resolving', () => {
+  // A fresh view has committed nothing yet, so getURL() is empty. The
+  // operator-supplied URL's own server redirects (http->https, CDN, shortlinks)
+  // fire `will-redirect` even though the load was started from the main process
+  // and must be allowed to resolve.
+  const wc = new FakeWebContents('')
+  secureStreamView(asWebContents(wc))
+
+  assert.equal(
+    wc.dispatchNavigation('will-redirect', 'https://cdn.example/live'),
+    false,
+  )
+})
+
+test('secureStreamView allows will-redirect to the same URL', (t) => {
+  // Silence the informational reload log so test output stays clean.
+  t.mock.method(console, 'log', () => undefined)
+  const wc = new FakeWebContents('https://example.com/stream')
+  secureStreamView(asWebContents(wc))
+
+  assert.equal(
+    wc.dispatchNavigation('will-redirect', 'https://example.com/stream'),
+    false,
+  )
+})

--- a/packages/streamwall/src/main/navigationSecurity.ts
+++ b/packages/streamwall/src/main/navigationSecurity.ts
@@ -1,0 +1,52 @@
+import type { WebContents } from 'electron'
+
+// A navigation event as surfaced by Electron's `will-navigate` / `will-redirect`.
+// Declared as a structural subset of Electron's event so the guards below can be
+// exercised without a running Electron app.
+interface NavigationEvent {
+  readonly url: string
+  preventDefault(): void
+}
+
+// Deny renderer-initiated popups (window.open, target="_blank", …). Neither a
+// loaded stream page nor a browsed page should ever be able to spawn a window.
+export function denyWindowOpen(webContents: WebContents): void {
+  webContents.setWindowOpenHandler(() => ({ action: 'deny' as const }))
+}
+
+// Keep a view pinned to its intended URL while still letting it reload itself.
+// Used for both `will-navigate` and `will-redirect`: a 302 on a reload bypasses
+// the `will-navigate` check, so the same guard must cover redirects too.
+function preventNavigationAway(
+  webContents: WebContents,
+  event: NavigationEvent,
+): void {
+  const currentURL = webContents.getURL()
+
+  // Allow the page to reload itself (navigating to the URL it is already on).
+  if (event.url === currentURL) {
+    console.log('Allowing page to reload:', event.url)
+    return
+  }
+
+  // Allow the initial load to resolve through server redirects. Until the view
+  // commits a page, `getURL()` is empty; the operator-supplied URL's own 302s
+  // (http->https, CDN, shortlinks) fire `will-redirect` even though the load was
+  // started from the main process, and must not be blocked.
+  if (currentURL === '') {
+    return
+  }
+
+  event.preventDefault()
+}
+
+// Lock a stream view's web contents down: deny popups and block both navigation
+// and redirect escapes away from the intended URL, while permitting self-reloads.
+export function secureStreamView(webContents: WebContents): void {
+  denyWindowOpen(webContents)
+
+  const guard = (event: NavigationEvent) =>
+    preventNavigationAway(webContents, event)
+  webContents.on('will-navigate', guard)
+  webContents.on('will-redirect', guard)
+}


### PR DESCRIPTION
## Problem

`setWindowOpenHandler` was set nowhere in the codebase, and stream views guarded only `will-navigate` (against the current URL) — not `will-redirect`. A loaded stream page could therefore:

- **spawn popups** via `window.open(...)` / `target="_blank"` (phishing/popup surface), and
- **escape its intended URL** through a 302 redirect on a reload — `will-navigate` allows a self-reload, and the server can then 302 that reload elsewhere, which the URL-equality check never sees.

The `browse` window set no window-open handler at all.

Fixes issue #5 (security audit, severity: medium).

## Technical solution

New module `packages/streamwall/src/main/navigationSecurity.ts` centralises the guards:

- **`denyWindowOpen(webContents)`** — installs a `setWindowOpenHandler` returning `{ action: 'deny' }` for every popup request.
- **`secureStreamView(webContents)`** — denies popups **and** installs a single guard on both `will-navigate` and `will-redirect` that blocks navigation away from the committed URL.

Wiring:
- `StreamWindow.createView()` calls `secureStreamView(view.webContents)`, replacing the inline `will-navigate`-only handler. This composes with the per-view ephemeral partition + `hardenSession` added in #97.
- `index.ts` calls `denyWindowOpen(browseWindow.webContents)` on each freshly created browse window (which also keeps #97's `hardenSession`). The browse window is intentionally allowed to navigate — it exists to load an operator-supplied URL — so it only denies popups.

### Redirect handling (important nuance)

Per Electron's docs, `will-navigate` does **not** fire for main-process `loadURL` calls, but `will-redirect` **does** fire for server redirects during those loads. A naive "block every redirect to a non-current URL" would break legitimate stream URLs that 302 on load (http→https, CDN, shortlinks), because `getURL()` is still empty before the first commit.

The guard therefore:
1. allows navigation/redirect to the URL the view is already on (self-reload);
2. allows redirects while the initial load is still resolving (`getURL()` empty, nothing committed yet — these are the operator URL's own 302s);
3. blocks everything else — i.e. once a page has committed, any navigation or redirect to a different URL is denied. This is exactly the reload-then-302 escape from the issue.

## Architecture decisions

- **Extract, don't inline.** The guard logic lives in one module and takes a `WebContents`, using only its public surface (`on`, `getURL`, `setWindowOpenHandler`). That makes the security-critical logic unit-testable without a running Electron app.
- **Behaviour-preserving for reloads.** The self-reload allowance (and its log line) from `Allow pages to reload themselves` is retained and now also applies to redirects.
- **No new dependencies.** Tests use the repo's existing Node built-in test runner (`node --test`, native TypeScript), matching `src/util.test.ts` / `src/main/partitions.test.ts`.

## Risks / breaking changes

- No breaking changes to intended behaviour: streams still load (including through initial-load redirects) and can reload themselves; popups and post-load escapes are denied.
- The browse window can still navigate/redirect freely (by design); only popups are denied.

## Test coverage

`navigationSecurity.test.ts` (Node test runner, 8 tests, all green) covers:
- popups denied by both `denyWindowOpen` and `secureStreamView`;
- `will-navigate` to a different URL blocked; to the same URL allowed (self-reload);
- `will-redirect` away from a committed page blocked (the 302 escape); to the same URL allowed;
- `will-redirect` allowed while the initial load is still resolving (empty `getURL()`).

Run with `npm -w streamwall test` (whole streamwall suite is green, incl. sibling `partitions`/`util` tests).

The one-line wiring calls into real Electron `WebContents` are integration glue that cannot run in a unit test (no Electron runtime); the guarded logic they delegate to is fully covered above.

Closes #5