### PR TITLE
fix(control-ui): commit drag-move/resize only over the grid; add cancel and button checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15356,7 +15356,8 @@
         "@preact/preset-vite": "^2.10.5",
         "@types/lodash-es": "^4.17.12",
         "@types/luxon": "^3.7.2",
-        "typescript": "^6.0.3"
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.10"
       }
     },
     "packages/streamwall-control-ui/node_modules/color": {

--- a/packages/streamwall-control-ui/package.json
+++ b/packages/streamwall-control-ui/package.json
@@ -26,9 +26,12 @@
     "@preact/preset-vite": "^2.10.5",
     "@types/lodash-es": "^4.17.12",
     "@types/luxon": "^3.7.2",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit -p tsconfig.json"
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
   }
 }

--- a/packages/streamwall-control-ui/src/gestures.test.ts
+++ b/packages/streamwall-control-ui/src/gestures.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  DRAG_THRESHOLD_PX,
+  isPrimaryButton,
+  resolveMoveTarget,
+} from './gestures'
+
+describe('isPrimaryButton', () => {
+  it('accepts the primary (left) button', () => {
+    expect(isPrimaryButton(0)).toBe(true)
+  })
+
+  it('rejects secondary/middle/other buttons', () => {
+    expect(isPrimaryButton(1)).toBe(false)
+    expect(isPrimaryButton(2)).toBe(false)
+    expect(isPrimaryButton(-1)).toBe(false)
+  })
+})
+
+describe('resolveMoveTarget', () => {
+  const moveStart = { idx: 3, x: 100, y: 100 }
+
+  it('returns undefined when there is no active move', () => {
+    expect(resolveMoveTarget(undefined, 5, 200, 200)).toBeUndefined()
+  })
+
+  it('returns undefined when released off the grid (no hover cell)', () => {
+    // Regression: releasing off-grid must not commit against the last
+    // in-grid cell that was hovered.
+    expect(resolveMoveTarget(moveStart, undefined, 500, 500)).toBeUndefined()
+  })
+
+  it('returns undefined when the pointer has not moved past the threshold', () => {
+    expect(
+      resolveMoveTarget(moveStart, 8, moveStart.x + 2, moveStart.y + 2),
+    ).toBeUndefined()
+  })
+
+  it('treats exactly the threshold distance as not-yet-a-drag', () => {
+    expect(
+      resolveMoveTarget(
+        moveStart,
+        8,
+        moveStart.x + DRAG_THRESHOLD_PX,
+        moveStart.y,
+      ),
+    ).toBeUndefined()
+  })
+
+  it('returns undefined when the pointer is back over the origin cell', () => {
+    expect(
+      resolveMoveTarget(moveStart, moveStart.idx, 400, 400),
+    ).toBeUndefined()
+  })
+
+  it('returns the hovered cell for a committed drag over a different cell', () => {
+    expect(resolveMoveTarget(moveStart, 8, 400, 400)).toBe(8)
+  })
+
+  it('honours a custom threshold', () => {
+    expect(resolveMoveTarget(moveStart, 8, 120, 100, 50)).toBeUndefined()
+    expect(resolveMoveTarget(moveStart, 8, 160, 100, 50)).toBe(8)
+  })
+})

