### PR TITLE
docs: rewrite [control] section of example.config.toml for token/endpoint architecture

### DIFF
--- a/example.config.toml
+++ b/example.config.toml
@@ -20,16 +20,10 @@
 #rows = 3
 
 [control]
-# Address to serve control server from
-address = "http://localhost:80"
-
-# Override hostname and port
-#hostname = "localhost"
-#port = 80
-
-# Username and password
-username = "streamwall"
-password = "please-change-this"
+# WebSocket URL (including the auth token) for the separate control server
+# that operators use to remotely arrange the grid. The control server prints
+# this URL to stdout on startup — copy it here verbatim.
+#endpoint = "ws://localhost/streamwall/<id>/ws?token=<secret>"
 
 [data]
 # Interval to refresh polled datasources


### PR DESCRIPTION
## Problem

`example.config.toml:20-30` documented `[control]` options (`address`, `hostname`, `port`, `username`, `password`) that do not exist anywhere in the codebase. The app only reads `control.endpoint` — a WebSocket URL that includes the auth token (`packages/streamwall/src/main/index.ts:209-211`). Authentication is handled entirely by the separate control server (`packages/streamwall-control-server`), which mints tokens and prints the uplink endpoint to stdout on startup (`packages/streamwall-control-server/src/index.ts:874-891`).

Anyone following the example config would set options the app silently ignores, leaving `control.endpoint` unset and remote control non-functional.

## Solution

Rewrote the `[control]` section to document the real option:

```toml
[control]
# WebSocket URL (including the auth token) for the separate control server
# that operators use to remotely arrange the grid. The control server prints
# this URL to stdout on startup — copy it here verbatim.
#endpoint = "ws://localhost/streamwall/<id>/ws?token=<secret>"
```

## Testing performed

Docs-only change with no testable behavior — verified by reading the actual config-parsing code (`packages/streamwall/src/main/index.ts`) and the control server's bootstrap/logging code (`packages/streamwall-control-server/src/index.ts`) to confirm `control.endpoint` is the only option the app consumes, and that the URL shape/token flow matches what's now documented.

## Risks / breaking changes

None — this only touches an example/template file.

Closes #67