### PR TITLE
ci: scale checks to the change and add a single CI OK gate

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,16 @@
+name: Setup Node.js and install dependencies
+description: >
+  Sets up Node.js with the npm cache and performs a clean install.
+  The repository must already be checked out.
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: 22
+        cache: npm
+    - name: Install dependencies
+      run: npm ci
+      shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,11 @@ updates:
         dependency-type: development
 
   # Keep GitHub Actions pinned-SHAs current (paired with SHA pinning in workflows).
+  # The extra directory covers the local composite action in .github/actions.
   - package-ecosystem: github-actions
-    directory: /
+    directories:
+      - /
+      - /.github/actions/setup
     schedule:
       interval: weekly
       day: monday

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,59 +4,83 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 # Least privilege: read-only by default. Jobs opt into more where needed.
 permissions:
   contents: read
 
-# Cancel superseded runs on the same ref (e.g. rapid pushes to a PR).
+# Cancel superseded runs on PRs (e.g. rapid pushes). Never cancel runs on
+# main so every merged commit gets a complete verdict.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  lint:
-    name: Lint (ESLint)
+  # Classify the change so docs-only edits skip the heavy jobs. Downstream
+  # jobs skip based on these outputs; the ci-ok gate treats skipped as OK.
+  changes:
+    name: Detect changes
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read # paths-filter lists changed files via the PR API
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      dependencies: ${{ steps.filter.outputs.dependencies }}
+      workflows: ${{ steps.filter.outputs.workflows }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
-          cache: npm
-      - run: npm ci
-      - run: npm run lint
+          persist-credentials: false
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          filters: |
+            # Anything that can influence lint/typecheck/test/build results.
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!LICENSE'
+              - '!.gitignore'
+              - '!.gitattributes'
+              - '!example.config.toml'
+              - '!example.streams.toml'
+              - '!.github/dependabot.yml'
+            dependencies:
+              - 'package.json'
+              - 'package-lock.json'
+              - 'packages/*/package.json'
+            workflows:
+              - '.github/workflows/**'
+              - '.github/actions/**'
 
-  format:
-    name: Format (Prettier)
+  # One install, three checks. Prettier always runs because it also checks
+  # Markdown and YAML; ESLint and tsc only matter for code changes. Later
+  # steps run even if an earlier one fails so a single run reports them all.
+  checks:
+    name: Static checks
+    needs: changes
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
-          cache: npm
-      - run: npm ci
-      - run: npm run format:check
-
-  typecheck:
-    name: Typecheck (tsc)
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-          cache: npm
-      - run: npm ci
-      - run: npm run typecheck
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - name: Format (Prettier)
+        run: npm run format:check
+      - name: Lint (ESLint)
+        if: ${{ !cancelled() && needs.changes.outputs.code == 'true' }}
+        run: npm run lint
+      - name: Typecheck (tsc)
+        if: ${{ !cancelled() && needs.changes.outputs.code == 'true' }}
+        run: npm run typecheck
 
   test:
     name: Test (${{ matrix.os }})
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
@@ -65,34 +89,72 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
-          cache: npm
-      - run: npm ci
+          persist-credentials: false
+      - uses: ./.github/actions/setup
       - run: npm test
 
   build:
     name: Build (web control client)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
-          cache: npm
-      - run: npm ci
+          persist-credentials: false
+      - uses: ./.github/actions/setup
       - run: npm -w streamwall-control-client run build
 
+  # Reviews the dependency diff of a PR for known vulnerabilities.
   dependency-review:
     name: Dependency review
-    # Only meaningful on PRs: reviews the dependency diff for known vulnerabilities.
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.dependencies == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write # posts a summary comment when the review fails
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
+          comment-summary-in-pr: on-failure
+
+  # Lints the workflow files themselves (also shellchecks run: scripts).
+  actionlint:
+    name: Lint workflows (actionlint)
+    needs: changes
+    if: needs.changes.outputs.workflows == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: docker://rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
+        with:
+          args: -color
+
+  # Single required status check: green when every needed job succeeded or
+  # was skipped (docs-only changes), red when any failed. Configure branch
+  # protection to require only this check.
+  ci-ok:
+    name: CI OK
+    if: ${{ !cancelled() }}
+    needs: [changes, checks, test, build, dependency-review, actionlint]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Report job results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: echo "$NEEDS_JSON"
+      - name: Fail if any needed job failed
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,24 @@ name: CodeQL
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.gitattributes'
+      - 'example.config.toml'
+      - 'example.streams.toml'
+      - '.github/dependabot.yml'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.gitattributes'
+      - 'example.config.toml'
+      - 'example.streams.toml'
+      - '.github/dependabot.yml'
   schedule:
     # Weekly scan (Mondays 03:30 UTC) to catch newly disclosed patterns.
     - cron: '30 3 * * 1'
@@ -27,6 +43,8 @@ jobs:
         language: [javascript-typescript]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Initialize CodeQL
         uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,29 @@
+name: PR title
+
+# PRs are squash-merged, so the PR title becomes the commit subject on main.
+# Enforce Conventional Commits so the history and changelogs stay consistent.
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions: {}
+
+jobs:
+  conventional-title:
+    name: Conventional Commits title
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check PR title
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          regex='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9./-]+\))?!?: .+'
+          if [[ "$TITLE" =~ $regex ]]; then
+            echo "PR title OK: $TITLE"
+          else
+            echo "::error::PR title must follow Conventional Commits, e.g. 'fix(control-ui): handle empty grid'."
+            echo "::error::Allowed types: feat fix docs style refactor perf test build ci chore revert."
+            echo "Got: $TITLE"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Streamwall
 
+[![CI](https://github.com/NilsR0711/streamwall/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/NilsR0711/streamwall/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/NilsR0711/streamwall/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/NilsR0711/streamwall/actions/workflows/codeql.yml)
+
 Streamwall makes it easy to compose multiple livestreams into a mosaic, with source attributions and audio control.
 
 It's a cross-platform desktop app built with Electron and TypeScript. Streams are arranged in a grid you can rearrange on the fly, audio is switchable per tile, and the whole wall runs locally with an optional control server for remote operation.


### PR DESCRIPTION
## What

Reworks CI so the amount of work scales with what actually changed, while keeping one always-reliable required check.

### Change detection (docs-only fast path)
A new `changes` job classifies each push/PR via [`dorny/paths-filter`](https://github.com/dorny/paths-filter) (SHA-pinned). Docs-only changes (Markdown, LICENSE, example TOMLs, …) skip lint, typecheck, the 3-OS test matrix, the web build, and CodeQL (`paths-ignore`). Prettier still runs on every change because it also checks Markdown and YAML, so a badly formatted README can never slip through and break the next code PR.

### Single required check: `CI OK`
A final gate job is green when every needed job either succeeded or was skipped, and red when any failed. This avoids the classic `paths-ignore` + required-checks deadlock (PRs stuck on *Expected — waiting for status*). Branch protection only ever needs to require **CI OK**.

### Less duplicated work
Lint, format, and typecheck now share one job and one `npm ci` (via a local composite action in `.github/actions/setup`) instead of three separate installs. Later steps still run when an earlier one fails, so a single run reports all findings.

### New guards
- **actionlint** lints the workflow files themselves (including shellcheck on `run:` scripts) whenever workflows change; pinned by image digest.
- **PR title check** enforces Conventional Commits — with squash merges the PR title becomes the commit subject on `main`. Plain bash regex, no third-party action; the title is passed via `env` (injection-safe).
- **dependency-review** now only runs when manifests change and posts a PR comment on failure.

### Hardening
- `persist-credentials: false` on every checkout (token is never written into `.git/config`).
- Runs on `main` are never cancelled by concurrency; superseded PR runs still are.
- `pull_request` trigger no longer limited to `main` targets, so stacked PRs get CI too.
- Dependabot now also covers the local composite action directory.

## Follow-up (not in this PR)

- Set branch protection on `main` to require exactly the **CI OK** check (currently no protection is configured).
- Optional: OSSF Scorecard workflow for a public security posture badge.

## Verification

- `actionlint` v1.7.12 (same version as pinned in CI) passes on all workflows.
- `npm run format:check` passes repo-wide (the always-on Prettier step stays green).
- PR title regex tested against the repo's commit history plus Dependabot titles (`chore(deps-dev): …`) and invalid samples.
- This PR itself exercises the full pipeline: it touches workflows, so `changes` must report `code=true` and `workflows=true`, running every job including actionlint.