### PR TITLE
fix(streamwall): update grid config before the resize transact so views survive (#15)

### DIFF
--- a/packages/streamwall/src/main/gridResize.test.ts
+++ b/packages/streamwall/src/main/gridResize.test.ts
@@ -1,0 +1,225 @@
+import {
+  boxesFromViewContentMap,
+  GRID_MAX,
+  type ViewContentMap,
+} from 'streamwall-shared'
+import { describe, expect, it } from 'vitest'
+import * as Y from 'yjs'
+import { applyGridResize, type GridResizeContext } from './gridResize'
+
+/**
+ * Minimal-but-faithful stand-in for `StreamWindow`. It reproduces the one
+ * behaviour that matters for issue #15: a running view survives a re-layout iff
+ * its content still occupies a box in the *current* grid. The destroy/reuse
+ * decision is delegated to the real shared geometry (`boxesFromViewContentMap`),
+ * so it matches production without pulling in the Electron runtime.
+ */
+class FakeWall {
+  cols: number
+  rows: number
+  /** content url -> stable view id (kept across setViews while still boxed). */
+  live = new Map<string, number>()
+  destroyed: number[] = []
+  created: number[] = []
+  private nextId = 1
+
+  constructor(cols: number, rows: number) {
+    this.cols = cols
+    this.rows = rows
+  }
+
+  setGridSize(cols: number, rows: number) {
+    this.cols = cols
+    this.rows = rows
+  }
+
+  setViews(viewContentMap: ViewContentMap) {
+    const boxes = boxesFromViewContentMap(this.cols, this.rows, viewContentMap)
+    const wanted = new Set<string>()
+    for (const box of boxes) {
+      if (box.content) {
+        wanted.add(box.content.url)
+      }
+    }
+    // Destroy views whose content no longer has a box in the current grid.
+    for (const [url, id] of [...this.live]) {
+      if (!wanted.has(url)) {
+        this.destroyed.push(id)
+        this.live.delete(url)
+      }
+    }
+    // Create views for newly boxed content.
+    for (const url of wanted) {
+      if (!this.live.has(url)) {
+        const id = this.nextId++
+        this.live.set(url, id)
+        this.created.push(id)
+      }
+    }
+  }
+}
+
+/**
+ * Wires up a Yjs doc, a `viewsState` map and a `FakeWall` exactly like the main
+ * process does, including the synchronous `observeDeep` observer that re-lays
+ * the wall out (`updateViewsFromStateDoc`).
+ */
+function setupWall(cols: number, rows: number) {
+  const doc = new Y.Doc()
+  const viewsState = doc.getMap<Y.Map<string | undefined>>('views')
+  const wall = new FakeWall(cols, rows)
+
+  function updateViewsFromStateDoc() {
+    const viewContentMap: ViewContentMap = new Map()
+    for (const [key, viewData] of viewsState) {
+      const streamId = viewData.get('streamId')
+      if (streamId === undefined || streamId === '') {
+        continue
+      }
+      // The streamId doubles as the content url in these tests.
+      viewContentMap.set(key, { url: streamId, kind: 'video' })
+    }
+    wall.setViews(viewContentMap)
+  }
+
+  const ctx: GridResizeContext = {
+    viewsState,
+    transact: (fn) => doc.transact(fn),
+    getCols: () => wall.cols,
+    setGridSize: (c, r) => wall.setGridSize(c, r),
+  }
+
+  return { doc, viewsState, wall, updateViewsFromStateDoc, ctx }
+}
+
+/** Seeds `viewsState` with a full grid; `streams` maps cell index -> streamId. */
+function seedAssignments(
+  viewsState: Y.Map<Y.Map<string | undefined>>,
+  cols: number,
+  rows: number,
+  streams: Record<number, string>,
+) {
+  viewsState.doc!.transact(() => {
+    for (let i = 0; i < cols * rows; i++) {
+      const data = new Y.Map<string | undefined>()
+      data.set('streamId', streams[i])
+      viewsState.set(String(i), data)
+    }
+  })
+}
+
+describe('applyGridResize', () => {
+  it('preserves the running view when the grid grows (issue #15)', () => {
+    const { viewsState, wall, updateViewsFromStateDoc, ctx } = setupWall(2, 2)
+
+    // 2x2 grid with a single stream assigned to cell 3 (x=1, y=1).
+    seedAssignments(viewsState, 2, 2, { 3: 'stream-a' })
+
+    // Initial layout: exactly one view is created for the stream.
+    updateViewsFromStateDoc()
+    const initialId = wall.live.get('stream-a')
+    expect(initialId).toBeDefined()
+    expect(wall.created).toEqual([initialId])
+
+    // Attach the synchronous observer, mirroring the main process.
+    viewsState.observeDeep(updateViewsFromStateDoc)
+
+    // Grow to 3x3: remapGridAssignments moves the stream from cell 3 to cell 4.
+    applyGridResize(ctx, 3, 3)
+
+    // The view must be reused, not destroyed and reloaded. Before the fix the
+    // observer fired mid-transact against the stale 2x2 config, cell 4 produced
+    // no box, and the view was destroyed then recreated (a full reload).
+    expect(wall.destroyed).toEqual([])
+    expect(wall.created).toEqual([initialId])
+    expect(wall.live.get('stream-a')).toBe(initialId)
+    // The stream really did move to cell 4 of the new grid.
+    expect(viewsState.get('4')?.get('streamId')).toBe('stream-a')
+    expect(wall.cols).toBe(3)
+    expect(wall.rows).toBe(3)
+  })
+
+  it('applies the new grid size before the transact observer runs', () => {
+    const doc = new Y.Doc()
+    const viewsState = doc.getMap<Y.Map<string | undefined>>('views')
+    seedAssignments(viewsState, 2, 2, { 3: 'stream-a' })
+
+    let cols = 2
+    let rows = 2
+    const observedDims: Array<[number, number]> = []
+    // Runs synchronously at the end of transact, like updateViewsFromStateDoc.
+    viewsState.observeDeep(() => observedDims.push([cols, rows]))
+
+    const ctx: GridResizeContext = {
+      viewsState,
+      transact: (fn) => doc.transact(fn),
+      getCols: () => cols,
+      setGridSize: (c, r) => {
+        cols = c
+        rows = r
+      },
+    }
+
+    applyGridResize(ctx, 3, 3)
+
+    expect(observedDims.length).toBeGreaterThan(0)
+    for (const dims of observedDims) {
+      expect(dims).toEqual([3, 3])
+    }
+  })
+
+  it('keeps each stream at its (x, y) position when the grid grows', () => {
+    const { viewsState, ctx } = setupWall(2, 2)
+    // cell 1 = (x=1, y=0); cell 2 = (x=0, y=1).
+    seedAssignments(viewsState, 2, 2, { 1: 'stream-a', 2: 'stream-b' })
+
+    applyGridResize(ctx, 4, 4)
+
+    // (1,0) -> 4*0 + 1 = 1; (0,1) -> 4*1 + 0 = 4.
+    expect(viewsState.get('1')?.get('streamId')).toBe('stream-a')
+    expect(viewsState.get('4')?.get('streamId')).toBe('stream-b')
+  })
+
+  it('drops and destroys a stream that falls outside a shrunk grid', () => {
+    const { viewsState, wall, updateViewsFromStateDoc, ctx } = setupWall(3, 3)
+    // cell 8 = (x=2, y=2), only reachable in a 3x3 (or larger) grid.
+    seedAssignments(viewsState, 3, 3, { 8: 'stream-a' })
+
+    updateViewsFromStateDoc()
+    const initialId = wall.live.get('stream-a')
+    expect(initialId).toBeDefined()
+
+    viewsState.observeDeep(updateViewsFromStateDoc)
+
+    // Shrink to 2x2: (2,2) no longer exists, so the stream is dropped.
+    applyGridResize(ctx, 2, 2)
+
+    expect(wall.destroyed).toEqual([initialId])
+    expect(wall.live.has('stream-a')).toBe(false)
+    // No cell in the new 2x2 grid references the dropped stream.
+    for (let i = 0; i < 4; i++) {
+      expect(viewsState.get(String(i))?.get('streamId')).toBeUndefined()
+    }
+  })
+
+  it('rebuilds viewsState to exactly cover the new grid', () => {
+    const { viewsState, ctx } = setupWall(2, 2)
+    seedAssignments(viewsState, 2, 2, {})
+
+    applyGridResize(ctx, 3, 2)
+
+    expect(
+      [...viewsState.keys()].sort((a, b) => Number(a) - Number(b)),
+    ).toEqual(['0', '1', '2', '3', '4', '5'])
+  })
+
+  it('clamps requested dimensions into the valid range and returns them', () => {
+    const { viewsState, ctx } = setupWall(2, 2)
+    seedAssignments(viewsState, 2, 2, {})
+
+    const applied = applyGridResize(ctx, 0, 999)
+
+    expect(applied).toEqual({ cols: 1, rows: GRID_MAX })
+    expect(viewsState.size).toBe(1 * GRID_MAX)
+  })
+})

--- a/packages/streamwall/src/main/gridResize.ts
+++ b/packages/streamwall/src/main/gridResize.ts
@@ -1,0 +1,75 @@
+import { clampGridDimension, remapGridAssignments } from 'streamwall-shared'
+import * as Y from 'yjs'
+
+/**
+ * Collaborators the grid-resize orchestration needs from the main process,
+ * expressed as an explicit interface so the ordering-sensitive logic can be
+ * unit-tested without the Electron runtime.
+ */
+export interface GridResizeContext {
+  /** Yjs map of grid cell index (as string) -> a `{ streamId }` map. */
+  viewsState: Y.Map<Y.Map<string | undefined>>
+  /** Runs `fn` inside the shared `stateDoc.transact`, batching the mutations. */
+  transact: (fn: () => void) => void
+  /** Current column count of the wall (used to read each cell's (x, y)). */
+  getCols: () => number
+  /** Applies the new grid dimensions to the wall (mutates the shared config). */
+  setGridSize: (cols: number, rows: number) => void
+}
+
+/**
+ * Resizes the wall grid in response to a `set-grid-size` command, preserving
+ * every stream that still fits the new grid.
+ *
+ * Ordering is critical. The stateDoc's `observeDeep` observer
+ * (`updateViewsFromStateDoc`) runs *synchronously* at the end of `transact`,
+ * re-laying the wall out from the freshly written assignments. That layout reads
+ * the grid dimensions from the shared config, so the config MUST already hold
+ * the new `cols`/`rows` before the transact runs. Otherwise a stream remapped
+ * into a cell beyond the old grid (e.g. cell 3 of a 2x2 grid moving to cell 4 of
+ * a 3x3 grid) produces no layout box, and `StreamWindow.setViews` destroys the
+ * running view — making the stream go black and fully reload on every grid grow
+ * (issue #15).
+ *
+ * @returns the clamped dimensions actually applied.
+ */
+export function applyGridResize(
+  ctx: GridResizeContext,
+  requestedCols: number,
+  requestedRows: number,
+): { cols: number; rows: number } {
+  const cols = clampGridDimension(requestedCols)
+  const rows = clampGridDimension(requestedRows)
+  const oldCols = ctx.getCols()
+
+  // Read current assignments keyed by old cell index.
+  const oldAssignments = new Map<number, string | undefined>()
+  for (const [key, viewData] of ctx.viewsState) {
+    oldAssignments.set(Number(key), viewData.get('streamId'))
+  }
+
+  // Remap by (x, y) into the new grid, then rebuild the views map.
+  const newAssignments = remapGridAssignments(
+    oldCols,
+    cols,
+    rows,
+    oldAssignments,
+  )
+
+  // Update the grid dimensions BEFORE the transact so the synchronous observer
+  // lays the wall out against the new grid. See the ordering note above.
+  ctx.setGridSize(cols, rows)
+
+  ctx.transact(() => {
+    for (const key of [...ctx.viewsState.keys()]) {
+      ctx.viewsState.delete(key)
+    }
+    for (const [idx, streamId] of newAssignments) {
+      const data = new Y.Map<string | undefined>()
+      data.set('streamId', streamId)
+      ctx.viewsState.set(String(idx), data)
+    }
+  })
+
+  return { cols, rows }
+}

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -11,10 +11,8 @@ import 'source-map-support/register'
 import {
   ControlCommand,
   StreamwallState,
-  clampGridDimension,
   isCommandAllowedFromUplink,
   isSecureControlEndpoint,
-  remapGridAssignments,
 } from 'streamwall-shared'
 import { updateElectronApp } from 'update-electron-app'
 import WebSocket from 'ws'
@@ -30,6 +28,7 @@ import {
   pollDataURL,
   watchDataFile,
 } from './data'
+import { applyGridResize } from './gridResize'
 import { loadStorage } from './storage'
 import StreamdelayClient from './StreamdelayClient'
 import StreamWindow from './StreamWindow'
@@ -457,41 +456,25 @@ async function main(argv: ReturnType<typeof parseArgs>) {
       console.debug('Setting stream running:', msg.isStreamRunning)
       streamdelayClient.setStreamRunning(msg.isStreamRunning)
     } else if (msg.type === 'set-grid-size') {
-      const cols = clampGridDimension(msg.cols)
-      const rows = clampGridDimension(msg.rows)
-      const oldCols = streamWindowConfig.cols
-
-      // Read current assignments keyed by old cell index.
-      const oldAssignments = new Map<number, string | undefined>()
-      for (const [key, viewData] of viewsState) {
-        oldAssignments.set(Number(key), viewData.get('streamId'))
-      }
-
-      // Remap by (x, y) into the new grid, then rebuild the views map.
-      const newAssignments = remapGridAssignments(
-        oldCols,
-        cols,
-        rows,
-        oldAssignments,
+      applyGridResize(
+        {
+          viewsState,
+          transact: (fn) => stateDoc.transact(fn),
+          getCols: () => streamWindowConfig.cols,
+          setGridSize: (cols, rows) => streamWindow.setGridSize(cols, rows),
+        },
+        msg.cols,
+        msg.rows,
       )
-      stateDoc.transact(() => {
-        for (const key of [...viewsState.keys()]) {
-          viewsState.delete(key)
-        }
-        for (const [idx, streamId] of newAssignments) {
-          const data = new Y.Map<string | undefined>()
-          data.set('streamId', streamId)
-          viewsState.set(String(idx), data)
-        }
-      })
 
       // streamWindow.config, streamWindowConfig and clientState.config are the
       // same shared object, and setGridSize mutates it in place. Broadcast that
       // shared object via updateState({}) rather than detaching a copy, so a
       // later window resize keeps the overlay/control grid in sync with the wall
-      // (issue #14).
-      streamWindow.setGridSize(cols, rows)
-      updateViewsFromStateDoc()
+      // (issue #14). The wall itself was already re-laid-out by the stateDoc
+      // observer during applyGridResize's transact — now that the config holds
+      // the new dimensions (issue #15) — so no explicit updateViewsFromStateDoc()
+      // call is needed here.
       updateState({})
     }
   }


### PR DESCRIPTION
## Problem

`set-grid-size` destroyed and reloaded a running stream on **every grid grow** — the affected view went black and fully reloaded instead of smoothly moving to its new cell.

**Root cause (issue #15):** The handler wrote the remapped cell assignments inside `stateDoc.transact()` and only called `streamWindow.setGridSize(cols, rows)` *afterwards*. Yjs runs `observeDeep` observers **synchronously at the end of `transact`**, so `updateViewsFromStateDoc` re-laid the wall out while `streamWindowConfig` still held the **old** `cols`/`rows`.

A stream remapped into a cell beyond the old grid (e.g. cell 3 of a 2×2 grid → cell 4 of a 3×3 grid) produced no layout box in `boxesFromViewContentMap`, so `StreamWindow.setViews` treated the running view as unused and destroyed it (`view.stop()`, `webContents.close()`, `offscreenWin.destroy()`). The trailing explicit `updateViewsFromStateDoc()` — now running with the correct dimensions — then re-created the view from scratch.

## Solution

- Extracted the resize orchestration into `applyGridResize()` (`packages/streamwall/src/main/gridResize.ts`).
- **Update the grid dimensions before the transact**, so the synchronous observer lays the wall out against the new grid and *reuses* the existing view instead of destroying it.
- Dropped the now-redundant explicit `updateViewsFromStateDoc()` call (the observer already re-laid the wall out during the transact).

This is the primary fix recommended in the issue. `setGridSize` only mutates the shared config in place (no side effects), so moving it earlier is safe; `oldCols` is still captured before the mutation for the `(x, y)` remap.

## Architecture

The orchestration was inlined in `main()` — an Electron-bound closure that can't be unit-tested. Extracting `applyGridResize()` behind a small `GridResizeContext` interface (viewsState / transact / getCols / setGridSize) gives the ordering-critical logic a testable seam **without** pulling in the Electron runtime, matching the existing `StreamWindow.test.ts` approach.

## Test coverage

New `gridResize.test.ts` (6 tests). The two headline tests were verified to **fail against the pre-fix ordering** (view destroyed; observer saw stale `2×2`) and pass after:

- **Regression:** a running view is *reused, not destroyed + reloaded* when the grid grows (reproduces the bug via a faithful fake wall driven by the real `boxesFromViewContentMap` + a real Yjs observer).
- **Ordering invariant:** the synchronous observer only ever sees the *new* dimensions.
- `(x, y)` position preservation on grow.
- Streams outside a shrunk grid are dropped and their views destroyed.
- Dimension clamping (`GRID_MIN`/`GRID_MAX`) and full `viewsState` rebuild.

Full `streamwall` suite: **22 passed**. No new TypeScript errors (verified via before/after `tsc` diff). Prettier-clean. Main-process graph bundles cleanly.

## Risks / breaking changes

None. Behaviour is unchanged except that the reassigned view is now preserved across a grid grow. No public API or wire-protocol change. Keeps the shared-config-object invariant from #14 intact (`setGridSize` still mutates in place; `updateState({})` still broadcasts it).

Closes #15

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches main-process grid resize and view lifecycle ordering; behavior change is intentional but affects live stream rendering during `set-grid-size`.
> 
> **Overview**
> Fixes **grid grow** causing running streams to go black and fully reload (#15). The `set-grid-size` handler now calls **`applyGridResize`**, which applies the new **`cols`/`rows` via `setGridSize` before** the Yjs `transact` that rebuilds cell assignments. That way the synchronous `observeDeep` layout runs against the **new** grid instead of stale dimensions, so remapped cells still get layout boxes and **`StreamWindow` reuses** existing views.
> 
> Resize orchestration is extracted from `index.ts` into testable **`gridResize.ts`** behind a **`GridResizeContext`** seam. The handler no longer calls **`updateViewsFromStateDoc()`** after resize—the observer already re-lays the wall during the transact. **`gridResize.test.ts`** adds regression coverage (view reuse on grow, ordering invariant, shrink/drop, remap, clamping).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e53ecf4a8fa392aef9fb3b8dfde66667ab0df66d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->