### PR TITLE
fix(main): guard onCommand against malformed control messages (#16)

### DIFF
--- a/packages/streamwall/src/main/controlCommand.test.ts
+++ b/packages/streamwall/src/main/controlCommand.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { isControlCommand } from './controlCommand.ts'
+
+test('isControlCommand accepts a well-formed control command', () => {
+  assert.equal(
+    isControlCommand({ type: 'set-listening-view', viewIdx: 0 }),
+    true,
+  )
+})
+
+test('isControlCommand accepts any object with a string "type" (dispatch ignores unknown types)', () => {
+  assert.equal(isControlCommand({ type: 'not-a-real-command' }), true)
+})
+
+// Regression test for issue #16: a failed JSON.parse yields undefined, which
+// previously reached onCommand and threw on `msg.type`.
+test('isControlCommand rejects undefined (the result of a failed JSON.parse)', () => {
+  assert.equal(isControlCommand(undefined), false)
+})
+
+// Regression test for issue #16: `JSON.parse('null')` returns null, another
+// value that previously threw on `msg.type`.
+test('isControlCommand rejects null', () => {
+  assert.equal(isControlCommand(null), false)
+})
+
+test('isControlCommand rejects primitive values', () => {
+  assert.equal(isControlCommand('set-listening-view'), false)
+  assert.equal(isControlCommand(42), false)
+  assert.equal(isControlCommand(true), false)
+})
+
+test('isControlCommand rejects objects without a "type" property', () => {
+  assert.equal(isControlCommand({}), false)
+  assert.equal(isControlCommand({ viewIdx: 0 }), false)
+})
+
+test('isControlCommand rejects objects whose "type" is not a string', () => {
+  assert.equal(isControlCommand({ type: 42 }), false)
+  assert.equal(isControlCommand({ type: null }), false)
+  assert.equal(isControlCommand({ type: undefined }), false)
+})

--- a/packages/streamwall/src/main/controlCommand.ts
+++ b/packages/streamwall/src/main/controlCommand.ts
@@ -1,0 +1,19 @@
+import type { ControlCommand } from 'streamwall-shared'
+
+/**
+ * Structural guard for control messages arriving from the network-exposed
+ * control server (and the control window IPC channel).
+ *
+ * A failed `JSON.parse` yields `undefined` and a literal `null` frame parses to
+ * `null`; both previously reached the command dispatcher and threw on
+ * `msg.type`. This asserts only the minimum the dispatcher relies on — an object
+ * with a string `type`. Unknown type strings dispatch safely (they match no
+ * branch and are ignored); full per-command validation is a separate concern.
+ */
+export function isControlCommand(msg: unknown): msg is ControlCommand {
+  return (
+    typeof msg === 'object' &&
+    msg !== null &&
+    typeof (msg as { type?: unknown }).type === 'string'
+  )
+}

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -8,16 +8,13 @@ import EventEmitter from 'node:events'
 import { join } from 'node:path'
 import ReconnectingWebSocket from 'reconnecting-websocket'
 import 'source-map-support/register'
-import {
-  ControlCommand,
-  resolveGridDimensions,
-  StreamwallState,
-} from 'streamwall-shared'
+import { StreamwallState, resolveGridDimensions } from 'streamwall-shared'
 import { updateElectronApp } from 'update-electron-app'
 import WebSocket from 'ws'
 import yargs from 'yargs'
 import * as Y from 'yjs'
 import { ensureValidURL } from '../util'
+import { isControlCommand } from './controlCommand'
 import ControlWindow from './ControlWindow'
 import {
   LocalStreamData,
@@ -370,7 +367,12 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   updateViewsFromStateDoc()
   viewsState.observeDeep(updateViewsFromStateDoc)
 
-  const onCommand = async (msg: ControlCommand) => {
+  const onCommand = async (rawMsg: unknown) => {
+    if (!isControlCommand(rawMsg)) {
+      console.warn('Ignoring malformed control message:', rawMsg)
+      return
+    }
+    const msg = rawMsg
     console.debug('Received message:', msg)
     if (msg.type === 'set-listening-view') {
       console.debug('Setting listening view:', msg.viewIdx)
@@ -507,6 +509,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
           msg = JSON.parse(ev.data)
         } catch (err) {
           console.warn('Failed to parse control WebSocket message:', err)
+          return
         }
 
         onCommand(msg)


### PR DESCRIPTION
## Problem

The main process dispatches control commands through `onCommand` from two call
sites in `packages/streamwall/src/main/index.ts`:

- the **control WebSocket** (`ws.addEventListener('message', …)`), which is
  exposed to the network via the control server, and
- the **control window** IPC channel (`controlWindow.on('command', …)`).

On the WebSocket path a `JSON.parse` failure was logged but **not** returned, so
`onCommand(msg)` then ran with `msg === undefined`. A valid-JSON `null` frame
reached `onCommand` the same way. Because `onCommand` is `async` and its callers
do not `await` it, the resulting `msg.type` access threw a `TypeError` that
surfaced as an **unhandled promise rejection on every malformed frame** — a
robustness/DoS concern for a network-exposed surface.

Fixes #16.

## Solution

- **Return after a failed parse** in the WebSocket handler so a broken frame
  never reaches `onCommand`.
- **Validate the message structurally in `onCommand`** before dispatch — an
  object carrying a string `type`. Placing the guard in `onCommand` covers
  *both* call sites (WebSocket and control-window IPC) and the valid-`null`
  case. Unknown `type` strings remain safe: they match no dispatch branch and
  are ignored (there is no `else`), so this is intentionally a minimal
  structural guard, not full per-command schema validation.

The `onCommand` parameter is widened to `unknown` and narrowed through the
type-guard, so the existing dispatch body is unchanged.

## Architecture notes

The guard lives in a new, electron-free module (`controlCommand.ts`) so it can
be unit-tested in isolation — `index.ts` itself pulls in electron and cannot be
imported by the `node:test` runner. This mirrors the existing `partitions.ts` /
`partitions.test.ts` split.

## Test coverage

New `controlCommand.test.ts` (project's `node --experimental-strip-types --test`
runner) covers:

- accepts well-formed commands and any object with a string `type`
- **rejects `undefined`** (failed `JSON.parse`) and **`null`** — the two cases
  from the report
- rejects primitives, objects without `type`, and non-string `type`

Full suite: `npm -w streamwall test` → **46 passing**.

## Risks / breaking changes

None. Behaviour for well-formed commands is unchanged; only malformed input that
previously crashed is now logged and ignored.