### PR TITLE
fix: type-check the whole monorepo cleanly

### DIFF
--- a/packages/streamwall-control-client/package.json
+++ b/packages/streamwall-control-client/package.json
@@ -5,7 +5,8 @@
   "main": "src/index.tsx",
   "type": "module",
   "scripts": {
-    "build": "vite build"
+    "build": "vite build",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "repository": "github:NilsR0711/streamwall",
   "author": "Nils Reeh <info@nilsreeh.de>",

--- a/packages/streamwall-control-client/src/assets.d.ts
+++ b/packages/streamwall-control-client/src/assets.d.ts
@@ -1,0 +1,4 @@
+// Ambient declarations for side-effect imports resolved by the bundler (Vite)
+// but opaque to tsc: stylesheet imports and @fontsource font packages.
+declare module '*.css'
+declare module '@fontsource/*'

--- a/packages/streamwall-control-client/tsconfig.json
+++ b/packages/streamwall-control-client/tsconfig.json
@@ -4,6 +4,7 @@
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
     "types": ["vite/client"],
+    "allowImportingTsExtensions": true,
     "paths": {
       "react": ["./node_modules/preact/compat/"],
       "react-dom": ["./node_modules/preact/compat/"]

--- a/packages/streamwall-control-ui/package.json
+++ b/packages/streamwall-control-ui/package.json
@@ -27,5 +27,8 @@
     "@types/lodash-es": "^4.17.12",
     "@types/luxon": "^3.7.2",
     "typescript": "^6.0.3"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   }
 }

--- a/packages/streamwall-control-ui/src/assets.d.ts
+++ b/packages/streamwall-control-ui/src/assets.d.ts
@@ -1,0 +1,4 @@
+// Ambient declarations for side-effect imports resolved by the bundler (Vite)
+// but opaque to tsc: stylesheet imports and @fontsource font packages.
+declare module '*.css'
+declare module '@fontsource/*'

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -19,7 +19,6 @@ import {
   useState,
 } from 'preact/hooks'
 import { useHotkeys } from 'react-hotkeys-hook'
-import { type IconBaseProps } from 'react-icons'
 import {
   FaExchangeAlt,
   FaRedoAlt,
@@ -1477,12 +1476,23 @@ function StreamDelayBox({
 
 function OrientationIndicator({
   orientation,
-  ...props
-}: { orientation: 'V' | 'H' | null | undefined } & IconBaseProps) {
+  className,
+}: {
+  orientation: 'V' | 'H' | null | undefined
+  className?: string
+}) {
   if (orientation === 'V') {
-    return <MdOutlineStayCurrentPortrait {...props} />
+    return (
+      <span className={className}>
+        <MdOutlineStayCurrentPortrait />
+      </span>
+    )
   } else if (orientation === 'H') {
-    return <MdOutlineStayCurrentLandscape {...props} />
+    return (
+      <span className={className}>
+        <MdOutlineStayCurrentLandscape />
+      </span>
+    )
   } else {
     return null
   }

--- a/packages/streamwall-control-ui/tsconfig.json
+++ b/packages/streamwall-control-ui/tsconfig.json
@@ -17,10 +17,14 @@
       "react": ["./node_modules/preact/compat/"],
       "react-dom": ["./node_modules/preact/compat/"]
     },
-    "lib": ["DOM.iterable"],
+    "lib": ["ES2024", "DOM", "DOM.iterable"],
     "baseUrl": ".",
     "outDir": "dist",
     "moduleResolution": "node",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    // tsc here only type-checks (Vite does the build), so allow the .ts import
+    // extensions the shared package requires.
+    "allowImportingTsExtensions": true,
+    "noEmit": true
   }
 }

--- a/packages/streamwall/package.json
+++ b/packages/streamwall/package.json
@@ -12,7 +12,8 @@
     "publish": "electron-forge publish",
     "lint": "eslint .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.11.2",

--- a/packages/streamwall/src/assets.d.ts
+++ b/packages/streamwall/src/assets.d.ts
@@ -1,0 +1,4 @@
+// Ambient declarations for side-effect imports resolved by the bundler (Vite)
+// but opaque to tsc: stylesheet imports and @fontsource font packages.
+declare module '*.css'
+declare module '@fontsource/*'