--- a/packages/streamwall-control-ui/src/gestures.ts
+++ b/packages/streamwall-control-ui/src/gestures.ts
@@ -1,0 +1,50 @@
+/**
+ * Pure decision helpers for grid drag-move and resize gestures.
+ *
+ * These rules live outside the `ControlUI` component so the logic that decides
+ * *whether* and *where* a gesture commits can be unit-tested in isolation. They
+ * encode the fix for the "released off the grid commits against a stale cell"
+ * bug: a gesture only commits while the pointer is over a grid cell.
+ */
+
+/** Minimum pointer travel (px) before a mouse-down is treated as a drag-move. */
+export const DRAG_THRESHOLD_PX = 5
+
+export interface MoveStart {
+  idx: number
+  x: number
+  y: number
+}
+
+/**
+ * A gesture may only be started or committed with the primary (left) button.
+ * Right/middle-button presses must not move or resize tiles.
+ */
+export function isPrimaryButton(button: number): boolean {
+  return button === 0
+}
+
+/**
+ * Resolve which cell a drag-move should commit to.
+ *
+ * Returns the target cell index, or `undefined` when the gesture should be a
+ * no-op — including when the pointer is released off the grid (`hoveringIdx`
+ * is `undefined`), has not travelled past the drag threshold, or is back over
+ * the origin cell.
+ */
+export function resolveMoveTarget(
+  moveStart: MoveStart | undefined,
+  hoveringIdx: number | undefined,
+  pointerX: number,
+  pointerY: number,
+  threshold: number = DRAG_THRESHOLD_PX,
+): number | undefined {
+  if (moveStart == null || hoveringIdx == null) {
+    return undefined
+  }
+  const moved = Math.hypot(pointerX - moveStart.x, pointerY - moveStart.y)
+  if (moved <= threshold || hoveringIdx === moveStart.idx) {
+    return undefined
+  }
+  return hoveringIdx
+}

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -53,6 +53,8 @@ import {
 import { createGlobalStyle, styled } from 'styled-components'
 import { matchesState } from 'xstate'
 import * as Y from 'yjs'
+
+import { isPrimaryButton, resolveMoveTarget } from './gestures'
 import './index.css'
 
 export interface ViewInfo {
@@ -642,7 +644,9 @@ export function ControlUI({
     },
     [setHoveringIdx, cols, rows],
   )
-  const DRAG_THRESHOLD_PX = 5
+  // Clear the hovered cell when the pointer leaves the grid so a gesture
+  // released off-grid can't commit against a stale cell.
+  const clearHoveringIdx = useCallback(() => setHoveringIdx(undefined), [])
   const [moveStart, setMoveStart] = useState<
     { idx: number; x: number; y: number } | undefined
   >()
@@ -650,7 +654,7 @@ export function ControlUI({
 
   const handleGridMouseDown = useCallback(
     (ev: MouseEvent) => {
-      if (hoveringIdx == null) {
+      if (!isPrimaryButton(ev.button) || hoveringIdx == null) {
         return
       }
       if (swapStartIdx !== undefined) {
@@ -675,16 +679,14 @@ export function ControlUI({
       if (moveStart == null) {
         return
       }
-      const moved = Math.hypot(
-        ev.clientX - moveStart.x,
-        ev.clientY - moveStart.y,
+      const targetIdx = resolveMoveTarget(
+        moveStart,
+        hoveringIdx,
+        ev.clientX,
+        ev.clientY,
       )
-      if (
-        moved > DRAG_THRESHOLD_PX &&
-        hoveringIdx != null &&
-        hoveringIdx !== moveStart.idx
-      ) {
-        swapBoxes(moveStart.idx, hoveringIdx)
+      if (targetIdx != null) {
+        swapBoxes(moveStart.idx, targetIdx)
       }
       setMoveStart(undefined)
     }
@@ -698,6 +700,9 @@ export function ControlUI({
 
   const handleResizeStart = useCallback(
     (anchorIdx: number, ev: MouseEvent) => {
+      if (!isPrimaryButton(ev.button)) {
+        return
+      }
       ev.preventDefault()
       ev.stopPropagation()
       const streamId = sharedState?.views?.[anchorIdx]?.streamId ?? undefined
@@ -711,6 +716,9 @@ export function ControlUI({
 
   useLayoutEffect(() => {
     function endResize() {
+      // A resize only commits while the pointer is over the grid; released
+      // off-grid `hoveringIdx` is cleared (mouseleave), so this aborts instead
+      // of snapping to a stale cell.
       if (
         resize == null ||
         cols == null ||
@@ -992,6 +1000,18 @@ export function ControlUI({
     },
     [handleSwapView, focusedInputIdx],
   )
+  // Escape cancels an in-progress drag-move or resize without committing. The
+  // window mouseup listeners are no-ops once these are cleared.
+  useHotkeys(
+    `escape`,
+    () => {
+      setMoveStart(undefined)
+      setResize(undefined)
+    },
+    // Also fire while a grid input is focused during a gesture.
+    { enableOnFormTags: true },
+    [setMoveStart, setResize],
+  )
 
   const wallStreamIds = useMemo(
     () =>
@@ -1078,6 +1098,7 @@ export function ControlUI({
             <StyledGridContainer
               className="grid"
               onMouseMove={updateHoveringIdx}
+              onMouseLeave={clearHoveringIdx}
               windowWidth={windowWidth}
               windowHeight={windowHeight}
             >


### PR DESCRIPTION
## Problem

In the Preact control UI, `hoveringIdx` is only updated by the grid's
`onMouseMove` and is never cleared. Because both the drag-move and resize
gestures read `hoveringIdx` on the window-level `mouseup`, releasing a
gesture **off** the grid committed it against the last in-grid cell that had
been hovered — moving/resizing a tile to the wrong place. There was also no
way to cancel a gesture, and right/middle-button drags moved tiles.

Fixes the "high" severity bug reported in #31.

## Solution

- **Commit only over the grid:** clear `hoveringIdx` on the grid container's
  `mouseleave`. The existing `endMove`/`endResize` guards already treat a
  `null` hover as "no target", so a gesture released off-grid now aborts
  instead of snapping to a stale cell.
- **Primary-button only:** `handleGridMouseDown` and `handleResizeStart`
  now act only on `ev.button === 0`, so right/middle-button presses no
  longer start a move or resize.
- **Escape to cancel:** a new `escape` hotkey clears an in-progress
  move/resize without committing (the window `mouseup` handlers become
  no-ops once the gesture state is cleared).

### Architecture

The commit-decision logic — which was the source of the stale-cell bug — is
extracted from the ~1800-line component into a small pure module,
`packages/streamwall-control-ui/src/gestures.ts` (`resolveMoveTarget`,
`isPrimaryButton`). This makes the rules unit-testable in isolation and keeps
the component wiring thin. The behaviour of `endMove` is preserved exactly
(same drag threshold, same "different cell" requirement).

This chose the lower-risk of the two approaches suggested in the issue
(clear-hover-on-leave over a full pointer-capture rewrite): it fixes the same
failure scenario with a much smaller, well-typed change and no change to the
existing event model.

## Testing

- Adds `vitest` to `streamwall-control-ui` (matching the existing
  `streamwall-shared` test setup) and a `gestures.test.ts` suite (9 tests)
  covering the primary-button check, drag threshold, same-cell no-op, and the
  **off-grid regression** (`resolveMoveTarget(..., hoveringIdx = undefined)`
  returns `undefined`).
- Full quality gate green locally: `format:check`, `lint`, `typecheck` (all 5
  packages), `npm test` (all workspaces), and the control-client `build`.

The DOM wiring itself (mouseleave clearing, Escape, button filtering) is
covered by typecheck/build plus the pure-logic regression tests; a manual
pass in the running control UI is still recommended for the interaction feel.

## Risks / breaking changes

None. Behaviour changes are limited to rejecting off-grid commits,
non-primary-button gestures, and adding Escape-to-cancel. No public API or
config changes.

Closes #31
