### PR TITLE
fix(streamwall): keep set-grid-size sharing the wall config object

### DIFF
--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -1,0 +1,80 @@
+import type { StreamWindowConfig } from 'streamwall-shared'
+import { describe, expect, it, vi } from 'vitest'
+
+// StreamWindow pulls in Electron (directly and via ./loadHTML and
+// ./viewStateMachine). Stub the module so the file can be imported without an
+// Electron runtime; setGridSize under test never touches these.
+vi.mock('electron', () => ({
+  BrowserWindow: class {},
+  WebContentsView: class {},
+  WebContents: class {},
+  ipcMain: { handle: () => {}, on: () => {} },
+  app: {},
+}))
+
+const { default: StreamWindow } = await import('./StreamWindow')
+
+function makeConfig(
+  overrides: Partial<StreamWindowConfig> = {},
+): StreamWindowConfig {
+  return {
+    cols: 3,
+    rows: 3,
+    width: 1920,
+    height: 1080,
+    frameless: false,
+    activeColor: '#fff',
+    backgroundColor: '#000',
+    ...overrides,
+  }
+}
+
+/**
+ * Builds a StreamWindow instance without running the constructor (which would
+ * create real Electron windows), so `setGridSize` can be exercised in
+ * isolation against a plain config object.
+ */
+function makeStreamWindow(config: StreamWindowConfig) {
+  const sw = Object.create(StreamWindow.prototype) as InstanceType<
+    typeof StreamWindow
+  >
+  sw.config = config
+  return sw
+}
+
+describe('StreamWindow.setGridSize', () => {
+  it('updates the grid dimensions', () => {
+    const config = makeConfig()
+    const sw = makeStreamWindow(config)
+
+    sw.setGridSize(5, 4)
+
+    expect(sw.config.cols).toBe(5)
+    expect(sw.config.rows).toBe(4)
+  })
+
+  it('mutates the shared config object in place instead of replacing it', () => {
+    const config = makeConfig()
+    const sw = makeStreamWindow(config)
+
+    sw.setGridSize(5, 4)
+
+    // The config reference must be preserved: the main process shares one
+    // config object across streamWindow.config, clientState.config and the
+    // resize pipeline. Replacing it detaches those references and desyncs the
+    // overlay/control grid from the wall on the next resize (issue #14).
+    expect(sw.config).toBe(config)
+    expect(config.cols).toBe(5)
+    expect(config.rows).toBe(4)
+  })
+
+  it('leaves the window dimensions untouched', () => {
+    const config = makeConfig({ width: 2560, height: 1440 })
+    const sw = makeStreamWindow(config)
+
+    sw.setGridSize(2, 6)
+
+    expect(config.width).toBe(2560)
+    expect(config.height).toBe(1440)
+  })
+})

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -237,9 +237,17 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
    * Reconfigures the grid dimensions at runtime. The actual re-layout happens on
    * the next `setViews()` call (driven by the server after it remaps the views
    * state), which reads `cols`/`rows` from `this.config`.
+   *
+   * Mutates `this.config` in place rather than replacing it: the main process
+   * shares a single config object across `streamWindow.config`,
+   * `clientState.config` and the resize pipeline (`handleResize` likewise
+   * mutates it in place). Replacing the object would detach those references and
+   * leave the overlay/control grid drawing stale dimensions after the next
+   * resize.
    */
   setGridSize(cols: number, rows: number) {
-    this.config = { ...this.config, cols, rows }
+    this.config.cols = cols
+    this.config.rows = rows
   }
 
   setViews(viewContentMap: ViewContentMap, streams: StreamList) {

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -454,11 +454,14 @@ async function main(argv: ReturnType<typeof parseArgs>) {
         }
       })
 
-      streamWindowConfig.cols = cols
-      streamWindowConfig.rows = rows
+      // streamWindow.config, streamWindowConfig and clientState.config are the
+      // same shared object, and setGridSize mutates it in place. Broadcast that
+      // shared object via updateState({}) rather than detaching a copy, so a
+      // later window resize keeps the overlay/control grid in sync with the wall
+      // (issue #14).
       streamWindow.setGridSize(cols, rows)
       updateViewsFromStateDoc()
-      updateState({ config: { ...clientState.config, cols, rows } })
+      updateState({})
     }
   }
 


### PR DESCRIPTION
## Problem

`set-grid-size` leaves three divergent config objects, desyncing the overlay/control grid from the wall.

The main process shares **one** config object across `streamWindowConfig`, `clientState.config` and `streamWindow.config`. The resize pipeline depends on this: `StreamWindow.handleResize` mutates `width`/`height` in place and the overlay/control read the same object.

`StreamWindow.setGridSize` broke that by replacing the object (`this.config = { ...this.config, cols, rows }`), and the `set-grid-size` handler compounded it by broadcasting a detached copy (`updateState({ config: { ...clientState.config, cols, rows } })`).

### Failure scenario
Send `set-grid-size` (works) → then resize/maximize the window. `handleResize` now updates only the detached `streamWindow.config`, while `updateState({})` broadcasts the old dimensions from the separately-detached `clientState.config`. Tiles are laid out for the new size but the overlay/control grid draws the old size — a permanent desync until the next `set-grid-size`.

## Fix

Preserve the single shared config reference:

- `StreamWindow.setGridSize` mutates `cols`/`rows` **in place** instead of replacing `this.config`.
- The `set-grid-size` handler broadcasts the shared object via `updateState({})` instead of spreading a detached `{ ...config, cols, rows }`, and drops the now-redundant `streamWindowConfig` mutation (`setGridSize` owns it).

This mirrors how the resize path already works (`handleResize` mutates in place → `updateState({})`), so grid changes and window resizes stay consistent in either order. Behavior at grid-change time is unchanged (identical broadcast content); the fix only restores the shared reference so a subsequent resize stays in sync.

## Test coverage

Adds `StreamWindow.setGridSize` unit tests (Vitest, Electron mocked) asserting the config object reference is preserved and `cols`/`rows` update in place without disturbing the window dimensions.

```
npm -w streamwall run test         # 8 passing (incl. 3 new)
npm -w streamwall-shared run test  # 9 passing
```

## Risks / breaking changes

None. No API or dependency changes.

Closes #14