--- a/packages/streamwall/src/main/TwitchBot.ts
+++ b/packages/streamwall/src/main/TwitchBot.ts
@@ -22,13 +22,13 @@ type TwitchBotConfig = StreamwallConfig['twitch'] & {
 export default class TwitchBot extends EventEmitter {
   config: TwitchBotConfig
   announceTemplate: ejs.TemplateFunction
-  voteTemplate: ejs.TemplateFunction
+  voteTemplate!: ejs.TemplateFunction
   client: ChatClient
   streams: StreamList
   listeningURL: string | null
   dwellTimeout: NodeJS.Timeout | undefined
   announceTimeouts: Map<string, NodeJS.Timeout>
-  votes: Map<number, number>
+  votes!: Map<number, number>
 
   constructor(config: TwitchBotConfig) {
     super()

--- a/packages/streamwall/src/main/data.ts
+++ b/packages/streamwall/src/main/data.ts
@@ -14,7 +14,7 @@ import {
 
 const sleep = promisify(setTimeout)
 
-type DataSource = AsyncGenerator<StreamDataContent[]>
+type DataSource = AsyncIterableIterator<StreamDataContent[]>
 
 export async function* pollDataURL(url: string, intervalSecs: number) {
   const refreshInterval = intervalSecs * 1000
@@ -135,7 +135,7 @@ export class LocalStreamData extends EventEmitter<LocalStreamDataEvents> {
     this.emit('update', [...this.dataByURL.values()])
   }
 
-  gen(): AsyncGenerator<StreamDataContent[]> {
+  gen(): AsyncIterableIterator<StreamDataContent[]> {
     return new Repeater(async (push, stop) => {
       await push([...this.dataByURL.values()])
       this.on('update', push)

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -121,7 +121,7 @@ function parseArgs(): StreamwallConfig {
   try {
     configText = fs.readFileSync(configPath, 'utf-8')
   } catch (err) {
-    if (err.code !== 'ENOENT') {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
       throw err
     }
   }

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -75,7 +75,7 @@ const pageReady = new Promise((resolve) =>
 
 class RotationController {
   video: HTMLVideoElement
-  siteRotation: number
+  siteRotation = 0
   customRotation: number
 
   constructor(video: HTMLVideoElement) {
@@ -99,7 +99,7 @@ class RotationController {
 
 class SnapshotController {
   canvas: HTMLCanvasElement
-  ctx: CanvasRenderingContext2D
+  ctx!: CanvasRenderingContext2D
   latestSnapshotURL: string | null = null
 
   constructor() {

--- a/packages/streamwall/tsconfig.json
+++ b/packages/streamwall/tsconfig.json
@@ -18,11 +18,15 @@
       "react": ["./node_modules/preact/compat/"],
       "react-dom": ["./node_modules/preact/compat/"]
     },
-    "lib": ["DOM.iterable"],
+    "lib": ["ES2024", "DOM", "DOM.iterable"],
     "baseUrl": ".",
     "outDir": "dist",
     "moduleResolution": "node",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    // tsc here only type-checks (Vite/Electron Forge does the build), so allow
+    // the .ts import extensions the shared package requires.
+    "allowImportingTsExtensions": true,
+    "noEmit": true
   },
   "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }


### PR DESCRIPTION
Bringt den Typecheck-Gate von **2 auf alle 5 Pakete** und behebt die **63 vorbestehenden Typfehler**, die zuvor durch früh abbrechende tsconfig-Deprecation-Warnungen verdeckt waren.

## Ursachen & Fixes
- **`.ts`-Import-Extensions (24×)**: shared nutzt `@tsconfig/node-ts` (`rewriteRelativeImportExtensions`) und braucht die Extensions. Die konsumierenden Pakete bekommen `allowImportingTsExtensions` + `noEmit` (tsc dort nur zum Typecheck; gebaut wird via Vite/Forge).
- **`lib` (5×)**: streamwall + control-ui hatten `lib: ["DOM.iterable"]`, was die ES-Standardbibliothek abschnitt → `Object.fromEntries/values` und `new Error(msg, {cause})` fehlten. Korrigiert auf `["ES2024", "DOM", "DOM.iterable"]`.
- **CSS/Font-Imports (22×)**: Ambient-Declarations (`*.css`, `@fontsource/*`) je Paket ergänzt.
- **OrientationIndicator**: `className` Preact-kompatibel gemacht (react-icons-Icon in `<span>` gewrappt) — behebt einen Preact/React-Prop-Konflikt, Styling bleibt erhalten.
- **Rest**: Definite-Assignment für bedingt gesetzte Felder, Node-Error-Cast, `DataSource` als `AsyncIterableIterator` (Repeater ist kein `AsyncGenerator`).

## Verifikation
Lokal alle Gates grün: Format · Lint · **Typecheck (alle 5 Pakete)** · Test (218) · Build.

Erledigt die tech-debt aus PR #120.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are tooling, ambient declarations, and type annotations with one small UI wrapper tweak; no intended behavior change beyond fixing the typecheck gate.
> 
> **Overview**
> **Enables `tsc --noEmit` typechecking** on `streamwall`, `streamwall-control-client`, and `streamwall-control-ui` via new `typecheck` npm scripts, alongside tsconfig updates so checking matches how Vite/Forge actually build.
> 
> **TypeScript config changes** add `allowImportingTsExtensions` (and `noEmit` where needed) for consumers of shared `.ts` imports, expand `lib` to `ES2024` + full `DOM` on streamwall and control-ui, and ship per-package `assets.d.ts` for `*.css` and `@fontsource/*` side-effect imports.
> 
> **Runtime-neutral type fixes** include definite assignment on conditionally initialized fields (`TwitchBot`, `mediaPreload`), `AsyncIterableIterator` instead of `AsyncGenerator` for Repeater-backed data sources, a cast on config read errors, and **Preact-safe** `OrientationIndicator` (optional `className` on a wrapper `span` instead of spreading react-icons props onto icons).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64e9481aca231612afd9d0abb4d052239fdf5b10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->