### PR TITLE
fix(security): stop leaking control-server secrets via storage, logs, and URLs (#4)

### DIFF
--- a/packages/streamwall-control-server/src/bootstrap.test.ts
+++ b/packages/streamwall-control-server/src/bootstrap.test.ts
@@ -1,0 +1,165 @@
+import assert from 'node:assert/strict'
+import { after, describe, test } from 'node:test'
+
+import { initApp, initialInviteCodes } from './index.ts'
+import type { StorageDB } from './storage.ts'
+import { inMemoryDb, makeStaticDir } from './testHelpers.ts'
+
+const BASE_URL = 'https://wall.example.com'
+
+/**
+ * Boots the control app against a given storage backend and runs the bootstrap
+ * step, faithfully wiring the same auth-persistence hook `runServer` relies on.
+ * Calling it twice against the same `db` simulates a server restart.
+ */
+async function boot(db: StorageDB) {
+  const { app, auth } = await initApp({
+    baseURL: BASE_URL,
+    clientStaticPath: makeStaticDir(),
+    db,
+  })
+  after(() => app.close())
+  const result = await initialInviteCodes({ db, auth, baseURL: BASE_URL })
+  return { app, auth, result }
+}
+
+/** Serializes storage the way it lands on disk, to detect leaked plaintext. */
+function storageContains(db: StorageDB, needle: string) {
+  return JSON.stringify(db.data).includes(needle)
+}
+
+describe('initialInviteCodes uplink token', () => {
+  test('mints an uplink token and reveals its secret exactly once', async () => {
+    const db = inMemoryDb()
+    const { result } = await boot(db)
+
+    assert.ok(result.uplinkSecret, 'the secret is surfaced when freshly minted')
+    assert.ok(db.data.streamwallToken, 'the uplink token id is persisted')
+    assert.equal(
+      db.data.streamwallToken.tokenId,
+      db.data.auth.tokens.find((t) => t.kind === 'streamwall')?.tokenId,
+      'the persisted id matches the hashed auth token',
+    )
+  })
+
+  test('never persists the plaintext uplink secret to storage', async () => {
+    const db = inMemoryDb()
+    const { result } = await boot(db)
+
+    assert.ok(result.uplinkSecret)
+    assert.equal(
+      (db.data.streamwallToken as { secret?: string }).secret,
+      undefined,
+      'the stored uplink record must not carry a secret field',
+    )
+    assert.equal(
+      storageContains(db, result.uplinkSecret),
+      false,
+      'the plaintext uplink secret must not appear anywhere in storage',
+    )
+  })
+
+  test('reuses the existing uplink token without re-revealing the secret', async () => {
+    const db = inMemoryDb()
+    const { result: first } = await boot(db)
+    const firstId = db.data.streamwallToken?.tokenId
+
+    const { result: second } = await boot(db)
+
+    assert.ok(first.uplinkSecret)
+    assert.equal(
+      second.uplinkSecret,
+      null,
+      'a restart cannot recover (and must not re-reveal) the secret',
+    )
+    assert.equal(
+      db.data.streamwallToken?.tokenId,
+      firstId,
+      'the uplink token id is stable across restarts',
+    )
+    const streamwallTokens = db.data.auth.tokens.filter(
+      (t) => t.kind === 'streamwall',
+    )
+    assert.equal(
+      streamwallTokens.length,
+      1,
+      'restarting must not mint a second uplink token',
+    )
+  })
+
+  test('strips a legacy plaintext secret from storage on startup', async () => {
+    const db = inMemoryDb()
+    const { result: first } = await boot(db)
+    const tokenId = db.data.streamwallToken!.tokenId
+
+    // Recreate the pre-fix on-disk shape: the hashed auth token is untouched,
+    // but the uplink record still carries the plaintext secret it used to hold.
+    const legacyPlaintext = 'legacy-plaintext-secret'
+    db.data.streamwallToken = {
+      tokenId,
+      secret: legacyPlaintext,
+    } as StorageDB['data']['streamwallToken']
+
+    const { result: second } = await boot(db)
+
+    assert.ok(first.uplinkSecret)
+    assert.equal(
+      second.uplinkSecret,
+      null,
+      'a legacy secret is not re-revealed',
+    )
+    assert.equal(
+      (db.data.streamwallToken as { secret?: string }).secret,
+      undefined,
+      'the legacy plaintext secret is scrubbed from storage',
+    )
+    assert.equal(
+      storageContains(db, legacyPlaintext),
+      false,
+      'no trace of the legacy plaintext secret remains on disk',
+    )
+  })
+
+  test('rotates the uplink token when its storage record is cleared', async () => {
+    const db = inMemoryDb()
+    const { result: first } = await boot(db)
+    assert.ok(first.uplinkSecret)
+
+    // Operator rotates by removing the persisted uplink record and restarting.
+    db.data.streamwallToken = null
+    const { result: second } = await boot(db)
+
+    assert.ok(second.uplinkSecret, 'a fresh secret is revealed after rotation')
+    assert.notEqual(
+      second.uplinkSecret,
+      first.uplinkSecret,
+      'rotation produces a new secret',
+    )
+    const streamwallTokens = db.data.auth.tokens.filter(
+      (t) => t.kind === 'streamwall',
+    )
+    assert.equal(
+      streamwallTokens.length,
+      1,
+      'the superseded uplink token is removed so the old secret stops working',
+    )
+  })
+
+  test('the surfaced uplink endpoint carries no secret', async () => {
+    const db = inMemoryDb()
+    const { result } = await boot(db)
+
+    assert.ok(result.uplinkSecret)
+    assert.match(result.uplinkEndpoint, /^wss:\/\//)
+    assert.equal(
+      result.uplinkEndpoint.includes(result.uplinkSecret),
+      false,
+      'the endpoint string must not embed the secret',
+    )
+    assert.equal(
+      result.uplinkEndpoint.includes('token='),
+      false,
+      'the endpoint must not carry a token query parameter',
+    )
+  })
+})

--- a/packages/streamwall-control-server/src/index.test.ts
+++ b/packages/streamwall-control-server/src/index.test.ts
@@ -16,8 +16,9 @@ function inMemoryDb(): Low<StoredData> {
 
 /**
  * Build an isolated control-server app backed by in-memory storage, mint a
- * fresh invite token and redeem it via `GET /invite/:id`. Returns the raw
- * `Set-Cookie` header produced for the resulting session cookie.
+ * fresh invite token and redeem it via `POST /invite/:id` (the secret travels
+ * in the body, never the URL). Returns the raw `Set-Cookie` header produced for
+ * the resulting session cookie.
  */
 async function redeemInvite(baseURL: string) {
   const { app, auth } = await initApp({
@@ -34,8 +35,10 @@ async function redeemInvite(baseURL: string) {
   })
 
   const response = await app.inject({
-    method: 'GET',
-    url: `/invite/${tokenId}?token=${secret}`,
+    method: 'POST',
+    url: `/invite/${tokenId}`,
+    headers: { 'content-type': 'application/json' },
+    payload: { token: secret },
   })
 
   const rawSetCookie = response.headers['set-cookie']
@@ -89,8 +92,10 @@ describe('session cookie security attributes', () => {
     after(() => app.close())
 
     const response = await app.inject({
-      method: 'GET',
-      url: '/invite/does-not-exist?token=bogus',
+      method: 'POST',
+      url: '/invite/does-not-exist',
+      headers: { 'content-type': 'application/json' },
+      payload: { token: 'bogus' },
     })
 
     assert.equal(response.statusCode, 403)

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -616,7 +616,24 @@ export async function initApp({
   return { app, db, auth }
 }
 
-async function initialInviteCodes({
+/** Builds the uplink WebSocket endpoint URL, which never embeds the secret. */
+function uplinkEndpointURL(baseURL: string, tokenId: string) {
+  return `${baseURL.replace(/^http/, 'ws')}/streamwall/${tokenId}/ws`
+}
+
+export interface BootstrapResult {
+  /**
+   * The plaintext uplink secret, exposed *only* when the token was freshly
+   * minted. `null` on a restart, where the secret is unrecoverable by design.
+   */
+  uplinkSecret: string | null
+  /** The uplink WebSocket endpoint (never carries the secret). */
+  uplinkEndpoint: string
+  /** A fresh single-use admin invite link (regenerated every startup). */
+  adminInviteLink: string
+}
+
+export async function initialInviteCodes({
   db,
   auth,
   baseURL,
@@ -624,17 +641,44 @@ async function initialInviteCodes({
   db: StorageDB
   auth: Auth
   baseURL: string
-}) {
-  // Create a token for streamwall uplink (if not existing):
-  let streamwallToken = db.data.streamwallToken
-  if (!streamwallToken) {
-    streamwallToken = await auth.createToken({
+}): Promise<BootstrapResult> {
+  // The uplink token is validated against its scrypt hash in `auth.tokens`,
+  // exactly like session and invite tokens. We persist only its id; the
+  // plaintext secret is shown once, at creation, and never written to disk.
+  const record = db.data.streamwallToken
+  const hasValidUplinkToken =
+    record != null && auth.tokensById.has(record.tokenId)
+
+  let uplinkSecret: string | null = null
+  let uplinkTokenId: string
+
+  if (hasValidUplinkToken) {
+    uplinkTokenId = record.tokenId
+    // Scrub any plaintext secret a pre-fix server version may have persisted
+    // alongside the id, so it stops leaking through storage.json.
+    if ((record as { secret?: string }).secret !== undefined) {
+      db.update((data) => {
+        data.streamwallToken = { tokenId: uplinkTokenId }
+      })
+    }
+  } else {
+    // Minting a fresh uplink token (first run, or a rotation triggered by
+    // clearing the stored record). Delete any superseded uplink tokens first so
+    // an old secret can never authenticate again.
+    for (const token of [...auth.tokensById.values()]) {
+      if (token.kind === 'streamwall') {
+        auth.deleteToken(token.tokenId)
+      }
+    }
+    const minted = await auth.createToken({
       kind: 'streamwall',
       role: 'admin',
       name: 'Streamwall',
     })
+    uplinkSecret = minted.secret
+    uplinkTokenId = minted.tokenId
     db.update((data) => {
-      data.streamwallToken = streamwallToken
+      data.streamwallToken = { tokenId: minted.tokenId }
     })
   }
 
@@ -650,18 +694,40 @@ async function initialInviteCodes({
     name: 'Server admin',
   })
 
-  console.log(
-    '🔌 Streamwall endpoint:',
-    `${baseURL.replace(/^http/, 'ws')}/streamwall/${streamwallToken.tokenId}/ws?token=${streamwallToken.secret}`,
-  )
-  console.log(
-    '🔑 Admin invite:',
-    inviteLink({
+  return {
+    uplinkSecret,
+    uplinkEndpoint: uplinkEndpointURL(baseURL, uplinkTokenId),
+    adminInviteLink: inviteLink({
       baseURL,
       tokenId: adminToken.tokenId,
       secret: adminToken.secret,
     }),
-  )
+  }
+}
+
+/**
+ * Logs the bootstrap credentials to stdout. The uplink secret is printed only
+ * when it was just minted (shown once); on subsequent starts we print the
+ * endpoint without it and point the operator at how to rotate.
+ */
+function logBootstrap({
+  uplinkSecret,
+  uplinkEndpoint,
+  adminInviteLink,
+}: BootstrapResult) {
+  if (uplinkSecret) {
+    console.log(
+      '🔌 Streamwall uplink (shown once — save it now):',
+      `${uplinkEndpoint}?token=${uplinkSecret}`,
+    )
+  } else {
+    console.log('🔌 Streamwall uplink endpoint:', uplinkEndpoint)
+    console.log(
+      '   (the uplink secret is shown only at creation; to rotate it, clear ' +
+        '"streamwallToken" in storage.json and restart)',
+    )
+  }
+  console.log('🔑 Admin invite:', adminInviteLink)
 }
 
 export default async function runServer({
@@ -680,7 +746,8 @@ export default async function runServer({
     clientStaticPath,
   })
 
-  await initialInviteCodes({ db, auth, baseURL })
+  const bootstrap = await initialInviteCodes({ db, auth, baseURL })
+  logBootstrap(bootstrap)
 
   await app.listen({ port, host: hostname })
 

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -41,6 +41,54 @@ const DEFAULT_RATE_LIMIT_WINDOW = '1 minute'
 const DEFAULT_WS_MSG_RATE = 100
 const DEFAULT_WS_MSG_BURST = 1000
 
+// Served at `/invite/:id`. It carries no secret and no inline script (so it
+// satisfies the strict `script-src 'self'` CSP); the loaded script reads the
+// invite secret from the URL fragment and POSTs it to redeem the invite.
+const INVITE_EXCHANGE_HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Streamwall — joining…</title>
+  </head>
+  <body>
+    <p>Signing you in…</p>
+    <script src="/invite-exchange.js"></script>
+  </body>
+</html>
+`
+
+// Reads the invite secret from `location.hash` (which the browser never sends
+// to the server), scrubs it from the address bar, and exchanges it for a
+// session cookie via POST. On success it navigates to the app.
+const INVITE_EXCHANGE_SCRIPT = `(function () {
+  var status = document.querySelector('p')
+  var token = new URLSearchParams(window.location.hash.slice(1)).get('token')
+  window.history.replaceState(null, '', window.location.pathname)
+  if (!token) {
+    if (status) status.textContent = 'This invite link is missing its token.'
+    return
+  }
+  fetch(window.location.pathname, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ token: token }),
+  })
+    .then(function (res) {
+      if (res.ok) {
+        window.location.replace('/')
+      } else if (status) {
+        status.textContent = 'This invite is invalid or has expired.'
+      }
+    })
+    .catch(function () {
+      if (status) {
+        status.textContent = 'Could not reach the server. Please try again.'
+      }
+    })
+})()
+`
+
 /** Parses a positive numeric env value, falling back when unset or invalid. */
 function parsePositiveNumber(value: string | undefined, fallback: number) {
   const parsed = Number(value)
@@ -256,7 +304,27 @@ export async function initApp({
     },
   })
 
-  app.get<{ Params: { id: string }; Querystring: { token?: string } }>(
+  // The invite page never receives the secret — it lives in the URL fragment,
+  // which the browser does not send — so this bare GET only serves the exchange
+  // page and needs no auth rate limit.
+  app.get<{ Params: { id: string } }>(
+    '/invite/:id',
+    async (_request, reply) => {
+      return reply.type('text/html').send(INVITE_EXCHANGE_HTML)
+    },
+  )
+
+  app.get('/invite-exchange.js', async (_request, reply) => {
+    return reply
+      .type('application/javascript')
+      .header('cache-control', 'no-store')
+      .send(INVITE_EXCHANGE_SCRIPT)
+  })
+
+  // Redeems an invite. The secret arrives in the request body (not the URL),
+  // and this route runs the expensive scrypt verification, so it carries the
+  // strict auth rate limit.
+  app.post<{ Params: { id: string }; Body: { token?: string } }>(
     '/invite/:id',
     {
       config: {
@@ -268,7 +336,7 @@ export async function initApp({
     },
     async (request, reply) => {
       const { id } = request.params
-      const { token } = request.query
+      const token = request.body?.token
 
       if (!token || typeof token !== 'string') {
         return reply.code(403).send()
@@ -298,7 +366,7 @@ export async function initApp({
       )
 
       await auth.deleteToken(tokenInfo.tokenId)
-      return reply.redirect('/')
+      return reply.code(204).send()
     },
   )
 

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -47,6 +47,20 @@ function parsePositiveNumber(value: string | undefined, fallback: number) {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
 }
 
+/**
+ * Extracts a Bearer token from an `Authorization` header. Uplink credentials
+ * travel in this header rather than the URL query string so the secret never
+ * lands in server or proxy access logs. The scheme name is matched
+ * case-insensitively per RFC 7235.
+ */
+function bearerToken(authorization: string | undefined): string | null {
+  if (!authorization) {
+    return null
+  }
+  const match = /^Bearer[ ]+(.+)$/i.exec(authorization)
+  return match ? match[1] : null
+}
+
 interface RateLimitConfig {
   globalMax: number
   authMax: number
@@ -288,7 +302,7 @@ export async function initApp({
     },
   )
 
-  app.get<{ Params: { id: string }; Querystring: { token?: string } }>(
+  app.get<{ Params: { id: string } }>(
     '/streamwall/:id/ws',
     { websocket: true },
     async (ws, request) => {
@@ -296,9 +310,9 @@ export async function initApp({
       const handleMessage = queueWebSocketMessages(ws)
 
       const { id } = request.params
-      const { token } = request.query
+      const token = bearerToken(request.headers.authorization)
 
-      if (!token || typeof token !== 'string') {
+      if (!token) {
         ws.send(JSON.stringify({ error: 'unauthorized' }))
         ws.close()
         return

--- a/packages/streamwall-control-server/src/inviteExchange.test.ts
+++ b/packages/streamwall-control-server/src/inviteExchange.test.ts
@@ -1,0 +1,167 @@
+import assert from 'node:assert/strict'
+import { after, describe, test } from 'node:test'
+
+import { SESSION_COOKIE_NAME } from './index.ts'
+import { buildTestApp } from './testHelpers.ts'
+
+async function appWithInvite(role = 'admin' as const) {
+  const { app, auth } = await buildTestApp()
+  after(() => app.close())
+  const { tokenId, secret } = await auth.createToken({
+    kind: 'invite',
+    role,
+    name: 'Test invite',
+  })
+  return { app, auth, tokenId, secret }
+}
+
+function postInvite(
+  app: Awaited<ReturnType<typeof appWithInvite>>['app'],
+  tokenId: string,
+  token: string,
+) {
+  return app.inject({
+    method: 'POST',
+    url: `/invite/${tokenId}`,
+    headers: { 'content-type': 'application/json' },
+    payload: { token },
+  })
+}
+
+describe('invite redemption keeps the secret out of the URL', () => {
+  test('GET /invite/:id serves an exchange page that carries no secret', async () => {
+    const { app, tokenId, secret } = await appWithInvite()
+
+    const res = await app.inject({ method: 'GET', url: `/invite/${tokenId}` })
+
+    assert.equal(res.statusCode, 200)
+    assert.match(String(res.headers['content-type']), /text\/html/)
+    assert.equal(
+      res.body.includes(secret),
+      false,
+      'the server never sees the secret, so the page cannot contain it',
+    )
+    assert.match(
+      res.body,
+      /invite-exchange\.js/,
+      'the page loads the client exchange script',
+    )
+    assert.equal(
+      res.headers['set-cookie'],
+      undefined,
+      'a bare GET must not start a session',
+    )
+  })
+
+  test('GET /invite/:id ignores a legacy ?token= query and sets no cookie', async () => {
+    const { app, tokenId, secret } = await appWithInvite()
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/invite/${tokenId}?token=${secret}`,
+    })
+
+    assert.equal(res.statusCode, 200)
+    assert.equal(
+      res.headers['set-cookie'],
+      undefined,
+      'the query-string token path must no longer authenticate',
+    )
+  })
+
+  test('the invite page CSP permits the exchange script and its POST', async () => {
+    const { app, tokenId } = await appWithInvite()
+
+    const res = await app.inject({ method: 'GET', url: `/invite/${tokenId}` })
+    const csp = String(res.headers['content-security-policy'] ?? '')
+
+    // The exchange page loads a same-origin script and POSTs same-origin, with
+    // no inline script. These directives must keep allowing that.
+    assert.match(
+      csp,
+      /script-src[^;]*'self'/,
+      'exchange script must be allowed',
+    )
+    assert.match(
+      csp,
+      /connect-src[^;]*'self'/,
+      'the redeem POST must be allowed',
+    )
+    assert.equal(
+      res.body.includes('<script>'),
+      false,
+      'the page must have no inline script (blocked by script-src)',
+    )
+  })
+
+  test('GET /invite-exchange.js serves the client exchange script', async () => {
+    const { app } = await appWithInvite()
+
+    const res = await app.inject({ method: 'GET', url: '/invite-exchange.js' })
+
+    assert.equal(res.statusCode, 200)
+    assert.match(String(res.headers['content-type']), /javascript/)
+    assert.match(res.body, /location\.hash/)
+    assert.match(res.body, /fetch\(/)
+  })
+
+  test('POST /invite/:id redeems a valid token and starts a session', async () => {
+    const { app, tokenId, secret } = await appWithInvite()
+
+    const res = await postInvite(app, tokenId, secret)
+
+    assert.equal(res.statusCode, 204)
+    const setCookie = String(res.headers['set-cookie'] ?? '')
+    assert.match(setCookie, new RegExp(`^${SESSION_COOKIE_NAME}=`))
+    assert.match(setCookie, /HttpOnly/i)
+    assert.match(setCookie, /SameSite=Strict/i)
+  })
+
+  test('POST /invite/:id consumes the invite (single use)', async () => {
+    const { app, tokenId, secret } = await appWithInvite()
+
+    const first = await postInvite(app, tokenId, secret)
+    assert.equal(first.statusCode, 204)
+
+    const second = await postInvite(app, tokenId, secret)
+    assert.equal(second.statusCode, 403, 'a redeemed invite cannot be reused')
+    assert.equal(second.headers['set-cookie'], undefined)
+  })
+
+  test('POST /invite/:id rejects a wrong secret without a cookie', async () => {
+    const { app, tokenId } = await appWithInvite()
+
+    const res = await postInvite(app, tokenId, 'not-the-secret')
+
+    assert.equal(res.statusCode, 403)
+    assert.equal(res.headers['set-cookie'], undefined)
+  })
+
+  test('POST /invite/:id rejects a non-invite token kind', async () => {
+    const { app, auth } = await appWithInvite()
+    const { tokenId, secret } = await auth.createToken({
+      kind: 'session',
+      role: 'admin',
+      name: 'A session',
+    })
+
+    const res = await postInvite(app, tokenId, secret)
+
+    assert.equal(res.statusCode, 403)
+    assert.equal(res.headers['set-cookie'], undefined)
+  })
+
+  test('POST /invite/:id rejects a missing token body', async () => {
+    const { app, tokenId } = await appWithInvite()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/invite/${tokenId}`,
+      headers: { 'content-type': 'application/json' },
+      payload: {},
+    })
+
+    assert.equal(res.statusCode, 403)
+    assert.equal(res.headers['set-cookie'], undefined)
+  })
+})

--- a/packages/streamwall-control-server/src/rateLimit.test.ts
+++ b/packages/streamwall-control-server/src/rateLimit.test.ts
@@ -9,7 +9,12 @@ test('rate-limits the invite auth route with a strict per-route budget', async (
 
   const codes: number[] = []
   for (let i = 0; i < 5; i++) {
-    const res = await app.inject({ method: 'GET', url: '/invite/x?token=y' })
+    const res = await app.inject({
+      method: 'POST',
+      url: '/invite/x',
+      headers: { 'content-type': 'application/json' },
+      payload: { token: 'y' },
+    })
     codes.push(res.statusCode)
   }
 
@@ -49,7 +54,12 @@ test('the auth route budget is stricter than the global budget', async () => {
 
   const inviteCodes: number[] = []
   for (let i = 0; i < 4; i++) {
-    const res = await app.inject({ method: 'GET', url: '/invite/x?token=y' })
+    const res = await app.inject({
+      method: 'POST',
+      url: '/invite/x',
+      headers: { 'content-type': 'application/json' },
+      payload: { token: 'y' },
+    })
     inviteCodes.push(res.statusCode)
   }
 

--- a/packages/streamwall-control-server/src/storage.ts
+++ b/packages/streamwall-control-server/src/storage.ts
@@ -8,9 +8,12 @@ export interface StoredData {
     salt: string | null
     tokens: AuthToken[]
   }
+  // Only the uplink token's *id* is persisted. Its secret is never stored in
+  // clear: the token is verified against the scrypt hash held in `auth.tokens`
+  // (like every other token), and the plaintext secret is revealed only once,
+  // at creation time.
   streamwallToken: null | {
     tokenId: string
-    secret: string
   }
 }
 

--- a/packages/streamwall-control-server/src/uplinkAuth.test.ts
+++ b/packages/streamwall-control-server/src/uplinkAuth.test.ts
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict'
+import { once } from 'node:events'
+import type { AddressInfo } from 'node:net'
+import { after, test } from 'node:test'
+import { setTimeout as delay } from 'node:timers/promises'
+import WebSocket from 'ws'
+
+import { buildTestApp } from './testHelpers.ts'
+
+/**
+ * Boots a listening control app and mints a streamwall uplink token, returning
+ * the details needed to open an uplink WebSocket various ways.
+ */
+async function startUplinkServer() {
+  process.env.STREAMWALL_RATE_LIMIT_MAX = '1000'
+  const { app, auth } = await buildTestApp()
+  await app.listen({ port: 0, host: '127.0.0.1' })
+  after(() => app.close())
+  const { port } = app.server.address() as AddressInfo
+
+  const { tokenId, secret } = await auth.createToken({
+    kind: 'streamwall',
+    role: 'admin',
+    name: 'test',
+  })
+
+  const path = `/streamwall/${tokenId}/ws`
+  const base = `ws://127.0.0.1:${port}${path}`
+  return { app, port, tokenId, secret, base }
+}
+
+/**
+ * Captures the first app-level message from the moment the socket is created,
+ * so an error the server sends immediately on connect is never missed to a
+ * listener-attachment race. `next(timeoutMs)` resolves with that message or
+ * null if none arrives within the window.
+ */
+function messageCollector(ws: WebSocket) {
+  let first: unknown | undefined
+  const received = new Promise<void>((resolve) => {
+    ws.once('message', (data) => {
+      first = JSON.parse(data.toString())
+      resolve()
+    })
+  })
+  return async (timeoutMs: number): Promise<unknown | null> => {
+    await Promise.race([received, delay(timeoutMs)])
+    return first === undefined ? null : first
+  }
+}
+
+// Rejections run an async scrypt verification before the error is sent, so
+// negative cases wait generously; the positive case only needs a short window
+// to confirm the server stays silent.
+const REJECTION_WINDOW_MS = 2000
+const SILENCE_WINDOW_MS = 500
+
+test('accepts an uplink authenticated via the Authorization header', async () => {
+  const { base, secret } = await startUplinkServer()
+
+  const ws = new WebSocket(base, {
+    headers: { authorization: `Bearer ${secret}` },
+  })
+  after(() => ws.terminate())
+  const nextMessage = messageCollector(ws)
+  await once(ws, 'open')
+
+  assert.equal(
+    await nextMessage(SILENCE_WINDOW_MS),
+    null,
+    'an authorized uplink receives no error and stays connected',
+  )
+  assert.equal(ws.readyState, WebSocket.OPEN)
+})
+
+test('rejects an uplink that presents its secret only in the query string', async () => {
+  const { base, secret } = await startUplinkServer()
+
+  const ws = new WebSocket(`${base}?token=${secret}`)
+  after(() => ws.terminate())
+  const nextMessage = messageCollector(ws)
+
+  assert.deepEqual(
+    await nextMessage(REJECTION_WINDOW_MS),
+    { error: 'unauthorized' },
+    'the query-string token path must no longer authenticate',
+  )
+})
+
+test('rejects an uplink with no credentials', async () => {
+  const { base } = await startUplinkServer()
+
+  const ws = new WebSocket(base)
+  after(() => ws.terminate())
+  const nextMessage = messageCollector(ws)
+
+  assert.deepEqual(await nextMessage(REJECTION_WINDOW_MS), {
+    error: 'unauthorized',
+  })
+})
+
+test('rejects an uplink whose Authorization header carries a wrong secret', async () => {
+  const { base } = await startUplinkServer()
+
+  const ws = new WebSocket(base, {
+    headers: { authorization: 'Bearer not-the-secret' },
+  })
+  after(() => ws.terminate())
+  const nextMessage = messageCollector(ws)
+
+  assert.deepEqual(await nextMessage(REJECTION_WINDOW_MS), {
+    error: 'unauthorized',
+  })
+})

--- a/packages/streamwall-control-server/src/wsRateLimit.test.ts
+++ b/packages/streamwall-control-server/src/wsRateLimit.test.ts
@@ -20,9 +20,9 @@ async function startStreamwallSocket(env: Record<string, string>) {
     name: 'test',
   })
 
-  const ws = new WebSocket(
-    `ws://127.0.0.1:${port}/streamwall/${tokenId}/ws?token=${secret}`,
-  )
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/streamwall/${tokenId}/ws`, {
+    headers: { authorization: `Bearer ${secret}` },
+  })
   await once(ws, 'open')
 
   return { app, ws }

--- a/packages/streamwall-shared/src/controlEndpoint.ts
+++ b/packages/streamwall-shared/src/controlEndpoint.ts
@@ -13,6 +13,40 @@ function normalizeHostname(hostname: string): string {
   return hostname
 }
 
+export interface ParsedControlEndpoint {
+  /** The endpoint URL to open, with any `token` query parameter removed. */
+  url: string
+  /** The `Authorization` header value to send, or null when no token was set. */
+  authorization: string | null
+}
+
+/**
+ * Splits a control-server endpoint into the URL to connect to and an
+ * `Authorization` header carrying the token.
+ *
+ * The uplink secret used to travel in the `?token=` query string, where it
+ * leaked into server and proxy access logs. Moving it into a Bearer token
+ * keeps it out of the request line while leaving the rest of the URL intact.
+ * A malformed endpoint is returned unchanged with no header so callers can
+ * apply their own validation (see {@link isSecureControlEndpoint}).
+ */
+export function parseControlEndpoint(endpoint: string): ParsedControlEndpoint {
+  let url: URL
+  try {
+    url = new URL(endpoint)
+  } catch {
+    return { url: endpoint, authorization: null }
+  }
+
+  const token = url.searchParams.get('token')
+  if (!token) {
+    return { url: endpoint, authorization: null }
+  }
+
+  url.searchParams.delete('token')
+  return { url: url.toString(), authorization: `Bearer ${token}` }
+}
+
 /**
  * Returns whether a control-server endpoint is safe for the Streamwall desktop
  * to connect to.

--- a/packages/streamwall-shared/src/parseControlEndpoint.test.ts
+++ b/packages/streamwall-shared/src/parseControlEndpoint.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'vitest'
+import { parseControlEndpoint } from './controlEndpoint.ts'
+
+describe('parseControlEndpoint', () => {
+  test('moves a token query parameter into an Authorization header', () => {
+    const result = parseControlEndpoint(
+      'wss://example.com/streamwall/abc/ws?token=s3cr3t',
+    )
+    expect(result.authorization).toBe('Bearer s3cr3t')
+    expect(result.url).toBe('wss://example.com/streamwall/abc/ws')
+  })
+
+  test('strips only the token, preserving any other query parameters', () => {
+    const result = parseControlEndpoint(
+      'wss://example.com/streamwall/abc/ws?token=s3cr3t&debug=1',
+    )
+    expect(result.authorization).toBe('Bearer s3cr3t')
+    expect(result.url).toBe('wss://example.com/streamwall/abc/ws?debug=1')
+  })
+
+  test('never leaves the secret in the connection URL', () => {
+    const result = parseControlEndpoint(
+      'wss://example.com/streamwall/abc/ws?token=s3cr3t',
+    )
+    expect(result.url).not.toContain('s3cr3t')
+    expect(result.url).not.toContain('token=')
+  })
+
+  test('returns no Authorization header when the endpoint has no token', () => {
+    const result = parseControlEndpoint('wss://example.com/streamwall/abc/ws')
+    expect(result.authorization).toBeNull()
+    expect(result.url).toBe('wss://example.com/streamwall/abc/ws')
+  })
+
+  test('treats an empty token as absent', () => {
+    const result = parseControlEndpoint(
+      'wss://example.com/streamwall/abc/ws?token=',
+    )
+    expect(result.authorization).toBeNull()
+  })
+
+  test('passes a malformed endpoint through unchanged with no header', () => {
+    const result = parseControlEndpoint('not a url')
+    expect(result.authorization).toBeNull()
+    expect(result.url).toBe('not a url')
+  })
+})

--- a/packages/streamwall-shared/src/roles.test.ts
+++ b/packages/streamwall-shared/src/roles.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { roleCan } from './roles.ts'
+import { inviteLink, roleCan } from './roles.ts'
 
 describe('roleCan set-grid-size', () => {
   it('allows operators to resize the grid', () => {
@@ -14,5 +14,25 @@ describe('roleCan set-grid-size', () => {
   })
   it('does not allow unauthenticated clients to resize the grid', () => {
     expect(roleCan(null, 'set-grid-size')).toBe(false)
+  })
+})
+
+describe('inviteLink', () => {
+  it('carries the secret in the URL fragment, not the query string', () => {
+    const link = inviteLink({
+      baseURL: 'https://wall.example.com',
+      tokenId: 'abc',
+      secret: 's3cr3t',
+    })
+    expect(link).toBe('https://wall.example.com/invite/abc#token=s3cr3t')
+    expect(link).not.toContain('?token=')
+  })
+
+  it('keeps the secret out of the part the browser sends to the server', () => {
+    const link = inviteLink({ tokenId: 'abc', secret: 's3cr3t' })
+    // Everything before the "#" is what lands in the request line and logs.
+    const [beforeFragment] = link.split('#')
+    expect(beforeFragment).not.toContain('s3cr3t')
+    expect(beforeFragment).toBe('/invite/abc')
   })
 })

--- a/packages/streamwall-shared/src/roles.ts
+++ b/packages/streamwall-shared/src/roles.ts
@@ -58,5 +58,8 @@ export function inviteLink({
   tokenId: string
   secret: string
 }) {
-  return `${baseURL}/invite/${tokenId}?token=${secret}`
+  // The secret goes in the URL fragment, which browsers never send to the
+  // server: it stays out of access logs, the `Referer` header, and the request
+  // line. The invite page reads it client-side and exchanges it via POST.
+  return `${baseURL}/invite/${tokenId}#token=${secret}`
 }

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -13,6 +13,7 @@ import {
   StreamwallState,
   isCommandAllowedFromUplink,
   isSecureControlEndpoint,
+  parseControlEndpoint,
 } from 'streamwall-shared'
 import { updateElectronApp } from 'update-electron-app'
 import WebSocket from 'ws'
@@ -38,16 +39,27 @@ const SENTRY_DSN =
   'https://e630a21dcf854d1a9eb2a7a8584cbd0b@o459879.ingest.sentry.io/5459505'
 
 /**
- * WebSocket that enforces TLS certificate validation on wss:// connections.
- * Together with the wss:// requirement on the control endpoint, this
- * authenticates the control server to the desktop and prevents a
- * man-in-the-middle from impersonating it. `rejectUnauthorized` defaults to
- * true in `ws`, but we set it explicitly so the guarantee cannot be silently
- * lost to a future change.
+ * Builds a WebSocket subclass for the control uplink.
+ *
+ * It enforces TLS certificate validation on wss:// connections: together with
+ * the wss:// requirement on the control endpoint, this authenticates the
+ * control server to the desktop and prevents a man-in-the-middle from
+ * impersonating it. `rejectUnauthorized` defaults to true in `ws`, but we set
+ * it explicitly so the guarantee cannot be silently lost to a future change.
+ *
+ * It also injects the uplink credential as an `Authorization` header rather
+ * than a URL query parameter, keeping the secret out of server and proxy
+ * access logs. `reconnecting-websocket` does not forward constructor options,
+ * so the header is baked into the subclass here.
  */
-class SecureWebSocket extends WebSocket {
-  constructor(url: string, protocols?: string | string[]) {
-    super(url, protocols, { rejectUnauthorized: true })
+function makeControlWebSocket(authorization: string | null) {
+  return class ControlWebSocket extends WebSocket {
+    constructor(url: string, protocols?: string | string[]) {
+      super(url, protocols, {
+        rejectUnauthorized: true,
+        headers: authorization ? { authorization } : undefined,
+      })
+    }
   }
 }
 
@@ -537,8 +549,13 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     )
   } else if (argv.control.endpoint) {
     console.debug('Connecting to control server...')
-    const ws = new ReconnectingWebSocket(argv.control.endpoint, [], {
-      WebSocket: SecureWebSocket,
+    // Move the uplink secret out of the URL query string and into an
+    // Authorization header so it never reaches server or proxy access logs.
+    const { url: controlURL, authorization } = parseControlEndpoint(
+      argv.control.endpoint,
+    )
+    const ws = new ReconnectingWebSocket(controlURL, [], {
+      WebSocket: makeControlWebSocket(authorization),
       maxReconnectionDelay: 5000,
       minReconnectionDelay: 100 + Math.random() * 500,
       reconnectionDelayGrowFactor: 1.25,


### PR DESCRIPTION
Closes #4

## Problem

The control server exposed authentication secrets through three channels flagged by the security audit:

1. **Storage** — the Streamwall uplink token's **plaintext secret** was written to `storage.json`, while every other token stores only a scrypt hash. Read access to `storage.json` recovered the admin-role uplink secret (full control).
2. **Logs** — the uplink secret and the admin invite link (with secret) were printed to stdout on **every** startup.
3. **URLs** — the uplink and invite secrets travelled in the `?token=` **query string** of the WebSocket handshake / invite link, landing in server and reverse-proxy access logs, browser history, and the `Referer` header.

## Solution

Three focused, independently-green commits:

### 1. Stop persisting/re-logging the uplink secret (`fix(control-server): stop persisting and re-logging…`)
- Persist only the uplink token **id** — the secret is verified against the scrypt hash in `auth.tokens` like every other token.
- Reveal the plaintext **once, at creation**; on restart the endpoint is logged without it, plus rotation guidance.
- **Scrub** any legacy plaintext secret from `storage.json` on load (auto-migration).
- Delete superseded uplink tokens on rotation so an old secret can no longer authenticate.

### 2. Move the uplink token to the `Authorization` header (`fix(control): carry the uplink token in an Authorization header…`)
- Server reads the uplink secret from `Authorization: Bearer …` and no longer accepts the query-string token.
- Desktop parses the token out of the configured control endpoint and sends it as a header instead. **The endpoint config format is unchanged**, so operators need not reconfigure — the token is simply relocated off the wire. Extraction is a shared, unit-tested helper (`parseControlEndpoint`).

### 3. Redeem invites via a fragment + POST (`fix(control): redeem invites via a fragment + POST…`)
- `inviteLink` puts the secret in the URL **fragment** (`#token=…`), which browsers never send to the server — keeping it out of access logs and `Referer`.
- `GET /invite/:id` serves a tiny same-origin exchange page whose script reads the fragment, scrubs it from the address bar, and `POST`s the secret to redeem it.
- New `POST /invite/:id` validates and sets the session cookie, and carries the strict auth rate limit (it runs scrypt). The page has no inline script and stays within the existing `script-src`/`connect-src 'self'` CSP.

## Architecture decisions
- **Header vs. query for the uplink**: the uplink is a Node (`ws`) client that can set headers, so `Authorization` is the natural fit. The desktop keeps a single endpoint URL in config; the token is extracted at connect time via a `WebSocket` subclass (`reconnecting-websocket` doesn't forward constructor options, matching the existing `SecureWebSocket` pattern).
- **Fragment + POST for invites**: browsers can't set headers on a navigation, and a fragment is the only way to keep a clickable link whose secret never reaches the server. A same-origin external script (not inline) satisfies the strict CSP.
- **Token-hash comparison hardening** was intentionally **dropped** from this branch: #116 landed the same raw-buffer, constant-time comparison (plus per-token salts) on `deps-modernization` first. This PR is rebased on top of it and relies on it.

## Risks / breaking changes
- **Uplink**: clients presenting the token only in the query string are now rejected. The desktop is the sole uplink client and is updated in lockstep; operator config is unchanged.
- **Invites**: `GET /invite/:id` no longer redeems via redirect — redemption is `POST`. Old `?token=` invite links won't auto-redeem, but invites are single-use and regenerated, so this is inconsequential.
- **Uplink secret** is now shown only once at creation; to rotate, clear `streamwallToken` in `storage.json` and restart (printed at startup).
- **Storage**: `streamwallToken` shrank to `{ tokenId }`; existing files are migrated (secret scrubbed) automatically on startup.

## Test coverage
Strict TDD (red → green) throughout. New/updated tests:
- `bootstrap.test.ts` (7) — secret never persisted, shown once, legacy scrub, rotation, endpoint carries no secret.
- `uplinkAuth.test.ts` (4) — header accepted; query-string / no-cred / wrong-secret rejected.
- `parseControlEndpoint.test.ts` (6, shared) — token → header, URL stripped, edge cases.
- `inviteExchange.test.ts` (9) — exchange page carries no secret, legacy query ignored, POST redeem/single-use/reject, CSP compatibility.
- `roles.test.ts` (+2, shared) — `inviteLink` uses the fragment.
- `index.test.ts` / `rateLimit.test.ts` / `wsRateLimit.test.ts` migrated to the header/POST flows.

**All suites green:** control-server 46, shared 30, desktop 22. Typechecks clean; Prettier clean. (Repo-wide ESLint is currently non-functional — ESLint 10 is installed but the flat-config migration is pending — so lint is unavailable on this branch as elsewhere.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication for the admin-role uplink and invite flows; query-string tokens are rejected and invite redemption is POST-only, though the desktop ships in lockstep and invites are single-use.
> 
> **Overview**
> This PR closes audit findings where **uplink and invite secrets** were recoverable from `storage.json`, repeated in startup logs, or carried in URLs that end up in access logs and `Referer`.
> 
> **Uplink token:** `streamwallToken` in storage now keeps only `{ tokenId }`; verification uses the scrypt hash in `auth.tokens` like other tokens. The plaintext secret is returned **once** at mint time via `initialInviteCodes` / `logBootstrap`, not on every restart. Legacy `{ secret }` on disk is scrubbed on boot; clearing the record rotates by deleting old `streamwall` auth tokens before minting a new one.
> 
> **Uplink wire format:** `/streamwall/:id/ws` reads `Authorization: Bearer …` only; `?token=` is rejected. The desktop uses shared `parseControlEndpoint` to strip `?token=` from the configured URL and inject the header via a `ControlWebSocket` subclass (unchanged operator URL shape).
> 
> **Invites:** `inviteLink` uses `#token=…` instead of `?token=`. `GET /invite/:id` serves a CSP-safe exchange page; `POST /invite/:id` redeems JSON `{ token }` (204 + session cookie) with the strict auth rate limit. Legacy GET-with-query no longer authenticates.
> 
> Tests cover bootstrap persistence, uplink header auth, invite fragment/POST flow, and `parseControlEndpoint`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fee1313cd1d59a611ec793a714a11d707c8a5b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->