### PR TITLE
Security: use an effective allow-scripts sandbox for overlay/background frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,25 @@ Streamwall can load stream data from both JSON APIs and TOML files. Data sources
 npm start -- --data.json-url="https://your-site/api/streams.json" --data.toml-file="./streams.toml"
 ```
 
+## Security: overlay and background streams
+
+Streams added with the `overlay` or `background` kind are loaded as live web
+pages layered over the whole wall, inside sandboxed `<iframe>`s. Anyone with
+control access can point these tiles at an arbitrary URL, so treat their
+contents as untrusted.
+
+These frames run with `sandbox="allow-scripts"` only. Scripts are allowed so
+widget-style overlays (scoreboards, alerts, players) still work, but the page
+runs in an opaque origin: it cannot escape its sandbox, reach Streamwall's
+internal APIs, or read the app's cookies and storage. Top-level navigation,
+popups, forms and downloads stay blocked.
+
+`allow-same-origin` is intentionally not granted — combined with `allow-scripts`
+it would let a page remove its own sandbox attribute and defeat the protection.
+As a result, overlay/background pages have no access to their own origin's
+cookies or local storage; widgets that depend on same-origin persistence are not
+supported by design.
+
 ## Hotkeys
 
 The following hotkeys are available with the "control" webpage focused:

--- a/packages/streamwall/src/renderer/background.tsx
+++ b/packages/streamwall/src/renderer/background.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'preact/hooks'
 import { styled } from 'styled-components'
 import { StreamData, StreamList } from '../../../streamwall-shared/src/types'
 import { StreamwallLayerGlobal } from '../preload/layerPreload'
+import { LAYER_FRAME_SANDBOX } from './layerFrameSandbox'
 
 declare global {
   interface Window {
@@ -21,7 +22,7 @@ function Background({ streams }: { streams: StreamList }) {
         <BackgroundIFrame
           key={s._id}
           src={s.link}
-          sandbox="allow-scripts allow-same-origin"
+          sandbox={LAYER_FRAME_SANDBOX}
           allow="autoplay"
           scrolling="no"
         />

--- a/packages/streamwall/src/renderer/layerFrameSandbox.sources.test.ts
+++ b/packages/streamwall/src/renderer/layerFrameSandbox.sources.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Source regression guard: the two layer renderers must not fall back to the
+ * ineffective `allow-scripts allow-same-origin` sandbox, and must instead
+ * apply the shared LAYER_FRAME_SANDBOX policy to their iframe.
+ */
+describe('layer renderer iframe sandbox', () => {
+  for (const file of ['overlay.tsx', 'background.tsx']) {
+    const source = readFileSync(new URL(`./${file}`, import.meta.url), 'utf8')
+
+    it(`${file} does not hardcode the ineffective allow-same-origin sandbox`, () => {
+      expect(source).not.toMatch(/allow-same-origin/)
+    })
+
+    it(`${file} applies the shared LAYER_FRAME_SANDBOX policy to its iframe`, () => {
+      expect(source).toMatch(/sandbox=\{LAYER_FRAME_SANDBOX\}/)
+    })
+  }
+})

--- a/packages/streamwall/src/renderer/layerFrameSandbox.test.ts
+++ b/packages/streamwall/src/renderer/layerFrameSandbox.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { LAYER_FRAME_SANDBOX } from './layerFrameSandbox.ts'
+
+const tokens = LAYER_FRAME_SANDBOX.split(' ').filter(Boolean)
+
+describe('LAYER_FRAME_SANDBOX', () => {
+  it('allows scripts so overlay/background widgets can render', () => {
+    expect(tokens, 'allow-scripts must be granted').toContain('allow-scripts')
+  })
+
+  it('never grants allow-same-origin, which would defeat the sandbox', () => {
+    expect(tokens, 'allow-same-origin must not be granted').not.toContain(
+      'allow-same-origin',
+    )
+    expect(LAYER_FRAME_SANDBOX).not.toMatch(/allow-same-origin/)
+  })
+
+  it('grants no navigation, popup, form or download escape hatches', () => {
+    const escapes = [
+      'allow-top-navigation',
+      'allow-top-navigation-by-user-activation',
+      'allow-top-navigation-to-custom-protocols',
+      'allow-popups',
+      'allow-popups-to-escape-sandbox',
+      'allow-forms',
+      'allow-modals',
+      'allow-downloads',
+      'allow-pointer-lock',
+    ]
+    for (const escape of escapes) {
+      expect(tokens, `${escape} must not be granted`).not.toContain(escape)
+    }
+  })
+
+  it('is a normalized, space-separated token list', () => {
+    expect(LAYER_FRAME_SANDBOX).toBe(tokens.join(' '))
+    expect(LAYER_FRAME_SANDBOX).toBe(LAYER_FRAME_SANDBOX.trim())
+  })
+})

--- a/packages/streamwall/src/renderer/layerFrameSandbox.ts
+++ b/packages/streamwall/src/renderer/layerFrameSandbox.ts
@@ -1,0 +1,33 @@
+/**
+ * Sandbox policy for the `<iframe>` elements that host `overlay` and
+ * `background` custom streams inside the wall's layer renderers
+ * (see `overlay.tsx` and `background.tsx`).
+ *
+ * Trust model
+ * -----------
+ * Overlay/background URLs are supplied by control-UI operators as custom
+ * streams (see `CreateCustomStreamInput` in `streamwall-control-ui`). Anyone
+ * with control access can point a `background`/`overlay` tile at an arbitrary
+ * URL, so the framed document must be treated as untrusted and confined.
+ *
+ * These frames intentionally grant ONLY `allow-scripts`:
+ *
+ *   - Scripts are required so widget-style overlays (scoreboards, alerts,
+ *     embedded players, …) can render.
+ *   - `allow-same-origin` is deliberately omitted. Pairing `allow-scripts`
+ *     with `allow-same-origin` is a documented no-op: a same-origin document
+ *     can reach its own frame element and remove the `sandbox` attribute,
+ *     which is no more secure than not sandboxing at all. Without
+ *     `allow-same-origin` the framed document runs in an opaque origin — it
+ *     cannot strip its own sandbox, cannot reach the layer renderer's
+ *     privileged `streamwallLayer` bridge, and has no access to the app's
+ *     cookies or storage.
+ *   - Top-level navigation, popups, forms, modals and downloads stay blocked
+ *     because their `allow-*` tokens are not present.
+ *
+ * Trade-off: because the frame runs in an opaque origin, an overlay/background
+ * document cannot read or write its own origin's cookies or local storage.
+ * Widgets that depend on same-origin persistence are unsupported by design;
+ * that is the cost of an effective sandbox.
+ */
+export const LAYER_FRAME_SANDBOX = 'allow-scripts'

--- a/packages/streamwall/src/renderer/overlay.tsx
+++ b/packages/streamwall/src/renderer/overlay.tsx
@@ -18,6 +18,7 @@ import { TailSpin } from 'svg-loaders-react'
 import { matchesState } from 'xstate'
 import packageInfo from '../../package.json'
 import { StreamwallLayerGlobal } from '../preload/layerPreload'
+import { LAYER_FRAME_SANDBOX } from './layerFrameSandbox'
 
 import '@fontsource/noto-sans'
 import 'streamwall-control-ui/src/index.css'
@@ -103,7 +104,7 @@ function Overlay({
         <OverlayIFrame
           key={s._id}
           src={s.link}
-          sandbox="allow-scripts allow-same-origin"
+          sandbox={LAYER_FRAME_SANDBOX}
           allow="autoplay"
           scrolling="no"
         />


### PR DESCRIPTION
Ports the overlay/background iframe sandbox hardening from #96 (merged to
`main`) onto `deps-modernization`, which still carries the identical
vulnerable lines.

## Problem

The overlay and background layer renderers embed operator-supplied custom
stream URLs with `sandbox="allow-scripts allow-same-origin"`. That
combination is a documented no-op: a same-origin document can reach its own
frame element and remove the `sandbox` attribute, so a malicious
overlay/background URL effectively runs **unsandboxed** inside the wall
window (with reach to the privileged `streamwallLayer` bridge and the app's
cookies/storage).

## Fix

- New `packages/streamwall/src/renderer/layerFrameSandbox.ts` exports
  `LAYER_FRAME_SANDBOX = 'allow-scripts'` as the single source of truth, with
  a documented trust-model comment.
- `overlay.tsx` and `background.tsx` now use `sandbox={LAYER_FRAME_SANDBOX}`.
  The framed document runs in an opaque origin: it can still render widgets,
  but cannot strip its own sandbox, reach the layer bridge, or touch the
  app's cookies/storage. Navigation/popups/forms/downloads stay blocked.
- README gains a "Security: overlay and background streams" section
  documenting the trust model and the (by-design) loss of same-origin
  persistence.

## Toolchain note

The `main` version of this fix (#96) shipped its two specs as native
`node:test` files. `deps-modernization` uses **vitest** (`vitest run`, the
convention already used by `csp.test.ts` / `geometry.test.ts`), so the two
specs were re-authored as vitest and **not** node:test:

- `layerFrameSandbox.test.ts` — pins the policy invariants (allow-scripts
  granted; `allow-same-origin` and every navigation/popup/form/download
  escape hatch withheld).
- `layerFrameSandbox.sources.test.ts` — source regression guard so the
  renderers can't drift back to `allow-same-origin`.

## Verification

- `npm test` (vitest) in `packages/streamwall`: **16/16 pass** (8 new + the
  existing `csp`/`StreamWindow` specs).
- Changed source files are Prettier-clean.
- `npm run lint` does **not** run on `deps-modernization`: ESLint 10 requires
  a flat config and the repo still ships only the legacy `.eslintrc.json`
  (pre-existing; the ESLint 10 migration is unrelated to this change and out
  of scope here).

Refs #6, ports #96.
