### PR TITLE
fix(streamwall): stop malformed data sources from crashing the app (#12)

### DIFF
--- a/packages/streamwall/src/main/data.ts
+++ b/packages/streamwall/src/main/data.ts
@@ -3,7 +3,6 @@ import { Repeater } from '@repeaterjs/repeater'
 import { watch } from 'chokidar'
 import { EventEmitter, once } from 'events'
 import { promises as fsPromises } from 'fs'
-import { isArray } from 'lodash-es'
 import fetch from 'node-fetch'
 import { promisify } from 'util'
 import {
@@ -11,6 +10,7 @@ import {
   StreamDataContent,
   StreamList,
 } from '../../../streamwall-shared/src/types'
+import { sanitizeStreamDataList } from './streamData'
 
 const sleep = promisify(setTimeout)
 
@@ -23,7 +23,7 @@ export async function* pollDataURL(url: string, intervalSecs: number) {
     let data: StreamDataContent[] = []
     try {
       const resp = await fetch(url)
-      data = (await resp.json()) as StreamDataContent[]
+      data = sanitizeStreamDataList(await resp.json())
     } catch (err) {
       console.warn('error loading stream data', err)
     }
@@ -50,12 +50,7 @@ export async function* watchDataFile(path: string): DataSource {
     } catch (err) {
       console.warn('error reading data file', err)
     }
-    if (data && isArray(data.streams)) {
-      // TODO: type validate with Zod
-      yield data.streams as unknown as StreamList
-    } else {
-      yield []
-    }
+    yield sanitizeStreamDataList(data?.streams)
     await once(watcher, 'change')
   }
 }
@@ -74,18 +69,26 @@ export async function* combineDataSources(
   idGen: StreamIDGenerator,
 ) {
   for await (const streamLists of Repeater.latest(dataSources)) {
-    const dataByURL = new Map<string, StreamData>()
-    for (const list of streamLists) {
-      for (const data of list) {
-        const existing = dataByURL.get(data.link)
-        dataByURL.set(data.link, { ...existing, ...data } as StreamData)
+    let streams: StreamList
+    try {
+      const dataByURL = new Map<string, StreamData>()
+      for (const list of streamLists) {
+        for (const data of list) {
+          const existing = dataByURL.get(data.link)
+          dataByURL.set(data.link, { ...existing, ...data } as StreamData)
+        }
       }
+
+      streams = idGen.process([...dataByURL.values()]) as StreamList
+
+      // Retain the index to speed up local lookups
+      streams.byURL = dataByURL
+    } catch (err) {
+      // A malformed data source must not take down the whole pipeline;
+      // skip this batch and keep serving the next update.
+      console.warn('error combining stream data', err)
+      continue
     }
-
-    const streams = idGen.process([...dataByURL.values()]) as StreamList
-
-    // Retain the index to speed up local lookups
-    streams.byURL = dataByURL
     yield streams
   }
 }

--- a/packages/streamwall/src/main/streamData.test.ts
+++ b/packages/streamwall/src/main/streamData.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import { sanitizeStreamDataList } from './streamData.ts'
+
+describe('sanitizeStreamDataList', () => {
+  test('returns an empty array for non-array payloads', () => {
+    assert.deepEqual(sanitizeStreamDataList(null), [])
+    assert.deepEqual(sanitizeStreamDataList(undefined), [])
+    assert.deepEqual(sanitizeStreamDataList(42), [])
+    assert.deepEqual(sanitizeStreamDataList('nope'), [])
+    assert.deepEqual(sanitizeStreamDataList(true), [])
+    assert.deepEqual(sanitizeStreamDataList({}), [])
+    // The classic crash payload: an object wrapping the array.
+    assert.deepEqual(
+      sanitizeStreamDataList({ streams: [{ link: 'https://a' }] }),
+      [],
+    )
+  })
+
+  test('keeps valid entries with a non-empty string link', () => {
+    const input = [
+      { link: 'https://a', kind: 'video' },
+      { link: 'https://b' },
+    ]
+    assert.deepEqual(sanitizeStreamDataList(input), input)
+  })
+
+  test('drops null and non-object entries', () => {
+    const valid = { link: 'https://a' }
+    assert.deepEqual(
+      sanitizeStreamDataList([null, undefined, 5, 'x', true, valid]),
+      [valid],
+    )
+  })
+
+  test('drops entries without a usable link', () => {
+    assert.deepEqual(
+      sanitizeStreamDataList([
+        { kind: 'video' }, // no link
+        { link: '' }, // empty link
+        { link: 123 }, // non-string link
+        { link: null }, // null link
+        { link: 'https://ok' },
+      ]),
+      [{ link: 'https://ok' }],
+    )
+  })
+
+  test('preserves entry order and extra fields', () => {
+    const input = [
+      { link: 'https://a', label: 'A', city: 'X', notes: 'n' },
+      { link: 'https://b', source: 'S' },
+    ]
+    assert.deepEqual(sanitizeStreamDataList(input), input)
+  })
+
+  test('does not mutate the input array', () => {
+    const input = [{ link: 'https://a' }, null]
+    const copy = [...input]
+    sanitizeStreamDataList(input)
+    assert.deepEqual(input, copy)
+  })
+})

--- a/packages/streamwall/src/main/streamData.ts
+++ b/packages/streamwall/src/main/streamData.ts
@@ -1,0 +1,26 @@
+import type { StreamDataContent } from '../../../streamwall-shared/src/types'
+
+/**
+ * Validate and normalize an untrusted stream-data payload (e.g. from a remote
+ * json-url or a watched toml-file) into a list of usable entries.
+ *
+ * Data sources are operator-supplied and can return malformed data: a
+ * non-array wrapper object, null/primitive entries, or entries without a
+ * link. Such payloads previously propagated into the data pipeline and
+ * crashed the whole app (a non-iterable or a property access on a non-object
+ * throws, rejecting `main()` and triggering `process.exit(1)`). This drops
+ * anything that isn't a well-formed entry with a non-empty string link, so a
+ * bad source degrades to "no streams" instead of killing the process.
+ */
+export function sanitizeStreamDataList(payload: unknown): StreamDataContent[] {
+  if (!Array.isArray(payload)) {
+    return []
+  }
+  return payload.filter(
+    (entry): entry is StreamDataContent =>
+      entry != null &&
+      typeof entry === 'object' &&
+      typeof (entry as { link?: unknown }).link === 'string' &&
+      (entry as { link: string }).link.length > 0,
+  )
+}


### PR DESCRIPTION
## Problem

Fixes #12 — **a malformed data source crashes the entire app.**

`pollDataURL` casts `await resp.json()` straight to `StreamDataContent[]` with no validation. Because data sources (`--data.json-url`, `--data.toml-file`) are operator-supplied and fetched from the network, a malformed response propagates unchecked into the data pipeline and throws, rejecting `main()` and hitting the top-level `.catch(() => process.exit(1))` — the whole app goes down.

Concrete failure scenarios:
- A response that is an **object** (e.g. `{"streams":[…]}`) instead of an array → `for (const data of list)` iterates a non-iterable → `TypeError`.
- An **array containing `null`** / primitives → property access (`data.link`, `s._dataSource = …`) on a non-object → `TypeError`.
- Entries **missing `link`** → all collapse onto the `undefined` map key, silently corrupting the stream list.

`watchDataFile` had the same shape (an unchecked `as unknown as StreamList` cast plus a `// TODO: type validate with Zod`).

## Solution

- **`sanitizeStreamDataList(payload: unknown): StreamDataContent[]`** (new, pure, unit-tested): non-array payloads become `[]`; entries that aren't objects with a non-empty string `link` are dropped; order and extra fields are preserved. It lives in its own dependency-free module so it runs under the repo's native `node:test` runner.
- Both untrusted sources — **`pollDataURL`** and **`watchDataFile`** — now route their payloads through the validator, replacing the unchecked casts (and removing the Zod TODO).
- **`combineDataSources`** wraps each batch in `try/catch` so any residual error skips a single update instead of killing the process — the resilience net called for in the issue ("one bad poll cannot kill the process").

## Architecture notes

- Validation lives in a separate `streamData.ts` module rather than inline in `data.ts` because `data.ts` pulls heavy runtime deps (`chokidar`, `node-fetch`, `@repeaterjs/repeater`) that make it non-importable under the native test runner. Keeping the pure logic isolated makes it fully unit-testable — the same pattern as `partitions.ts` (#97).
- Belt-and-suspenders: sanitizing at the two untrusted entry points prevents bad data from entering the pipeline, and the `combineDataSources` guard ensures even an unexpected error (e.g. a non-string `source` reaching the ID generator) degrades to a skipped update rather than a crash.

## Risks / breaking changes

- **No breaking changes.** Well-formed data sources behave exactly as before.
- Malformed entries are now **silently dropped** (with a warning already emitted upstream on fetch/parse errors) rather than crashing — the intended, safer behaviour.

## Test coverage

6 new tests via the native `node:test` runner (`sanitizeStreamDataList`): non-array payloads, the object-wrapper crash payload, `null`/primitive entries, missing/empty/non-string links, order + extra-field preservation, and input immutability. Full suite green (`npm test`): streamwall 45, streamwall-shared 29.

> `data.ts` itself isn't unit-testable in this worktree (uninstalled native deps), so its wiring is covered by the isolated validator tests plus the type checker; the pipeline `try/catch` follows the issue's recommendation directly.

Note: this PR targets `main` (not the default branch), so `Fixes #12` will not auto-close the issue on merge — close it manually afterward.
