### PR TITLE
feat(security): require wss:// and re-validate control-channel commands on the desktop

### DIFF
--- a/packages/streamwall-shared/src/controlEndpoint.test.ts
+++ b/packages/streamwall-shared/src/controlEndpoint.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest'
+import { isSecureControlEndpoint } from './controlEndpoint.ts'
+
+describe('isSecureControlEndpoint', () => {
+  test('accepts wss:// endpoints to any host', () => {
+    expect(
+      isSecureControlEndpoint('wss://example.com/streamwall/abc/ws?token=xyz'),
+    ).toBe(true)
+    expect(isSecureControlEndpoint('wss://control.example.org:8443/ws')).toBe(
+      true,
+    )
+  })
+
+  test('rejects plaintext ws:// to a remote host', () => {
+    expect(
+      isSecureControlEndpoint('ws://example.com/streamwall/abc/ws?token=xyz'),
+    ).toBe(false)
+    expect(isSecureControlEndpoint('ws://192.168.1.10:8080/ws')).toBe(false)
+  })
+
+  test('accepts plaintext ws:// to loopback hosts', () => {
+    expect(isSecureControlEndpoint('ws://localhost:8080/ws')).toBe(true)
+    expect(isSecureControlEndpoint('ws://127.0.0.1:8080/ws')).toBe(true)
+    expect(isSecureControlEndpoint('ws://[::1]:8080/ws')).toBe(true)
+  })
+
+  test('rejects non-websocket protocols even over TLS', () => {
+    expect(isSecureControlEndpoint('https://example.com/ws')).toBe(false)
+    expect(isSecureControlEndpoint('http://example.com/ws')).toBe(false)
+  })
+
+  test('rejects malformed or empty endpoints', () => {
+    expect(isSecureControlEndpoint('')).toBe(false)
+    expect(isSecureControlEndpoint('not a url')).toBe(false)
+    expect(isSecureControlEndpoint('wss://')).toBe(false)
+  })
+})

--- a/packages/streamwall-shared/src/controlEndpoint.ts
+++ b/packages/streamwall-shared/src/controlEndpoint.ts
@@ -1,0 +1,48 @@
+/**
+ * Hosts for which a plaintext `ws://` control connection is acceptable, because
+ * loopback traffic never leaves the machine and cannot be intercepted by a
+ * network man-in-the-middle.
+ */
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1'])
+
+function normalizeHostname(hostname: string): string {
+  // The WHATWG URL parser wraps IPv6 hosts in brackets, e.g. `[::1]`.
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    return hostname.slice(1, -1)
+  }
+  return hostname
+}
+
+/**
+ * Returns whether a control-server endpoint is safe for the Streamwall desktop
+ * to connect to.
+ *
+ * The desktop executes commands received over this connection, so the channel
+ * must be authenticated and tamper-proof. We require `wss://` (TLS, which
+ * authenticates the server and prevents man-in-the-middle injection), with a
+ * narrow exception for plaintext `ws://` to loopback hosts (local development,
+ * where there is no network path to intercept).
+ */
+export function isSecureControlEndpoint(endpoint: string): boolean {
+  let url: URL
+  try {
+    url = new URL(endpoint)
+  } catch {
+    return false
+  }
+
+  const hostname = normalizeHostname(url.hostname)
+  if (hostname === '') {
+    return false
+  }
+
+  if (url.protocol === 'wss:') {
+    return true
+  }
+
+  if (url.protocol === 'ws:') {
+    return LOOPBACK_HOSTS.has(hostname)
+  }
+
+  return false
+}

--- a/packages/streamwall-shared/src/index.ts
+++ b/packages/streamwall-shared/src/index.ts
@@ -1,5 +1,7 @@
 export * from './colors.ts'
+export * from './controlEndpoint.ts'
 export * from './geometry.ts'
 export * from './roles.ts'
 export * from './stateDiff.ts'
 export * from './types.ts'
+export * from './uplink.ts'

