### PR TITLE
fix(shared): authorize operators to invoke set-grid-size

### DIFF
--- a/packages/streamwall-shared/src/roles.test.ts
+++ b/packages/streamwall-shared/src/roles.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { roleCan } from './roles.ts'
+
+describe('roleCan set-grid-size', () => {
+  it('allows operators to resize the grid', () => {
+    expect(roleCan('operator', 'set-grid-size')).toBe(true)
+  })
+  it('allows admins and local to resize the grid', () => {
+    expect(roleCan('admin', 'set-grid-size')).toBe(true)
+    expect(roleCan('local', 'set-grid-size')).toBe(true)
+  })
+  it('does not allow monitors to resize the grid', () => {
+    expect(roleCan('monitor', 'set-grid-size')).toBe(false)
+  })
+  it('does not allow unauthenticated clients to resize the grid', () => {
+    expect(roleCan(null, 'set-grid-size')).toBe(false)
+  })
+})

--- a/packages/streamwall-shared/src/roles.ts
+++ b/packages/streamwall-shared/src/roles.ts
@@ -19,6 +19,7 @@ const operatorActions = [
   'set-stream-censored',
   'set-stream-running',
   'mutate-state-doc',
+  'set-grid-size',
 ] as const
 
 const monitorActions = ['set-view-blurred', 'set-stream-censored'] as const


### PR DESCRIPTION
## Problem

`npx tsc --noEmit` in `packages/streamwall-control-server` failed on `deps-modernization`:

```
src/index.ts(398,39): error TS2345: Argument of type '... | "set-grid-size"'
is not assignable to parameter of type 'StreamwallAction'.
  Type '"set-grid-size"' is not assignable to type 'StreamwallAction'.
```

The `set-grid-size` control command was added to `ControlCommand` (`streamwall-shared/src/types.ts`) and is sent by the control UI and handled by the main process, but it was never added to the role action lists in `streamwall-shared/src/roles.ts`. So `StreamwallAction` did not include it and `roleCan(identity.role, msg.type)` at `index.ts:398` no longer typechecked.

## Fix

Add `set-grid-size` to `operatorActions`. This is the correct permission tier: the control UI already gates the grid-size controls behind `roleCan(role, 'mutate-state-doc')`, an operator-tier action. `admin`/`local` inherit all actions; `monitor` (restricted to blur/censor) stays excluded.

## Verification

- Reproduced the exact TS2345 error on the `deps-modernization` base (red), then confirmed `npx tsc --noEmit` in the control server reaches **0 errors** with the fix resolved against the edited shared package (green).
- `streamwall-shared` typechecks cleanly.
- Added `roles.test.ts` asserting `operator`/`admin`/`local` can invoke `set-grid-size` and `monitor`/unauthenticated cannot — `vitest run` passes (13 tests).