### PR TITLE
Fail views on load error and add a loading timeout (#13)

### DIFF
--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -197,6 +197,24 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
 
     actor.start()
 
+    // Surface main-frame load failures (e.g. ERR_NAME_NOT_RESOLVED) as view
+    // errors so the state machine leaves the loading state instead of hanging.
+    // loadPage intentionally does not await loadURL — awaiting would delay the
+    // navigate->waitForInit transition past the preload's early VIEW_INIT and
+    // hang every view — so failures are reported here instead.
+    view.webContents.on(
+      'did-fail-load',
+      (_event, errorCode, errorDescription, _validatedURL, isMainFrame) => {
+        // -3 is ERR_ABORTED: superseded navigation or self-reload, not a failure.
+        if (isMainFrame && errorCode !== -3) {
+          actor.send({
+            type: 'VIEW_ERROR',
+            error: new Error(`Failed to load (${errorCode}): ${errorDescription}`),
+          })
+        }
+      },
+    )
+
     return actor
   }
 

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -15,6 +15,11 @@ import { Actor, assign, fromPromise, setup } from 'xstate'
 import { ensureValidURL } from '../util'
 import { loadHTML } from './loadHTML'
 
+// Safety net for the whole loading phase (navigate -> waitForInit -> waitForVideo).
+// Longer than the media preload's own acquisition timeouts (~20s) so that slow but
+// healthy streams are not cut off; only trips when the renderer never responds at all.
+const LOADING_TIMEOUT = 45 * 1000
+
 const viewStateMachine = setup({
   types: {
     input: {} as {
@@ -165,7 +170,12 @@ const viewStateMachine = setup({
         if (/\.m3u8?$/.test(content.url)) {
           loadHTML(wc, 'playHLS', { query: { src: content.url } })
         } else {
-          wc.loadURL(content.url)
+          // Do NOT await: the preload sends VIEW_INIT before loadURL resolves
+          // (did-finish-load), so awaiting here would strand that event and hang
+          // the view in waitForInit. Load failures are surfaced via the
+          // webContents 'did-fail-load' listener in StreamWindow; swallow the
+          // rejection so it isn't an unhandled promise rejection.
+          wc.loadURL(content.url).catch(() => {})
         }
       },
     ),
@@ -246,6 +256,17 @@ const viewStateMachine = setup({
       states: {
         loading: {
           initial: 'navigate',
+          // If the whole loading phase stalls (e.g. the renderer never sends
+          // VIEW_INIT/VIEW_LOADED), fail the view instead of hanging forever.
+          after: {
+            [LOADING_TIMEOUT]: {
+              target: '#view.displaying.error',
+              actions: {
+                type: 'logError',
+                params: { error: 'Timed out waiting for view to load' },
+              },
+            },
+          },
           states: {
             navigate: {
               invoke: {


### PR DESCRIPTION
Closes #13.

## Problem

`loadPage` called `wc.loadURL(content.url)` without handling its rejection.
`loadURL` rejects on any load failure, so `ERR_NAME_NOT_RESOLVED` / offline /
dead-page errors never reached the `error` state. The machine advanced to
`waitForInit`, which has **no timeout and no error path**, so the tile stayed
black indefinitely with no error indication.

## Why not the naive fix

The issue suggested `await wc.loadURL(...)`. That would **break every view**,
not just fix errors: the preload sends `VIEW_INIT` very early (on preload
start, via `ipcRenderer.invoke('view-init')`), *before* `loadURL` resolves at
`did-finish-load`. Awaiting would keep the machine in `navigate` (which has no
`VIEW_INIT` handler) until then, stranding that event, so even successful loads
would hang in `waitForInit` until the timeout.

Verified empirically in Electron — the ordering is:
`preload invoke(view-init)` → *then* `did-finish-load`.

## Fix

- **`StreamWindow.createView`** listens for the webContents `did-fail-load`
  event and sends `VIEW_ERROR` (ignoring `ERR_ABORTED` / `-3`, i.e. superseded
  navigations and self-reloads). This drives the **existing**
  `onError -> displaying.error` transition without changing load timing, so the
  `VIEW_INIT` race above never happens.
- `loadURL`'s rejection is swallowed with `.catch(() => {})` so it is not an
  unhandled promise rejection; the error surfaces via the listener.
- The `loading` state gets an `after: { 45000 }` timeout to `error` as a safety
  net for the case the renderer never responds at all (covers the issue's
  "waitForInit has no timeout" point). 45s is longer than the media preload's
  own acquisition timeouts (~20s), so healthy slow streams are not cut off.

## Verification

- Type-checks clean (no errors in the changed files).
- The `VIEW_INIT`-before-`did-finish-load` ordering was confirmed in a real
  Electron render.
- The state-machine semantics were confirmed with xstate's `SimulatedClock`:
  the `loading` `after` timeout stays armed across `navigate → waitForInit →
  waitForVideo`, fires to `error` at 45s, is cancelled on a successful move to
  `running`, and `VIEW_ERROR` from a loading substate lands in `error`.
- Not exercised: the live `did-fail-load` path with a real failing navigation
  (needs a running wall); it drives the pre-existing, tested
  `VIEW_ERROR -> error` transition.

## Base branch

Targets `main` (not the default `deps-modernization`). Because the base is not
the default branch, merging will not auto-close #13 — close it manually after.