### PR TITLE
build(eslint): wire up import-x with the TypeScript resolver

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 // Flat ESLint configuration (ESLint 10+).
 // Replaces the legacy .eslintrc.json, which ESLint 9+ no longer reads.
 import js from '@eslint/js'
+import importX from 'eslint-plugin-import-x'
 import globals from 'globals'
 import tseslint from 'typescript-eslint'
 
@@ -17,6 +18,10 @@ export default tseslint.config(
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,
+  // Import hygiene backed by the TypeScript resolver, so import paths
+  // (including workspace packages and `.ts` extensions) are validated.
+  importX.flatConfigs.recommended,
+  importX.flatConfigs.typescript,
   {
     languageOptions: {
       ecmaVersion: 2024,
@@ -37,6 +42,11 @@ export default tseslint.config(
           caughtErrors: 'none',
         },
       ],
+      // Default-importing a CJS module whose interop name collides with one of
+      // its named exports (e.g. `import WebSocket from 'ws'`) is intentional
+      // and idiomatic here; these stylistic checks add noise without value.
+      'import-x/no-named-as-default': 'off',
+      'import-x/no-named-as-default-member': 'off',
     },
   },
   {

--- a/packages/streamwall/src/main/TwitchBot.ts
+++ b/packages/streamwall/src/main/TwitchBot.ts
@@ -5,7 +5,7 @@ import {
   PrivmsgMessage,
   SlowModeRateLimiter,
 } from 'dank-twitch-irc'
-import ejs from 'ejs'
+import * as ejs from 'ejs'
 import EventEmitter from 'events'
 import { StreamList, StreamwallState } from 'streamwall-shared'
 import { matchesState } from 'xstate'


### PR DESCRIPTION
## Problem

Issue #59 reported that ESLint was hard-broken because only a legacy `.eslintrc.json` existed while ESLint 10 was installed. That migration was in fact already completed by #120: `eslint.config.mjs` exists, `.eslintrc.json` is gone, `npm run lint` exits 0, and lint runs in CI.

What #120 left unfinished is the part the issue explicitly asked for: `eslint-plugin-import-x` and `eslint-import-resolver-typescript` were installed (staged in `8803e73`) but never wired into the flat config, so they were dead weight and import paths went unvalidated.

## Solution

- Enable `importX.flatConfigs.recommended` + `importX.flatConfigs.typescript` in `eslint.config.mjs`, so imports — including workspace packages and `.ts` extensions — are resolved and checked via the TypeScript resolver.
- Turn off `import-x/no-named-as-default` and `import-x/no-named-as-default-member`. These are purely stylistic and fire on the idiomatic pattern of default-importing a CJS module whose interop name matches one of its named exports (e.g. `import WebSocket from 'ws'`, the fastify plugins, `preact`, `hls.js`). They add noise without catching real problems.
- Fix the single real finding surfaced by `import-x/default`: `packages/streamwall/src/main/TwitchBot.ts` used `import ejs from 'ejs'`, but `@types/ejs` exposes only named exports and `export as namespace ejs` — no default export. Switched to `import * as ejs from 'ejs'`, which is the correct namespace import and keeps both the value (`ejs.compile`) and type (`ejs.TemplateFunction`) usages working.

## Architecture decisions

- The `ejs` change is a proper fix, not a rule suppression — the module genuinely has no default export.
- Disabling the two `no-named-as-default*` rules is a deliberate, documented trade-off (comment in the config) rather than blanket-disabling import-x. The correctness rules (`no-unresolved`, `default`, `named`, `export`, …) stay on.

## Testing performed

Full quality gate, all green locally:

- `npm run format:check` — clean
- `npm run lint` — 0 problems (was 0 before too; now with import-x actually enforcing)
- `npm run typecheck` — all 5 workspaces pass (incl. `streamwall`, covering the `ejs` change)
- `npm test` — all suites pass
- `npm -w streamwall-control-client run build` — builds

No unit tests were added: this is a lint-config/tooling change with no new runtime behavior; the effective test is that `npm run lint` stays green while import-x now validates imports.

## Risks / breaking changes

None. No runtime behavior changes. The `ejs` import compiles to the same `require('ejs')` under CommonJS.

Closes #59