### PR TITLE
fix: prevent grid-size inputs from collapsing the wall (NaN → 1×N)

### DIFF
--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -38,10 +38,12 @@ import {
   type ControlCommand,
   GRID_MAX,
   GRID_MIN,
+  gridWouldDropAssignments,
   idColor,
   idxInBox,
   inviteLink,
   type LocalStreamData,
+  parseGridDimensionInput,
   roleCan,
   type StreamData,
   type StreamDelayStatus,
@@ -760,13 +762,31 @@ export function ControlUI({
 
   const handleSetGridSize = useCallback(
     (nextCols: number, nextRows: number) => {
+      const targetCols = clampGridDimension(nextCols)
+      const targetRows = clampGridDimension(nextRows)
+      // Shrinking the grid permanently drops any placement whose (x, y) no
+      // longer fits. Warn before that happens so it is never silent.
+      if (cols != null && sharedState) {
+        const assignments = new Map<number, string | undefined>()
+        for (const [idx, view] of Object.entries(sharedState.views)) {
+          assignments.set(Number(idx), view.streamId)
+        }
+        if (
+          gridWouldDropAssignments(cols, targetCols, targetRows, assignments) &&
+          !window.confirm(
+            'Das neue Raster ist kleiner und entfernt belegte Kacheln dauerhaft. Fortfahren?',
+          )
+        ) {
+          return
+        }
+      }
       send({
         type: 'set-grid-size',
-        cols: clampGridDimension(nextCols),
-        rows: clampGridDimension(nextRows),
+        cols: targetCols,
+        rows: targetRows,
       })
     },
-    [send],
+    [send, cols, sharedState],
   )
 
   const handleSetBackgroundListening = useCallback(
@@ -1697,6 +1717,44 @@ function GridSizeControls({
   onSetGridSize: (cols: number, rows: number) => void
 }) {
   const disabled = !roleCan(role, 'mutate-state-doc')
+
+  // The inputs hold a local draft while the user types so that transient
+  // states (an empty or out-of-range field) never reach the grid. The change
+  // is committed only on blur/Enter, and only when it parses to a valid,
+  // in-range dimension — otherwise the field reverts to the authoritative
+  // value. This prevents a cleared field (NaN) from collapsing the wall.
+  const [colsDraft, setColsDraft] = useState(String(cols))
+  const [rowsDraft, setRowsDraft] = useState(String(rows))
+  useEffect(() => setColsDraft(String(cols)), [cols])
+  useEffect(() => setRowsDraft(String(rows)), [rows])
+
+  const commitCols = useCallback(
+    (raw: string) => {
+      const parsed = parseGridDimensionInput(raw)
+      if (parsed !== null && parsed !== cols) {
+        onSetGridSize(parsed, rows)
+      }
+      setColsDraft(String(cols))
+    },
+    [cols, rows, onSetGridSize],
+  )
+  const commitRows = useCallback(
+    (raw: string) => {
+      const parsed = parseGridDimensionInput(raw)
+      if (parsed !== null && parsed !== rows) {
+        onSetGridSize(cols, parsed)
+      }
+      setRowsDraft(String(rows))
+    },
+    [cols, rows, onSetGridSize],
+  )
+
+  const commitOnEnter: JSX.KeyboardEventHandler<HTMLInputElement> = (ev) => {
+    if (ev.key === 'Enter') {
+      ev.currentTarget.blur()
+    }
+  }
+
   return (
     <StyledGridSizeControls>
       {GRID_PRESETS.map(([c, r]) => (
@@ -1716,9 +1774,11 @@ function GridSizeControls({
           type="number"
           min={GRID_MIN}
           max={GRID_MAX}
-          value={cols}
+          value={colsDraft}
           disabled={disabled}
-          onChange={(ev) => onSetGridSize(ev.currentTarget.valueAsNumber, rows)}
+          onInput={(ev) => setColsDraft(ev.currentTarget.value)}
+          onBlur={(ev) => commitCols(ev.currentTarget.value)}
+          onKeyDown={commitOnEnter}
         />
       </label>
       <label>
@@ -1727,9 +1787,11 @@ function GridSizeControls({
           type="number"
           min={GRID_MIN}
           max={GRID_MAX}
-          value={rows}
+          value={rowsDraft}
           disabled={disabled}
-          onChange={(ev) => onSetGridSize(cols, ev.currentTarget.valueAsNumber)}
+          onInput={(ev) => setRowsDraft(ev.currentTarget.value)}
+          onBlur={(ev) => commitRows(ev.currentTarget.value)}
+          onKeyDown={commitOnEnter}
         />
       </label>
     </StyledGridSizeControls>

--- a/packages/streamwall-shared/src/geometry.test.ts
+++ b/packages/streamwall-shared/src/geometry.test.ts
@@ -3,7 +3,9 @@ import {
   clampGridDimension,
   GRID_MAX,
   GRID_MIN,
+  gridWouldDropAssignments,
   idxToCoords,
+  parseGridDimensionInput,
   remapGridAssignments,
 } from './geometry.ts'
 
@@ -71,5 +73,56 @@ describe('remapGridAssignments', () => {
     const result = remapGridAssignments(2, 2, 1, old)
     expect(result.get(0)).toBeUndefined()
     expect(result.get(1)).toBe('a')
+  })
+})
+
+describe('parseGridDimensionInput', () => {
+  it('parses a valid in-range integer', () => {
+    expect(parseGridDimensionInput('6')).toBe(6)
+  })
+  it('accepts the inclusive bounds', () => {
+    expect(parseGridDimensionInput(String(GRID_MIN))).toBe(GRID_MIN)
+    expect(parseGridDimensionInput(String(GRID_MAX))).toBe(GRID_MAX)
+  })
+  it('ignores an empty or whitespace-only field', () => {
+    expect(parseGridDimensionInput('')).toBeNull()
+    expect(parseGridDimensionInput('   ')).toBeNull()
+  })
+  it('ignores non-numeric and NaN input', () => {
+    expect(parseGridDimensionInput('abc')).toBeNull()
+    expect(parseGridDimensionInput('NaN')).toBeNull()
+  })
+  it('ignores values below the minimum', () => {
+    expect(parseGridDimensionInput(String(GRID_MIN - 1))).toBeNull()
+  })
+  it('ignores values above the maximum', () => {
+    expect(parseGridDimensionInput(String(GRID_MAX + 1))).toBeNull()
+  })
+  it('rounds fractional input that lands in range', () => {
+    expect(parseGridDimensionInput('3.4')).toBe(3)
+  })
+})
+
+describe('gridWouldDropAssignments', () => {
+  it('returns true when a non-empty cell falls outside the shrunk grid', () => {
+    // 4x4: 'a' at (3,3)=idx15 is dropped when shrinking to 2x2
+    const assignments = new Map<number, string | undefined>([[15, 'a']])
+    expect(gridWouldDropAssignments(4, 2, 2, assignments)).toBe(true)
+  })
+  it('returns false when every non-empty cell survives', () => {
+    // 4x4: 'a' at (0,0)=idx0 survives a shrink to 2x2
+    const assignments = new Map<number, string | undefined>([[0, 'a']])
+    expect(gridWouldDropAssignments(4, 2, 2, assignments)).toBe(false)
+  })
+  it('ignores empty and empty-string cells that would be dropped', () => {
+    const assignments = new Map<number, string | undefined>([
+      [15, ''],
+      [14, undefined],
+    ])
+    expect(gridWouldDropAssignments(4, 2, 2, assignments)).toBe(false)
+  })
+  it('returns false when the grid grows', () => {
+    const assignments = new Map<number, string | undefined>([[3, 'a']])
+    expect(gridWouldDropAssignments(2, 4, 4, assignments)).toBe(false)
   })
 })

--- a/packages/streamwall-shared/src/geometry.ts
+++ b/packages/streamwall-shared/src/geometry.ts
@@ -132,6 +132,58 @@ export function clampGridDimension(n: number): number {
 }
 
 /**
+ * Parses raw grid-dimension input from a text field. Unlike
+ * {@link clampGridDimension}, this does *not* silently clamp: an empty field,
+ * non-numeric text, `NaN`, or a value outside [GRID_MIN, GRID_MAX] all return
+ * `null` so the caller can ignore the intermediate keystroke instead of
+ * collapsing the grid. Fractional input that rounds into range is accepted.
+ */
+export function parseGridDimensionInput(raw: string): number | null {
+  const trimmed = raw.trim()
+  if (trimmed === '') {
+    return null
+  }
+  const parsed = Number(trimmed)
+  if (!Number.isFinite(parsed)) {
+    return null
+  }
+  const rounded = Math.round(parsed)
+  if (rounded < GRID_MIN || rounded > GRID_MAX) {
+    return null
+  }
+  return rounded
+}
+
+/**
+ * Reports whether resizing the grid would permanently drop any non-empty cell.
+ * Mirrors the (x, y)-preserving drop rule of {@link remapGridAssignments}: a
+ * cell survives only if its coordinates still fall within the new grid.
+ *
+ * @param oldCols Column count of the current grid (needed to read (x, y)).
+ * @param newCols Column count of the target grid.
+ * @param newRows Row count of the target grid.
+ * @param assignments Map of current cell index -> streamId (undefined/'' = empty).
+ */
+export function gridWouldDropAssignments(
+  oldCols: number,
+  newCols: number,
+  newRows: number,
+  assignments: Map<number, string | undefined>,
+): boolean {
+  for (const [oldIdx, streamId] of assignments) {
+    if (streamId === undefined || streamId === '') {
+      continue
+    }
+    const x = oldIdx % oldCols
+    const y = Math.floor(oldIdx / oldCols)
+    if (x >= newCols || y >= newRows) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
  * Remaps grid cell assignments when the grid dimensions change. Each non-empty
  * assignment is preserved at the same (x, y) position if that position still
  * exists in the new grid; assignments that fall outside the new grid are


### PR DESCRIPTION
## Problem

The columns/rows number inputs in the control UI fired `set-grid-size` on **every keystroke**. Clearing a field yields `valueAsNumber === NaN`, which `clampGridDimension` maps to `GRID_MIN` (1). The server then rebuilds the grid at `1×N` and `remapGridAssignments` permanently drops every placement whose `(x, y)` no longer fits — with no confirmation and no undo.

**Failure scenario:** on a 4×4 wall, pressing Backspace in "Spalten" to retype "6" leaves the field empty for an instant → `NaN` → server rebuilds a 1×4 grid → 12 of 16 placements are irrevocably deleted before the user finishes typing.

## Solution

Three layered guards, matching the fix outlined in the issue:

1. **Ignore invalid input.** New pure helper `parseGridDimensionInput` returns `null` for empty, non-numeric, `NaN`, and out-of-range input instead of silently clamping. A transient keystroke can no longer force a dimension.
2. **Commit on blur/Enter, not on every input.** `GridSizeControls` now holds a local draft per field (`onInput` updates only the draft) and commits on blur or Enter. Invalid drafts revert to the authoritative value; valid ones are sent. Presets still apply immediately.
3. **Confirm destructive shrink.** New pure helper `gridWouldDropAssignments` detects when a resize would drop a non-empty cell (mirroring `remapGridAssignments`' `(x, y)` rule). `handleSetGridSize` warns via `window.confirm` before sending — this also covers shrinking presets.

## Architecture

The decision logic lives as two pure, framework-agnostic functions in `streamwall-shared/geometry.ts`, next to the existing `clampGridDimension`/`remapGridAssignments` grid helpers, so it is unit-testable and reused by the UI. The control-ui component stays a thin wrapper.

## Testing

- **TDD**: 11 new vitest cases in `geometry.test.ts` (red → green) covering `parseGridDimensionInput` (valid, bounds, empty/whitespace, non-numeric/NaN, below/above range, fractional rounding) and `gridWouldDropAssignments` (drop, survive, empty-cell, grow).
- Full quality gate green locally: `prettier --check`, `eslint .`, `tsc --noEmit` (all 5 packages), `npm test` (85 + 83 + 61 pass), `npm -w streamwall-control-client run build`.
- The `streamwall-control-ui` package has no component-test harness (only `typecheck`); the React wiring (draft state, blur commit, confirm) is covered by the type checker, while the extracted decision logic is fully unit-tested. Adding a Preact test harness would be out of scope for this fix.

## Risks / breaking changes

None. Grid resizing behaves identically for valid input; only the destructive intermediate-state and silent-data-loss paths change. `window.confirm` is available in both the Electron control window and the standalone web client.

Closes #28