### PR TITLE
Per-stream contain fit option (#13)

### DIFF
--- a/docs/superpowers/specs/2026-07-04-video-contain-fit-design.md
+++ b/docs/superpowers/specs/2026-07-04-video-contain-fit-design.md
@@ -1,0 +1,151 @@
+# Design: Per-Stream „contain"-Fit (Video ohne Crop einpassen)
+
+**Issue:** [#13 – Size video to contain (instead of cover) grid space](https://github.com/chromakode/streamwall/issues/13)
+**Datum:** 2026-07-04
+
+## Problem
+
+Videos werden aktuell mit `object-fit: cover` gerendert (siehe
+`packages/streamwall/src/preload/mediaPreload.ts`, `VIDEO_OVERRIDE_STYLE`). Das
+füllt die zugewiesene(n) Grid-Zelle(n) vollständig, beschneidet aber Quellen mit
+abweichendem Seitenverhältnis. Nutzer wünschen sich die Möglichkeit, eine Quelle
+**ohne Beschneidung** einzupassen (`object-fit: contain`) — auf Kosten von
+schwarzen Rändern bei ungewöhnlich geformten Quellen.
+
+## Ziel
+
+Eine **pro Stream** wählbare Option, die zwischen `cover` (Standard) und
+`contain` umschaltet. Standardmäßig **nicht** aktiv — das bestehende Verhalten
+bleibt unverändert.
+
+## Nicht-Ziele (YAGNI)
+
+- Kein globaler Toggle für alle Streams gleichzeitig.
+- Keine weiteren `object-fit`-Modi (`fill`, `scale-down`, …) — der Typ ist aber
+  erweiterbar gewählt.
+- Keine Persistenz über Neustarts hinaus (siehe „Persistenz").
+
+## Architektur-Ansatz
+
+Die Option folgt **exakt dem etablierten `rotation`-Muster**. `rotation` ist
+bereits eine per-Stream-`ContentDisplayOption`, die diesen Weg nimmt:
+
+```
+Control-UI (Toggle-Button)
+  → ControlCommand  → Control-Server → Main-Prozess (onCommand)
+  → overlayStreamData.update(url, { fit })
+  → combineDataSources → updateState → StreamWindow.onState
+  → getDisplayOptions() → View-State-Machine (OPTIONS-Event)
+  → IPC 'options' → mediaPreload (FitController) → CSS-Klasse am <video>
+```
+
+Es wird ein **dedizierter Command** `set-stream-fit` eingeführt (analog zu
+`rotate-stream`), kein generischer „set-display-options"-Command. Begründung:
+minimal-invasiv, konsistent mit dem vorhandenen Muster; eine generische
+Umstellung lohnt sich erst bei einer dritten Option.
+
+## Datenmodell
+
+Neue Property auf `ContentDisplayOptions`
+(`packages/streamwall-shared/src/types.ts`):
+
+```typescript
+export interface ContentDisplayOptions {
+  rotation?: number
+  fit?: 'cover' | 'contain'
+}
+```
+
+Modellierung als String-Union (nicht `boolean`), weil sie direkt dem
+CSS-`object-fit`-Wert entspricht, selbstdokumentierend und erweiterbar ist.
+`undefined` ⇒ Default `cover`.
+
+Neuer `ControlCommand`:
+
+```typescript
+| { type: 'set-stream-fit'; url: string; fit: 'cover' | 'contain' }
+```
+
+## Komponenten & Änderungen
+
+### 1. `packages/streamwall-shared/src/types.ts`
+- `fit?: 'cover' | 'contain'` zu `ContentDisplayOptions` hinzufügen.
+- `set-stream-fit`-Variante zur `ControlCommand`-Union hinzufügen.
+
+### 2. `packages/streamwall-shared/src/roles.ts`
+- `'set-stream-fit'` in `operatorActions` aufnehmen (analog zu `'rotate-stream'`).
+  Dadurch dürfen `local`, `admin`, `operator` die Option schalten. `StreamwallAction`
+  erweitert sich automatisch über den `typeof`-Ausdruck.
+
+### 3. `packages/streamwall-control-ui/src/index.tsx`
+- Neuer Handler `handleFitStream(streamId)` analog zu `handleRotateStream`:
+  liest den aktuellen `fit` des Streams, sendet `set-stream-fit` mit dem
+  umgeschalteten Wert (`contain` ⇄ `cover`).
+- `GridControls` erhält den aktuellen `fit`-Wert (bzw. ein `isContain`-Flag) und
+  einen `onFitView`-Callback als Props — dieselbe Verdrahtung wie `onRotateView`.
+- Neuer Icon-Toggle-Button neben dem Rotate-Button, sichtbar unter
+  `roleCan(role, 'set-stream-fit')`. Aktiv-Zustand (`isActive`) wenn
+  `fit === 'contain'` — nach dem Muster des vorhandenen Blur/Swap-Toggles.
+  Icon: ein „einpassen"-Symbol aus `react-icons/fa` (z. B. `FaCompressArrowsAlt`
+  oder `FaExpand`; finale Wahl bei der Umsetzung).
+
+### 4. `packages/streamwall/src/main/index.ts`
+- `onCommand`-Zweig für `set-stream-fit`:
+  ```typescript
+  } else if (msg.type === 'set-stream-fit') {
+    overlayStreamData.update(msg.url, { fit: msg.fit })
+  }
+  ```
+
+### 5. `packages/streamwall/src/main/StreamWindow.ts`
+- `getDisplayOptions()` extrahiert zusätzlich `fit`:
+  ```typescript
+  const { rotation, fit } = stream
+  return { rotation, fit }
+  ```
+
+### 6. `packages/streamwall/src/preload/mediaPreload.ts`
+- Default `object-fit: cover` bleibt auf `video`. Neue Klasse im
+  `VIDEO_OVERRIDE_STYLE`:
+  ```css
+  video.__contain__ { object-fit: contain !important; }
+  ```
+- Kleiner `FitController` (analog `RotationController`), der die Klasse
+  `__contain__` je nach `fit`-Wert am Video-Element setzt/entfernt.
+- `updateOptions()` ruft `fitController.set(options.fit)` auf.
+- `FitController` wird — wie `RotationController` — nur für `content.kind === 'video'`
+  instanziiert.
+
+## Persistenz
+
+Wie `rotation` läuft die Option über `overlayStreamData` (In-Memory-Overlay,
+**nicht** an die Storage-Schicht gebunden). Der Wert überlebt keinen
+App-Neustart und fällt dann auf `cover` zurück. Das ist bewusst konsistent mit
+dem bestehenden Rotations-Verhalten; eine Persistenz wäre eine separate,
+breitere Änderung (beträfe auch `rotation`).
+
+## Zusammenspiel mit Rotation
+
+Bei 90°/270°-Rotation positioniert das bestehende CSS das Video mit
+vertauschten Dimensionen und wendet ein `transform` an. `object-fit` wirkt auf
+den Videoinhalt **innerhalb** der Element-Box (vor dem `transform`), sollte also
+korrekt mit der Rotation kombinierbar sein. Wird beim Testen mit einem gedrehten
+Stream verifiziert.
+
+## Fehlerbehandlung
+
+- Ungültige `fit`-Werte sind durch die TypeScript-String-Union ausgeschlossen.
+  Der `FitController` behandelt jeden Wert ≠ `'contain'` (inkl. `undefined`) als
+  `cover` (Klasse entfernen) — fail-safe zum bisherigen Verhalten.
+
+## Testing / Verifikation
+
+Manuell (kein automatisiertes UI-Test-Harness im Projekt vorhanden):
+1. Streamwall starten, einen Stream mit abweichendem Seitenverhältnis auf mehrere
+   Zellen legen.
+2. Toggle-Button in der Control-UI klicken → Video passt sich ohne Crop ein
+   (schwarze Ränder), Button zeigt Aktiv-Zustand.
+3. Erneut klicken → zurück auf `cover` (vollflächig, beschnitten).
+4. Gedrehten Stream (90°) mit `contain` prüfen — korrekte, unbeschnittene
+   Darstellung.
+5. `tsc --noEmit` über die betroffenen Pakete läuft sauber durch.

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -13,6 +13,7 @@ import {
 import { useHotkeys } from 'react-hotkeys-hook'
 import { IconType } from 'react-icons'
 import {
+  FaCompressArrowsAlt,
   FaExchangeAlt,
   FaRedoAlt,
   FaRegLifeRing,
@@ -451,6 +452,21 @@ export function ControlUI({
     [streams],
   )
 
+  const handleFitStream = useCallback(
+    (streamId: string) => {
+      const stream = streams.find((d) => d._id === streamId)
+      if (!stream) {
+        return
+      }
+      send({
+        type: 'set-stream-fit',
+        url: stream.link,
+        fit: stream.fit === 'contain' ? 'cover' : 'contain',
+      })
+    },
+    [streams],
+  )
+
   const handleBrowse = useCallback(
     (streamId: string) => {
       const stream = streams.find((d) => d._id === streamId)
@@ -770,6 +786,7 @@ export function ControlUI({
                   if (!streamId) {
                     return null
                   }
+                  const streamData = streams.find((d) => d._id === streamId)
                   return (
                     <GridControls
                       idx={pos.spaces[0]}
@@ -784,6 +801,7 @@ export function ControlUI({
                       isListening={isListening}
                       isBackgroundListening={isBackgroundListening}
                       isBlurred={isBlurred}
+                      isContain={streamData?.fit === 'contain'}
                       isSwapping={
                         swapStartIdx != null &&
                         pos.spaces.includes(swapStartIdx)
@@ -796,6 +814,7 @@ export function ControlUI({
                       onReloadView={handleReloadView}
                       onSwapView={handleSwapView}
                       onRotateView={handleRotateStream}
+                      onFitView={handleFitStream}
                       onBrowse={handleBrowse}
                       onDevTools={handleDevTools}
                       onMouseDown={handleDragStart}
@@ -1173,6 +1192,7 @@ function GridControls({
   isListening,
   isBackgroundListening,
   isBlurred,
+  isContain,
   isSwapping,
   showDebug,
   role,
@@ -1182,6 +1202,7 @@ function GridControls({
   onReloadView,
   onSwapView,
   onRotateView,
+  onFitView,
   onBrowse,
   onDevTools,
   onMouseDown,
@@ -1193,6 +1214,7 @@ function GridControls({
   isListening: boolean
   isBackgroundListening: boolean
   isBlurred: boolean
+  isContain: boolean
   isSwapping: boolean
   showDebug: boolean
   role: StreamwallRole | null
@@ -1205,6 +1227,7 @@ function GridControls({
   onReloadView: (idx: number) => void
   onSwapView: (idx: number) => void
   onRotateView: (streamId: string) => void
+  onFitView: (streamId: string) => void
   onBrowse: (streamId: string) => void
   onDevTools: (idx: number) => void
   onMouseDown: JSX.MouseEventHandler<HTMLDivElement>
@@ -1238,6 +1261,10 @@ function GridControls({
   const handleRotateClick = useCallback(
     () => onRotateView(streamId),
     [streamId, onRotateView],
+  )
+  const handleFitClick = useCallback(
+    () => onFitView(streamId),
+    [streamId, onFitView],
   )
   const handleBrowseClick = useCallback(
     () => onBrowse(streamId),
@@ -1288,6 +1315,15 @@ function GridControls({
               {roleCan(role, 'rotate-stream') && (
                 <StyledSmallButton onClick={handleRotateClick} tabIndex={1}>
                   <FaRedoAlt />
+                </StyledSmallButton>
+              )}
+              {roleCan(role, 'set-stream-fit') && (
+                <StyledSmallButton
+                  isActive={isContain}
+                  onClick={handleFitClick}
+                  tabIndex={1}
+                >
+                  <FaCompressArrowsAlt />
                 </StyledSmallButton>
               )}
             </>

--- a/packages/streamwall-shared/src/roles.ts
+++ b/packages/streamwall-shared/src/roles.ts
@@ -15,6 +15,7 @@ const operatorActions = [
   'update-custom-stream',
   'delete-custom-stream',
   'rotate-stream',
+  'set-stream-fit',
   'reload-view',
   'set-stream-censored',
   'set-stream-running',

--- a/packages/streamwall-shared/src/types.ts
+++ b/packages/streamwall-shared/src/types.ts
@@ -15,6 +15,7 @@ export interface StreamWindowConfig {
 
 export interface ContentDisplayOptions {
   rotation?: number
+  fit?: 'cover' | 'contain'
 }
 
 /** Metadata scraped from a loaded view */
@@ -124,6 +125,7 @@ export type ControlCommand =
     }
   | { type: 'set-view-blurred'; viewIdx: number; blurred: boolean }
   | { type: 'rotate-stream'; url: string; rotation: number }
+  | { type: 'set-stream-fit'; url: string; fit: 'cover' | 'contain' }
   | { type: 'update-custom-stream'; url: string; data: LocalStreamData }
   | { type: 'delete-custom-stream'; url: string }
   | { type: 'reload-view'; viewIdx: number }

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -24,8 +24,8 @@ function getDisplayOptions(stream: StreamData): ContentDisplayOptions {
   if (!stream) {
     return {}
   }
-  const { rotation } = stream
-  return { rotation }
+  const { rotation, fit } = stream
+  return { rotation, fit }
 }
 
 export interface StreamWindowEventMap {

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -390,6 +390,11 @@ async function main(argv: ReturnType<typeof parseArgs>) {
       overlayStreamData.update(msg.url, {
         rotation: msg.rotation,
       })
+    } else if (msg.type === 'set-stream-fit') {
+      console.debug('Setting stream fit:', msg.url, msg.fit)
+      overlayStreamData.update(msg.url, {
+        fit: msg.fit,
+      })
     } else if (msg.type === 'update-custom-stream') {
       console.debug('Updating custom stream:', msg.url)
       localStreamData.update(msg.url, msg.data)

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -97,6 +97,26 @@ class RotationController {
   }
 }
 
+// Controls whether the video fills its space (object-fit: cover, the default) or
+// is contained without cropping (object-fit: contain). Uses an inline !important
+// style rather than a CSS class because RotationController owns the video's
+// className, and a class here would be clobbered by rotation changes.
+class FitController {
+  video: HTMLVideoElement
+
+  constructor(video: HTMLVideoElement) {
+    this.video = video
+  }
+
+  set(fit: ContentDisplayOptions['fit']) {
+    if (fit === 'contain') {
+      this.video.style.setProperty('object-fit', 'contain', 'important')
+    } else {
+      this.video.style.removeProperty('object-fit')
+    }
+  }
+}
+
 class SnapshotController {
   canvas: HTMLCanvasElement
   ctx: CanvasRenderingContext2D
@@ -288,6 +308,7 @@ async function main() {
   const snapshotController = new SnapshotController()
 
   let rotationController: RotationController | undefined
+  let fitController: FitController | undefined
   async function acquireMedia(elementTimeout: number) {
     let snapshotInterval: number | undefined
 
@@ -298,6 +319,7 @@ async function main() {
 
     if (content.kind === 'video' && media instanceof HTMLVideoElement) {
       rotationController = new RotationController(media)
+      fitController = new FitController(media)
       snapshotInterval = window.setInterval(() => {
         snapshotController.snapshotVideo(media)
       }, 1000)
@@ -337,6 +359,9 @@ async function main() {
   function updateOptions(options: ContentDisplayOptions) {
     if (rotationController) {
       rotationController.setCustom(options.rotation)
+    }
+    if (fitController) {
+      fitController.set(options.fit)
     }
   }
   ipcRenderer.on('options', (ev, options) => updateOptions(options))


### PR DESCRIPTION
Closes #13.

## What

Adds an operator-toggleable per-stream option to display a source with
`object-fit: contain` instead of the default `cover`, fitting the whole
video into its grid cell(s) without cropping (at the cost of black bars
for oddly-shaped sources). Off by default — existing behaviour unchanged.

## How

Follows the existing `rotation` option's path end-to-end:

- `streamwall-shared`: `fit?: 'cover' | 'contain'` on `ContentDisplayOptions`,
  a new `set-stream-fit` control command, and a `set-stream-fit` operator
  permission.
- Main process: `onCommand` writes the value into `overlayStreamData`;
  `getDisplayOptions` passes `fit` through to the view.
- `mediaPreload`: a small `FitController` applies `object-fit: contain` as an
  inline `!important` style on the video element. Deliberately **not** a CSS
  class, because `RotationController` overwrites the video's entire
  `className` — a fit class would be clobbered on rotation. The inline style
  lives on the `style` attribute and coexists with rotation cleanly.
- Control UI: a toggle button next to the rotate button, active when the
  stream is set to `contain`.

Design spec: `docs/superpowers/specs/2026-07-04-video-contain-fit-design.md`.

## Verification

- Type-checks clean (no errors in the changed files) once `streamwall-shared`
  resolves correctly.
- The one non-trivial CSS assumption — that an inline `!important` `object-fit`
  overrides the stylesheet's `object-fit: cover !important`, **and** survives
  the `RotationController` rewriting `className` — was confirmed empirically in
  a real Electron/Chromium render (`initial: cover → contain → still contain
  after rotation → back to cover`).
- Not yet exercised: the full visual end-to-end with a running wall and live
  streams (needs real stream URLs); the data flow is mechanically identical to
  the working `rotation` option.

## Note on base branch

Cut from and targeted at `main` (not the default `deps-modernization`), since
it was built and tested on the `main` toolchain. Because the base is not the
default branch, merging will **not** auto-close #13 — close it manually
afterwards.