### PR TITLE
fix(control-ui): place newly-appeared streams instead of clearing the cell

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15356,7 +15356,8 @@
         "@preact/preset-vite": "^2.10.5",
         "@types/lodash-es": "^4.17.12",
         "@types/luxon": "^3.7.2",
-        "typescript": "^6.0.3"
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.10"
       }
     },
     "packages/streamwall-control-ui/node_modules/color": {

--- a/packages/streamwall-control-ui/package.json
+++ b/packages/streamwall-control-ui/package.json
@@ -26,9 +26,12 @@
     "@preact/preset-vite": "^2.10.5",
     "@types/lodash-es": "^4.17.12",
     "@types/luxon": "^3.7.2",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit -p tsconfig.json"
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
   }
 }

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -54,6 +54,7 @@ import { createGlobalStyle, styled } from 'styled-components'
 import { matchesState } from 'xstate'
 import * as Y from 'yjs'
 import './index.css'
+import { resolveTargetViewIdx, resolveWriteStreamId } from './viewPlacement.ts'
 
 export interface ViewInfo {
   state: ViewState
@@ -739,11 +740,10 @@ export function ControlUI({
 
   const handleSetView = useCallback(
     (idx: number, streamId: string) => {
-      const stream = streams.find((d) => d._id === streamId)
       stateDoc
         .getMap<Y.Map<string | undefined>>('views')
         .get(String(idx))
-        ?.set('streamId', stream ? streamId : '')
+        ?.set('streamId', resolveWriteStreamId(streams, streamId))
     },
     [stateDoc, streams],
   )
@@ -852,20 +852,17 @@ export function ControlUI({
         console.warn('Unable to copy stream id to clipboard:', err)
       }
 
-      if (focusedInputIdx !== undefined) {
-        handleSetView(focusedInputIdx, streamId)
+      const targetIdx = resolveTargetViewIdx({
+        views: sharedState.views,
+        cellCount: cols * rows,
+        focusedInputIdx,
+      })
+      if (targetIdx === undefined) {
         return
       }
-
-      const availableIdx = range(cols * rows).find(
-        (i) => !sharedState.views[i].streamId,
-      )
-      if (availableIdx === undefined) {
-        return
-      }
-      handleSetView(availableIdx, streamId)
+      handleSetView(targetIdx, streamId)
     },
-    [cols, rows, sharedState, focusedInputIdx],
+    [cols, rows, sharedState, focusedInputIdx, handleSetView],
   )
 
   const handleChangeCustomStream = useCallback(

--- a/packages/streamwall-control-ui/src/viewPlacement.test.ts
+++ b/packages/streamwall-control-ui/src/viewPlacement.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { resolveTargetViewIdx, resolveWriteStreamId } from './viewPlacement.ts'
+
+describe('resolveTargetViewIdx', () => {
+  it('targets the focused input cell regardless of occupancy', () => {
+    expect(
+      resolveTargetViewIdx({
+        views: { '0': { streamId: 'a' }, '2': { streamId: 'b' } },
+        cellCount: 4,
+        focusedInputIdx: 2,
+      }),
+    ).toBe(2)
+  })
+
+  it('picks the first empty cell when no input is focused', () => {
+    expect(
+      resolveTargetViewIdx({
+        views: { '0': { streamId: 'a' }, '1': { streamId: 'b' } },
+        cellCount: 4,
+        focusedInputIdx: undefined,
+      }),
+    ).toBe(2)
+  })
+
+  it('returns undefined when every cell is occupied', () => {
+    expect(
+      resolveTargetViewIdx({
+        views: {
+          '0': { streamId: 'a' },
+          '1': { streamId: 'b' },
+          '2': { streamId: 'c' },
+          '3': { streamId: 'd' },
+        },
+        cellCount: 4,
+        focusedInputIdx: undefined,
+      }),
+    ).toBeUndefined()
+  })
+
+  it('treats a missing view slot as empty without throwing', () => {
+    // After a grid enlargement the Yjs views map can momentarily lack entries
+    // for the new cells while the JSON config already reports the larger grid.
+    expect(
+      resolveTargetViewIdx({
+        views: { '0': { streamId: 'a' } },
+        cellCount: 4,
+        focusedInputIdx: undefined,
+      }),
+    ).toBe(1)
+  })
+
+  it('treats an empty streamId as an available cell', () => {
+    expect(
+      resolveTargetViewIdx({
+        views: { '0': { streamId: 'a' }, '1': { streamId: '' } },
+        cellCount: 4,
+        focusedInputIdx: undefined,
+      }),
+    ).toBe(1)
+  })
+})
+
+describe('resolveWriteStreamId', () => {
+  it('keeps the streamId when the stream is known', () => {
+    // Regression: a freshly-appeared stream must be placed, not cleared.
+    expect(resolveWriteStreamId([{ _id: 'old' }, { _id: 'new' }], 'new')).toBe(
+      'new',
+    )
+  })
+
+  it('clears the cell when the stream is unknown', () => {
+    expect(resolveWriteStreamId([{ _id: 'old' }], 'missing')).toBe('')
+  })
+
+  it('clears the cell when there are no streams', () => {
+    expect(resolveWriteStreamId([], 'new')).toBe('')
+  })
+})

--- a/packages/streamwall-control-ui/src/viewPlacement.ts
+++ b/packages/streamwall-control-ui/src/viewPlacement.ts
@@ -1,0 +1,46 @@
+import { range } from 'lodash-es'
+
+/** A collaborative view cell as mirrored from the Yjs `views` map. */
+interface ViewSlot {
+  streamId: string | undefined
+}
+
+/**
+ * Decide which grid cell a stream-id click should fill.
+ *
+ * When an input is focused the click targets that cell; otherwise it picks the
+ * first empty cell (returning `undefined` when the grid is full). Reads the
+ * views map defensively: right after a grid enlargement the JSON-config channel
+ * can already report the larger grid while the Yjs `views` map still lacks
+ * entries for the new cells, so a missing slot counts as empty instead of
+ * throwing a `TypeError`.
+ */
+export function resolveTargetViewIdx({
+  views,
+  cellCount,
+  focusedInputIdx,
+}: {
+  views: Record<string, ViewSlot | undefined>
+  cellCount: number
+  focusedInputIdx: number | undefined
+}): number | undefined {
+  if (focusedInputIdx !== undefined) {
+    return focusedInputIdx
+  }
+  return range(cellCount).find((idx) => !views[idx]?.streamId)
+}
+
+/**
+ * The streamId to write into a view cell: the clicked id when it still exists
+ * among the known streams, or `''` to clear the cell when it does not.
+ *
+ * Callers must pass the *current* streams — a stale list makes a freshly
+ * appeared stream look unknown and would wrongly clear the cell instead of
+ * placing the stream.
+ */
+export function resolveWriteStreamId(
+  streams: readonly { _id: string }[],
+  streamId: string,
+): string {
+  return streams.some((stream) => stream._id === streamId) ? streamId : ''
+}


### PR DESCRIPTION
## Problem

Clicking a stream id in the control UI to place a newly appeared stream could silently leave the grid cell empty instead of placing the stream — and, in a narrow timing window, could throw.

Two root causes in `packages/streamwall-control-ui/src/index.tsx`:

1. **Stale callback (the visible bug).** `handleClickId` omitted `handleSetView` from its `useCallback` dependency array (`[cols, rows, sharedState, focusedInputIdx]`). When a new stream appeared, `streams` changed but the shared views did not, so `handleClickId` kept an old `handleSetView` whose captured `streams` lacked the new entry. `streams.find` missed → `''` was written into the Yjs doc → the click left the cell empty with no feedback.
2. **Missing optional chaining.** The available-cell scan read `sharedState.views[i].streamId` directly. Right after a grid enlargement the JSON-config channel can already report the larger grid while the Yjs `views` map still lacks entries for the new cells, so `views[i]` can be `undefined` and `.streamId` throws a `TypeError`.

## Solution

- Extracted the two decisions into pure, unit-tested helpers in `viewPlacement.ts`:
  - `resolveTargetViewIdx` — picks the focused cell, or the first empty cell, reading the views map defensively (`views[idx]?.streamId`), so a missing slot counts as empty instead of throwing.
  - `resolveWriteStreamId` — returns the clicked id when the stream is known, or `''` to clear the cell when it is not.
- Wired both into `ControlUI` and added `handleSetView` to the `handleClickId` dependency array so the callback always closes over the **current** `streams`.

## Architecture notes

The control-ui package had no test setup. The interaction logic lives inside a ~1800-line component, so the decision logic was extracted into small pure functions that are unit-testable without a full render harness. The dependency-array fix itself is a React-hooks correctness change (verified by typecheck and review); the extracted decision logic it depends on is covered by tests.

## Testing

- Added a **vitest** setup to the previously untested `streamwall-control-ui` package (matching the convention already used by `streamwall` and `streamwall-shared`); the root `test` script picks it up via `--workspaces --if-present`.
- 8 new unit tests covering: focused-input targeting, first-empty-cell selection, full grid, **missing view slot after grid enlargement (no throw)**, empty-`streamId` cells, and the write-value regression (a freshly appeared stream is placed, not cleared).
- Full quality gate green locally: `format:check`, `lint`, `typecheck` (all packages), full test suite (all workspaces), and the control-client Vite build (which bundles control-ui).

## Risks / breaking changes

None. Behavior is unchanged except for the two fixed defects; no public API changes.

Closes #30