### PR TITLE
fix(control-server): harden token comparison and use per-token scrypt salt

### DIFF
--- a/packages/streamwall-control-server/src/auth.test.ts
+++ b/packages/streamwall-control-server/src/auth.test.ts
@@ -157,3 +157,23 @@ test('validateToken accepts a legacy token hashed with the shared salt and no pe
     name: 'legacy',
   })
 })
+
+test('validateToken rejects a token revoked while its hash is being computed', async () => {
+  const auth = new Auth()
+  const { tokenId, secret } = await auth.createToken({
+    kind: 'session',
+    role: 'admin',
+    name: 'race',
+  })
+
+  // Kick off validation, then revoke the token before the (async) scrypt hash
+  // resolves. validateToken reads the token record before awaiting the hash;
+  // without a post-hash freshness check it would authenticate the already
+  // revoked secret against its stale snapshot.
+  const pending = auth.validateToken(tokenId, secret)
+  auth.deleteToken(tokenId)
+
+  const info = await pending
+
+  assert.equal(info, null)
+})

--- a/packages/streamwall-control-server/src/auth.test.ts
+++ b/packages/streamwall-control-server/src/auth.test.ts
@@ -1,0 +1,159 @@
+import baseX from 'base-x'
+import assert from 'node:assert/strict'
+import { scrypt as scryptCb } from 'node:crypto'
+import { test } from 'node:test'
+import { promisify } from 'node:util'
+import { type AuthToken, Auth, rand62 } from './auth.ts'
+
+const scrypt = promisify(scryptCb)
+
+// Independent re-implementation of the *legacy* stored-hash format (base62 of a
+// 24-byte scrypt digest computed with Node's default cost parameters, using the
+// shared salt). Used to assert backward compatibility with tokens that were
+// persisted before per-token salts existed.
+const base62 = baseX(
+  '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ',
+)
+async function legacyStoredHash(secret: string, salt: string): Promise<string> {
+  return base62.encode((await scrypt(secret, salt, 24)) as Buffer)
+}
+
+test('validateToken accepts the correct id and secret', async () => {
+  const auth = new Auth()
+  const { tokenId, secret } = await auth.createToken({
+    kind: 'session',
+    role: 'operator',
+    name: 'alice',
+  })
+
+  const info = await auth.validateToken(tokenId, secret)
+
+  assert.deepEqual(info, {
+    tokenId,
+    kind: 'session',
+    role: 'operator',
+    name: 'alice',
+  })
+})
+
+test('validateToken rejects a wrong secret with null', async () => {
+  const auth = new Auth()
+  const { tokenId } = await auth.createToken({
+    kind: 'session',
+    role: 'admin',
+    name: 'bob',
+  })
+
+  const info = await auth.validateToken(tokenId, 'not-the-secret')
+
+  assert.equal(info, null)
+})
+
+test('validateToken returns null for an unknown token id', async () => {
+  const auth = new Auth()
+
+  const info = await auth.validateToken('does-not-exist', 'whatever')
+
+  assert.equal(info, null)
+})
+
+test('validateToken returns null (never throws) when the stored hash length differs from the computed hash', async () => {
+  // A hand-crafted stored record whose base62 hash decodes to a single byte,
+  // while a freshly computed scrypt digest is always 24 bytes. Comparing the
+  // variable-length base62 *strings* (the previous behaviour) fed unequal-length
+  // buffers to timingSafeEqual, which throws RangeError instead of failing
+  // closed. This must now return null without throwing.
+  const auth = new Auth()
+  const tokenId = 'crafted0'
+  auth.tokensById.set(tokenId, {
+    tokenId,
+    tokenHash: 'z',
+    salt: rand62(24),
+    kind: 'session',
+    role: 'admin',
+    name: 'crafted',
+  })
+
+  const info = await auth.validateToken(tokenId, 'any-secret-whatsoever')
+
+  assert.equal(info, null)
+})
+
+test('createToken assigns each token a unique per-token salt distinct from the shared salt', async () => {
+  const auth = new Auth({ salt: 'SHARED-GLOBAL-SALT' })
+
+  const a = await auth.createToken({
+    kind: 'session',
+    role: 'admin',
+    name: 'a',
+  })
+  const b = await auth.createToken({
+    kind: 'session',
+    role: 'admin',
+    name: 'b',
+  })
+
+  const tokenA = auth.tokensById.get(a.tokenId)
+  const tokenB = auth.tokensById.get(b.tokenId)
+
+  assert.ok(tokenA?.salt, 'token A should carry a per-token salt')
+  assert.ok(tokenB?.salt, 'token B should carry a per-token salt')
+  assert.notEqual(tokenA.salt, 'SHARED-GLOBAL-SALT')
+  assert.notEqual(tokenA.salt, tokenB.salt)
+})
+
+test('getStoredData persists each token together with its per-token salt', async () => {
+  const auth = new Auth()
+  const { tokenId } = await auth.createToken({
+    kind: 'invite',
+    role: 'operator',
+    name: 'carol',
+  })
+
+  const stored = auth.getStoredData()
+  const token = stored.tokens.find((t) => t.tokenId === tokenId)
+
+  assert.ok(token?.salt, 'stored token should carry its per-token salt')
+})
+
+test('a token survives a storage round-trip and still validates', async () => {
+  const auth1 = new Auth()
+  const { tokenId, secret } = await auth1.createToken({
+    kind: 'session',
+    role: 'admin',
+    name: 'dave',
+  })
+
+  // Reload from persisted data into a fresh instance (fresh shared salt).
+  const auth2 = new Auth(auth1.getStoredData())
+  const info = await auth2.validateToken(tokenId, secret)
+
+  assert.deepEqual(info, {
+    tokenId,
+    kind: 'session',
+    role: 'admin',
+    name: 'dave',
+  })
+})
+
+test('validateToken accepts a legacy token hashed with the shared salt and no per-token salt', async () => {
+  const sharedSalt = rand62(24)
+  const secret = rand62(24)
+  const legacyToken: AuthToken = {
+    tokenId: 'legacy00',
+    tokenHash: await legacyStoredHash(secret, sharedSalt),
+    kind: 'session',
+    role: 'admin',
+    name: 'legacy',
+  }
+  const auth = new Auth({ salt: sharedSalt, tokens: [legacyToken] })
+
+  const info = await auth.validateToken('legacy00', secret)
+
+  assert.deepEqual(info, {
+    tokenId: 'legacy00',
+    kind: 'session',
+    role: 'admin',
+    name: 'legacy',
+  })
+})

