### PR TITLE
test: cover roleCan matrix and StateWrapper.view role scoping

### DIFF
--- a/packages/streamwall-control-server/src/auth.test.ts
+++ b/packages/streamwall-control-server/src/auth.test.ts
@@ -3,7 +3,14 @@ import assert from 'node:assert/strict'
 import { scrypt as scryptCb } from 'node:crypto'
 import { test } from 'node:test'
 import { promisify } from 'node:util'
-import { type AuthToken, Auth, rand62, uniqueRand62 } from './auth.ts'
+import type { StreamwallRole, StreamwallState } from 'streamwall-shared'
+import {
+  type AuthToken,
+  Auth,
+  rand62,
+  StateWrapper,
+  uniqueRand62,
+} from './auth.ts'
 
 const scrypt = promisify(scryptCb)
 
@@ -276,4 +283,90 @@ test('validateToken returns null (never throws) when the stored hash is not vali
   const info = await auth.validateToken(tokenId, 'any-secret')
 
   assert.equal(info, null)
+})
+
+// A representative, fully-populated state whose `auth` block (the token list)
+// is the sensitive payload StateWrapper.view scopes by role.
+function makeState(): StreamwallState {
+  return {
+    identity: { role: 'admin' },
+    auth: {
+      invites: [
+        { tokenId: 'inv1', kind: 'invite', role: 'operator', name: 'invitee' },
+      ],
+      sessions: [
+        { tokenId: 'sess1', kind: 'session', role: 'admin', name: 'owner' },
+      ],
+    },
+    config: {
+      cols: 3,
+      rows: 3,
+      width: 1920,
+      height: 1080,
+      frameless: false,
+      activeColor: '#ffffff',
+      backgroundColor: '#000000',
+    },
+    streams: [],
+    customStreams: [],
+    views: [],
+    streamdelay: null,
+  }
+}
+
+test('StateWrapper.view("admin") exposes the auth token list', () => {
+  const state = makeState()
+  const view = new StateWrapper(state).view('admin')
+
+  assert.ok('auth' in view, 'admin view must carry the auth key')
+  assert.deepEqual(view.auth, state.auth)
+  assert.equal(view.identity.role, 'admin')
+})
+
+// Only admins see the token list. Every other role — including all-powerful
+// `local` — gets a view with no `auth` key at all (not merely `undefined`), so
+// the secret-bearing invite/session names never reach a non-admin client.
+for (const role of [
+  'operator',
+  'monitor',
+  'local',
+] satisfies StreamwallRole[]) {
+  test(`StateWrapper.view("${role}") omits the auth token list entirely`, () => {
+    const view = new StateWrapper(makeState()).view(role)
+
+    assert.ok(!('auth' in view), `${role} view must not have an auth key`)
+    assert.equal(view.auth, undefined)
+    assert.equal(view.identity.role, role)
+  })
+}
+
+test('StateWrapper.view re-stamps identity.role without mutating the source', () => {
+  const state = makeState()
+  const wrapper = new StateWrapper(state)
+
+  const operatorView = wrapper.view('operator')
+
+  assert.equal(operatorView.identity.role, 'operator')
+  // The wrapped value is untouched: viewing under one role must not rewrite the
+  // identity seen by a subsequent viewer.
+  assert.equal(state.identity.role, 'admin')
+  assert.equal(wrapper.view('admin').identity.role, 'admin')
+})
+
+test('StateWrapper.view passes non-sensitive fields through unchanged', () => {
+  const state = makeState()
+  const view = new StateWrapper(state).view('monitor')
+
+  assert.equal(view.config, state.config)
+  assert.equal(view.streams, state.streams)
+  assert.equal(view.customStreams, state.customStreams)
+  assert.equal(view.views, state.views)
+  assert.equal(view.streamdelay, state.streamdelay)
+})
+
+test('StateWrapper.info returns an unprivileged (monitor) view with no auth', () => {
+  const view = new StateWrapper(makeState()).info
+
+  assert.ok(!('auth' in view), 'the info getter must not leak the auth key')
+  assert.equal(view.identity.role, 'monitor')
 })

