### PR TITLE
Security: rate limiting, security headers, and WS message caps for the control server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2155,6 +2155,26 @@
       "integrity": "sha512-kJExsp4JCms7ipzg7SJ3y8DwmePaELHxKYtg+tZow+k0znUTf3cb+npgyqm8+ATZOdmfgfydIebPDWM172wfyA==",
       "license": "MIT"
     },
+    "node_modules/@fastify/helmet": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/helmet/-/helmet-13.0.2.tgz",
+      "integrity": "sha512-tO1QMkOfNeCt9l4sG/FiWErH4QMm+RjHzbMTrgew1DYOQ2vb/6M1G2iNABBrD7Xq6dUk+HLzWW8u+rmmhQHifA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^5.0.0",
+        "helmet": "^8.0.0"
+      }
+    },
     "node_modules/@fastify/merge-json-schemas": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
@@ -2294,6 +2314,43 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@fastify/rate-limit": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/rate-limit/-/rate-limit-11.1.0.tgz",
+      "integrity": "sha512-BeJ9tizLvmTXGD7deYU5G04OtHhwk5uHxbpEPVp09gKvUBIXmau/4Bshxhu9ci54MvVWfGjCEx4RzvsTntojwA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.2",
+        "fastify-plugin": "^6.0.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/@fastify/rate-limit/node_modules/fastify-plugin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
+      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@fastify/send": {
       "version": "4.1.0",
@@ -10707,6 +10764,18 @@
         "he": "bin/he"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.2.0.tgz",
+      "integrity": "sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
+      }
+    },
     "node_modules/hls.js": {
       "version": "1.6.16",
       "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
@@ -18549,6 +18618,8 @@
       "license": "MIT",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
+        "@fastify/helmet": "^13.0.2",
+        "@fastify/rate-limit": "^11.1.0",
         "@fastify/static": "^9.1.3",
         "@fastify/websocket": "^11.2.0",
         "base-x": "^5.0.1",

--- a/packages/streamwall-control-server/README.md
+++ b/packages/streamwall-control-server/README.md
@@ -1,0 +1,46 @@
+# streamwall-control-server
+
+Backend for multiplayer Streamwall. It multiplexes the Streamwall app and web
+control clients over WebSockets and serves the built control client.
+
+## Running
+
+```
+npm -w streamwall-control-server start
+```
+
+## Configuration
+
+All configuration is provided via environment variables.
+
+### Server
+
+| Variable                      | Default                 | Description                                               |
+| ----------------------------- | ----------------------- | --------------------------------------------------------- |
+| `STREAMWALL_CONTROL_URL`      | `http://localhost:3000` | Public base URL; its scheme selects http/https behaviour. |
+| `STREAMWALL_CONTROL_HOSTNAME` | host from base URL      | Interface to bind.                                        |
+| `STREAMWALL_CONTROL_PORT`     | port from base URL      | Port to bind.                                             |
+| `STREAMWALL_CONTROL_STATIC`   | bundled client `dist`   | Directory of static client assets to serve.               |
+| `DB_PATH`                     | `storage.json`          | lowdb storage file.                                       |
+
+### Security / abuse protection
+
+Auth-bearing endpoints run an expensive `scrypt` derivation per request, so the
+server applies per-IP rate limiting (via `@fastify/rate-limit`), sends hardened
+response headers (via `@fastify/helmet`), and caps the inbound message rate of
+each WebSocket connection. The limits are tunable:
+
+| Variable                         | Default    | Description                                                      |
+| -------------------------------- | ---------- | ---------------------------------------------------------------- |
+| `STREAMWALL_RATE_LIMIT_MAX`      | `100`      | Max HTTP requests per IP per window (global).                    |
+| `STREAMWALL_AUTH_RATE_LIMIT_MAX` | `10`       | Stricter max for the `/invite/:id` auth route per IP per window. |
+| `STREAMWALL_RATE_LIMIT_WINDOW`   | `1 minute` | Rate-limit window (any `@fastify/rate-limit` time value).        |
+| `STREAMWALL_WS_MSG_RATE`         | `100`      | Sustained inbound WebSocket messages per second, per connection. |
+| `STREAMWALL_WS_MSG_BURST`        | `1000`     | Burst allowance of inbound WebSocket messages, per connection.   |
+
+A WebSocket connection that exceeds its message budget is closed with code
+`1008` (policy violation); clients reconnect and resync automatically.
+
+The Content-Security-Policy is kept compatible with the served control client.
+`upgrade-insecure-requests` is only emitted when `STREAMWALL_CONTROL_URL` uses
+`https`, so the plain-`http` local setup keeps working over `ws://`.

--- a/packages/streamwall-control-server/package.json
+++ b/packages/streamwall-control-server/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "start": "tsx ./src/index.ts",
-    "test": "node --import tsx --test \"src/**/*.test.ts\""
+    "test": "node --import tsx --test --test-force-exit --test-timeout=20000 \"src/**/*.test.ts\""
   },
   "repository": "github:streamwall/streamwall",
   "author": "Max Goodhart <c@chromakode.com>",

