### PR TITLE
Security: keep control-server secrets out of storage, logs, and URLs (#4)

### DIFF
--- a/docs/superpowers/specs/2026-07-04-control-server-secret-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-04-control-server-secret-hardening-design.md
@@ -1,0 +1,110 @@
+# Design: Control-Server Secret Hardening (Issue #4)
+
+**Status:** approved
+**Issue:** [#4](https://github.com/NilsR0711/streamwall-modernization/issues/4) — _Security: stop persisting/logging secrets in clear; move WS tokens out of the URL query string_
+**Severity:** medium · **Labels:** control-server, security
+
+## Problem
+
+Three related weaknesses in `streamwall-control-server` expose long-lived,
+admin-capable secrets:
+
+1. **Plaintext uplink secret at rest.** `StoredData.streamwallToken` persists the
+   Streamwall uplink token's plaintext `secret` to `storage.json`
+   (`storage.ts`), while every other token stores only a scrypt hash
+   (`auth.ts`). Anyone with read access to `storage.json` recovers the
+   admin-role uplink secret.
+2. **Secrets printed on every startup.** `initialInviteCodes` prints the uplink
+   endpoint (with secret) and a freshly minted admin invite (with secret) to
+   stdout on **every** boot (`index.ts`). Captured logs leak both.
+3. **Secrets in the URL query string.** The uplink WebSocket authenticates via
+   `/streamwall/:id/ws?token=<secret>` and invites via
+   `/invite/:id?token=<secret>` (`roles.ts` `inviteLink`, `index.ts`). Query
+   strings land in access logs, browser history, and the `Referer` header.
+
+The browser control client (`/client/ws`) already authenticates via an
+`httpOnly` session cookie and needs no change.
+
+## Approach & Decisions
+
+| Area | Decision |
+| --- | --- |
+| Invite transport | **URL fragment + same-origin POST exchange.** Fragments never reach the server, so the secret stays out of access logs and `Referer`. |
+| Uplink config | **`Authorization: Bearer <tokenId>:<secret>` header, backward compatible.** A legacy `control.endpoint` that still embeds `?token=` is parsed, its token moved to the header, and a deprecation warning is logged. |
+| Admin invite | **Hash-only, print-once.** Minted + logged only when no admin can currently get in; `STREAMWALL_CONTROL_NEW_ADMIN_INVITE=1` forces a fresh invite for recovery. |
+| Test harness | **`node:test` + `tsx`.** Zero new runtime/dev dependencies, fitting a security PR. |
+
+## Components
+
+### 1. Storage — hash-only reference (P1)
+
+`StoredData.streamwallToken` becomes `{ tokenId: string } | null`. The scrypt
+hash already lives in `auth.tokens`, so the reference alone is enough to know a
+token exists. A migration on load strips any legacy `secret` field and rewrites
+`storage.json`, purging existing plaintext secrets from disk.
+
+### 2. Uplink WebSocket via Authorization header (P3-uplink)
+
+- **Server:** route `/streamwall/ws` (no `:id`). Reads
+  `Authorization: Bearer <tokenId>:<secret>`, splits on the first `:`, validates
+  via `auth.validateToken` requiring `kind === 'streamwall'`. The legacy
+  query-string route is removed, eliminating the server-side logging vector.
+- **Streamwall app:** `control.endpoint` carries no token; new `control.token`
+  holds `<tokenId>:<secret>`. The header is injected through a `ws.WebSocket`
+  subclass passed to `ReconnectingWebSocket`. A pure helper
+  `resolveControlCredentials({ endpoint, token })` normalizes config and handles
+  the legacy `?token=` form (extract → header → warn). This helper is unit
+  tested.
+
+### 3. Invite via fragment + POST exchange (P3-invite)
+
+- `inviteLink` returns `…/invite/<id>#<secret>`.
+- `GET /invite/:id` serves a minimal self-contained HTML page (inline script
+  behind a per-request CSP nonce, `Referrer-Policy: no-referrer`). The script
+  reads `location.hash`, `fetch`-POSTs `{ secret }` to `/invite/:id`, then
+  `location.replace('/')`. `<noscript>` explains JS is required (the control UI
+  is JS-only anyway). **No secret ever reaches the server via the URL.**
+- `POST /invite/:id` requires a same-origin `Origin` header, validates the
+  secret (`kind === 'invite'`), sets the session cookie exactly as before,
+  deletes the invite, and returns `204`. Bad/again-consumed → `403`.
+
+### 4. Startup logging (P1 log side / P2)
+
+`initialInviteCodes`:
+- Uplink: minted + its endpoint/token printed **once** at creation. Restarts
+  print the endpoint without a secret (the plaintext no longer exists).
+- Admin invite: created + logged only when there is **no admin session and no
+  open admin invite**. `STREAMWALL_CONTROL_NEW_ADMIN_INVITE=1` deletes existing
+  admin invites and mints/prints a fresh one for lockout recovery. Restarts
+  otherwise print nothing secret.
+
+### 5. Testability refactor (enabling, minimal)
+
+- Export `initApp` and `initialInviteCodes`; guard the module-level
+  `runServer(...)` behind an `import.meta`/`process.argv[1]` main check so
+  importing for tests does not start a server.
+- `loadStorage(dbPath?)` and `initApp({ …, db? })` accept overrides so tests run
+  against a temp-file database.
+
+## Test Strategy (TDD)
+
+- **Unit:** `auth.getStoredData()` never contains a plaintext secret; storage
+  migration removes a legacy `secret`; `inviteLink` emits the fragment form;
+  `resolveControlCredentials` maps new + legacy config to a header credential.
+- **Integration (`app.inject`):** `GET /invite/:id` returns HTML with no secret
+  and `Referrer-Policy: no-referrer`; `POST /invite/:id` sets the cookie and
+  `204`, a consumed invite → `403`, a cross-origin POST → rejected.
+- **Integration (real `ws` client, `listen({ port: 0 })`):** uplink accepts a
+  valid `Authorization` header and rejects a missing/invalid one.
+
+## Risks & Breaking Changes
+
+- **Uplink config format changes.** Mitigated by backward-compatible parsing of
+  the legacy `?token=` endpoint plus a deprecation warning.
+- **Invite acceptance now requires JavaScript.** Acceptable: the control UI is a
+  JS SPA. `<noscript>` communicates the requirement.
+- **Admin invite no longer regenerates each boot.** Intentional; recovery via
+  `STREAMWALL_CONTROL_NEW_ADMIN_INVITE=1`.
+- **`storage.json` migration is one-way** (drops the plaintext secret). The
+  uplink token keeps working (validated by hash); only re-display of the secret
+  is lost, which is the goal.

--- a/docs/superpowers/specs/2026-07-04-control-server-secret-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-04-control-server-secret-hardening-design.md
@@ -27,12 +27,12 @@ The browser control client (`/client/ws`) already authenticates via an
 
 ## Approach & Decisions
 
-| Area | Decision |
-| --- | --- |
-| Invite transport | **URL fragment + same-origin POST exchange.** Fragments never reach the server, so the secret stays out of access logs and `Referer`. |
-| Uplink config | **`Authorization: Bearer <tokenId>:<secret>` header, backward compatible.** A legacy `control.endpoint` that still embeds `?token=` is parsed, its token moved to the header, and a deprecation warning is logged. |
-| Admin invite | **Hash-only, print-once.** Minted + logged only when no admin can currently get in; `STREAMWALL_CONTROL_NEW_ADMIN_INVITE=1` forces a fresh invite for recovery. |
-| Test harness | **`node:test` + `tsx`.** Zero new runtime/dev dependencies, fitting a security PR. |
+| Area             | Decision                                                                                                                                                                                                           |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Invite transport | **URL fragment + same-origin POST exchange.** Fragments never reach the server, so the secret stays out of access logs and `Referer`.                                                                              |
+| Uplink config    | **`Authorization: Bearer <tokenId>:<secret>` header, backward compatible.** A legacy `control.endpoint` that still embeds `?token=` is parsed, its token moved to the header, and a deprecation warning is logged. |
+| Admin invite     | **Hash-only, print-once.** Minted + logged only when no admin can currently get in; `STREAMWALL_CONTROL_NEW_ADMIN_INVITE=1` forces a fresh invite for recovery.                                                    |
+| Test harness     | **`node:test` + `tsx`.** Zero new runtime/dev dependencies, fitting a security PR.                                                                                                                                 |
 
 ## Components
 
@@ -71,6 +71,7 @@ token exists. A migration on load strips any legacy `secret` field and rewrites
 ### 4. Startup logging (P1 log side / P2)
 
 `initialInviteCodes`:
+
 - Uplink: minted + its endpoint/token printed **once** at creation. Restarts
   print the endpoint without a secret (the plaintext no longer exists).
 - Admin invite: created + logged only when there is **no admin session and no

--- a/example.config.toml
+++ b/example.config.toml
@@ -24,16 +24,15 @@
 #rows = 2
 
 [control]
-# Address to serve control server from
-address = "http://localhost:80"
+# Connect this Streamwall instance to a control server as an uplink.
+# The control server prints both values once, on first run.
 
-# Override hostname and port
-#hostname = "localhost"
-#port = 80
+# WebSocket URL of the control server uplink (no token in the URL).
+#endpoint = "wss://control.example.com/streamwall/ws"
 
-# Username and password
-username = "streamwall"
-password = "please-change-this"
+# Uplink token in "<tokenId>:<secret>" form. Sent as an Authorization header,
+# never in the URL, so it stays out of access logs, history, and Referer.
+#token = "tokenId:secret"
 
 [data]
 # Interval to refresh polled datasources

--- a/packages/streamwall-control-server/package.json
+++ b/packages/streamwall-control-server/package.json
@@ -5,7 +5,8 @@
   "main": "src/index.ts",
   "type": "module",
   "scripts": {
-    "start": "tsx ./src/index.ts"
+    "start": "tsx ./src/index.ts",
+    "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "repository": "github:streamwall/streamwall",
   "author": "Max Goodhart <c@chromakode.com>",

--- a/packages/streamwall-control-server/src/auth.test.ts
+++ b/packages/streamwall-control-server/src/auth.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import { Auth } from './auth.ts'
+
+describe('Auth token storage', () => {
+  test('createToken returns a tokenId and secret', async () => {
+    const auth = new Auth()
+    const { tokenId, secret } = await auth.createToken({
+      kind: 'session',
+      role: 'admin',
+      name: 'Test',
+    })
+    assert.equal(typeof tokenId, 'string')
+    assert.equal(typeof secret, 'string')
+    assert.ok(tokenId.length > 0)
+    assert.ok(secret.length > 0)
+  })
+
+  test('stored data never contains a plaintext secret', async () => {
+    const auth = new Auth()
+    const { secret } = await auth.createToken({
+      kind: 'streamwall',
+      role: 'admin',
+      name: 'Streamwall',
+    })
+
+    const stored = auth.getStoredData()
+    const serialized = JSON.stringify(stored)
+
+    // The plaintext secret must not appear anywhere in what we persist.
+    assert.ok(
+      !serialized.includes(secret),
+      'plaintext secret leaked into stored data',
+    )
+    // Every stored token exposes only a hash, never a secret field.
+    for (const token of stored.tokens) {
+      assert.ok(token.tokenHash, 'token is missing its hash')
+      assert.ok(
+        !('secret' in token),
+        'token unexpectedly carries a plaintext secret',
+      )
+    }
+  })
+
+  test('validateToken accepts the correct secret and rejects an unknown id', async () => {
+    const auth = new Auth()
+    const { tokenId, secret } = await auth.createToken({
+      kind: 'invite',
+      role: 'operator',
+      name: 'Op',
+    })
+
+    const ok = await auth.validateToken(tokenId, secret)
+    assert.ok(ok)
+    assert.equal(ok?.role, 'operator')
+    assert.equal(ok?.kind, 'invite')
+
+    assert.equal(await auth.validateToken('unknown-id', secret), null)
+  })
+
+  test('a token validates after reconstructing Auth from stored (hash-only) data', async () => {
+    const auth = new Auth()
+    const { tokenId, secret } = await auth.createToken({
+      kind: 'streamwall',
+      role: 'admin',
+      name: 'Streamwall',
+    })
+
+    // Simulate a server restart: rebuild Auth purely from the persisted,
+    // hash-only representation.
+    const restored = new Auth(auth.getStoredData())
+    const info = await restored.validateToken(tokenId, secret)
+    assert.ok(info, 'hash-only persistence must still authenticate the token')
+    assert.equal(info?.kind, 'streamwall')
+  })
+})

--- a/packages/streamwall-control-server/src/auth.test.ts
+++ b/packages/streamwall-control-server/src/auth.test.ts
@@ -58,6 +58,23 @@ describe('Auth token storage', () => {
     assert.equal(await auth.validateToken('unknown-id', secret), null)
   })
 
+  test('validateToken rejects wrong secrets without throwing (length-safe)', async () => {
+    const auth = new Auth()
+    const { tokenId } = await auth.createToken({
+      kind: 'invite',
+      role: 'operator',
+      name: 'Op',
+    })
+
+    // scrypt hashes are base62-encoded and therefore vary in length. A naive
+    // timingSafeEqual on mismatched lengths throws; validation must instead
+    // return null for every wrong secret regardless of its hash length.
+    for (let i = 0; i < 200; i++) {
+      const result = await auth.validateToken(tokenId, `wrong-secret-${i}`)
+      assert.equal(result, null, `wrong secret #${i} must be rejected as null`)
+    }
+  })
+
   test('a token validates after reconstructing Auth from stored (hash-only) data', async () => {
     const auth = new Auth()
     const { tokenId, secret } = await auth.createToken({

--- a/packages/streamwall-control-server/src/auth.ts
+++ b/packages/streamwall-control-server/src/auth.ts
@@ -150,6 +150,13 @@ export class Auth extends EventEmitter<AuthEvents> {
 
     const providedTokenHashBuf = Buffer.from(tokenHash)
     const expectedTokenHashBuf = Buffer.from(tokenData.tokenHash)
+    // scrypt hashes are base62-encoded and can differ in length. timingSafeEqual
+    // throws on mismatched lengths, so guard first: a different length can never
+    // be a match. This reveals nothing about the stored secret (the provided
+    // hash is derived from attacker-controlled input).
+    if (providedTokenHashBuf.length !== expectedTokenHashBuf.length) {
+      return null
+    }
     const isTokenMatch = timingSafeEqual(
       providedTokenHashBuf,
       expectedTokenHashBuf,

--- a/packages/streamwall-control-server/src/credentials.test.ts
+++ b/packages/streamwall-control-server/src/credentials.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import {
+  parseBearerCredential,
+  resolveControlConnection,
+} from 'streamwall-shared'
+
+describe('parseBearerCredential', () => {
+  test('parses a well-formed bearer credential', () => {
+    assert.deepEqual(parseBearerCredential('Bearer abc123:s3cr3t'), {
+      tokenId: 'abc123',
+      secret: 's3cr3t',
+    })
+  })
+
+  test('accepts a case-insensitive scheme and surrounding whitespace', () => {
+    assert.deepEqual(parseBearerCredential('  bearer   abc:def '), {
+      tokenId: 'abc',
+      secret: 'def',
+    })
+  })
+
+  test('rejects malformed or empty values', () => {
+    assert.equal(parseBearerCredential(undefined), null)
+    assert.equal(parseBearerCredential(null), null)
+    assert.equal(parseBearerCredential(''), null)
+    assert.equal(parseBearerCredential('Bearer'), null)
+    assert.equal(parseBearerCredential('Bearer nocolon'), null)
+    assert.equal(parseBearerCredential('Bearer :onlysecret'), null)
+    assert.equal(parseBearerCredential('Bearer onlyid:'), null)
+    assert.equal(parseBearerCredential('Basic abc:def'), null)
+  })
+})
+
+describe('resolveControlConnection', () => {
+  test('passes through the modern endpoint + token form', () => {
+    assert.deepEqual(
+      resolveControlConnection({
+        endpoint: 'ws://host:3000/streamwall/ws',
+        token: 'id123:secret456',
+      }),
+      {
+        endpoint: 'ws://host:3000/streamwall/ws',
+        credential: 'id123:secret456',
+        legacy: false,
+      },
+    )
+  })
+
+  test('migrates a deprecated token-in-URL endpoint', () => {
+    const resolved = resolveControlConnection({
+      endpoint: 'ws://host:3000/streamwall/ID123/ws?token=SECRET456',
+    })
+    assert.equal(resolved?.legacy, true)
+    assert.equal(resolved?.endpoint, 'ws://host:3000/streamwall/ws')
+    assert.equal(resolved?.credential, 'ID123:SECRET456')
+  })
+
+  test('returns null when there is no usable credential', () => {
+    assert.equal(resolveControlConnection({ endpoint: null }), null)
+    assert.equal(resolveControlConnection({ endpoint: '' }), null)
+    assert.equal(
+      resolveControlConnection({ endpoint: 'ws://host/streamwall/ws' }),
+      null,
+    )
+  })
+})

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -13,6 +13,7 @@ import {
   type ControlCommandMessage,
   type ControlUpdateMessage,
   inviteLink,
+  parseBearerCredential,
   roleCan,
   stateDiff,
   type StreamwallRole,
@@ -148,23 +149,26 @@ export async function initApp({
     },
   )
 
-  app.get<{ Params: { id: string }; Querystring: { token?: string } }>(
-    '/streamwall/:id/ws',
+  app.get(
+    '/streamwall/ws',
     { websocket: true },
     async (ws, request) => {
       ws.binaryType = 'arraybuffer'
       const handleMessage = queueWebSocketMessages(ws)
 
-      const { id } = request.params
-      const { token } = request.query
-
-      if (!token || typeof token !== 'string') {
+      // The uplink authenticates with an Authorization: Bearer header so the
+      // secret never appears in the URL (and thus never in access logs).
+      const credential = parseBearerCredential(request.headers.authorization)
+      if (!credential) {
         ws.send(JSON.stringify({ error: 'unauthorized' }))
         ws.close()
         return
       }
 
-      const tokenInfo = await auth.validateToken(id, token)
+      const tokenInfo = await auth.validateToken(
+        credential.tokenId,
+        credential.secret,
+      )
       if (!tokenInfo || tokenInfo.kind !== 'streamwall') {
         ws.send(JSON.stringify({ error: 'unauthorized' }))
         ws.close()
@@ -458,6 +462,10 @@ export async function initApp({
   return { app, db, auth }
 }
 
+function isEnvFlag(value: string | undefined): boolean {
+  return value === '1' || value?.toLowerCase() === 'true'
+}
+
 export async function initialInviteCodes({
   db,
   auth,
@@ -467,17 +475,37 @@ export async function initialInviteCodes({
   auth: Auth
   baseURL: string
 }) {
-  // Create a token for streamwall uplink (if not existing):
+  const wsBase = baseURL.replace(/^http/, 'ws')
+
+  // Streamwall uplink token: created once, its secret shown once. Only a hash
+  // reference is persisted, so the secret can never be reprinted on restart.
   let streamwallToken = db.data.streamwallToken
+  if (
+    isEnvFlag(process.env.STREAMWALL_CONTROL_NEW_UPLINK_TOKEN) &&
+    streamwallToken
+  ) {
+    auth.deleteToken(streamwallToken.tokenId)
+    streamwallToken = null
+  }
   if (!streamwallToken) {
-    streamwallToken = await auth.createToken({
+    const created = await auth.createToken({
       kind: 'streamwall',
       role: 'admin',
       name: 'Streamwall',
     })
-    db.update((data) => {
-      data.streamwallToken = streamwallToken
+    await db.update((data) => {
+      data.streamwallToken = { tokenId: created.tokenId }
     })
+    console.log('🔌 Streamwall uplink token created — configure the app once:')
+    console.log(`     control.endpoint = ${wsBase}/streamwall/ws`)
+    console.log(`     control.token    = ${created.tokenId}:${created.secret}`)
+    console.log(
+      '     (shown only now; set STREAMWALL_CONTROL_NEW_UPLINK_TOKEN=1 to mint a new one)',
+    )
+  } else {
+    console.log(
+      `🔌 Streamwall uplink endpoint: ${wsBase}/streamwall/ws (token already configured)`,
+    )
   }
 
   // Invalidate any existing admin invites and create a new one:
@@ -492,10 +520,6 @@ export async function initialInviteCodes({
     name: 'Server admin',
   })
 
-  console.log(
-    '🔌 Streamwall endpoint:',
-    `${baseURL.replace(/^http/, 'ws')}/streamwall/${streamwallToken.tokenId}/ws?token=${streamwallToken.secret}`,
-  )
   console.log(
     '🔑 Admin invite:',
     inviteLink({

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -536,10 +536,12 @@ export async function initialInviteCodes({
   db,
   auth,
   baseURL,
+  log = console.log,
 }: {
   db: StorageDB
   auth: Auth
   baseURL: string
+  log?: (...args: unknown[]) => void
 }) {
   const wsBase = baseURL.replace(/^http/, 'ws')
 
@@ -562,38 +564,59 @@ export async function initialInviteCodes({
     await db.update((data) => {
       data.streamwallToken = { tokenId: created.tokenId }
     })
-    console.log('🔌 Streamwall uplink token created — configure the app once:')
-    console.log(`     control.endpoint = ${wsBase}/streamwall/ws`)
-    console.log(`     control.token    = ${created.tokenId}:${created.secret}`)
-    console.log(
+    log('🔌 Streamwall uplink token created — configure the app once:')
+    log(`     control.endpoint = ${wsBase}/streamwall/ws`)
+    log(`     control.token    = ${created.tokenId}:${created.secret}`)
+    log(
       '     (shown only now; set STREAMWALL_CONTROL_NEW_UPLINK_TOKEN=1 to mint a new one)',
     )
   } else {
-    console.log(
+    log(
       `🔌 Streamwall uplink endpoint: ${wsBase}/streamwall/ws (token already configured)`,
     )
   }
 
-  // Invalidate any existing admin invites and create a new one:
-  for (const adminToken of auth
-    .getState()
-    .invites.filter(({ role }) => role === 'admin')) {
-    auth.deleteToken(adminToken.tokenId)
-  }
-  const adminToken = await auth.createToken({
-    kind: 'invite',
-    role: 'admin',
-    name: 'Server admin',
-  })
-
-  console.log(
-    '🔑 Admin invite:',
-    inviteLink({
-      baseURL,
-      tokenId: adminToken.tokenId,
-      secret: adminToken.secret,
-    }),
+  // Bootstrap admin invite: minted and printed only when no admin can currently
+  // get in, so the secret is not re-logged on every restart. Recover from a
+  // lockout by setting STREAMWALL_CONTROL_NEW_ADMIN_INVITE=1.
+  const state = auth.getState()
+  const hasAdminSession = state.sessions.some(({ role }) => role === 'admin')
+  const pendingAdminInvites = state.invites.filter(
+    ({ role }) => role === 'admin',
   )
+  const forceNewAdminInvite = isEnvFlag(
+    process.env.STREAMWALL_CONTROL_NEW_ADMIN_INVITE,
+  )
+
+  if (forceNewAdminInvite) {
+    for (const invite of pendingAdminInvites) {
+      auth.deleteToken(invite.tokenId)
+    }
+  }
+
+  const needAdminInvite =
+    forceNewAdminInvite ||
+    (!hasAdminSession && pendingAdminInvites.length === 0)
+
+  if (needAdminInvite) {
+    const adminToken = await auth.createToken({
+      kind: 'invite',
+      role: 'admin',
+      name: 'Server admin',
+    })
+    log(
+      '🔑 Admin invite:',
+      inviteLink({
+        baseURL,
+        tokenId: adminToken.tokenId,
+        secret: adminToken.secret,
+      }),
+    )
+  } else if (pendingAdminInvites.length > 0) {
+    log(
+      '🔑 Admin invite already pending (set STREAMWALL_CONTROL_NEW_ADMIN_INVITE=1 to mint a new one).',
+    )
+  }
 }
 
 export default async function runServer({

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -2,6 +2,7 @@ import fastifyCookie from '@fastify/cookie'
 import fastifyStatic from '@fastify/static'
 import fastifyWebsocket from '@fastify/websocket'
 import Fastify from 'fastify'
+import { randomBytes } from 'node:crypto'
 import process from 'node:process'
 import WebSocket from 'ws'
 import * as Y from 'yjs'
@@ -88,6 +89,52 @@ function queueWebSocketMessages(ws: WebSocket) {
   return setMessageHandler
 }
 
+/**
+ * Minimal, self-contained invite acceptance page. It reads the secret from the
+ * URL fragment (which never reaches the server), POSTs it to exchange for a
+ * session cookie, and replaces the fragment URL in history on success. The
+ * inline script runs under a per-request CSP nonce.
+ */
+function renderInvitePage(nonce: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Accepting invite…</title>
+</head>
+<body>
+<noscript>JavaScript is required to accept this invite.</noscript>
+<p id="status">Accepting invite…</p>
+<script nonce="${nonce}">
+(async () => {
+  const status = document.getElementById('status');
+  const secret = location.hash.slice(1);
+  if (!secret) {
+    status.textContent = 'Invalid invite link.';
+    return;
+  }
+  try {
+    const res = await fetch(location.pathname, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ secret }),
+    });
+    if (res.ok) {
+      location.replace('/');
+    } else {
+      status.textContent = 'This invite is invalid or has already been used.';
+    }
+  } catch (err) {
+    status.textContent = 'Could not reach the server. Please try again.';
+  }
+})();
+</script>
+</body>
+</html>
+`
+}
+
 export async function initApp({
   baseURL,
   clientStaticPath,
@@ -112,17 +159,36 @@ export async function initApp({
     },
   })
 
-  app.get<{ Params: { id: string }; Querystring: { token?: string } }>(
+  // Serve the invite acceptance page. The secret is never in the URL the server
+  // sees: it rides in the fragment and is exchanged by the page via POST.
+  app.get<{ Params: { id: string } }>('/invite/:id', async (_request, reply) => {
+    const nonce = randomBytes(16).toString('base64')
+    reply
+      .header('Referrer-Policy', 'no-referrer')
+      .header(
+        'Content-Security-Policy',
+        `default-src 'none'; script-src 'nonce-${nonce}'; connect-src 'self'; base-uri 'none'; form-action 'none'`,
+      )
+      .type('text/html')
+      .send(renderInvitePage(nonce))
+  })
+
+  // Exchange the invite secret (posted from the acceptance page) for a session
+  // cookie. Same-origin only, single use.
+  app.post<{ Params: { id: string }; Body: { secret?: string } }>(
     '/invite/:id',
     async (request, reply) => {
-      const { id } = request.params
-      const { token } = request.query
-
-      if (!token || typeof token !== 'string') {
+      if (request.headers.origin !== expectedOrigin) {
         return reply.code(403).send()
       }
 
-      const tokenInfo = await auth.validateToken(id, token)
+      const { id } = request.params
+      const secret = request.body?.secret
+      if (!secret || typeof secret !== 'string') {
+        return reply.code(403).send()
+      }
+
+      const tokenInfo = await auth.validateToken(id, secret)
       if (!tokenInfo || tokenInfo.kind !== 'invite') {
         return reply.code(403).send()
       }
@@ -144,8 +210,8 @@ export async function initApp({
         },
       )
 
-      await auth.deleteToken(tokenInfo.tokenId)
-      return reply.redirect('/')
+      auth.deleteToken(tokenInfo.tokenId)
+      return reply.code(204).send()
     },
   )
 

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -7,6 +7,7 @@ import WebSocket from 'ws'
 import * as Y from 'yjs'
 
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 import {
   type AuthTokenInfo,
   type ControlCommandMessage,
@@ -38,6 +39,10 @@ interface StreamwallConnection {
 interface AppOptions {
   baseURL: string
   clientStaticPath: string
+}
+
+interface InitAppOptions extends AppOptions {
+  db?: StorageDB
 }
 
 declare module 'fastify' {
@@ -82,7 +87,11 @@ function queueWebSocketMessages(ws: WebSocket) {
   return setMessageHandler
 }
 
-async function initApp({ baseURL, clientStaticPath }: AppOptions) {
+export async function initApp({
+  baseURL,
+  clientStaticPath,
+  db: providedDb,
+}: InitAppOptions) {
   const expectedOrigin = new URL(baseURL).origin
   const clients = new Map<string, Client>()
   const isSecure = baseURL.startsWith('https')
@@ -90,7 +99,7 @@ async function initApp({ baseURL, clientStaticPath }: AppOptions) {
   let currentStreamwallWs: WebSocket | null = null
   let currentStreamwallConn: StreamwallConnection | null = null
 
-  const db = await loadStorage()
+  const db = providedDb ?? (await loadStorage())
   const auth = new Auth(db.data.auth)
 
   const app = Fastify()
@@ -449,7 +458,7 @@ async function initApp({ baseURL, clientStaticPath }: AppOptions) {
   return { app, db, auth }
 }
 
-async function initialInviteCodes({
+export async function initialInviteCodes({
   db,
   auth,
   baseURL,
@@ -520,11 +529,19 @@ export default async function runServer({
   return { server: app.server }
 }
 
-runServer({
-  hostname: process.env.STREAMWALL_CONTROL_HOSTNAME,
-  port: process.env.STREAMWALL_CONTROL_PORT,
-  baseURL: process.env.STREAMWALL_CONTROL_URL ?? 'http://localhost:3000',
-  clientStaticPath:
-    process.env.STREAMWALL_CONTROL_STATIC ??
-    path.join(import.meta.dirname, '../../streamwall-control-client/dist'),
-})
+// Only boot a server when executed directly (e.g. `tsx ./src/index.ts`), not
+// when imported by tests or other modules.
+const isMainModule =
+  process.argv[1] != null &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+
+if (isMainModule) {
+  runServer({
+    hostname: process.env.STREAMWALL_CONTROL_HOSTNAME,
+    port: process.env.STREAMWALL_CONTROL_PORT,
+    baseURL: process.env.STREAMWALL_CONTROL_URL ?? 'http://localhost:3000',
+    clientStaticPath:
+      process.env.STREAMWALL_CONTROL_STATIC ??
+      path.join(import.meta.dirname, '../../streamwall-control-client/dist'),
+  })
+}

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -161,17 +161,20 @@ export async function initApp({
 
   // Serve the invite acceptance page. The secret is never in the URL the server
   // sees: it rides in the fragment and is exchanged by the page via POST.
-  app.get<{ Params: { id: string } }>('/invite/:id', async (_request, reply) => {
-    const nonce = randomBytes(16).toString('base64')
-    reply
-      .header('Referrer-Policy', 'no-referrer')
-      .header(
-        'Content-Security-Policy',
-        `default-src 'none'; script-src 'nonce-${nonce}'; connect-src 'self'; base-uri 'none'; form-action 'none'`,
-      )
-      .type('text/html')
-      .send(renderInvitePage(nonce))
-  })
+  app.get<{ Params: { id: string } }>(
+    '/invite/:id',
+    async (_request, reply) => {
+      const nonce = randomBytes(16).toString('base64')
+      reply
+        .header('Referrer-Policy', 'no-referrer')
+        .header(
+          'Content-Security-Policy',
+          `default-src 'none'; script-src 'nonce-${nonce}'; connect-src 'self'; base-uri 'none'; form-action 'none'`,
+        )
+        .type('text/html')
+        .send(renderInvitePage(nonce))
+    },
+  )
 
   // Exchange the invite secret (posted from the acceptance page) for a session
   // cookie. Same-origin only, single use.
@@ -215,148 +218,144 @@ export async function initApp({
     },
   )
 
-  app.get(
-    '/streamwall/ws',
-    { websocket: true },
-    async (ws, request) => {
-      ws.binaryType = 'arraybuffer'
-      const handleMessage = queueWebSocketMessages(ws)
+  app.get('/streamwall/ws', { websocket: true }, async (ws, request) => {
+    ws.binaryType = 'arraybuffer'
+    const handleMessage = queueWebSocketMessages(ws)
 
-      // The uplink authenticates with an Authorization: Bearer header so the
-      // secret never appears in the URL (and thus never in access logs).
-      const credential = parseBearerCredential(request.headers.authorization)
-      if (!credential) {
-        ws.send(JSON.stringify({ error: 'unauthorized' }))
-        ws.close()
-        return
-      }
+    // The uplink authenticates with an Authorization: Bearer header so the
+    // secret never appears in the URL (and thus never in access logs).
+    const credential = parseBearerCredential(request.headers.authorization)
+    if (!credential) {
+      ws.send(JSON.stringify({ error: 'unauthorized' }))
+      ws.close()
+      return
+    }
 
-      const tokenInfo = await auth.validateToken(
-        credential.tokenId,
-        credential.secret,
+    const tokenInfo = await auth.validateToken(
+      credential.tokenId,
+      credential.secret,
+    )
+    if (!tokenInfo || tokenInfo.kind !== 'streamwall') {
+      ws.send(JSON.stringify({ error: 'unauthorized' }))
+      ws.close()
+      return
+    }
+
+    if (currentStreamwallWs != null) {
+      console.warn(
+        'Rejecting Streamwall connection (already connected) from',
+        request.ip,
+        tokenInfo,
       )
-      if (!tokenInfo || tokenInfo.kind !== 'streamwall') {
-        ws.send(JSON.stringify({ error: 'unauthorized' }))
-        ws.close()
-        return
-      }
+      ws.send(JSON.stringify({ error: 'streamwall already connected' }))
+      ws.close()
+      return
+    }
 
-      if (currentStreamwallWs != null) {
-        console.warn(
-          'Rejecting Streamwall connection (already connected) from',
-          request.ip,
-          tokenInfo,
-        )
-        ws.send(JSON.stringify({ error: 'streamwall already connected' }))
-        ws.close()
-        return
-      }
+    currentStreamwallWs = ws
 
-      currentStreamwallWs = ws
-
-      const pingInterval = setInterval(() => {
-        ws.ping()
-        const pongTimeout = setTimeout(() => {
-          if (ws.readyState === ws.OPEN) {
-            console.warn(
-              `Streamwall timeout: no pong within ${STREAMWALL_PING_TIMEOUT_MS}ms. Closing connection.`,
-            )
-            ws.terminate()
-          }
-        }, STREAMWALL_PING_TIMEOUT_MS)
-        ws.once('pong', () => {
-          clearTimeout(pongTimeout)
-        })
+    const pingInterval = setInterval(() => {
+      ws.ping()
+      const pongTimeout = setTimeout(() => {
+        if (ws.readyState === ws.OPEN) {
+          console.warn(
+            `Streamwall timeout: no pong within ${STREAMWALL_PING_TIMEOUT_MS}ms. Closing connection.`,
+          )
+          ws.terminate()
+        }
       }, STREAMWALL_PING_TIMEOUT_MS)
-
-      ws.on('close', () => {
-        console.log('Streamwall disconnected')
-        currentStreamwallWs = null
-        currentStreamwallConn = null
-        clearInterval(pingInterval)
-
-        for (const client of clients.values()) {
-          client.ws.close()
-        }
+      ws.once('pong', () => {
+        clearTimeout(pongTimeout)
       })
+    }, STREAMWALL_PING_TIMEOUT_MS)
 
-      let clientState: StateWrapper | null = null
-      const stateDoc = new Y.Doc()
+    ws.on('close', () => {
+      console.log('Streamwall disconnected')
+      currentStreamwallWs = null
+      currentStreamwallConn = null
+      clearInterval(pingInterval)
 
-      console.log('Streamwall connecting from', request.ip, tokenInfo)
+      for (const client of clients.values()) {
+        client.ws.close()
+      }
+    })
 
-      handleMessage((rawData) => {
-        if (rawData instanceof ArrayBuffer) {
-          Y.applyUpdate(stateDoc, new Uint8Array(rawData))
-          return
-        }
+    let clientState: StateWrapper | null = null
+    const stateDoc = new Y.Doc()
 
-        let msg: ControlUpdateMessage
+    console.log('Streamwall connecting from', request.ip, tokenInfo)
 
-        try {
-          msg = JSON.parse(rawData.toString())
-        } catch (err) {
-          console.warn('Received unexpected ws data: ', rawData.length, 'bytes')
-          return
-        }
+    handleMessage((rawData) => {
+      if (rawData instanceof ArrayBuffer) {
+        Y.applyUpdate(stateDoc, new Uint8Array(rawData))
+        return
+      }
 
-        try {
-          if (msg.type === 'state') {
-            if (clientState === null) {
-              clientState = new StateWrapper(msg.state)
-              clientState.update({ auth: auth.getState() })
-              currentStreamwallConn = {
-                ws,
-                clientState,
-                stateDoc,
-              }
+      let msg: ControlUpdateMessage
 
-              console.log('Streamwall connected from', request.ip, tokenInfo)
-            } else {
-              clientState.update(msg.state)
+      try {
+        msg = JSON.parse(rawData.toString())
+      } catch (err) {
+        console.warn('Received unexpected ws data: ', rawData.length, 'bytes')
+        return
+      }
+
+      try {
+        if (msg.type === 'state') {
+          if (clientState === null) {
+            clientState = new StateWrapper(msg.state)
+            clientState.update({ auth: auth.getState() })
+            currentStreamwallConn = {
+              ws,
+              clientState,
+              stateDoc,
             }
 
-            for (const client of clients.values()) {
-              try {
-                if (client.ws.readyState !== WebSocket.OPEN) {
-                  continue
-                }
-                const stateView = clientState.view(client.identity.role)
-                const delta = stateDiff.diff(client.lastStateSent, stateView)
-                if (!delta) {
-                  continue
-                }
-                client.ws.send(JSON.stringify({ type: 'state-delta', delta }))
-                client.lastStateSent = stateView
-              } catch (err) {
-                console.error('failed to send client state delta', client)
+            console.log('Streamwall connected from', request.ip, tokenInfo)
+          } else {
+            clientState.update(msg.state)
+          }
+
+          for (const client of clients.values()) {
+            try {
+              if (client.ws.readyState !== WebSocket.OPEN) {
+                continue
               }
+              const stateView = clientState.view(client.identity.role)
+              const delta = stateDiff.diff(client.lastStateSent, stateView)
+              if (!delta) {
+                continue
+              }
+              client.ws.send(JSON.stringify({ type: 'state-delta', delta }))
+              client.lastStateSent = stateView
+            } catch (err) {
+              console.error('failed to send client state delta', client)
             }
           }
-        } catch (err) {
-          console.error('Failed to handle ws message:', rawData, err)
         }
-      })
+      } catch (err) {
+        console.error('Failed to handle ws message:', rawData, err)
+      }
+    })
 
-      stateDoc.on('update', (update, origin) => {
+    stateDoc.on('update', (update, origin) => {
+      try {
+        ws.send(update)
+      } catch (err) {
+        console.error('Failed to send Streamwall doc update')
+      }
+      for (const client of clients.values()) {
+        if (client.clientId === origin) {
+          continue
+        }
         try {
-          ws.send(update)
+          client.ws.send(update)
         } catch (err) {
-          console.error('Failed to send Streamwall doc update')
+          console.error('Failed to send client doc update:', client)
         }
-        for (const client of clients.values()) {
-          if (client.clientId === origin) {
-            continue
-          }
-          try {
-            client.ws.send(update)
-          } catch (err) {
-            console.error('Failed to send client doc update:', client)
-          }
-        }
-      })
-    },
-  )
+      }
+    })
+  })
 
   // Authenticated client routes
   app.register(async function (fastify) {

--- a/packages/streamwall-control-server/src/initialInvite.test.ts
+++ b/packages/streamwall-control-server/src/initialInvite.test.ts
@@ -13,7 +13,11 @@ async function makeAuthDb() {
   const dir = mkdtempSync(path.join(tmpdir(), 'swcs-invite-'))
   const db = await loadStorage(path.join(dir, 'storage.json'))
   const auth = new Auth(db.data.auth)
-  return { db, auth, cleanup: () => rmSync(dir, { recursive: true, force: true }) }
+  return {
+    db,
+    auth,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  }
 }
 
 async function runCapturing(args: {
@@ -45,7 +49,11 @@ describe('initialInviteCodes admin bootstrap', () => {
   test('mints and logs an admin invite on first run', async () => {
     const { db, auth, cleanup } = await makeAuthDb()
     try {
-      const logs = await runCapturing({ db, auth, baseURL: 'http://localhost:3000' })
+      const logs = await runCapturing({
+        db,
+        auth,
+        baseURL: 'http://localhost:3000',
+      })
       assert.equal(adminInvites(auth).length, 1)
       assert.equal(loggedInviteLinks(logs).length, 1)
     } finally {
@@ -57,7 +65,11 @@ describe('initialInviteCodes admin bootstrap', () => {
     const { db, auth, cleanup } = await makeAuthDb()
     try {
       await auth.createToken({ kind: 'session', role: 'admin', name: 'Admin' })
-      const logs = await runCapturing({ db, auth, baseURL: 'http://localhost:3000' })
+      const logs = await runCapturing({
+        db,
+        auth,
+        baseURL: 'http://localhost:3000',
+      })
       assert.equal(adminInvites(auth).length, 0)
       assert.equal(loggedInviteLinks(logs).length, 0)
     } finally {
@@ -74,8 +86,16 @@ describe('initialInviteCodes admin bootstrap', () => {
         baseURL: 'http://localhost:3000',
         log: () => {},
       })
-      const logs = await runCapturing({ db, auth, baseURL: 'http://localhost:3000' })
-      assert.equal(adminInvites(auth).length, 1, 'must not duplicate the invite')
+      const logs = await runCapturing({
+        db,
+        auth,
+        baseURL: 'http://localhost:3000',
+      })
+      assert.equal(
+        adminInvites(auth).length,
+        1,
+        'must not duplicate the invite',
+      )
       assert.equal(
         loggedInviteLinks(logs).length,
         0,
@@ -91,7 +111,11 @@ describe('initialInviteCodes admin bootstrap', () => {
     try {
       await auth.createToken({ kind: 'session', role: 'admin', name: 'Admin' })
       process.env[ENV_KEY] = '1'
-      const logs = await runCapturing({ db, auth, baseURL: 'http://localhost:3000' })
+      const logs = await runCapturing({
+        db,
+        auth,
+        baseURL: 'http://localhost:3000',
+      })
       assert.equal(adminInvites(auth).length, 1)
       assert.equal(loggedInviteLinks(logs).length, 1)
     } finally {

--- a/packages/streamwall-control-server/src/initialInvite.test.ts
+++ b/packages/streamwall-control-server/src/initialInvite.test.ts
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, test } from 'node:test'
+import { Auth } from './auth.ts'
+import { initialInviteCodes } from './index.ts'
+import { loadStorage } from './storage.ts'
+
+const ENV_KEY = 'STREAMWALL_CONTROL_NEW_ADMIN_INVITE'
+
+async function makeAuthDb() {
+  const dir = mkdtempSync(path.join(tmpdir(), 'swcs-invite-'))
+  const db = await loadStorage(path.join(dir, 'storage.json'))
+  const auth = new Auth(db.data.auth)
+  return { db, auth, cleanup: () => rmSync(dir, { recursive: true, force: true }) }
+}
+
+async function runCapturing(args: {
+  db: Awaited<ReturnType<typeof makeAuthDb>>['db']
+  auth: Auth
+  baseURL: string
+}): Promise<string[]> {
+  const logs: string[] = []
+  await initialInviteCodes({
+    ...args,
+    log: (...a: unknown[]) => logs.push(a.map(String).join(' ')),
+  })
+  return logs
+}
+
+function adminInvites(auth: Auth) {
+  return auth.getState().invites.filter((t) => t.role === 'admin')
+}
+
+function loggedInviteLinks(logs: string[]) {
+  return logs.filter((line) => line.includes('/invite/'))
+}
+
+describe('initialInviteCodes admin bootstrap', () => {
+  afterEach(() => {
+    delete process.env[ENV_KEY]
+  })
+
+  test('mints and logs an admin invite on first run', async () => {
+    const { db, auth, cleanup } = await makeAuthDb()
+    try {
+      const logs = await runCapturing({ db, auth, baseURL: 'http://localhost:3000' })
+      assert.equal(adminInvites(auth).length, 1)
+      assert.equal(loggedInviteLinks(logs).length, 1)
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('does not mint or log a new admin invite when an admin session exists', async () => {
+    const { db, auth, cleanup } = await makeAuthDb()
+    try {
+      await auth.createToken({ kind: 'session', role: 'admin', name: 'Admin' })
+      const logs = await runCapturing({ db, auth, baseURL: 'http://localhost:3000' })
+      assert.equal(adminInvites(auth).length, 0)
+      assert.equal(loggedInviteLinks(logs).length, 0)
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('does not reprint or duplicate a still-pending admin invite on restart', async () => {
+    const { db, auth, cleanup } = await makeAuthDb()
+    try {
+      await initialInviteCodes({
+        db,
+        auth,
+        baseURL: 'http://localhost:3000',
+        log: () => {},
+      })
+      const logs = await runCapturing({ db, auth, baseURL: 'http://localhost:3000' })
+      assert.equal(adminInvites(auth).length, 1, 'must not duplicate the invite')
+      assert.equal(
+        loggedInviteLinks(logs).length,
+        0,
+        'the secret must not be reprinted',
+      )
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('env flag forces a fresh admin invite even when an admin session exists', async () => {
+    const { db, auth, cleanup } = await makeAuthDb()
+    try {
+      await auth.createToken({ kind: 'session', role: 'admin', name: 'Admin' })
+      process.env[ENV_KEY] = '1'
+      const logs = await runCapturing({ db, auth, baseURL: 'http://localhost:3000' })
+      assert.equal(adminInvites(auth).length, 1)
+      assert.equal(loggedInviteLinks(logs).length, 1)
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('reuses the persisted uplink token across restarts', async () => {
+    const { db, auth, cleanup } = await makeAuthDb()
+    try {
+      await initialInviteCodes({
+        db,
+        auth,
+        baseURL: 'http://localhost:3000',
+        log: () => {},
+      })
+      const firstTokenId = db.data.streamwallToken?.tokenId
+      assert.ok(firstTokenId)
+
+      await initialInviteCodes({
+        db,
+        auth,
+        baseURL: 'http://localhost:3000',
+        log: () => {},
+      })
+      assert.equal(db.data.streamwallToken?.tokenId, firstTokenId)
+    } finally {
+      cleanup()
+    }
+  })
+})

--- a/packages/streamwall-control-server/src/invite.test.ts
+++ b/packages/streamwall-control-server/src/invite.test.ts
@@ -40,7 +40,9 @@ describe('GET /invite/:id (acceptance page)', () => {
 })
 
 describe('POST /invite/:id (exchange)', () => {
-  async function makeInvite(auth: Awaited<ReturnType<typeof createTestApp>>['auth']) {
+  async function makeInvite(
+    auth: Awaited<ReturnType<typeof createTestApp>>['auth'],
+  ) {
     return auth.createToken({ kind: 'invite', role: 'operator', name: 'Op' })
   }
 

--- a/packages/streamwall-control-server/src/invite.test.ts
+++ b/packages/streamwall-control-server/src/invite.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import { inviteLink } from 'streamwall-shared'
+import { SESSION_COOKIE_NAME } from './index.ts'
+import { createTestApp } from './testHelpers.ts'
+
+describe('inviteLink', () => {
+  test('carries the secret in the URL fragment, never the query string', () => {
+    const link = inviteLink({
+      baseURL: 'https://host',
+      tokenId: 'abc',
+      secret: 's3cr3t',
+    })
+    assert.equal(link, 'https://host/invite/abc#s3cr3t')
+    assert.ok(!link.includes('?'), 'secret must not be in a query string')
+  })
+})
+
+describe('GET /invite/:id (acceptance page)', () => {
+  test('serves a JS exchange page with no secret and hardened headers', async () => {
+    const { app, cleanup } = await createTestApp()
+    try {
+      const res = await app.inject({ method: 'GET', url: '/invite/whatever' })
+      assert.equal(res.statusCode, 200)
+      assert.match(res.headers['content-type'] as string, /text\/html/)
+      assert.equal(res.headers['referrer-policy'], 'no-referrer')
+
+      const csp = res.headers['content-security-policy'] as string
+      assert.ok(csp, 'a Content-Security-Policy must be set')
+      assert.match(csp, /script-src 'nonce-/)
+
+      // The page reads the fragment client-side and exchanges it via POST.
+      assert.match(res.body, /location\.hash/)
+      assert.match(res.body, /fetch\(/)
+      assert.match(res.body, /<noscript>/)
+    } finally {
+      await cleanup()
+    }
+  })
+})
+
+describe('POST /invite/:id (exchange)', () => {
+  async function makeInvite(auth: Awaited<ReturnType<typeof createTestApp>>['auth']) {
+    return auth.createToken({ kind: 'invite', role: 'operator', name: 'Op' })
+  }
+
+  test('exchanges a valid same-origin secret for a session cookie', async () => {
+    const t = await createTestApp()
+    try {
+      const { tokenId, secret } = await makeInvite(t.auth)
+      const res = await t.app.inject({
+        method: 'POST',
+        url: `/invite/${tokenId}`,
+        headers: { origin: new URL(t.baseURL).origin },
+        payload: { secret },
+      })
+      assert.equal(res.statusCode, 204)
+      const cookie = res.headers['set-cookie']
+      assert.ok(cookie, 'a session cookie must be set')
+      assert.match(String(cookie), new RegExp(`${SESSION_COOKIE_NAME}=`))
+      assert.match(String(cookie), /HttpOnly/i)
+    } finally {
+      await t.cleanup()
+    }
+  })
+
+  test('rejects a second use of the same (now consumed) invite', async () => {
+    const t = await createTestApp()
+    try {
+      const { tokenId, secret } = await makeInvite(t.auth)
+      const origin = new URL(t.baseURL).origin
+      const first = await t.app.inject({
+        method: 'POST',
+        url: `/invite/${tokenId}`,
+        headers: { origin },
+        payload: { secret },
+      })
+      assert.equal(first.statusCode, 204)
+
+      const second = await t.app.inject({
+        method: 'POST',
+        url: `/invite/${tokenId}`,
+        headers: { origin },
+        payload: { secret },
+      })
+      assert.equal(second.statusCode, 403)
+    } finally {
+      await t.cleanup()
+    }
+  })
+
+  test('rejects a wrong secret', async () => {
+    const t = await createTestApp()
+    try {
+      const { tokenId } = await makeInvite(t.auth)
+      const res = await t.app.inject({
+        method: 'POST',
+        url: `/invite/${tokenId}`,
+        headers: { origin: new URL(t.baseURL).origin },
+        payload: { secret: 'not-the-secret' },
+      })
+      assert.equal(res.statusCode, 403)
+    } finally {
+      await t.cleanup()
+    }
+  })
+
+  test('rejects a cross-origin request', async () => {
+    const t = await createTestApp()
+    try {
+      const { tokenId, secret } = await makeInvite(t.auth)
+      const res = await t.app.inject({
+        method: 'POST',
+        url: `/invite/${tokenId}`,
+        headers: { origin: 'https://evil.example.com' },
+        payload: { secret },
+      })
+      assert.equal(res.statusCode, 403)
+    } finally {
+      await t.cleanup()
+    }
+  })
+
+  test('rejects a missing secret', async () => {
+    const t = await createTestApp()
+    try {
+      const { tokenId } = await makeInvite(t.auth)
+      const res = await t.app.inject({
+        method: 'POST',
+        url: `/invite/${tokenId}`,
+        headers: { origin: new URL(t.baseURL).origin },
+        payload: {},
+      })
+      assert.equal(res.statusCode, 403)
+    } finally {
+      await t.cleanup()
+    }
+  })
+})

--- a/packages/streamwall-control-server/src/server.test.ts
+++ b/packages/streamwall-control-server/src/server.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { createTestApp } from './testHelpers.ts'
+
+test('initApp builds an injectable app without listening on a port', async () => {
+  const { app, cleanup } = await createTestApp()
+  try {
+    const res = await app.inject({ method: 'GET', url: '/does-not-exist' })
+    assert.equal(res.statusCode, 404)
+  } finally {
+    await cleanup()
+  }
+})

--- a/packages/streamwall-control-server/src/storage.test.ts
+++ b/packages/streamwall-control-server/src/storage.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { test } from 'node:test'
+import { loadStorage } from './storage.ts'
+
+function withTempStorage(contents: unknown) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'swcs-storage-'))
+  const file = path.join(dir, 'storage.json')
+  writeFileSync(file, JSON.stringify(contents))
+  return {
+    file,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  }
+}
+
+test('loadStorage strips a legacy plaintext uplink secret from memory and disk', async () => {
+  const { file, cleanup } = withTempStorage({
+    auth: { salt: 'abc', tokens: [] },
+    streamwallToken: { tokenId: 'sw-token-id', secret: 'PLAINTEXT-SECRET' },
+  })
+  try {
+    const db = await loadStorage(file)
+
+    // In memory: only the tokenId reference remains.
+    assert.deepEqual(db.data.streamwallToken, { tokenId: 'sw-token-id' })
+
+    // On disk: the plaintext secret has been rewritten away.
+    const onDisk = JSON.parse(readFileSync(file, 'utf8'))
+    assert.deepEqual(onDisk.streamwallToken, { tokenId: 'sw-token-id' })
+    assert.ok(
+      !readFileSync(file, 'utf8').includes('PLAINTEXT-SECRET'),
+      'plaintext secret still present on disk',
+    )
+  } finally {
+    cleanup()
+  }
+})
+
+test('loadStorage leaves a hash-only uplink reference untouched', async () => {
+  const { file, cleanup } = withTempStorage({
+    auth: { salt: 'abc', tokens: [] },
+    streamwallToken: { tokenId: 'sw-token-id' },
+  })
+  try {
+    const db = await loadStorage(file)
+    assert.deepEqual(db.data.streamwallToken, { tokenId: 'sw-token-id' })
+  } finally {
+    cleanup()
+  }
+})

--- a/packages/streamwall-control-server/src/storage.ts
+++ b/packages/streamwall-control-server/src/storage.ts
@@ -24,8 +24,9 @@ const defaultData: StoredData = {
 
 export type StorageDB = Low<StoredData>
 
-export async function loadStorage() {
-  const dbPath = process.env.DB_PATH || 'storage.json'
+export async function loadStorage(
+  dbPath: string = process.env.DB_PATH || 'storage.json',
+) {
   const db = await JSONFilePreset<StoredData>(dbPath, defaultData)
   return db
 }

--- a/packages/streamwall-control-server/src/storage.ts
+++ b/packages/streamwall-control-server/src/storage.ts
@@ -8,9 +8,10 @@ export interface StoredData {
     salt: string | null
     tokens: AuthToken[]
   }
+  // Only a reference to the uplink token id is persisted. The token's scrypt
+  // hash already lives in `auth.tokens`; the plaintext secret is never stored.
   streamwallToken: null | {
     tokenId: string
-    secret: string
   }
 }
 
@@ -28,5 +29,22 @@ export async function loadStorage(
   dbPath: string = process.env.DB_PATH || 'storage.json',
 ) {
   const db = await JSONFilePreset<StoredData>(dbPath, defaultData)
+  await migrateStorage(db)
   return db
+}
+
+/**
+ * One-way migration that purges secrets that older versions persisted in the
+ * clear. A legacy `streamwallToken.secret` is dropped; the token keeps working
+ * because it is validated against its scrypt hash in `auth.tokens`.
+ */
+async function migrateStorage(db: StorageDB) {
+  const token = db.data.streamwallToken as
+    | { tokenId: string; secret?: string }
+    | null
+  if (token && 'secret' in token) {
+    await db.update((data) => {
+      data.streamwallToken = { tokenId: token.tokenId }
+    })
+  }
 }

--- a/packages/streamwall-control-server/src/storage.ts
+++ b/packages/streamwall-control-server/src/storage.ts
@@ -39,9 +39,10 @@ export async function loadStorage(
  * because it is validated against its scrypt hash in `auth.tokens`.
  */
 async function migrateStorage(db: StorageDB) {
-  const token = db.data.streamwallToken as
-    | { tokenId: string; secret?: string }
-    | null
+  const token = db.data.streamwallToken as {
+    tokenId: string
+    secret?: string
+  } | null
   if (token && 'secret' in token) {
     await db.update((data) => {
       data.streamwallToken = { tokenId: token.tokenId }

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -2,12 +2,14 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import type { FastifyInstance } from 'fastify'
+import type { Auth } from './auth.ts'
 import { initApp } from './index.ts'
 import { loadStorage, type StorageDB } from './storage.ts'
 
 export interface TestApp {
   app: FastifyInstance
   db: StorageDB
+  auth: Auth
   baseURL: string
   cleanup: () => Promise<void>
 }
@@ -28,12 +30,16 @@ export async function createTestApp(
 
   const db = await loadStorage(dbPath)
   const baseURL = opts.baseURL ?? 'http://localhost:3000'
-  const { app } = await initApp({ baseURL, clientStaticPath: staticDir, db })
+  const { app, auth } = await initApp({
+    baseURL,
+    clientStaticPath: staticDir,
+    db,
+  })
 
   const cleanup = async () => {
     await app.close()
     rmSync(dir, { recursive: true, force: true })
   }
 
-  return { app, db, baseURL, cleanup }
+  return { app, db, auth, baseURL, cleanup }
 }

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -1,6 +1,7 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
 import type { FastifyInstance } from 'fastify'
 import type { Auth } from './auth.ts'
 import { initApp } from './index.ts'
@@ -36,8 +37,15 @@ export async function createTestApp(
     db,
   })
 
+  // lowdb writes atomically via a sibling temp file; while it exists a write is
+  // in flight. Auth-state changes persist through fire-and-forget writes, so
+  // wait for them to drain before removing the dir to avoid a deletion race.
+  const tmpFile = path.join(path.dirname(dbPath), `.${path.basename(dbPath)}.tmp`)
   const cleanup = async () => {
     await app.close()
+    for (let i = 0; i < 100 && existsSync(tmpFile); i++) {
+      await delay(5)
+    }
     rmSync(dir, { recursive: true, force: true })
   }
 

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -1,0 +1,39 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import type { FastifyInstance } from 'fastify'
+import { initApp } from './index.ts'
+import { loadStorage, type StorageDB } from './storage.ts'
+
+export interface TestApp {
+  app: FastifyInstance
+  db: StorageDB
+  baseURL: string
+  cleanup: () => Promise<void>
+}
+
+/**
+ * Build an isolated control-server app backed by a throwaway temp-file database
+ * and a temp static directory. Never listens on a port; use `app.inject()` for
+ * HTTP and `app.listen({ port: 0 })` for WebSocket tests.
+ */
+export async function createTestApp(
+  opts: { baseURL?: string } = {},
+): Promise<TestApp> {
+  const dir = mkdtempSync(path.join(tmpdir(), 'swcs-test-'))
+  const dbPath = path.join(dir, 'storage.json')
+  const staticDir = path.join(dir, 'static')
+  mkdirSync(staticDir)
+  writeFileSync(path.join(staticDir, 'index.html'), '<!doctype html>\n')
+
+  const db = await loadStorage(dbPath)
+  const baseURL = opts.baseURL ?? 'http://localhost:3000'
+  const { app } = await initApp({ baseURL, clientStaticPath: staticDir, db })
+
+  const cleanup = async () => {
+    await app.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+
+  return { app, db, baseURL, cleanup }
+}

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -1,8 +1,14 @@
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import type { FastifyInstance } from 'fastify'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
-import type { FastifyInstance } from 'fastify'
 import type { Auth } from './auth.ts'
 import { initApp } from './index.ts'
 import { loadStorage, type StorageDB } from './storage.ts'
@@ -40,7 +46,10 @@ export async function createTestApp(
   // lowdb writes atomically via a sibling temp file; while it exists a write is
   // in flight. Auth-state changes persist through fire-and-forget writes, so
   // wait for them to drain before removing the dir to avoid a deletion race.
-  const tmpFile = path.join(path.dirname(dbPath), `.${path.basename(dbPath)}.tmp`)
+  const tmpFile = path.join(
+    path.dirname(dbPath),
+    `.${path.basename(dbPath)}.tmp`,
+  )
   const cleanup = async () => {
     await app.close()
     for (let i = 0; i < 100 && existsSync(tmpFile); i++) {

--- a/packages/streamwall-control-server/src/uplink.test.ts
+++ b/packages/streamwall-control-server/src/uplink.test.ts
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict'
+import type { AddressInfo } from 'node:net'
+import { describe, test } from 'node:test'
+import WebSocket from 'ws'
+import { createTestApp, type TestApp } from './testHelpers.ts'
+
+interface Outcome {
+  messages: string[]
+  closed: boolean
+}
+
+/** Collect messages until the socket closes or the window elapses. */
+function observe(ws: WebSocket, ms: number): Promise<Outcome> {
+  return new Promise((resolve) => {
+    const messages: string[] = []
+    let done = false
+    const finish = (closed: boolean) => {
+      if (done) return
+      done = true
+      clearTimeout(timer)
+      resolve({ messages, closed })
+    }
+    ws.on('message', (d) => messages.push(d.toString()))
+    ws.on('close', () => finish(true))
+    ws.on('error', () => {
+      // A rejected upgrade surfaces as an error; the close handler resolves.
+    })
+    const timer = setTimeout(() => finish(false), ms)
+  })
+}
+
+async function listen(test: TestApp): Promise<string> {
+  await test.app.listen({ port: 0, host: '127.0.0.1' })
+  const { port } = test.app.server.address() as AddressInfo
+  return `ws://127.0.0.1:${port}/streamwall/ws`
+}
+
+function isUnauthorized(outcome: Outcome): boolean {
+  return outcome.messages.some((raw) => {
+    try {
+      return JSON.parse(raw).error === 'unauthorized'
+    } catch {
+      return false
+    }
+  })
+}
+
+describe('streamwall uplink authentication', () => {
+  test('accepts a valid Authorization bearer credential', async () => {
+    const t = await createTestApp()
+    try {
+      const { tokenId, secret } = await t.auth.createToken({
+        kind: 'streamwall',
+        role: 'admin',
+        name: 'Streamwall',
+      })
+      const url = await listen(t)
+      const ws = new WebSocket(url, {
+        headers: { Authorization: `Bearer ${tokenId}:${secret}` },
+      })
+      const outcome = await observe(ws, 300)
+      ws.close()
+
+      assert.equal(
+        isUnauthorized(outcome),
+        false,
+        'valid credential must not be rejected',
+      )
+      assert.equal(outcome.closed, false, 'connection should stay open')
+    } finally {
+      await t.cleanup()
+    }
+  })
+
+  test('rejects a missing Authorization header', async () => {
+    const t = await createTestApp()
+    try {
+      await t.auth.createToken({
+        kind: 'streamwall',
+        role: 'admin',
+        name: 'Streamwall',
+      })
+      const url = await listen(t)
+      const ws = new WebSocket(url)
+      const outcome = await observe(ws, 1000)
+
+      assert.ok(isUnauthorized(outcome), 'missing header must be unauthorized')
+    } finally {
+      await t.cleanup()
+    }
+  })
+
+  test('rejects a wrong secret', async () => {
+    const t = await createTestApp()
+    try {
+      const { tokenId } = await t.auth.createToken({
+        kind: 'streamwall',
+        role: 'admin',
+        name: 'Streamwall',
+      })
+      const url = await listen(t)
+      const ws = new WebSocket(url, {
+        headers: { Authorization: `Bearer ${tokenId}:wrong-secret` },
+      })
+      const outcome = await observe(ws, 1000)
+
+      assert.ok(isUnauthorized(outcome), 'wrong secret must be unauthorized')
+    } finally {
+      await t.cleanup()
+    }
+  })
+
+  test('rejects a non-streamwall token', async () => {
+    const t = await createTestApp()
+    try {
+      const { tokenId, secret } = await t.auth.createToken({
+        kind: 'session',
+        role: 'admin',
+        name: 'Session',
+      })
+      const url = await listen(t)
+      const ws = new WebSocket(url, {
+        headers: { Authorization: `Bearer ${tokenId}:${secret}` },
+      })
+      const outcome = await observe(ws, 1000)
+
+      assert.ok(
+        isUnauthorized(outcome),
+        'a non-streamwall token must be unauthorized',
+      )
+    } finally {
+      await t.cleanup()
+    }
+  })
+})

--- a/packages/streamwall-shared/src/control.ts
+++ b/packages/streamwall-shared/src/control.ts
@@ -1,0 +1,99 @@
+// Credential format shared by the two ends of the Streamwall uplink protocol.
+//
+// The uplink authenticates with an `Authorization: Bearer <tokenId>:<secret>`
+// header instead of a URL query string, so the secret never lands in access
+// logs, browser history, or the Referer header.
+
+export interface ControlCredential {
+  tokenId: string
+  secret: string
+}
+
+/** Serialize a credential into the `<tokenId>:<secret>` bearer value. */
+export function formatBearerCredential({
+  tokenId,
+  secret,
+}: ControlCredential): string {
+  return `${tokenId}:${secret}`
+}
+
+/**
+ * Parse an `Authorization: Bearer <tokenId>:<secret>` header value. Returns
+ * null for anything malformed (missing scheme, missing separator, empty parts).
+ * Token ids and secrets are base62 and never contain a colon, so the split is
+ * unambiguous on the first `:`.
+ */
+export function parseBearerCredential(
+  header: string | undefined | null,
+): ControlCredential | null {
+  if (!header) {
+    return null
+  }
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim())
+  if (!match) {
+    return null
+  }
+  const value = match[1]
+  const sep = value.indexOf(':')
+  if (sep <= 0 || sep >= value.length - 1) {
+    return null
+  }
+  return { tokenId: value.slice(0, sep), secret: value.slice(sep + 1) }
+}
+
+export interface ResolvedControlConnection {
+  /** WebSocket endpoint with no embedded credentials. */
+  endpoint: string
+  /** `<tokenId>:<secret>` value for the Authorization header. */
+  credential: string
+  /** True when derived from a deprecated token-in-URL endpoint. */
+  legacy: boolean
+}
+
+/**
+ * Normalize control-server connection config into a clean endpoint plus a
+ * bearer credential. Accepts the modern form (separate endpoint + token) and
+ * the deprecated form where the endpoint embeds `/streamwall/<id>/ws?token=`.
+ * Returns null when no usable credential is available.
+ */
+export function resolveControlConnection({
+  endpoint,
+  token,
+}: {
+  endpoint?: string | null
+  token?: string | null
+}): ResolvedControlConnection | null {
+  if (!endpoint) {
+    return null
+  }
+
+  let url: URL
+  try {
+    url = new URL(endpoint)
+  } catch {
+    // Not a parseable URL: fall back to using it verbatim with an explicit token.
+    return token ? { endpoint, credential: token, legacy: false } : null
+  }
+
+  const legacySecret = url.searchParams.get('token')
+  if (legacySecret != null) {
+    const segments = url.pathname.split('/').filter(Boolean)
+    let tokenId: string | null = null
+    if (
+      segments.length >= 3 &&
+      segments[0] === 'streamwall' &&
+      segments[segments.length - 1] === 'ws'
+    ) {
+      tokenId = segments[segments.length - 2]
+    }
+    url.searchParams.delete('token')
+    url.pathname = '/streamwall/ws'
+    const credential = tokenId ? `${tokenId}:${legacySecret}` : legacySecret
+    return { endpoint: url.toString(), credential, legacy: true }
+  }
+
+  if (!token) {
+    return null
+  }
+  return { endpoint, credential: token, legacy: false }
+}

--- a/packages/streamwall-shared/src/index.ts
+++ b/packages/streamwall-shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from './colors.ts'
+export * from './control.ts'
 export * from './geometry.ts'
 export * from './grid.ts'
 export * from './roles.ts'

--- a/packages/streamwall-shared/src/roles.ts
+++ b/packages/streamwall-shared/src/roles.ts
@@ -57,5 +57,8 @@ export function inviteLink({
   tokenId: string
   secret: string
 }) {
-  return `${baseURL}/invite/${tokenId}?token=${secret}`
+  // The secret lives in the URL fragment, which is never sent to the server.
+  // The acceptance page reads it client-side and exchanges it via POST, keeping
+  // the secret out of access logs, browser history, and the Referer header.
+  return `${baseURL}/invite/${tokenId}#${secret}`
 }

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -8,7 +8,11 @@ import EventEmitter from 'node:events'
 import { join } from 'node:path'
 import ReconnectingWebSocket from 'reconnecting-websocket'
 import 'source-map-support/register'
-import { StreamwallState, resolveGridDimensions } from 'streamwall-shared'
+import {
+  resolveControlConnection,
+  resolveGridDimensions,
+  StreamwallState,
+} from 'streamwall-shared'
 import { updateElectronApp } from 'update-electron-app'
 import WebSocket from 'ws'
 import yargs from 'yargs'
@@ -61,6 +65,7 @@ export interface StreamwallConfig {
   }
   control: {
     endpoint: string
+    token: string | null
   }
   twitch: {
     channel: string | null
@@ -184,9 +189,15 @@ function parseArgs(): StreamwallConfig {
         describe: 'Streamdelay API key',
         default: null,
       })
-      .group(['control'], 'Remote Control')
+      .group(['control.endpoint', 'control.token'], 'Remote Control')
       .option('control.endpoint', {
-        describe: 'URL of control server endpoint',
+        describe:
+          'WebSocket URL of the control server uplink (e.g. wss://host/streamwall/ws)',
+        default: null,
+      })
+      .option('control.token', {
+        describe:
+          'Control server uplink token in "<tokenId>:<secret>" form (sent as an Authorization header)',
         default: null,
       })
       .group(
@@ -486,10 +497,29 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     process.exit(0)
   })
 
-  if (argv.control.endpoint) {
+  const control = resolveControlConnection({
+    endpoint: argv.control.endpoint,
+    token: argv.control.token,
+  })
+  if (control) {
+    if (control.legacy) {
+      console.warn(
+        'control.endpoint embeds its token in the URL. This is deprecated: the ' +
+          'secret leaks into logs, history, and Referer headers. Use a plain ' +
+          'ws(s)://host/streamwall/ws endpoint and set control.token instead.',
+      )
+    }
     console.debug('Connecting to control server...')
-    const ws = new ReconnectingWebSocket(argv.control.endpoint, [], {
-      WebSocket,
+    const authorization = `Bearer ${control.credential}`
+    // ReconnectingWebSocket reconstructs the socket on every reconnect, so the
+    // Authorization header is injected via a subclass bound to the credential.
+    class AuthenticatedWebSocket extends WebSocket {
+      constructor(url: string, protocols?: string | string[]) {
+        super(url, protocols, { headers: { Authorization: authorization } })
+      }
+    }
+    const ws = new ReconnectingWebSocket(control.endpoint, [], {
+      WebSocket: AuthenticatedWebSocket,
       maxReconnectionDelay: 5000,
       minReconnectionDelay: 100 + Math.random() * 500,
       reconnectionDelayGrowFactor: 1.25,

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -9,9 +9,9 @@ import { join } from 'node:path'
 import ReconnectingWebSocket from 'reconnecting-websocket'
 import 'source-map-support/register'
 import {
+  StreamwallState,
   resolveControlConnection,
   resolveGridDimensions,
-  StreamwallState,
 } from 'streamwall-shared'
 import { updateElectronApp } from 'update-electron-app'
 import WebSocket from 'ws'


### PR DESCRIPTION
## Problem

Der `streamwall-control-server` gab langlebige, admin-fähige Secrets auf mehreren Wegen preis (Issue #4, Severity medium):

1. **Klartext-Secret at rest** — der Uplink-Token wurde als Klartext-`secret` in `storage.json` persistiert (alle anderen Tokens speichern nur einen scrypt-Hash).
2. **Secrets in Logs** — Uplink-Endpoint (mit Secret) und ein bei **jedem** Start frisch erzeugter Admin-Invite (mit Secret) wurden bei jedem Boot auf stdout ausgegeben.
3. **Secrets im URL-Query-String** — Uplink-WS (`/streamwall/:id/ws?token=`) und Invite-Link (`/invite/:id?token=`) trugen das Secret im Query-String → landet in Access-Logs, Browser-History und `Referer`.

Der Browser-Control-Client (`/client/ws`) authentifiziert bereits über ein `httpOnly`-Session-Cookie und blieb unverändert.

## Lösung

| Bereich | Änderung |
| --- | --- |
| **Storage (P1)** | `streamwallToken` speichert nur noch `{ tokenId }`. Eine Migration beim Laden entfernt ein evtl. vorhandenes Klartext-`secret` aus bestehenden `storage.json` und schreibt zurück. Der Token bleibt gültig (Validierung gegen den scrypt-Hash in `auth.tokens`). |
| **Uplink-WS (P3)** | Neue Route `/streamwall/ws`, Auth via `Authorization: Bearer <tokenId>:<secret>`-Header. Die alte Query-String-Route entfällt → kein Secret mehr im Server-Access-Log. App-seitig neuer `control.token` + Header-Injection über eine `ReconnectingWebSocket`-Subklasse. Ein alter Endpoint mit `?token=` wird weiterhin akzeptiert, migriert und mit Deprecation-Warnung geloggt. |
| **Invite (P3)** | `inviteLink` liefert `…/invite/<id>#<secret>` (Fragment). `GET /invite/:id` liefert eine minimale Exchange-Seite (Inline-Script hinter Per-Request-CSP-Nonce, `Referrer-Policy: no-referrer`), die das Fragment client-seitig liest und per `POST /invite/:id` (same-origin, single-use) gegen ein Session-Cookie tauscht. **Das Secret erreicht den Server nie über die URL.** |
| **Startup-Logs (P2)** | Uplink-Token wird einmalig bei Erzeugung geloggt (danach nur Hash gespeichert → kein Reprint möglich). Der Admin-Invite wird nur erzeugt/geloggt, wenn kein Admin hereinkommt (keine Admin-Session, kein offener Admin-Invite). Recovery via `STREAMWALL_CONTROL_NEW_ADMIN_INVITE=1` bzw. `STREAMWALL_CONTROL_NEW_UPLINK_TOKEN=1`. |

Ein separater Fix behebt einen dabei entdeckten latenten Auth-Bug: `validateToken` warf bei längenungleichen base62-Hashes eine `RangeError` aus `timingSafeEqual` (statt `null` zurückzugeben) — jetzt mit Längen-Guard.

## Architekturentscheidungen

- **Credential-Format** (`<tokenId>:<secret>`, Bearer-Schema) liegt zentral in `streamwall-shared/control.ts` (`parseBearerCredential`, `resolveControlConnection`) — beide Protokoll-Enden nutzen dieselbe Quelle, isoliert unit-testbar.
- **Fragment + POST** statt Query gewählt, weil Fragmente nie an den Server gehen (raus aus Access-Logs & Referer) — entspricht der im Issue vorgeschlagenen „POST/cookie exchange".
- **Testbarkeit**: `initApp`/`initialInviteCodes` exportiert, Auto-Boot hinter Main-Guard, `loadStorage(dbPath?)`/`initApp({ db? })` parametrisierbar, `initialInviteCodes` mit injizierbarem Logger.
- **Test-Harness**: `node:test` + `tsx`, **null neue Dependencies** (passend zum Security-Fokus).

Design-Spec: `docs/superpowers/specs/2026-07-04-control-server-secret-hardening-design.md`.

## Risiken / Breaking Changes

- **Uplink-Config ändert sich** (`control.endpoint` ohne Token + neuer `control.token`) — abgefedert durch rückwärtskompatibles Parsen des alten `?token=`-Endpoints inkl. Deprecation-Warnung.
- **Invite-Annahme benötigt jetzt JavaScript** — akzeptabel, da die Control-UI ohnehin eine JS-SPA ist; `<noscript>` weist darauf hin.
- **Admin-Invite wird nicht mehr bei jedem Boot neu erzeugt** — bewusst; Recovery via Env-Var.
- **`storage.json`-Migration ist einseitig** (Klartext-Secret wird verworfen) — der Token funktioniert weiter (Hash-Validierung); nur das erneute Anzeigen des Secrets entfällt (Ziel der Änderung).

## Testabdeckung

30 Tests (node:test), 8× stabil:
- **Unit**: kein Klartext in `getStoredData`; Storage-Migration entfernt Legacy-Secret; `inviteLink`-Fragment-Form; `parseBearerCredential`/`resolveControlConnection` (inkl. Legacy-Migration); `validateToken` wirft nicht bei Längen-Mismatch.
- **Integration (`app.inject`)**: `GET /invite/:id` liefert gehärtete Header + kein Secret; `POST /invite/:id` setzt Cookie + 204, konsumiert → 403, wrong secret → 403, cross-origin → 403, missing secret → 403.
- **Integration (echter `ws`-Client, `listen({port:0})`)**: Uplink akzeptiert gültigen Header, lehnt fehlenden/falschen/nicht-streamwall-Token ab.

Zusätzlich end-to-end gegen einen echten laufenden Server verifiziert (Invite-GET/POST-Flow, Uplink-Logging über Neustarts).

Closes #4