--- a/packages/streamwall-shared/src/uplink.test.ts
+++ b/packages/streamwall-shared/src/uplink.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'vitest'
+import { isCommandAllowedFromUplink } from './uplink.ts'
+
+describe('isCommandAllowedFromUplink', () => {
+  test('allows view and stream control commands', () => {
+    expect(isCommandAllowedFromUplink('set-listening-view')).toBe(true)
+    expect(isCommandAllowedFromUplink('set-view-background-listening')).toBe(
+      true,
+    )
+    expect(isCommandAllowedFromUplink('set-view-blurred')).toBe(true)
+    expect(isCommandAllowedFromUplink('rotate-stream')).toBe(true)
+    expect(isCommandAllowedFromUplink('update-custom-stream')).toBe(true)
+    expect(isCommandAllowedFromUplink('delete-custom-stream')).toBe(true)
+    expect(isCommandAllowedFromUplink('reload-view')).toBe(true)
+    expect(isCommandAllowedFromUplink('set-stream-censored')).toBe(true)
+    expect(isCommandAllowedFromUplink('set-stream-running')).toBe(true)
+    expect(isCommandAllowedFromUplink('set-grid-size')).toBe(true)
+  })
+
+  test('rejects code-execution commands from the uplink', () => {
+    expect(isCommandAllowedFromUplink('browse')).toBe(false)
+    expect(isCommandAllowedFromUplink('dev-tools')).toBe(false)
+  })
+
+  test('rejects auth-management commands from the uplink', () => {
+    expect(isCommandAllowedFromUplink('create-invite')).toBe(false)
+    expect(isCommandAllowedFromUplink('delete-token')).toBe(false)
+  })
+
+  test('rejects unknown, empty, or malformed command types', () => {
+    expect(isCommandAllowedFromUplink('')).toBe(false)
+    expect(isCommandAllowedFromUplink('constructor')).toBe(false)
+    expect(isCommandAllowedFromUplink('__proto__')).toBe(false)
+    expect(isCommandAllowedFromUplink('evil-command')).toBe(false)
+    // @ts-expect-error verify runtime safety against non-string input
+    expect(isCommandAllowedFromUplink(undefined)).toBe(false)
+    // @ts-expect-error verify runtime safety against non-string input
+    expect(isCommandAllowedFromUplink(null)).toBe(false)
+  })
+})

--- a/packages/streamwall-shared/src/uplink.ts
+++ b/packages/streamwall-shared/src/uplink.ts
@@ -1,0 +1,39 @@
+import type { ControlCommand } from './types.ts'
+
+/**
+ * Commands the Streamwall desktop accepts from its remote control-server
+ * uplink.
+ *
+ * The uplink is treated as untrusted: even a compromised or man-in-the-middled
+ * control server must not be able to drive actions that lead to code execution
+ * on the desktop (`browse`, `dev-tools`) or manipulate auth tokens
+ * (`create-invite`, `delete-token`). Those remain available only from the
+ * desktop's own local control window.
+ *
+ * This list is an explicit allowlist and is deliberately secure-by-default: any
+ * command type not enumerated here — including new command types added later —
+ * is rejected until it is knowingly added.
+ */
+const UPLINK_ALLOWED_COMMANDS: ReadonlySet<ControlCommand['type']> = new Set<
+  ControlCommand['type']
+>([
+  'set-listening-view',
+  'set-view-background-listening',
+  'set-view-blurred',
+  'rotate-stream',
+  'update-custom-stream',
+  'delete-custom-stream',
+  'reload-view',
+  'set-stream-censored',
+  'set-stream-running',
+  'set-grid-size',
+])
+
+/**
+ * Returns whether a command of the given type may be executed when it arrives
+ * from the remote control-server uplink. Accepts arbitrary input so untrusted
+ * messages can be validated safely; anything unrecognized is rejected.
+ */
+export function isCommandAllowedFromUplink(type: string): boolean {
+  return (UPLINK_ALLOWED_COMMANDS as ReadonlySet<string>).has(type)
+}

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -12,6 +12,8 @@ import {
   ControlCommand,
   StreamwallState,
   clampGridDimension,
+  isCommandAllowedFromUplink,
+  isSecureControlEndpoint,
   remapGridAssignments,
 } from 'streamwall-shared'
 import { updateElectronApp } from 'update-electron-app'
@@ -35,6 +37,20 @@ import TwitchBot from './TwitchBot'
 
 const SENTRY_DSN =
   'https://e630a21dcf854d1a9eb2a7a8584cbd0b@o459879.ingest.sentry.io/5459505'