--- a/packages/streamwall-shared/src/roles.test.ts
+++ b/packages/streamwall-shared/src/roles.test.ts
@@ -1,19 +1,100 @@
 import { describe, expect, it } from 'vitest'
-import { inviteLink, roleCan } from './roles.ts'
+import {
+  inviteLink,
+  roleCan,
+  type StreamwallAction,
+  validRoles,
+} from './roles.ts'
 
-describe('roleCan set-grid-size', () => {
-  it('allows operators to resize the grid', () => {
-    expect(roleCan('operator', 'set-grid-size')).toBe(true)
+// Independently re-declared expectations for the role × action matrix. These
+// arrays intentionally mirror the (unexported) action sets in roles.ts so the
+// test pins the *intended* authorization contract rather than re-deriving it
+// from the implementation. `satisfies` keeps every listed action a valid
+// StreamwallAction, so removing an action from roles.ts breaks this file loudly.
+
+// Gated to admin/local only (the AdminAction union in roles.ts).
+const adminOnlyActions = [
+  'dev-tools',
+  'browse',
+  'create-invite',
+  'delete-token',
+] as const satisfies readonly StreamwallAction[]
+
+// Actions an operator may perform that a monitor may not.
+const operatorOnlyActions = [
+  'set-listening-view',
+  'set-view-background-listening',
+  'update-custom-stream',
+  'delete-custom-stream',
+  'rotate-stream',
+  'reload-view',
+  'set-stream-running',
+  'mutate-state-doc',
+  'set-grid-size',
+] as const satisfies readonly StreamwallAction[]
+
+// Available to every authenticated role down to monitor.
+const monitorActions = [
+  'set-view-blurred',
+  'set-stream-censored',
+] as const satisfies readonly StreamwallAction[]
+
+const allActions: readonly StreamwallAction[] = [
+  ...adminOnlyActions,
+  ...operatorOnlyActions,
+  ...monitorActions,
+]
+
+// The exact set of actions each role is expected to be allowed.
+const allowedByRole: Record<
+  (typeof validRoles)[number],
+  ReadonlySet<StreamwallAction>
+> = {
+  local: new Set(allActions),
+  admin: new Set(allActions),
+  operator: new Set<StreamwallAction>([
+    ...operatorOnlyActions,
+    ...monitorActions,
+  ]),
+  monitor: new Set<StreamwallAction>(monitorActions),
+}
+
+describe('roleCan authorization matrix', () => {
+  // Table-driven over the full role × action matrix. `set-grid-size` is a
+  // listed operator action here (operators may resize the grid); monitors and
+  // unauthenticated clients are denied it — see the default-deny block below
+  // for genuinely unlisted message types.
+  for (const role of validRoles) {
+    for (const action of allActions) {
+      const expected = allowedByRole[role].has(action)
+      it(`${expected ? 'allows' : 'denies'} ${role} → ${action}`, () => {
+        expect(roleCan(role, action)).toBe(expected)
+      })
+    }
+  }
+
+  // Unauthenticated clients (null role) may do nothing at all.
+  for (const action of allActions) {
+    it(`denies unauthenticated (null) → ${action}`, () => {
+      expect(roleCan(null, action)).toBe(false)
+    })
+  }
+})
+
+describe('roleCan default-deny for unlisted actions', () => {
+  // A message type absent from every role's action set (a future/unknown
+  // command) must fall through to the default deny for non-privileged roles.
+  // `local` and `admin` are intentionally all-powerful and excluded.
+  const unlisted = 'totally-unknown-action' as StreamwallAction
+
+  it('denies operators an action absent from every set', () => {
+    expect(roleCan('operator', unlisted)).toBe(false)
   })
-  it('allows admins and local to resize the grid', () => {
-    expect(roleCan('admin', 'set-grid-size')).toBe(true)
-    expect(roleCan('local', 'set-grid-size')).toBe(true)
+  it('denies monitors an action absent from every set', () => {
+    expect(roleCan('monitor', unlisted)).toBe(false)
   })
-  it('does not allow monitors to resize the grid', () => {
-    expect(roleCan('monitor', 'set-grid-size')).toBe(false)
-  })
-  it('does not allow unauthenticated clients to resize the grid', () => {
-    expect(roleCan(null, 'set-grid-size')).toBe(false)
+  it('denies unauthenticated clients an action absent from every set', () => {
+    expect(roleCan(null, unlisted)).toBe(false)
   })
 })
 
@@ -34,5 +115,11 @@ describe('inviteLink', () => {
     const [beforeFragment] = link.split('#')
     expect(beforeFragment).not.toContain('s3cr3t')
     expect(beforeFragment).toBe('/invite/abc')
+  })
+
+  it('defaults baseURL to an empty string when omitted', () => {
+    expect(inviteLink({ tokenId: 'abc', secret: 's3cr3t' })).toBe(
+      '/invite/abc#token=s3cr3t',
+    )
   })
 })


### PR DESCRIPTION
## Problem

Issue #47: the authorization surface was only thinly tested. `roleCan`
(`packages/streamwall-shared/src/roles.ts`) had ad-hoc coverage of a single
action (`set-grid-size`), and `StateWrapper.view`
(`packages/streamwall-control-server/src/auth.ts`) — which decides that only
admins see the token list — had **no** tests at all. A regression that widened
a role's permissions, or that leaked the `auth` token list to a non-admin view,
could ship silently.

## Solution

Test-only change covering the two authorization primitives the issue names.

**`roleCan` — table-driven role × action matrix** (streamwall-shared):
- Full matrix over every role (`local`, `admin`, `operator`, `monitor`) × every
  action, plus the unauthenticated `null` role. The expected allow-sets are
  re-declared independently of the implementation and pinned with `satisfies
  readonly StreamwallAction[]`, so removing an action from `roles.ts` breaks the
  test loudly.
- Explicitly asserts admin-only actions (`dev-tools`, `browse`, `create-invite`,
  `delete-token`) are denied to operator/monitor, and operator-only actions are
  denied to monitor.
- A dedicated default-deny block for an unlisted message type (a future/unknown
  command) falling through to a deny for non-privileged roles. Note: the issue's
  original `set-grid-size` example is now a *listed* operator action, so the
  matrix asserts operator ✓ / monitor ✗ for it and the default-deny block uses a
  genuinely unlisted action.
- Folds the old standalone `set-grid-size` cases into the matrix (subsumed);
  keeps and extends the `inviteLink` formatting tests.

**`StateWrapper.view` — role scoping** (control-server):
- Only the `admin` view carries the `auth` token list, present as an actual key.
- `operator`, `monitor`, and even all-powerful `local` views omit the `auth`
  key **entirely** (not merely `undefined`) — token-list visibility is
  admin-exclusive and independent of `roleCan`.
- The `info` getter yields an unprivileged monitor view with no `auth`.
- Pins `identity.role` re-stamping without mutating the wrapped source, and
  pass-through of non-sensitive fields.

## Architecture decisions

- Expected allow-sets are re-listed in the test rather than imported from the
  (unexported) action arrays, so the test encodes the *intended* contract
  instead of tautologically re-deriving it from the code under test.
- Tests live beside existing suites and use each package's established runner
  (vitest for streamwall-shared, `node:test` for control-server).

## Testing

- `npm -w packages/streamwall-shared test` → 158 passed (was 83).
- `npm -w packages/streamwall-control-server test` → 73 passed.
- Verified the new tests are non-vacuous by mutation: making `monitor`
  omnipotent in `roleCan` fails 14 matrix cases; leaking `auth` to all roles in
  `view` fails 4 StateWrapper cases. Source reverted after.
- `npm run typecheck`, `npm run lint`, and `prettier --check` on the changed
  files are clean.

## Risks / breaking changes

None — additive, test-only. No production code changed.

Closes #47