--- a/packages/streamwall-control-server/src/auth.ts
+++ b/packages/streamwall-control-server/src/auth.ts
@@ -175,7 +175,12 @@ export class Auth extends EventEmitter<AuthEvents> {
     const salt = tokenData?.salt ?? this.salt
     const providedTokenHash = await hashTokenRaw(secret, salt)
 
-    if (!tokenData) {
+    // Re-read the record after the (async) hash: `deleteToken` may have revoked
+    // it while scrypt was running. Authenticating against the stale snapshot
+    // would let an already revoked secret succeed. Reference equality also
+    // rejects the case where the id was deleted and later reused for a new
+    // token (whose hash was computed under a different salt).
+    if (!tokenData || this.tokensById.get(id) !== tokenData) {
       return null
     }
 

--- a/packages/streamwall-control-server/src/auth.ts
+++ b/packages/streamwall-control-server/src/auth.ts
@@ -7,11 +7,14 @@ import {
   type StreamwallState,
   validRolesSet,
 } from 'streamwall-shared'
-import { promisify } from 'util'
 import type { StoredData } from './storage.ts'
 
 export interface AuthToken extends AuthTokenInfo {
   tokenHash: string
+  // Per-token salt. Optional so that tokens persisted before this field
+  // existed (hashed with the shared `Auth.salt`) still type-check and keep
+  // validating via the shared-salt fallback in `validateToken`.
+  salt?: string
 }
 
 export interface AuthState {
@@ -22,8 +25,6 @@ export interface AuthState {
 interface AuthEvents {
   state: [AuthState]
 }
-
-const scrypt = promisify(scryptCb)
 
 const base62 = baseX(
   '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ',
@@ -42,9 +43,34 @@ export function uniqueRand62(len: number, map: Map<string, unknown>) {
   return val
 }
 
-async function hashToken62(token: string, salt: string) {
-  const hashBuffer = await scrypt(token, salt, 24)
-  return base62.encode(hashBuffer as Buffer)
+// Length of the raw scrypt digest, in bytes. Fixed regardless of input, which
+// is what lets `validateToken` compare digests in constant time.
+const SCRYPT_KEYLEN = 24
+
+// scrypt cost parameters, pinned explicitly rather than relying on Node's
+// implicit defaults. These MUST match the values used to hash every
+// already-persisted token (Node's defaults: N=16384, r=8, p=1) — raising them
+// would invalidate existing session, invite and streamwall-uplink tokens on
+// upgrade. The token secrets themselves are 24 random bytes (~143 bits), so a
+// higher work factor would add cost without meaningfully improving security.
+const SCRYPT_PARAMS = { N: 16384, r: 8, p: 1 } as const
+
+// Raw, fixed-length scrypt digest of a secret under a given salt.
+function hashTokenRaw(secret: string, salt: string): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    scryptCb(secret, salt, SCRYPT_KEYLEN, SCRYPT_PARAMS, (err, derivedKey) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(derivedKey)
+      }
+    })
+  })
+}
+
+// Persisted form of a token hash: the raw digest, base62-encoded.
+async function hashToken62(secret: string, salt: string): Promise<string> {
+  return base62.encode(await hashTokenRaw(secret, salt))
 }
 
 // Wrapper for state data to facilitate role-scoped data access.
@@ -141,20 +167,34 @@ export class Auth extends EventEmitter<AuthEvents> {
     id: string,
     secret: string,
   ): Promise<AuthTokenInfo | null> {
-    const tokenHash = await hashToken62(secret, this.salt)
     const tokenData = this.tokensById.get(id)
+
+    // Hash unconditionally — even for an unknown id — so the response time does
+    // not reveal whether the id exists (a user-enumeration oracle). Tokens
+    // persisted before per-token salts fall back to the shared salt.
+    const salt = tokenData?.salt ?? this.salt
+    const providedTokenHash = await hashTokenRaw(secret, salt)
 
     if (!tokenData) {
       return null
     }
 
-    const providedTokenHashBuf = Buffer.from(tokenHash)
-    const expectedTokenHashBuf = Buffer.from(tokenData.tokenHash)
-    const isTokenMatch = timingSafeEqual(
-      providedTokenHashBuf,
-      expectedTokenHashBuf,
-    )
-    if (!isTokenMatch) {
+    // Compare the fixed-length raw digests, not their base62 encodings: base62
+    // length depends on the digest's leading zero bytes, and feeding
+    // unequal-length buffers to `timingSafeEqual` throws a RangeError (and the
+    // early exit leaks the length). Malformed stored data that fails to decode
+    // is treated as a non-match.
+    let expectedTokenHash: Uint8Array
+    try {
+      expectedTokenHash = base62.decode(tokenData.tokenHash)
+    } catch {
+      return null
+    }
+
+    if (
+      providedTokenHash.length !== expectedTokenHash.length ||
+      !timingSafeEqual(providedTokenHash, expectedTokenHash)
+    ) {
       return null
     }
 
@@ -173,10 +213,12 @@ export class Auth extends EventEmitter<AuthEvents> {
 
     const tokenId = uniqueRand62(8, this.tokensById)
     const secret = rand62(24)
-    const tokenHash = await hashToken62(secret, this.salt)
-    const tokenData = {
+    const salt = rand62(24)
+    const tokenHash = await hashToken62(secret, salt)
+    const tokenData: AuthToken = {
       tokenId,
       tokenHash,
+      salt,
       kind,
       role,
       name,


### PR DESCRIPTION
## Problem

Issue #10 (security, control-server): the token authentication path had three weaknesses.

1. **`timingSafeEqual` on variable-length input.** `validateToken` compared the **base62 encodings** of the scrypt digests. base62 length depends on a digest's leading zero bytes, so a legitimate wrong-secret guess could produce an encoding of a different length than the stored one. `crypto.timingSafeEqual` throws `RangeError: Input buffers must have the same byte length` in that case. The throw was not caught at the callers, so instead of failing closed with a `403` the request surfaced as a `500` — and the length-dependent early exit defeats the constant-time intent (a length side channel).
2. **Single shared salt.** Every token was hashed with one `Auth`-wide salt, so there was no per-token separation.
3. **Implicit scrypt cost.** scrypt was called without explicit cost parameters, relying on Node's defaults.

## Solution

- **Compare fixed-length raw digests.** `validateToken` now hashes the presented secret to the raw 24-byte scrypt digest and compares it against the stored hash decoded back to raw bytes. Raw scrypt output is always `keylen` bytes, so `timingSafeEqual` always receives equal-length buffers on the real attack path. Decoding of the stored value is wrapped in `try/catch`, and a length guard precedes `timingSafeEqual` so malformed/legacy data fails closed instead of throwing.
- **Per-token salt.** `createToken` generates a fresh random salt per token and persists it alongside the hash. `validateToken` hashes with that token's salt.
- **Explicit scrypt parameters.** The cost parameters are pinned in code (`N=16384, r=8, p=1`).
- **Constant-time on unknown ids.** `validateToken` performs the scrypt hash unconditionally — even when the id is unknown — so an attacker cannot distinguish existing from non-existing token ids by response timing.
- **No auth against a stale snapshot** (from Bugbot review, see below). `validateToken` re-reads the token record after the async hash and rejects unless it is still present and reference-identical, so a token revoked via `deleteToken` while scrypt is running can no longer authenticate.

## Key decisions / backward compatibility

- **The pinned scrypt parameters equal Node's previous implicit defaults on purpose.** Every already-persisted token hash was produced with those defaults; raising the work factor would silently invalidate all existing session, invite and streamwall-uplink tokens on upgrade. The secrets are 24 random bytes (~143 bits), so a higher work factor would add cost without meaningful security benefit.
- **The per-token `salt` field is optional.** Tokens persisted before this change (no per-token salt) keep validating through a fallback to the shared `Auth.salt`. A dedicated test locks this in by reconstructing a legacy record with an independent re-implementation of the old stored-hash format.
- Storage format change is additive: `AuthToken` gains an optional `salt?: string`; the persisted hash encoding (base62) is unchanged, so `storage.json` stays readable.

## Risks / breaking changes

None expected. Existing tokens remain valid (verified by the legacy-compatibility test). No public API of `Auth` changed shape; `createToken`/`validateToken`/`getStoredData` signatures are unchanged.

## Test coverage

Written test-first (TDD). New `packages/streamwall-control-server/src/auth.test.ts` (`node:test`), 9 tests:

- accepts the correct id + secret (happy path)
- rejects a wrong secret with `null`
- returns `null` for an unknown token id
- **returns `null` without throwing on a stored/computed hash length mismatch** (regression for the `RangeError`)
- `createToken` assigns a unique per-token salt distinct from the shared salt
- `getStoredData` persists each token's per-token salt
- a token survives a storage round-trip and still validates
- accepts a legacy token hashed with the shared salt and no per-token salt (backward compatibility)
- **rejects a token revoked while its hash is being computed** (regression for the TOCTOU below)

Verification: full control-server suite **27/27 green**, `tsc --noEmit` clean, Prettier clean.

## Review

Cursor Bugbot (high effort) flagged one Medium issue — *"Stale token after concurrent delete"*: because per-token salting requires reading the record before the async hash, a token revoked mid-hash could still authenticate. This was a genuine regression (the previous code looked the record up *after* hashing) and is fixed in `6fe5c1c` with a post-hash freshness re-check plus a deterministic regression test. The follow-up Bugbot re-review passed with no findings.

> Note: this repo has no PR CI beyond Cursor Bugbot. Repo-wide ESLint is currently broken (ESLint 10 without a flat config) — a pre-existing, separate condition untouched by this PR.

Closes #10