### PR TITLE
ci: bump codeql-action to v4 and group github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,9 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    # Bundle all action updates into one PR so multi-step actions (e.g. CodeQL
+    # init + analyze) always move together and never mismatch versions.
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,9 +28,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           language: ${{ matrix.language }}
           queries: security-and-quality
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3


### PR DESCRIPTION
Hebt codeql-action (init + analyze gemeinsam) auf v4.36.3 und gruppiert künftige github-actions-Updates in einen Dependabot-PR.

Warum: Dependabot öffnete den v3→v4-Bump als zwei getrennte PRs (#121, #122). CodeQL verlangt für init und analyze dieselbe Version — jeder Einzel-PR erzeugt einen Mismatch und schlägt fehl. Dieser PR konsolidiert beide und verhindert die Aufsplittung künftig via groups. Ersetzt #121 und #122.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow and Dependabot config only; no application runtime or security logic changes.
> 
> **Overview**
> **CodeQL** `init` and `analyze` in `codeql.yml` are both bumped from **v3** to **v4.36.3** on the same pinned SHA so the two steps stay version-aligned.
> 
> **Dependabot** for `github-actions` now uses a **`github-actions` group** (`patterns: ['*']`) so future action bumps land in a single PR instead of splitting multi-step actions (e.g. CodeQL) across mismatched versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 116d2cda40f5d512710f8a813d5b316955b9ca7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->