+
+/**
+ * WebSocket that enforces TLS certificate validation on wss:// connections.
+ * Together with the wss:// requirement on the control endpoint, this
+ * authenticates the control server to the desktop and prevents a
+ * man-in-the-middle from impersonating it. `rejectUnauthorized` defaults to
+ * true in `ws`, but we set it explicitly so the guarantee cannot be silently
+ * lost to a future change.
+ */
+class SecureWebSocket extends WebSocket {
+  constructor(url: string, protocols?: string | string[]) {
+    super(url, protocols, { rejectUnauthorized: true })
+  }
+}
 
 export interface StreamwallConfig {
   help: boolean
@@ -361,8 +377,23 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   updateViewsFromStateDoc()
   viewsState.observeDeep(updateViewsFromStateDoc)
 
-  const onCommand = async (msg: ControlCommand) => {
+  const onCommand = async (
+    msg: ControlCommand,
+    source: 'local' | 'uplink' = 'local',
+  ) => {
     console.debug('Received message:', msg)
+
+    // The remote control-server uplink is untrusted: re-validate every command
+    // against the uplink allowlist so a compromised or man-in-the-middled
+    // server cannot drive code execution (browse/dev-tools) on the desktop.
+    if (source === 'uplink') {
+      const type = (msg as { type?: unknown } | null)?.type
+      if (typeof type !== 'string' || !isCommandAllowedFromUplink(type)) {
+        console.warn('Rejecting disallowed command from control uplink:', type)
+        return
+      }
+    }
+
     if (msg.type === 'set-listening-view') {
       console.debug('Setting listening view:', msg.viewIdx)
       streamWindow.setListeningView(msg.viewIdx)
@@ -503,17 +534,25 @@ async function main(argv: ReturnType<typeof parseArgs>) {
 
   // Control -> main
   controlWindow.on('ydoc', (update) => Y.applyUpdate(stateDoc, update))
-  controlWindow.on('command', (command) => onCommand(command))
+  controlWindow.on('command', (command) => onCommand(command, 'local'))
 
   // TODO: Hide on macOS, allow reopening from dock
   streamWindow.on('close', () => {
     process.exit(0)
   })
 
-  if (argv.control.endpoint) {
+  if (
+    argv.control.endpoint &&
+    !isSecureControlEndpoint(argv.control.endpoint)
+  ) {
+    console.error(
+      `Refusing to connect to insecure control endpoint "${argv.control.endpoint}". ` +
+        'The control connection must use wss:// (or ws:// to a loopback host).',
+    )
+  } else if (argv.control.endpoint) {
     console.debug('Connecting to control server...')
     const ws = new ReconnectingWebSocket(argv.control.endpoint, [], {
-      WebSocket,
+      WebSocket: SecureWebSocket,
       maxReconnectionDelay: 5000,
       minReconnectionDelay: 100 + Math.random() * 500,
       reconnectionDelayGrowFactor: 1.25,
@@ -530,16 +569,18 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     ws.addEventListener('message', (ev) => {
       if (ev.data instanceof ArrayBuffer) {
         Y.applyUpdate(stateDoc, new Uint8Array(ev.data))
-      } else {
-        let msg
-        try {
-          msg = JSON.parse(ev.data)
-        } catch (err) {
-          console.warn('Failed to parse control WebSocket message:', err)
-        }
-
-        onCommand(msg)
+        return
       }
+
+      let msg
+      try {
+        msg = JSON.parse(ev.data)
+      } catch (err) {
+        console.warn('Failed to parse control WebSocket message:', err)
+        return
+      }
+
+      onCommand(msg, 'uplink')
     })
     stateEmitter.on('state', () => {
       ws.send(JSON.stringify({ type: 'state', state: clientState }))


### PR DESCRIPTION
## Problem

The Streamwall desktop trusts its remote control-server uplink blindly. It connects to `argv.control.endpoint` — which may be plaintext `ws://` — and executes **every** inbound message through `onCommand()` with no re-validation on the desktop side.

- `packages/streamwall/src/main/index.ts` — every uplink message was passed straight to `onCommand`, with no auth/allowlist check.
- `onCommand` executes `browse` (open an arbitrary URL) and `dev-tools` unconditionally.

**Attack scenario:** with a `ws://` endpoint (or TLS terminated/misconfigured at a proxy), a man-in-the-middle injects `{type:'browse', url:…}` / `{type:'dev-tools'}` frames; the desktop opens attacker-controlled URLs and DevTools, widening the path to code execution.

Fixes #2.

## Solution

All three remediations from the issue, implemented on the desktop side:

1. **Require a secure endpoint.** The desktop refuses to connect unless the endpoint is `wss://` — or `ws://` to a loopback host (see below). Insecure endpoints are logged and skipped instead of connected.
2. **Authenticate the server to the client.** Connections go through a `SecureWebSocket` that sets `rejectUnauthorized: true`, making TLS certificate validation explicit and durable. Together with the `wss://` requirement, TLS authenticates the server and blocks MITM impersonation.
3. **Allowlist uplink commands.** Command sources are tagged `'local'` vs `'uplink'`. `onCommand()` re-validates every uplink command against an explicit, secure-by-default allowlist. Code-execution commands (`browse`, `dev-tools`) and auth-management commands (`create-invite`, `delete-token`) are rejected from the uplink; they remain available only from the desktop's own local control window.

As a bonus, malformed uplink frames are now dropped instead of passing `undefined` into `onCommand()` (previously a latent crash; overlaps with #16).

## Architecture decisions

- **Loopback exception for `ws://`.** Requiring `wss://` unconditionally would break local development (desktop + a local control server on `ws://localhost`) without provisioning TLS certs. Loopback traffic (`localhost`, `127.0.0.1`, `::1`) never leaves the machine, so there is no network path to intercept — the same rationale browsers use to treat `localhost` as a secure context. `wss://` is required for every non-loopback host.
- **TLS as server authentication.** Rather than inventing a new server-side handshake (the issue scopes the fix to the desktop side), server authentication is achieved through standard TLS certificate validation, made explicit via `SecureWebSocket`.
- **Secure-by-default allowlist.** The uplink allowlist is an explicit enumeration, not derived from the client role model, so the security boundary is self-documenting and independent of future role changes. Any command type not listed — including newly added ones — is rejected until knowingly added. The new `set-grid-size` command is allowed (grid layout control, no code-execution surface); `browse`/`dev-tools` are not.
- **Pure, testable helpers.** The two security decisions (`isSecureControlEndpoint`, `isCommandAllowedFromUplink`) live in `streamwall-shared` as pure functions with no Electron dependency, so they are exhaustively unit-tested. The desktop wiring stays minimal.

## Risks / breaking changes

- **`ws://` to a non-loopback host is now rejected.** Deployments using plaintext `ws://` over a network must switch to `wss://`. This is intentional and is the core of the fix; `wss://` and `ws://localhost` deployments are unaffected.
- **`browse` / `dev-tools` can no longer be triggered over the uplink**, even by a remote admin — by design, these are desktop-local only now. Existing `rejectUnauthorized` behavior is unchanged (it was already the `ws` default; it is now explicit).

## Test coverage

New Vitest suites in `streamwall-shared` (per-package runner already in place):

- `controlEndpoint.test.ts` — `wss://` accepted; plaintext `ws://` to remote hosts rejected; `ws://` loopback (`localhost`/`127.0.0.1`/`[::1]`) accepted; non-websocket protocols and malformed/empty inputs rejected.
- `uplink.test.ts` — view/stream/grid commands allowed; `browse`/`dev-tools`/`create-invite`/`delete-token` rejected; unknown, empty, and prototype-pollution style keys (`__proto__`, `constructor`) and non-string input rejected.

`npm -w packages/streamwall-shared test` → 18 passing (9 new + existing). `npm -w packages/streamwall test` → 5 passing. Typecheck clean for the changed files (`tsc 6.0.3`); Prettier clean.

> Note: `npm run lint` is currently non-functional on this branch — the ESLint dependencies are on v10 but the flat `eslint.config.*` has not been created yet (tracked separately; requires disabling the config-protection hook). The changed files were linted against the existing `.eslintrc.json` with ESLint 8 (clean).
