### PR TITLE
docs: fix dead [grid] count option in example.config.toml

### DIFF
--- a/example.config.toml
+++ b/example.config.toml
@@ -15,7 +15,9 @@
 #active-color = "#fff"
 
 [grid]
-#count = 3
+# Number of columns and rows in the stream grid (default: 3x3, each 1-8)
+#cols = 3
+#rows = 3
 
 [control]
 # Address to serve control server from


### PR DESCRIPTION
## Problem

`example.config.toml` documented the grid as:

```toml
[grid]
#count = 3
```

But the app reads only `grid.cols` / `grid.rows` (`packages/streamwall/src/main/index.ts`), each defaulting to 3. `grid.count` is not part of the config schema and is silently ignored, so anyone copying the example got the 3x3 default no matter what they set.

## Solution

Replace the dead `count` key with the keys the app actually reads, documenting the default and the valid range enforced by the Zod config validation (`GRID_MIN`=1, `GRID_MAX`=8):

```toml
[grid]
# Number of columns and rows in the stream grid (default: 3x3, each 1-8)
#cols = 3
#rows = 3
```

## Scope

Strictly the `[grid]` section. The `[control]` and `[cert]` sections of the same file are tracked separately in #67 and #68 and are intentionally untouched here.

## Testing

Docs-only change to an example TOML file — no runtime behavior and nothing testable, so no tests were added. Verified `npm run format:check` stays green (Prettier skips `.toml` under the directory glob).

## Risks / breaking changes

None. Comment-only edit to an example file that ships as documentation.

## Follow-up

- #148 — warn on unknown keys in `config.toml`, so a stale/misspelled key (like the old `grid.count`) surfaces instead of being silently dropped.

Closes #66