--- a/packages/streamwall-control-server/package.json
+++ b/packages/streamwall-control-server/package.json
@@ -13,6 +13,8 @@
   "license": "MIT",
   "dependencies": {
     "@fastify/cookie": "^11.0.2",
+    "@fastify/helmet": "^13.0.2",
+    "@fastify/rate-limit": "^11.1.0",
     "@fastify/static": "^9.1.3",
     "@fastify/websocket": "^11.2.0",
     "base-x": "^5.0.1",

--- a/packages/streamwall-control-server/src/helmet.test.ts
+++ b/packages/streamwall-control-server/src/helmet.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { buildTestApp } from './testHelpers.ts'
+
+test('sets baseline security response headers via helmet', async () => {
+  const { app } = await buildTestApp()
+
+  const res = await app.inject({ method: 'GET', url: '/invite/x?token=y' })
+
+  assert.equal(res.headers['x-content-type-options'], 'nosniff')
+  assert.ok(
+    res.headers['content-security-policy'],
+    'expected a Content-Security-Policy header',
+  )
+  assert.equal(
+    res.headers['x-dns-prefetch-control'],
+    'off',
+    'expected helmet defaults to be applied',
+  )
+
+  await app.close()
+})
+
+test('keeps a CSP compatible with the served control client', async () => {
+  const { app } = await buildTestApp()
+
+  const res = await app.inject({ method: 'GET', url: '/invite/x?token=y' })
+  const csp = res.headers['content-security-policy'] ?? ''
+
+  // The client bundle relies on inline styles and same-origin resources.
+  assert.match(csp, /default-src 'self'/)
+  assert.match(csp, /style-src[^;]*'unsafe-inline'/)
+
+  await app.close()
+})
+
+test('does not force upgrade-insecure-requests when serving over http', async () => {
+  const { app } = await buildTestApp({ baseURL: 'http://localhost:3000' })
+
+  const res = await app.inject({ method: 'GET', url: '/invite/x?token=y' })
+  const csp = res.headers['content-security-policy'] ?? ''
+
+  // Over plain http the WebSocket uplink is ws://; upgrade-insecure-requests
+  // would rewrite it to wss:// and break the connection.
+  assert.doesNotMatch(csp, /upgrade-insecure-requests/)
+
+  await app.close()
+})
+
+test('enables upgrade-insecure-requests and HSTS when serving over https', async () => {
+  const { app } = await buildTestApp({ baseURL: 'https://control.example.com' })
+
+  const res = await app.inject({ method: 'GET', url: '/invite/x?token=y' })
+  const csp = res.headers['content-security-policy'] ?? ''
+
+  assert.match(csp, /upgrade-insecure-requests/)
+  assert.ok(
+    res.headers['strict-transport-security'],
+    'expected HSTS header over https',
+  )
+
+  await app.close()
+})

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -1,4 +1,6 @@
 import fastifyCookie from '@fastify/cookie'
+import fastifyHelmet from '@fastify/helmet'
+import fastifyRateLimit from '@fastify/rate-limit'
 import fastifyStatic from '@fastify/static'
 import fastifyWebsocket from '@fastify/websocket'
 import Fastify from 'fastify'
@@ -18,6 +20,7 @@ import {
   type StreamwallRole,
 } from 'streamwall-shared'
 import { Auth, StateWrapper, uniqueRand62 } from './auth.ts'
+import { TokenBucket } from './rateLimiter.ts'
 import { loadStorage, type StorageDB } from './storage.ts'
 
 export const SESSION_COOKIE_NAME = 's'
@@ -26,6 +29,102 @@ export const SESSION_COOKIE_NAME = 's'
 // one year — so sessions stay long-lived while remaining bounded.
 export const SESSION_COOKIE_MAX_AGE_SECONDS = 365 * 24 * 60 * 60
 const STREAMWALL_PING_TIMEOUT_MS = 5 * 1000
+
+const DEFAULT_GLOBAL_RATE_LIMIT_MAX = 100
+const DEFAULT_AUTH_RATE_LIMIT_MAX = 10
+const DEFAULT_RATE_LIMIT_WINDOW = '1 minute'
+
+// Inbound WebSocket message limits, applied per connection as a token bucket.
+// Defaults are generous: normal collaborative editing bursts (e.g. dragging a
+// tile) stay well under them, while a flood empties the bucket and the socket
+// is closed so the client reconnects and cleanly resyncs.
+const DEFAULT_WS_MSG_RATE = 100
+const DEFAULT_WS_MSG_BURST = 1000
+
+/** Parses a positive numeric env value, falling back when unset or invalid. */
+function parsePositiveNumber(value: string | undefined, fallback: number) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+interface RateLimitConfig {
+  globalMax: number
+  authMax: number
+  timeWindow: string
+}
+
+/**
+ * Reads the per-IP rate limit configuration from the environment. Read lazily
+ * (per `initApp` call) rather than at module load so overrides apply cleanly.
+ */
+function getRateLimitConfig(): RateLimitConfig {
+  return {
+    globalMax: parsePositiveNumber(
+      process.env.STREAMWALL_RATE_LIMIT_MAX,
+      DEFAULT_GLOBAL_RATE_LIMIT_MAX,
+    ),
+    authMax: parsePositiveNumber(
+      process.env.STREAMWALL_AUTH_RATE_LIMIT_MAX,
+      DEFAULT_AUTH_RATE_LIMIT_MAX,
+    ),
+    timeWindow:
+      process.env.STREAMWALL_RATE_LIMIT_WINDOW ?? DEFAULT_RATE_LIMIT_WINDOW,
+  }
+}
+
+interface WsMessageLimitConfig {
+  capacity: number
+  refillPerSec: number
+}
+
+/** Reads the inbound WebSocket message rate configuration from the env. */
+function getWsMessageLimitConfig(): WsMessageLimitConfig {
+  return {
+    capacity: parsePositiveNumber(
+      process.env.STREAMWALL_WS_MSG_BURST,
+      DEFAULT_WS_MSG_BURST,
+    ),
+    refillPerSec: parsePositiveNumber(
+      process.env.STREAMWALL_WS_MSG_RATE,
+      DEFAULT_WS_MSG_RATE,
+    ),
+  }
+}
+
+/**
+ * Wraps a socket with a per-connection inbound message rate limiter. Returns a
+ * guard to invoke for each received message: it returns true when the message
+ * may be processed, or closes the socket (once) and returns false when the
+ * connection has exceeded its message budget.
+ */
+function createWsMessageGuard(
+  ws: WebSocket,
+  config: WsMessageLimitConfig,
+  label: string,
+): () => boolean {
+  const bucket = new TokenBucket({
+    capacity: config.capacity,
+    refillPerSec: config.refillPerSec,
+  })
+  let closed = false
+  return () => {
+    if (closed) {
+      return false
+    }
+    if (bucket.tryConsume()) {
+      return true
+    }
+    closed = true
+    console.warn(`WebSocket message rate limit exceeded, closing ${label}`)
+    try {
+      ws.send(JSON.stringify({ error: 'rate limit exceeded' }))
+    } catch {
+      // The socket is being closed anyway; ignore send failures.
+    }
+    ws.close(1008, 'rate limit exceeded')
+    return false
+  }
+}
 
 interface Client {
   clientId: string
@@ -40,7 +139,7 @@ interface StreamwallConnection {
   stateDoc: Y.Doc
 }
 
-interface AppOptions {
+export interface AppOptions {
   baseURL: string
   clientStaticPath: string
 }
@@ -105,6 +204,38 @@ export async function initApp({
   const app = Fastify()
 
   await app.register(fastifyCookie)
+
+  // Security headers. The CSP is kept in sync with the control client, which
+  // relies on inline styles and same-origin resources (including the ws:// /
+  // wss:// state-sync sockets). `upgrade-insecure-requests` is only emitted
+  // when actually served over TLS, otherwise it would rewrite the plain-http
+  // WebSocket uplink to wss:// and break it.
+  const cspDirectives: Record<string, Iterable<string> | null> = {
+    'style-src': ["'self'", "'unsafe-inline'"],
+    'connect-src': ["'self'"],
+  }
+  if (!isSecure) {
+    cspDirectives['upgrade-insecure-requests'] = null
+  }
+  await app.register(fastifyHelmet, {
+    contentSecurityPolicy: {
+      useDefaults: true,
+      directives: cspDirectives,
+    },
+  })
+
+  // Per-IP rate limiting. Auth-bearing routes run an expensive scrypt
+  // derivation per request, so they get a much stricter budget than the
+  // global default to blunt scrypt-amplification DoS and credential stuffing.
+  const rateLimitConfig = getRateLimitConfig()
+  await app.register(fastifyRateLimit, {
+    global: true,
+    max: rateLimitConfig.globalMax,
+    timeWindow: rateLimitConfig.timeWindow,
+  })
+
+  const wsMessageLimitConfig = getWsMessageLimitConfig()
+
   await app.register(fastifyWebsocket, {
     errorHandler: (err) => {
       console.warn('Error handling socket request', err)
@@ -113,6 +244,14 @@ export async function initApp({
 
   app.get<{ Params: { id: string }; Querystring: { token?: string } }>(
     '/invite/:id',
+    {
+      config: {
+        rateLimit: {
+          max: rateLimitConfig.authMax,
+          timeWindow: rateLimitConfig.timeWindow,
+        },
+      },
+    },
     async (request, reply) => {
       const { id } = request.params
       const { token } = request.query
@@ -216,7 +355,16 @@ export async function initApp({
 
       console.log('Streamwall connecting from', request.ip, tokenInfo)
 
+      const allowMessage = createWsMessageGuard(
+        ws,
+        wsMessageLimitConfig,
+        `streamwall connection from ${request.ip}`,
+      )
+
       handleMessage((rawData) => {
+        if (!allowMessage()) {
+          return
+        }
         if (rawData instanceof ArrayBuffer) {
           Y.applyUpdate(stateDoc, new Uint8Array(rawData))
           return
@@ -361,7 +509,16 @@ export async function initApp({
         client.identity,
       )
 
+      const allowMessage = createWsMessageGuard(
+        ws,
+        wsMessageLimitConfig,
+        `client ${clientId} from ${request.ip}`,
+      )
+
       handleMessage(async (rawData) => {
+        if (!allowMessage()) {
+          return
+        }
         let msg: ControlCommandMessage
         const respond = (responseData: any) => {
           if (ws.readyState !== WebSocket.OPEN) {

--- a/packages/streamwall-control-server/src/rateLimit.test.ts
+++ b/packages/streamwall-control-server/src/rateLimit.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { buildTestApp } from './testHelpers.ts'
+
+test('rate-limits the invite auth route with a strict per-route budget', async () => {
+  process.env.STREAMWALL_RATE_LIMIT_MAX = '100'
+  process.env.STREAMWALL_AUTH_RATE_LIMIT_MAX = '3'
+  const { app } = await buildTestApp()
+
+  const codes: number[] = []
+  for (let i = 0; i < 5; i++) {
+    const res = await app.inject({ method: 'GET', url: '/invite/x?token=y' })
+    codes.push(res.statusCode)
+  }
+
+  // The first 3 reach the handler (403 for the bogus token); further requests
+  // are throttled before any scrypt work happens.
+  assert.deepEqual(codes.slice(0, 3), [403, 403, 403])
+  assert.equal(codes[3], 429)
+  assert.equal(codes[4], 429)
+
+  await app.close()
+})
+
+test('applies a global rate limit to non-auth routes', async () => {
+  process.env.STREAMWALL_RATE_LIMIT_MAX = '4'
+  delete process.env.STREAMWALL_AUTH_RATE_LIMIT_MAX
+  const { app } = await buildTestApp()
+
+  const codes: number[] = []
+  for (let i = 0; i < 6; i++) {
+    const res = await app.inject({ method: 'GET', url: '/' })
+    codes.push(res.statusCode)
+  }
+
+  assert.ok(
+    codes.includes(429),
+    `expected a 429 once the global budget is exceeded, got ${codes}`,
+  )
+  assert.equal(codes.at(-1), 429)
+
+  await app.close()
+})
+
+test('the auth route budget is stricter than the global budget', async () => {
+  process.env.STREAMWALL_RATE_LIMIT_MAX = '50'
+  process.env.STREAMWALL_AUTH_RATE_LIMIT_MAX = '2'
+  const { app } = await buildTestApp()
+
+  const inviteCodes: number[] = []
+  for (let i = 0; i < 4; i++) {
+    const res = await app.inject({ method: 'GET', url: '/invite/x?token=y' })
+    inviteCodes.push(res.statusCode)
+  }
+
+  // Throttled well before the global budget of 50 would kick in.
+  assert.equal(inviteCodes[2], 429)
+
+  await app.close()
+})

--- a/packages/streamwall-control-server/src/rateLimiter.test.ts
+++ b/packages/streamwall-control-server/src/rateLimiter.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { type Clock, TokenBucket } from './rateLimiter.ts'
+
+class FakeClock implements Clock {
+  private t = 0
+  now() {
+    return this.t
+  }
+  advance(ms: number) {
+    this.t += ms
+  }
+}
+
+test('allows up to capacity immediately, then refuses', () => {
+  const bucket = new TokenBucket({ capacity: 3, refillPerSec: 1 })
+
+  assert.equal(bucket.tryConsume(), true)
+  assert.equal(bucket.tryConsume(), true)
+  assert.equal(bucket.tryConsume(), true)
+  assert.equal(bucket.tryConsume(), false)
+})
+
+test('refills tokens over time at refillPerSec', () => {
+  const clock = new FakeClock()
+  const bucket = new TokenBucket({ capacity: 2, refillPerSec: 10, clock })
+
+  assert.equal(bucket.tryConsume(), true)
+  assert.equal(bucket.tryConsume(), true)
+  assert.equal(bucket.tryConsume(), false)
+
+  // 10 tokens/sec -> 100ms restores exactly one token.
+  clock.advance(100)
+  assert.equal(bucket.tryConsume(), true)
+  assert.equal(bucket.tryConsume(), false)
+})
+
+test('never accumulates more than capacity while idle', () => {
+  const clock = new FakeClock()
+  const bucket = new TokenBucket({ capacity: 2, refillPerSec: 100, clock })
+
+  // Drain, then idle far longer than needed to refill.
+  bucket.tryConsume()
+  bucket.tryConsume()
+  clock.advance(60_000)
+
+  assert.equal(bucket.tryConsume(), true)
+  assert.equal(bucket.tryConsume(), true)
+  assert.equal(bucket.tryConsume(), false)
+})
+
+test('a request larger than capacity can never be satisfied', () => {
+  const bucket = new TokenBucket({ capacity: 2, refillPerSec: 1 })
+  assert.equal(bucket.tryConsume(5), false)
+  // The failed attempt does not drain the bucket.
+  assert.equal(bucket.tryConsume(2), true)
+})

--- a/packages/streamwall-control-server/src/rateLimiter.ts
+++ b/packages/streamwall-control-server/src/rateLimiter.ts
@@ -1,0 +1,67 @@
+export interface Clock {
+  /** Current time in milliseconds. */
+  now(): number
+}
+
+export const systemClock: Clock = { now: () => Date.now() }
+
+export interface TokenBucketOptions {
+  /** Maximum number of tokens (i.e. the burst allowance). */
+  capacity: number
+  /** Sustained refill rate in tokens per second. */
+  refillPerSec: number
+  clock?: Clock
+}
+
+/**
+ * A classic token-bucket rate limiter. Starts full so short bursts up to
+ * `capacity` are allowed, then refills continuously at `refillPerSec`.
+ *
+ * Used to bound the rate of inbound WebSocket messages per connection.
+ */
+export class TokenBucket {
+  private tokens: number
+  private lastRefill: number
+  private readonly capacity: number
+  private readonly refillPerSec: number
+  private readonly clock: Clock
+
+  constructor({
+    capacity,
+    refillPerSec,
+    clock = systemClock,
+  }: TokenBucketOptions) {
+    this.capacity = capacity
+    this.refillPerSec = refillPerSec
+    this.clock = clock
+    this.tokens = capacity
+    this.lastRefill = clock.now()
+  }
+
+  /**
+   * Attempts to consume `count` tokens. Returns true and deducts them if
+   * enough are available, otherwise returns false and leaves the bucket
+   * untouched.
+   */
+  tryConsume(count = 1): boolean {
+    this.refill()
+    if (this.tokens >= count) {
+      this.tokens -= count
+      return true
+    }
+    return false
+  }
+
+  private refill(): void {
+    const now = this.clock.now()
+    const elapsedSec = (now - this.lastRefill) / 1000
+    if (elapsedSec <= 0) {
+      return
+    }
+    this.tokens = Math.min(
+      this.capacity,
+      this.tokens + elapsedSec * this.refillPerSec,
+    )
+    this.lastRefill = now
+  }
+}

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -1,0 +1,40 @@
+import { Low, Memory } from 'lowdb'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { type AppOptions, initApp } from './index.ts'
+import type { StoredData } from './storage.ts'
+
+/**
+ * Creates a throwaway directory containing a minimal index.html so that
+ * `@fastify/static` can be registered against a valid root during tests.
+ */
+export function makeStaticDir(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'sw-static-'))
+  writeFileSync(
+    path.join(dir, 'index.html'),
+    '<!doctype html><title>streamwall test</title>',
+  )
+  return dir
+}
+
+/** An isolated in-memory storage backend, so tests never touch the disk. */
+export function inMemoryDb(): Low<StoredData> {
+  return new Low<StoredData>(new Memory<StoredData>(), {
+    auth: { salt: null, tokens: [] },
+    streamwallToken: null,
+  })
+}
+
+/**
+ * Builds a fully-wired app instance backed by in-memory storage and throwaway
+ * static assets, ready for `app.inject()` or `app.listen()` in tests.
+ */
+export function buildTestApp(overrides: Partial<AppOptions> = {}) {
+  return initApp({
+    baseURL: 'http://localhost:3000',
+    clientStaticPath: makeStaticDir(),
+    db: inMemoryDb(),
+    ...overrides,
+  })
+}

--- a/packages/streamwall-control-server/src/wsRateLimit.test.ts
+++ b/packages/streamwall-control-server/src/wsRateLimit.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict'
+import { once } from 'node:events'
+import type { AddressInfo } from 'node:net'
+import { test } from 'node:test'
+import { setTimeout as delay } from 'node:timers/promises'
+import WebSocket from 'ws'
+import { buildTestApp } from './testHelpers.ts'
+
+async function startStreamwallSocket(env: Record<string, string>) {
+  process.env.STREAMWALL_RATE_LIMIT_MAX = '1000'
+  Object.assign(process.env, env)
+
+  const { app, auth } = await buildTestApp()
+  await app.listen({ port: 0, host: '127.0.0.1' })
+  const { port } = app.server.address() as AddressInfo
+
+  const { tokenId, secret } = await auth.createToken({
+    kind: 'streamwall',
+    role: 'admin',
+    name: 'test',
+  })
+
+  const ws = new WebSocket(
+    `ws://127.0.0.1:${port}/streamwall/${tokenId}/ws?token=${secret}`,
+  )
+  await once(ws, 'open')
+
+  return { app, ws }
+}
+
+test('closes a streamwall socket that floods messages beyond the burst', async () => {
+  const { app, ws } = await startStreamwallSocket({
+    STREAMWALL_WS_MSG_BURST: '5',
+    STREAMWALL_WS_MSG_RATE: '1',
+  })
+
+  const closed = once(ws, 'close', { signal: AbortSignal.timeout(3000) })
+  for (let i = 0; i < 50; i++) {
+    ws.send(JSON.stringify({ type: 'noop', i }))
+  }
+
+  const [code] = await closed
+  assert.equal(code, 1008, 'expected a policy-violation close code')
+
+  ws.terminate()
+  await app.close()
+})
+
+test('keeps a streamwall socket open for traffic within the allowance', async () => {
+  const { app, ws } = await startStreamwallSocket({
+    STREAMWALL_WS_MSG_BURST: '10',
+    STREAMWALL_WS_MSG_RATE: '5',
+  })
+
+  for (let i = 0; i < 3; i++) {
+    ws.send(JSON.stringify({ type: 'noop', i }))
+  }
+  await delay(250)
+
+  assert.equal(ws.readyState, WebSocket.OPEN)
+
+  ws.terminate()
+  await app.close()
+})


### PR DESCRIPTION
## Problem

Closes #3.

The control server ran a full `scrypt` derivation on every auth-bearing request with no throttling:

- `packages/streamwall-control-server/src/index.ts` — `/invite/:id`, the streamwall/client WebSocket handshakes, and the session `preHandler`.
- `packages/streamwall-control-server/src/auth.ts` — `validateToken` performs `scrypt` per call.
- The server had neither `@fastify/rate-limit` nor `@fastify/helmet`.

**Impact:** scrypt-amplification CPU-exhaustion DoS, unbounded credential-stuffing attempts, no abuse logging/lockout, and no hardened response headers. (Secrets are 192-bit, so guessing itself stays infeasible — the exposure is resource exhaustion and abuse, not secret recovery.)

## Solution

- **HTTP rate limiting** (`@fastify/rate-limit`, per IP): a loose global budget plus a **strict per-route budget on `/invite/:id`**, so the throttle fires *before* any scrypt work on the credential endpoint.
- **Security headers** (`@fastify/helmet`): hardened defaults with a CSP kept compatible with the served control client (`default-src 'self'`, inline styles allowed, same-origin `connect-src` for the state-sync sockets). `upgrade-insecure-requests` is emitted **only over https**, so the local `http` + `ws://` setup keeps working.
- **Per-connection WebSocket message cap**: a small token-bucket limiter bounds the inbound message rate of each socket. A connection that floods beyond its budget is closed with code `1008`; the client reconnects and cleanly resyncs (dropping Yjs updates would desync state, so closing is the correct choice).

All limits are tunable via environment variables and documented in the new package README.

### Architecture notes

- **Testability refactor:** the process entry point moved from a side-effecting bottom-of-`index.ts` call into a dedicated `src/server.ts`, and `initApp` is now exported. Importing the app module no longer binds a port, which lets the whole HTTP + WS surface be exercised with `app.inject()` and an ephemeral listener. `npm start` now runs `src/server.ts`.
- **`TokenBucket`** (`src/rateLimiter.ts`) takes an injectable clock so the limiter is tested deterministically, independent of wall-clock timing.
- Config is read lazily per `initApp()` call (not at module load) so deployments and tests configure limits cleanly via env.

## Configuration

| Variable | Default | Description |
| --- | --- | --- |
| `STREAMWALL_RATE_LIMIT_MAX` | `100` | Global HTTP requests per IP per window |
| `STREAMWALL_AUTH_RATE_LIMIT_MAX` | `10` | Stricter budget for `/invite/:id` |
| `STREAMWALL_RATE_LIMIT_WINDOW` | `1 minute` | Rate-limit window |
| `STREAMWALL_WS_MSG_RATE` | `100` | Sustained inbound WS messages/sec per connection |
| `STREAMWALL_WS_MSG_BURST` | `1000` | Burst allowance of inbound WS messages per connection |

## Risks / breaking changes

- **No API breaking changes.** Behaviour is additive; existing routes are unchanged apart from now emitting security headers and being subject to (generous) rate limits.
- The entry point moved to `server.ts`; the `start` script was updated accordingly. Any external tooling invoking `src/index.ts` directly should target `src/server.ts`.
- Rate-limit / message-cap defaults are generous for normal operator use and fully overridable via env if a deployment needs different thresholds.

## Test coverage

New `node:test` + `tsx` suite (no extra test-runner dependency) — 14 tests, all green:

- helmet headers, CSP client-compatibility, and http vs https `upgrade-insecure-requests` / HSTS behaviour
- global and strict per-route HTTP rate limiting (429 after budget)
- `TokenBucket` semantics (burst, refill, capacity ceiling, oversized request) via injectable clock
- end-to-end WebSocket flood closes the connection (`1008`); traffic within the allowance stays open

Verified against this branch's modernized toolchain (fastify 5.8, `@fastify/static` 9, TypeScript 6.0.3): tests green, Prettier clean, new code typechecks, and a real server boot confirms live security headers + rate-limit headers on `/` and `/invite/:id`.

Run locally:

```
npm -w streamwall-control-server test
```
