### PR TITLE
fix(tsconfig): resolve react→preact/compat via hoisted node_modules

### DIFF
--- a/packages/streamwall-control-client/tsconfig.json
+++ b/packages/streamwall-control-client/tsconfig.json
@@ -6,8 +6,8 @@
     "types": ["vite/client"],
     "allowImportingTsExtensions": true,
     "paths": {
-      "react": ["./node_modules/preact/compat/"],
-      "react-dom": ["./node_modules/preact/compat/"]
+      "react": ["../../node_modules/preact/compat"],
+      "react-dom": ["../../node_modules/preact/compat"]
     }
   },
   "include": ["src"]

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -50,6 +50,7 @@ import {
   type StreamwallRole,
   type StreamwallState,
   type StreamWindowConfig,
+  type ViewPos,
   type ViewState,
 } from 'streamwall-shared'
 import { createGlobalStyle, styled } from 'styled-components'
@@ -59,6 +60,10 @@ import { isPrimaryButton, resolveMoveTarget } from './gestures'
 import './index.css'
 import { LazyChangeInput } from './LazyChangeInput.tsx'
 import { resolveTargetViewIdx, resolveWriteStreamId } from './viewPlacement.ts'
+
+// `import Color from 'color'` binds only the value; alias the instance type
+// (as returned by the Color factory) for use in styled-component prop types.
+type ColorInstance = ReturnType<typeof Color>
 
 export interface ViewInfo {
   state: ViewState
@@ -1417,7 +1422,13 @@ export function ControlUI({
   )
 }
 
-const Stack = styled.div`
+const Stack = styled.div<{
+  direction?: string
+  flex?: string
+  gap?: number
+  scroll?: boolean
+  minHeight?: number
+}>`
   display: flex;
   flex-direction: ${({ direction }) => direction ?? 'column'};
   flex: ${({ flex }) => flex};
@@ -1546,7 +1557,7 @@ function StreamLine({
     <StyledStreamLine>
       <StyledId
         $disabled={disabled}
-        onMouseDown={disabled ? null : handleMouseDownId}
+        onMouseDown={disabled ? undefined : handleMouseDownId}
         $color={idColor(id)}
       >
         {id}
@@ -2128,11 +2139,14 @@ const StyledStreamDelayBox = styled.div`
   color: var(--text);
 `
 
-const StyledDataContainer = styled.div`
+const StyledDataContainer = styled.div<{ isConnected?: boolean }>`
   opacity: ${({ isConnected }) => (isConnected ? 1 : 0.5)};
 `
 
-const StyledButton = styled.button`
+const StyledButton = styled.button<{
+  isActive?: boolean
+  activeColor?: string
+}>`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2190,7 +2204,15 @@ const StyledGridInfo = styled.div`
   z-index: 1000; /* Keep above grid inputs */
 `
 
-const StyledGridPreviewBox = styled.div.attrs(() => ({
+const StyledGridPreviewBox = styled.div.attrs<{
+  color: ColorInstance
+  isError: boolean
+  pos: ViewPos
+  windowWidth: number
+  windowHeight: number
+  isListening: boolean
+  borderWidth?: number
+}>(() => ({
   borderWidth: 2,
 }))`
   display: flex;
@@ -2259,7 +2281,7 @@ const StyledGridInputContainer = styled.div`
   position: absolute;
 `
 
-const StyledGridButtons = styled.div`
+const StyledGridButtons = styled.div<{ side?: 'left' | 'right' }>`
   display: flex;
   position: absolute;
   ${({ side }) =>
@@ -2271,7 +2293,10 @@ const StyledGridButtons = styled.div`
   }
 `
 
-const StyledGridInput = styled(LazyChangeInput)`
+const StyledGridInput = styled(LazyChangeInput)<{
+  color: ColorInstance
+  isHighlighted?: boolean
+}>`
   width: 100%;
   height: 100%;
   outline: 1px solid rgba(0, 0, 0, 0.5);
@@ -2300,7 +2325,10 @@ const StyledGridControlsContainer = styled.div`
   }
 `
 
-const StyledGridContainer = styled.div`
+const StyledGridContainer = styled.div<{
+  windowWidth: number
+  windowHeight: number
+}>`
   position: relative;
   /* Responsive: keep the wall's aspect ratio but fit the available space
      instead of a hard-coded pixel size, so the layout never overflows. */
@@ -2319,7 +2347,7 @@ const StyledGridContainer = styled.div`
   }
 `
 
-const StyledId = styled.div`
+const StyledId = styled.div<{ $color: ColorInstance; $disabled?: boolean }>`
   flex-shrink: 0;
   font-family: var(--font-mono);
   font-weight: 700;

--- a/packages/streamwall-control-ui/tsconfig.json
+++ b/packages/streamwall-control-ui/tsconfig.json
@@ -14,8 +14,8 @@
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
     "paths": {
-      "react": ["./node_modules/preact/compat/"],
-      "react-dom": ["./node_modules/preact/compat/"]
+      "react": ["../../node_modules/preact/compat"],
+      "react-dom": ["../../node_modules/preact/compat"]
     },
     "lib": ["ES2024", "DOM", "DOM.iterable"],
     "baseUrl": ".",

--- a/packages/streamwall/src/renderer/overlay.tsx
+++ b/packages/streamwall/src/renderer/overlay.tsx
@@ -12,7 +12,11 @@ import {
   FaYoutube,
 } from 'react-icons/fa'
 import { RiKickFill, RiTwitterXFill } from 'react-icons/ri'
-import { StreamwallState } from 'streamwall-shared'
+import {
+  type StreamData,
+  StreamwallState,
+  type ViewPos,
+} from 'streamwall-shared'
 import { styled } from 'styled-components'
 import { TailSpin } from 'svg-loaders-react'
 import { matchesState } from 'xstate'
@@ -46,7 +50,7 @@ function Overlay({
       <VersionFooter />
       {activeViews.map(({ state, context }) => {
         const { content, pos } = context
-        if (!content) {
+        if (!content || !pos) {
           return
         }
 
@@ -188,7 +192,14 @@ const OverlayContainer = styled.div`
   overflow: hidden;
 `
 
-const SpaceBorder = styled.div.attrs(() => ({
+const SpaceBorder = styled.div.attrs<{
+  pos: ViewPos
+  windowWidth: number
+  windowHeight: number
+  activeColor: string
+  isListening: boolean
+  borderWidth?: number
+}>(() => ({
   borderWidth: 2,
 }))`
   display: flex;
@@ -214,7 +225,11 @@ const SpaceBorder = styled.div.attrs(() => ({
   user-select: none;
 `
 
-const StreamTitle = styled.div`
+const StreamTitle = styled.div<{
+  position: StreamData['labelPosition']
+  isListening: boolean
+  activeColor: string
+}>`
   position: absolute;
   ${({ position }) => {
     if (position === 'top-left') {
@@ -240,13 +255,7 @@ const StreamTitle = styled.div`
   color: white;
   text-shadow: 0 0 4px black;
   letter-spacing: -0.025em;
-  background: ${({
-    isListening,
-    activeColor,
-  }: {
-    isListening: boolean
-    activeColor: string
-  }) =>
+  background: ${({ isListening, activeColor }) =>
     Color(isListening ? activeColor : 'black')
       .alpha(0.5)
       .toString()};
@@ -323,7 +332,7 @@ const LoadingSpinner = styled(TailSpin)<{ isVisible: boolean }>`
   visibility: ${({ isVisible }) => (isVisible ? 'visible' : 'hidden')};
 `
 
-const FilterCover = styled.div`
+const FilterCover = styled.div<{ isBlurred: boolean; isDesaturated: boolean }>`
   position: absolute;
   left: 0;
   right: 0;
@@ -335,7 +344,7 @@ const FilterCover = styled.div`
     )};
 `
 
-const VersionText = styled.div`
+const VersionText = styled.div<{ isShowing: boolean }>`
   position: fixed;
   bottom: 4px;
   right: 4px;

--- a/packages/streamwall/tsconfig.json
+++ b/packages/streamwall/tsconfig.json
@@ -15,8 +15,8 @@
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
     "paths": {
-      "react": ["./node_modules/preact/compat/"],
-      "react-dom": ["./node_modules/preact/compat/"]
+      "react": ["../../node_modules/preact/compat"],
+      "react-dom": ["../../node_modules/preact/compat"]
     },
     "lib": ["ES2024", "DOM", "DOM.iterable"],
     "baseUrl": ".",


### PR DESCRIPTION
## Problem

Three package tsconfigs mapped `react`/`react-dom` at a **package-local** path that npm never creates — workspace deps hoist to the repo root:

```jsonc
"react": ["./node_modules/preact/compat/"]      // packages/<pkg>/node_modules/... → does not exist
"react-dom": ["./node_modules/preact/compat/"]
```

Because the substitution pointed at a non-existent directory, `tsc` fell back to standard resolution and resolved `react` to the **untyped** real `react@19` package (`index.js`, no `.d.ts`). Verified via `--traceResolution`:

```
Module name 'react' was successfully resolved to '…/node_modules/react/index.js' … @19.0.0
```

The typecheck therefore *passed falsely*: every react-typed lib (react-icons, styled-components, react-hotkeys-hook) silently degraded to `any`. This is the "silently degrading react-typed libs to broken typings" the issue describes, and the root of the earlier `IconBaseProps`/`className` workarounds.

## Solution

Point the paths at the hoisted location in all three tsconfigs (control-client, streamwall, control-ui):

```jsonc
"react": ["../../node_modules/preact/compat"]
"react-dom": ["../../node_modules/preact/compat"]
```

After the fix `react` resolves correctly in every package:

```
Module name 'react' was successfully resolved to '…/node_modules/preact/compat/src/index.d.ts' … preact-compat@4.0.0
```

## Consequence: honest typecheck surfaced masked errors

Correcting the aliasing turned the false-green typecheck red (72 previously-masked styled-components v6 errors). Since the CI typecheck is a required gate, they are fixed in the same PR by giving each styled component its **prop-type generics** — no runtime change:

- `streamwall-control-ui/src/index.tsx`: `Stack`, `StyledDataContainer`, `StyledButton`, `StyledGridPreviewBox`, `StyledGridButtons`, `StyledGridInput`, `StyledGridContainer`, `StyledId` (+ a `ColorInstance` type alias for the `color`-lib instance type).
- `streamwall/src/renderer/overlay.tsx`: `SpaceBorder`, `StreamTitle`, `FilterCover`, `VersionText`.

Two latent correctness bugs the real types exposed are fixed alongside:
- `StyledId onMouseDown`: `null` → `undefined` (matches the `MouseEventHandler | undefined` contract).
- Overlay `map`: added a `pos` null-guard (`context.pos` is `ViewPos | null`); the old code would have thrown on `pos.x` had `pos` been null.

## Architecture note

Prop types are declared to match the existing prop names/usage exactly, so DOM output and component behavior are unchanged — this is a pure type-correctness pass. Transient props already used (`$color`, `$disabled`) are preserved.

## Testing

Full quality gate green locally:
- Prettier `format:check` ✓
- ESLint ✓
- `tsc --noEmit` across all 5 workspaces ✓ (0 errors; was a false 0 before, now honest 0)
- Full test suite ✓ (243+ tests incl. control-ui component tests — confirms no runtime regression)
- `streamwall-control-client` build ✓
- `--traceResolution` confirms `react` → `preact/compat` in all three packages

## Risks / breaking changes

None expected. Type-only change; runtime DOM/behavior identical. No public API change.

Closes #58