### PR TITLE
feat: interact with a view's native controls to adjust quality/bitrate (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Streamwall makes it easy to compose multiple livestreams into a mosaic, with sou
 
 Under the hood, think of Streamwall as a specialized web browser for mosaicing video streams. It uses [Electron](https://www.electronjs.org) to create a grid of web browser views, loading the specified webpages into them. Once the page loads, Streamwall finds the `<video>` tag and reformats the page so that the video fills the space. This works for a wide variety of web pages without specialized scrapers.
 
+Because reformatting hides the page's own controls, each view has an **interact** button (cog icon) in its overlay controls. It opens the stream's original page in a separate, interactive window — for example to lower a feed's video quality/bitrate using the site's native player controls. The window shares the view's isolated session, so changes the site persists (such as a chosen quality) carry over; when you close it, the corresponding view reloads to pick them up.
+
 
 ## Configuration
 

--- a/docs/superpowers/specs/2026-07-04-interact-view-popout-design.md
+++ b/docs/superpowers/specs/2026-07-04-interact-view-popout-design.md
@@ -1,0 +1,93 @@
+# Interact-Popout pro Feed (Issue #15)
+
+## Problem
+
+Streamwall zeigt fremde Livestreams (YouTube, Facebook, Twitch, …) in einem Grid.
+`mediaPreload.ts` reißt bei Video-/Audio-Feeds das nackte `<video>`-Element aus der
+Seite und blendet via `VIDEO_OVERRIDE_STYLE` (`* { display: none }`) **alle** übrigen
+Seiten-Elemente aus — inklusive der nativen Player-Bedienelemente (z. B. das
+YouTube-Zahnrad zur Qualitätswahl). Dadurch kann der Operator die Qualität/Bitrate
+eines laufenden Feeds nicht mehr steuern. Viele Feeds pushen dauerhaft 1080p mit hoher
+Bitrate, obwohl das im Grid nicht nötig ist.
+
+Issue [#15](https://github.com/streamwall/streamwall/issues/15) fordert die Fähigkeit,
+Views „herauszupoppen" und mit ihnen zu interagieren, um u. a. die Bitrate pro Feed zu
+senken.
+
+## Entscheidung
+
+**Interact-Popout (OBS-artig).** Ein neuer Per-View-Button im „cog wheel" öffnet den
+Feed in einem separaten, interaktiven Fenster mit **nativen** Player-Bedienelementen.
+Der Operator senkt die Qualität dort selbst (echtes YouTube-/Facebook-Zahnrad).
+
+Verworfen:
+- **Programmatische Qualitätssteuerung** (plattformspezifisches JS): fragil, bricht bei
+  jedem Player-Update, hoher Wartungsaufwand — unvereinbar mit „produktionsreif/wartbar".
+- **Nur HLS-Level-Auswahl**: trifft den eigentlichen Use-Case (YouTube/Facebook) nicht,
+  da diese nicht über `hls.js` laufen.
+
+## Funktionsweise
+
+Seit den Sicherheits-Fixes #94/#97 hat **jede Stream-View ihre eigene, isolierte
+ephemere Session** (`view.webContents.session`, Partition `view-N`) — Cookies,
+`localStorage` und Cache werden weder zwischen Views noch mit dem Browse-Fenster oder
+der Platte geteilt.
+
+Damit eine im Interact-Fenster vorgenommene Qualitätsänderung den Wall-Feed erreicht,
+wird das Interact-Fenster **gegen genau die Session der Ziel-View** erzeugt (Electron
+`webPreferences.session`). So teilen sich Interact-Fenster und View `localStorage`/
+Cookies (z. B. YouTube `yt-player-quality`, Twitch `video-quality`). Beim Schließen des
+Interact-Fensters wird die zugehörige Wall-View **automatisch neu geladen** und übernimmt
+die gesenkte Qualität. Die Isolation zwischen den Views bleibt dabei erhalten — geteilt
+wird ausschließlich die eine Ziel-View-Session.
+
+## Architektur
+
+Bestehender Datenfluss: Control-UI-Button → `ControlCommand` → `onCommand` (main) →
+`StreamWindow`. Rollen-Gating über `roles.ts`/`roleCan`.
+
+1. **`ControlCommand`** um `{ type: 'interact-view'; viewIdx: number }` erweitern
+   (`streamwall-shared/src/types.ts`). View-gebunden (nicht nur URL wie `browse`), damit
+   der Auto-Reload die richtige View trifft.
+2. **`InteractWindow<Session>`** (neu, `streamwall/src/main/InteractWindow.ts`): kapselt
+   den Fenster-Lifecycle.
+   - `open(target, onApply)`: öffnet/wiederverwendet ein Fenster für `target.session`.
+     Da jede View eine andere isolierte Session hat (bei Fenster-Erzeugung gebunden),
+     wird beim Wechsel auf eine andere View das Fenster **ersetzt** und die vorherige
+     View via `onApply` neu geladen. Beim Schließen wird die aktuelle View neu geladen.
+   - Die `BrowserWindow`-Factory ist **injizierbar** und generisch über den Session-Typ,
+     sodass die Klasse ohne echtes Electron unit-testbar ist.
+3. **`onCommand`-Handler** (`streamwall/src/main/index.ts`): löst zur `viewIdx` die
+   `content.url`, das Label und die `session` über `StreamWindow` auf, validiert die URL
+   (`await ensureValidURL`, SSRF-Schutz), erzeugt das Interact-Fenster gegen die
+   View-Session (`webPreferences.session`) und registriert `reloadView(viewIdx)` als
+   `onApply`.
+4. **`StreamWindow`**: neue Methoden `getViewContent(viewIdx)` und `getViewSession(viewIdx)`.
+5. **Control-UI** (`streamwall-control-ui/src/index.tsx`): Zahnrad-Button (`FaCog`) im
+   Per-View-`StyledGridButtons`, immer sichtbar (nicht nur Debug-Modus), gated über
+   `roleCan(role, 'interact-view')`.
+6. **Rollen** (`streamwall-shared/src/roles.ts`): `interact-view` als **operator**-Aktion.
+
+`browse` (admin, generische URL, eigene `BROWSE_PARTITION`) bleibt unverändert.
+
+## Tests
+
+Der Node.js-Test-Runner (`node --experimental-strip-types --test`, bestehende Konvention):
+
+- **`roles`**: `interact-view` ist für `operator`, `admin`, `local` erlaubt, nicht für
+  `monitor`; bestehende Berechtigungen unverändert.
+- **`InteractWindow`**: öffnet Fenster gegen die Ziel-Session mit korrekter URL/Titel;
+  wiederverwendet das Fenster bei gleicher Session; ersetzt es bei Session-Wechsel und
+  lädt die vorherige View neu; lädt beim Schließen die aktuelle View neu; wendet jede
+  View genau einmal an (kein Doppel-Reload über den asynchronen `closed`-Event). Getestet
+  mit einer gefakten Fenster-Factory (EventEmitter).
+
+Electron-spezifische UI-/Integrationsdetails werden manuell beim App-Start verifiziert.
+
+## Grenzen (bewusst, dokumentiert)
+
+- Qualitätsübernahme ist **best effort** und plattformabhängig: zuverlässig für
+  YouTube/Twitch (localStorage-Präferenz), unsicherer für Facebook. Rohe `.m3u8`-Feeds
+  haben kein natives Zahnrad und werden vom Feature nicht abgedeckt.
+- Der Reload verursacht eine kurze Unterbrechung des betroffenen Feeds — bewusster
+  Trade-off gegen fragile Live-Manipulation der laufenden View.

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -13,6 +13,7 @@ import {
 import { useHotkeys } from 'react-hotkeys-hook'
 import { IconType } from 'react-icons'
 import {
+  FaCog,
   FaExchangeAlt,
   FaRedoAlt,
   FaRegLifeRing,
@@ -436,6 +437,16 @@ export function ControlUI({
     [send],
   )
 
+  const handleInteractView = useCallback(
+    (viewIdx: number) => {
+      send({
+        type: 'interact-view',
+        viewIdx,
+      })
+    },
+    [send],
+  )
+
   const handleRotateStream = useCallback(
     (streamId: string) => {
       const stream = streams.find((d) => d._id === streamId)
@@ -794,6 +805,7 @@ export function ControlUI({
                       onSetBackgroundListening={handleSetBackgroundListening}
                       onSetBlurred={handleSetBlurred}
                       onReloadView={handleReloadView}
+                      onInteractView={handleInteractView}
                       onSwapView={handleSwapView}
                       onRotateView={handleRotateStream}
                       onBrowse={handleBrowse}
@@ -1180,6 +1192,7 @@ function GridControls({
   onSetBackgroundListening,
   onSetBlurred,
   onReloadView,
+  onInteractView,
   onSwapView,
   onRotateView,
   onBrowse,
@@ -1203,6 +1216,7 @@ function GridControls({
   ) => void
   onSetBlurred: (idx: number, isBlurred: boolean) => void
   onReloadView: (idx: number) => void
+  onInteractView: (idx: number) => void
   onSwapView: (idx: number) => void
   onRotateView: (streamId: string) => void
   onBrowse: (streamId: string) => void
@@ -1234,6 +1248,10 @@ function GridControls({
     () => onReloadView(idx),
     [idx, onReloadView],
   )
+  const handleInteractClick = useCallback(
+    () => onInteractView(idx),
+    [idx, onInteractView],
+  )
   const handleSwapClick = useCallback(() => onSwapView(idx), [idx, onSwapView])
   const handleRotateClick = useCallback(
     () => onRotateView(streamId),
@@ -1251,6 +1269,15 @@ function GridControls({
     <StyledGridControlsContainer style={style} onMouseDown={onMouseDown}>
       {isDisplaying && (
         <StyledGridButtons side="left">
+          {roleCan(role, 'interact-view') && (
+            <StyledSmallButton
+              onClick={handleInteractClick}
+              tabIndex={1}
+              title="Interact with stream (e.g. lower quality/bitrate)"
+            >
+              <FaCog />
+            </StyledSmallButton>
+          )}
           {showDebug ? (
             <>
               {roleCan(role, 'reload-view') && (

--- a/packages/streamwall-shared/src/roles.test.ts
+++ b/packages/streamwall-shared/src/roles.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import { roleCan } from './roles.ts'
+
+describe('roleCan', () => {
+  describe('interact-view', () => {
+    test('is allowed for local, admin and operator', () => {
+      assert.equal(roleCan('local', 'interact-view'), true)
+      assert.equal(roleCan('admin', 'interact-view'), true)
+      assert.equal(roleCan('operator', 'interact-view'), true)
+    })
+
+    test('is denied for monitor', () => {
+      assert.equal(roleCan('monitor', 'interact-view'), false)
+    })
+
+    test('is denied for a null role', () => {
+      assert.equal(roleCan(null, 'interact-view'), false)
+    })
+  })
+
+  describe('regression: existing permissions are unchanged', () => {
+    test('keeps reload-view as an operator action', () => {
+      assert.equal(roleCan('operator', 'reload-view'), true)
+      assert.equal(roleCan('monitor', 'reload-view'), false)
+    })
+
+    test('keeps browse as an admin-only action', () => {
+      assert.equal(roleCan('admin', 'browse'), true)
+      assert.equal(roleCan('operator', 'browse'), false)
+      assert.equal(roleCan('monitor', 'browse'), false)
+    })
+
+    test('keeps monitor limited to blur and censor', () => {
+      assert.equal(roleCan('monitor', 'set-view-blurred'), true)
+      assert.equal(roleCan('monitor', 'set-stream-censored'), true)
+      assert.equal(roleCan('monitor', 'set-listening-view'), false)
+    })
+  })
+})

--- a/packages/streamwall-shared/src/roles.ts
+++ b/packages/streamwall-shared/src/roles.ts
@@ -16,6 +16,7 @@ const operatorActions = [
   'delete-custom-stream',
   'rotate-stream',
   'reload-view',
+  'interact-view',
   'set-stream-censored',
   'set-stream-running',
   'mutate-state-doc',

--- a/packages/streamwall-shared/src/types.ts
+++ b/packages/streamwall-shared/src/types.ts
@@ -127,6 +127,7 @@ export type ControlCommand =
   | { type: 'update-custom-stream'; url: string; data: LocalStreamData }
   | { type: 'delete-custom-stream'; url: string }
   | { type: 'reload-view'; viewIdx: number }
+  | { type: 'interact-view'; viewIdx: number }
   | { type: 'browse'; url: string }
   | { type: 'dev-tools'; viewIdx: number }
   | { type: 'set-stream-censored'; isCensored: boolean }

--- a/packages/streamwall/src/main/InteractWindow.test.ts
+++ b/packages/streamwall/src/main/InteractWindow.test.ts
@@ -1,0 +1,186 @@
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { describe, test } from 'node:test'
+import { InteractWindow } from './InteractWindow.ts'
+
+class FakeWindow extends EventEmitter {
+  loadedURLs: string[] = []
+  titles: string[] = []
+  focusCount = 0
+  destroyed = false
+
+  loadURL(url: string) {
+    this.loadedURLs.push(url)
+  }
+  setTitle(title: string) {
+    this.titles.push(title)
+  }
+  focus() {
+    this.focusCount++
+  }
+  isDestroyed() {
+    return this.destroyed
+  }
+  destroy() {
+    if (!this.destroyed) {
+      this.destroyed = true
+      this.emit('closed')
+    }
+  }
+  // Simulate the operator closing the window from the UI.
+  userClose() {
+    this.destroy()
+  }
+}
+
+function noop() {
+  // no-op onApply for tests that do not assert on reloads
+}
+
+function setup() {
+  const windows: FakeWindow[] = []
+  const sessions: unknown[] = []
+  const interactWindow = new InteractWindow((session) => {
+    sessions.push(session)
+    const win = new FakeWindow()
+    windows.push(win)
+    return win
+  })
+  return { windows, sessions, interactWindow }
+}
+
+describe('InteractWindow', () => {
+  test('opens a window bound to the target session and loads url/title', () => {
+    const { windows, sessions, interactWindow } = setup()
+    const session = { id: 'view-0' }
+    let applied = 0
+
+    interactWindow.open(
+      { url: 'https://youtube.com/watch?v=x', title: 'Interact: A', session },
+      () => applied++,
+    )
+
+    assert.equal(windows.length, 1)
+    assert.deepEqual(sessions, [session])
+    assert.deepEqual(windows[0].loadedURLs, ['https://youtube.com/watch?v=x'])
+    assert.deepEqual(windows[0].titles, ['Interact: A'])
+    assert.equal(windows[0].focusCount, 1)
+    assert.equal(applied, 0)
+  })
+
+  test('reuses the window when the same session is targeted again', () => {
+    const { windows, interactWindow } = setup()
+    const session = { id: 'view-0' }
+    let applied = 0
+
+    interactWindow.open(
+      { url: 'https://a.example/', title: 'A', session },
+      () => applied++,
+    )
+    interactWindow.open(
+      { url: 'https://a.example/live', title: 'A live', session },
+      () => applied++,
+    )
+
+    assert.equal(windows.length, 1)
+    assert.deepEqual(windows[0].loadedURLs, [
+      'https://a.example/',
+      'https://a.example/live',
+    ])
+    assert.equal(applied, 0)
+  })
+
+  test('replaces the window and reloads the previous view when the session changes', () => {
+    const { windows, interactWindow } = setup()
+    const sessionA = { id: 'view-0' }
+    const sessionB = { id: 'view-1' }
+    let appliedA = 0
+    let appliedB = 0
+
+    interactWindow.open(
+      { url: 'https://a.example/', title: 'A', session: sessionA },
+      () => appliedA++,
+    )
+    interactWindow.open(
+      { url: 'https://b.example/', title: 'B', session: sessionB },
+      () => appliedB++,
+    )
+
+    assert.equal(windows.length, 2)
+    assert.equal(windows[0].destroyed, true)
+    assert.equal(appliedA, 1)
+    assert.equal(appliedB, 0)
+  })
+
+  test('reloads the current view when the window is closed by the operator', () => {
+    const { windows, interactWindow } = setup()
+    const session = { id: 'view-2' }
+    let applied = 0
+
+    interactWindow.open(
+      { url: 'https://a.example/', title: 'A', session },
+      () => applied++,
+    )
+    windows[0].userClose()
+
+    assert.equal(applied, 1)
+  })
+
+  test('applies each view exactly once across a switch and a later close', () => {
+    const { windows, interactWindow } = setup()
+    const sessionA = { id: 'view-0' }
+    const sessionB = { id: 'view-1' }
+    let appliedA = 0
+    let appliedB = 0
+
+    interactWindow.open(
+      { url: 'https://a.example/', title: 'A', session: sessionA },
+      () => appliedA++,
+    )
+    interactWindow.open(
+      { url: 'https://b.example/', title: 'B', session: sessionB },
+      () => appliedB++,
+    )
+    windows[1].userClose()
+
+    assert.equal(appliedA, 1)
+    assert.equal(appliedB, 1)
+  })
+
+  test('opens a fresh window after the previous one was closed', () => {
+    const { windows, interactWindow } = setup()
+    const session = { id: 'view-0' }
+
+    interactWindow.open(
+      { url: 'https://a.example/', title: 'A', session },
+      noop,
+    )
+    windows[0].userClose()
+    interactWindow.open(
+      { url: 'https://a.example/', title: 'A', session },
+      noop,
+    )
+
+    assert.equal(windows.length, 2)
+  })
+
+  test('does not reload a replaced window again if it emits closed later', () => {
+    const { windows, interactWindow } = setup()
+    const sessionA = { id: 'view-0' }
+    const sessionB = { id: 'view-1' }
+    let appliedA = 0
+
+    interactWindow.open(
+      { url: 'https://a.example/', title: 'A', session: sessionA },
+      () => appliedA++,
+    )
+    interactWindow.open(
+      { url: 'https://b.example/', title: 'B', session: sessionB },
+      noop,
+    )
+    // The already-destroyed window A must not trigger a second reload.
+    windows[0].emit('closed')
+
+    assert.equal(appliedA, 1)
+  })
+})

--- a/packages/streamwall/src/main/InteractWindow.ts
+++ b/packages/streamwall/src/main/InteractWindow.ts
@@ -1,0 +1,94 @@
+/**
+ * The subset of Electron's `BrowserWindow` that {@link InteractWindow} needs.
+ * Keeping this narrow lets the window be faked in tests without loading Electron.
+ */
+export interface InteractBrowserWindow {
+  loadURL(url: string): unknown
+  setTitle(title: string): void
+  focus(): void
+  isDestroyed(): boolean
+  destroy(): void
+  on(event: 'closed', listener: () => void): unknown
+}
+
+export type InteractBrowserWindowFactory<Session extends object> = (
+  session: Session,
+) => InteractBrowserWindow
+
+export interface InteractTarget<Session extends object> {
+  /** URL to open interactively (the stream's own page, with native controls). */
+  url: string
+  /** Window title, e.g. `Interact: <label>`. */
+  title: string
+  /**
+   * Session of the target view. The window is created against this session so
+   * it shares cookies/localStorage with the view, letting settings such as
+   * player quality/bitrate carry over when the view reloads. Compared by
+   * identity to decide whether an open window can be reused.
+   */
+  session: Session
+}
+
+/**
+ * Manages a single, reusable pop-out window that loads a stream's original page
+ * with its native player controls intact, so an operator can adjust settings
+ * such as video quality/bitrate that the wall's media override hides.
+ *
+ * Each view has its own isolated session, bound to a window when it is created,
+ * so interacting with a different view requires a new window. Whenever the
+ * operator finishes with a view — either by switching to another one or by
+ * closing the window — the supplied `onApply` callback fires so the caller can
+ * reload that wall view and pick up the new settings.
+ */
+export class InteractWindow<Session extends object> {
+  private readonly createWindow: InteractBrowserWindowFactory<Session>
+  private window: InteractBrowserWindow | null = null
+  private current: { session: Session; onApply: () => void } | null = null
+
+  constructor(createWindow: InteractBrowserWindowFactory<Session>) {
+    this.createWindow = createWindow
+  }
+
+  open(target: InteractTarget<Session>, onApply: () => void): void {
+    const window =
+      this.window !== null &&
+      !this.window.isDestroyed() &&
+      this.current?.session === target.session
+        ? this.window
+        : this.replaceWindow(target.session)
+
+    window.loadURL(target.url)
+    window.setTitle(target.title)
+    window.focus()
+    this.current = { session: target.session, onApply }
+  }
+
+  private replaceWindow(session: Session): InteractBrowserWindow {
+    const previous = this.window
+    const previousApply = this.current?.onApply
+    this.window = null
+    this.current = null
+
+    const window = this.createWindow(session)
+    window.on('closed', () => {
+      // Ignore stray close events from a window we have already replaced.
+      if (this.window !== window) {
+        return
+      }
+      this.window = null
+      const onApply = this.current?.onApply
+      this.current = null
+      onApply?.()
+    })
+    this.window = window
+
+    // Tear down the previous window (bound to another view's session) and
+    // reload its view. The guard above stops its close event double-applying.
+    if (previous && !previous.isDestroyed()) {
+      previous.destroy()
+    }
+    previousApply?.()
+
+    return window
+  }
+}

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -1,5 +1,11 @@
 import assert from 'assert'
-import { BrowserWindow, ipcMain, WebContents, WebContentsView } from 'electron'
+import {
+  BrowserWindow,
+  ipcMain,
+  Session,
+  WebContents,
+  WebContentsView,
+} from 'electron'
 import EventEmitter from 'events'
 import intersection from 'lodash/intersection'
 import isEqual from 'lodash/isEqual'
@@ -333,6 +339,15 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
         return view
       }
     }
+  }
+
+  getViewContent(viewIdx: number): ViewContent | null {
+    return this.findViewByIdx(viewIdx)?.getSnapshot().context.content ?? null
+  }
+
+  getViewSession(viewIdx: number): Session | null {
+    const view = this.findViewByIdx(viewIdx)
+    return view ? view.getSnapshot().context.view.webContents.session : null
   }
 
   sendViewEvent(viewIdx: number, event: EventFrom<typeof viewStateMachine>) {

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -1,6 +1,6 @@
 import TOML from '@iarna/toml'
 import * as Sentry from '@sentry/electron/main'
-import { BrowserWindow, app } from 'electron'
+import { BrowserWindow, app, type Session } from 'electron'
 import started from 'electron-squirrel-startup'
 import fs from 'fs'
 import { throttle } from 'lodash-es'
@@ -10,8 +10,8 @@ import ReconnectingWebSocket from 'reconnecting-websocket'
 import 'source-map-support/register'
 import {
   ControlCommand,
-  resolveGridDimensions,
   StreamwallState,
+  resolveGridDimensions,
 } from 'streamwall-shared'
 import { updateElectronApp } from 'update-electron-app'
 import WebSocket from 'ws'
@@ -27,6 +27,7 @@ import {
   pollDataURL,
   watchDataFile,
 } from './data'
+import { InteractWindow } from './InteractWindow'
 import { BROWSE_PARTITION, hardenSession } from './partitions'
 import { loadStorage } from './storage'
 import StreamdelayClient from './StreamdelayClient'
@@ -289,6 +290,22 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   }
   const streamWindow = new StreamWindow(streamWindowConfig)
   const controlWindow = new ControlWindow()
+  const interactWindow = new InteractWindow<Session>(
+    (session) =>
+      new BrowserWindow({
+        webPreferences: {
+          nodeIntegration: false,
+          contextIsolation: true,
+          sandbox: true,
+          // Share the target view's isolated session so quality/bitrate changes
+          // the operator makes here (persisted to the view's cookies /
+          // localStorage) carry over when the view reloads. That session was
+          // already hardened in StreamWindow.createView, so unlike the browse
+          // window it needs no separate hardenSession call here.
+          session,
+        },
+      }),
+  )
 
   let browseWindow: BrowserWindow | null = null
   let streamdelayClient: StreamdelayClient | null = null
@@ -399,6 +416,30 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     } else if (msg.type === 'reload-view') {
       console.debug('Reloading view:', msg.viewIdx)
       streamWindow.reloadView(msg.viewIdx)
+    } else if (msg.type === 'interact-view') {
+      console.debug('Opening interact window for view:', msg.viewIdx)
+      const content = streamWindow.getViewContent(msg.viewIdx)
+      const session = streamWindow.getViewSession(msg.viewIdx)
+      if (!content || !session) {
+        console.warn('No view to interact with at index:', msg.viewIdx)
+        return
+      }
+      try {
+        await ensureValidURL(content.url)
+      } catch (error) {
+        console.error('Invalid URL for interact-view:', content.url, error)
+        return
+      }
+      const stream = clientState.streams.byURL?.get(content.url)
+      const label = stream?.label ?? stream?.source ?? content.url
+      interactWindow.open(
+        {
+          url: content.url,
+          title: `Interact: ${label}`,
+          session,
+        },
+        () => streamWindow.reloadView(msg.viewIdx),
+      )
     } else if (msg.type === 'browse' || msg.type === 'dev-tools') {
       if (browseWindow && !browseWindow.isDestroyed()) {
         // DevTools needs a fresh webContents to work. Close any existing window.


### PR DESCRIPTION
## Problem

Closes #15.

Streamwall reformats each stream page down to its bare `<video>` element
(`mediaPreload.ts` hides everything else with `* { display: none }`). That also
hides the site's own player controls — including the quality/bitrate cog — so an
operator can no longer turn a feed down. Feeds that push full 1080p at high
bitrate can't be reined in from the wall.

## Solution

Add a per-view **interact** button (cog icon) that opens the stream's original
page in a separate, interactive window with its native controls intact. The
operator lowers the quality there, in the real YouTube/Facebook/Twitch player.

The key detail after #97: each stream view now has its **own isolated ephemeral
session** (`view-N`). For a change made in the interact window to reach the wall
feed, the interact window is created **against the target view's session**
(Electron `webPreferences.session`). The two then share `localStorage`/cookies
(e.g. YouTube `yt-player-quality`), so when the interact window closes the wall
view reloads and picks up the lowered quality. Isolation between views is
preserved — only the one target view's session is shared.

This mirrors OBS's "Interact" and matches the issue title ("pop out and interact
with views being streamed"). It needs no fragile per-platform scraping.

## Architecture

- `interact-view` `ControlCommand` (view-bound) in `streamwall-shared`, granted
  to the **operator** role.
- `InteractWindow<Session>` (`main/InteractWindow.ts`): owns a single reusable
  pop-out. Switching to another view (each with its own session, bound at window
  creation) replaces the window and reloads the previous view; closing it reloads
  the current view. The `BrowserWindow` factory is injected and generic over the
  session type, so the class is unit-tested without Electron.
- `onCommand` (`main/index.ts`): resolves the view's url/label/session, validates
  the url (`await ensureValidURL`, SSRF guard from #94), opens the pop-out sharing
  the view session, and registers `reloadView(viewIdx)` as the apply callback.
- `StreamWindow.getViewContent` / `getViewSession` expose the target view's
  content and session by grid index.
- Control UI: `FaCog` button in the per-view controls, gated on `interact-view`.

The existing `browse` command (admin, generic URL, its own `BROWSE_PARTITION`) is
unchanged. The shared interactive-window config is not forced together to avoid
regressing that path.

## Security

- The interact window reuses the target view's session, which was already
  hardened in `StreamWindow.createView` (`hardenSession` denies all permission
  requests), so no separate hardening is needed. Same sandbox/contextIsolation/
  `nodeIntegration:false` posture as the browse window.
- The URL is re-validated through the SSRF guard before loading.
- No cross-view data bleed is introduced: only the single target view's session
  is shared with its own interact window.

## Tests

Uses the repo's existing Node.js test runner (`node --experimental-strip-types
--test`). Added 13 tests:

- **roles**: `interact-view` allowed for operator/admin/local, denied for
  monitor/null; existing permissions unchanged.
- **InteractWindow**: opens against the target session with the right url/title;
  reuses on same session; replaces + reloads previous view on session switch;
  reloads current view on close; applies each view exactly once across a switch
  and a later close (guards the async `closed` event against double-apply).

All workspace tests pass (81 total). `main` bundles cleanly via esbuild; the
control UI builds via Vite; ESLint is clean on the changed files.

## Risks / limitations (documented)

- Quality carry-over is **best effort** and platform-dependent: reliable for
  YouTube/Twitch (localStorage preference), less certain for Facebook. Raw
  `.m3u8` feeds have no native cog and aren't covered.
- The reload briefly interrupts the affected feed — a deliberate trade-off
  against fragile live manipulation of the running view.
- No breaking changes.

## Verification

Core logic is covered by unit tests; `main` bundling, control-UI build, lint and
targeted type checks are clean. The Electron GUI flow (clicking the cog, the
pop-out window, session carry-over on real platforms) should be sanity-checked in
a running app, since it can't be exercised headlessly here.
