### PR TITLE
feat: surface stream load errors on the wall and add auto-retry with backoff

### DIFF
--- a/example.config.toml
+++ b/example.config.toml
@@ -42,6 +42,22 @@ json-url = []
 # See example.streams.toml for a sample.
 #toml-file = ["./example.streams.toml"]
 
+[retry]
+# Automatically reload views that fail to load or stall. Failed views show an
+# error badge with the reason on the wall and in the control UI while retrying.
+#enabled = true
+
+# Base backoff (in seconds) before the first reload. The delay doubles after each
+# failed attempt (exponential backoff), capped at max-delay.
+#delay = 5
+#max-delay = 60
+
+# Give up after this many automatic reloads (a manual reload resets the count).
+#max-retries = 5
+
+# How long (in seconds) a playing view may stall before it is reloaded.
+#stalled-timeout = 30
+
 [twitch]
 #channel = "woke"
 #username = "bot-username"

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -21,6 +21,7 @@ import {
 import { useHotkeys } from 'react-hotkeys-hook'
 import {
   FaExchangeAlt,
+  FaExclamationTriangle,
   FaRedoAlt,
   FaRegLifeRing,
   FaRegWindowMaximize,
@@ -1221,6 +1222,8 @@ export function ControlUI({
                   }
 
                   const isSmall = pos.height < 200
+                  const isError = matchesState('displaying.error', state.state)
+                  const errorReason = state.context.error
                   return (
                     <StyledGridPreviewBox
                       color={idColor(streamId)}
@@ -1234,7 +1237,7 @@ export function ControlUI({
                       windowWidth={windowWidth}
                       windowHeight={windowHeight}
                       isListening={isListening}
-                      isError={matchesState('displaying.error', state.state)}
+                      isError={isError}
                     >
                       <StyledGridInfo className={isSmall ? 'small' : undefined}>
                         <StyledGridLabel>
@@ -1249,6 +1252,12 @@ export function ControlUI({
                           <StyledGridLocation>
                             {data?.city} {data?.state}
                           </StyledGridLocation>
+                        )}
+                        {isError && (
+                          <StyledGridError title={errorReason ?? undefined}>
+                            <FaExclamationTriangle />
+                            <span>{errorReason ?? 'Stream error'}</span>
+                          </StyledGridError>
                         )}
                       </StyledGridInfo>
                     </StyledGridPreviewBox>
@@ -2263,6 +2272,37 @@ const StyledGridLabel = styled.div`
 const StyledGridLocation = styled.div`
   font-size: 13px;
   opacity: 0.75;
+`
+
+const StyledGridError = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  margin-top: 6px;
+  padding: 3px 8px;
+  border-radius: 8px;
+  max-width: 100%;
+  font-size: 12px;
+  font-weight: 600;
+  color: white;
+  background: ${Color('red').alpha(0.7).string()};
+
+  svg {
+    flex-shrink: 0;
+  }
+
+  span {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+
+  ${StyledGridInfo}.small & {
+    span {
+      display: none;
+    }
+  }
 `
 
 const StyledGridInputs = styled.div`

--- a/packages/streamwall-shared/src/types.ts
+++ b/packages/streamwall-shared/src/types.ts
@@ -60,6 +60,7 @@ export type ViewStateValue =
           }
         | {
             running: {
+              playback: 'playing' | 'stalled'
               video: 'normal' | 'blurred'
               audio: 'background' | 'muted' | 'listening'
             }
@@ -73,6 +74,8 @@ export interface ViewState {
     content: ViewContent | null
     info: ContentViewInfo | null
     pos: ViewPos | null
+    // Human-readable reason when the view is in displaying.error, else null.
+    error: string | null
   }
 }
 

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -19,7 +19,11 @@ import { createActor, EventFrom, SnapshotFrom } from 'xstate'
 import { loadHTML } from './loadHTML'
 import { secureStreamView } from './navigationSecurity'
 import { allocateViewPartition, hardenSession } from './partitions'
-import viewStateMachine, { ViewActor } from './viewStateMachine'
+import viewStateMachine, {
+  DEFAULT_RETRY_CONFIG,
+  RetryConfig,
+  ViewActor,
+} from './viewStateMachine'
 
 function getDisplayOptions(stream: StreamData): ContentDisplayOptions {
   if (!stream) {
@@ -38,14 +42,19 @@ export interface StreamWindowEventMap {
 
 export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
   config: StreamWindowConfig
+  retryConfig: RetryConfig
   win: BrowserWindow
   backgroundView: WebContentsView
   overlayView: WebContentsView
   views: Map<number, ViewActor>
 
-  constructor(config: StreamWindowConfig) {
+  constructor(
+    config: StreamWindowConfig,
+    retryConfig: RetryConfig = DEFAULT_RETRY_CONFIG,
+  ) {
     super()
     this.config = config
+    this.retryConfig = retryConfig
     this.views = new Map()
 
     const { width, height, x, y, frameless, backgroundColor } = this.config
@@ -201,6 +210,7 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
         view,
         win,
         offscreenWin,
+        retry: this.retryConfig,
       },
     })
 
@@ -248,6 +258,7 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
           content: context.content,
           info: context.info,
           pos: context.pos,
+          error: context.error,
         },
       } satisfies ViewState
     })

--- a/packages/streamwall/src/main/config.test.ts
+++ b/packages/streamwall/src/main/config.test.ts
@@ -16,6 +16,13 @@ function baseConfig() {
     data: { interval: 30, 'json-url': [], 'toml-file': [] },
     streamdelay: { endpoint: 'http://localhost:8404', key: null },
     control: { endpoint: null },
+    retry: {
+      enabled: true,
+      delay: 5,
+      'max-delay': 60,
+      'max-retries': 5,
+      'stalled-timeout': 30,
+    },
     twitch: {
       channel: null,
       username: null,
@@ -128,6 +135,30 @@ describe('validateConfig', () => {
   test('rejects a non-string window color', () => {
     const config = baseConfig()
     ;(config.window as Record<string, unknown>)['background-color'] = 123
+    expect(() => validateConfig(config)).toThrow(ConfigError)
+  })
+
+  test('accepts retry disabled with zeroed timings', () => {
+    const config = baseConfig()
+    config.retry = {
+      enabled: false,
+      delay: 0,
+      'max-delay': 0,
+      'max-retries': 0,
+      'stalled-timeout': 0,
+    }
+    expect(() => validateConfig(config)).not.toThrow()
+  })
+
+  test('rejects a negative retry delay', () => {
+    const config = baseConfig()
+    config.retry.delay = -1
+    expect(() => validateConfig(config)).toThrow(ConfigError)
+  })
+
+  test('rejects a fractional retry max-retries', () => {
+    const config = baseConfig()
+    config.retry['max-retries'] = 2.5
     expect(() => validateConfig(config)).toThrow(ConfigError)
   })
 })

--- a/packages/streamwall/src/main/config.ts
+++ b/packages/streamwall/src/main/config.ts
@@ -66,6 +66,13 @@ const streamwallConfigSchema = z.object({
   control: z.object({
     endpoint: z.string().nullable(),
   }),
+  retry: z.object({
+    enabled: z.boolean(),
+    delay: nonNegativeNumber,
+    'max-delay': nonNegativeNumber,
+    'max-retries': z.number().int().nonnegative(),
+    'stalled-timeout': nonNegativeNumber,
+  }),
   twitch: z.object({
     channel: z.string().nullable(),
     username: z.string().nullable(),

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -92,6 +92,13 @@ export interface StreamwallConfig {
   control: {
     endpoint: string
   }
+  retry: {
+    enabled: boolean
+    delay: number
+    'max-delay': number
+    'max-retries': number
+    'stalled-timeout': number
+  }
   twitch: {
     channel: string | null
     username: string | null
@@ -212,6 +219,41 @@ function parseArgs(): StreamwallConfig {
     })
     .group(
       [
+        'retry.enabled',
+        'retry.delay',
+        'retry.max-delay',
+        'retry.max-retries',
+        'retry.stalled-timeout',
+      ],
+      'Auto-retry',
+    )
+    .option('retry.enabled', {
+      describe: 'Automatically reload views that error or stall',
+      boolean: true,
+      default: true,
+    })
+    .option('retry.delay', {
+      describe: 'Base backoff (in seconds) before the first reload',
+      number: true,
+      default: 5,
+    })
+    .option('retry.max-delay', {
+      describe: 'Maximum backoff (in seconds) between reloads',
+      number: true,
+      default: 60,
+    })
+    .option('retry.max-retries', {
+      describe: 'Maximum number of automatic reloads before giving up',
+      number: true,
+      default: 5,
+    })
+    .option('retry.stalled-timeout', {
+      describe: 'How long (in seconds) a view may stall before it is reloaded',
+      number: true,
+      default: 30,
+    })
+    .group(
+      [
         'twitch.channel',
         'twitch.username',
         'twitch.token',
@@ -310,7 +352,16 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     activeColor: argv.window['active-color'],
     backgroundColor: argv.window['background-color'],
   }
-  const streamWindow = new StreamWindow(streamWindowConfig)
+  // The state machine works in milliseconds; the config is in seconds for
+  // consistency with the other interval options.
+  const retryConfig = {
+    enabled: argv.retry.enabled,
+    delay: argv.retry.delay * 1000,
+    maxDelay: argv.retry['max-delay'] * 1000,
+    maxRetries: argv.retry['max-retries'],
+    stalledTimeout: argv.retry['stalled-timeout'] * 1000,
+  }
+  const streamWindow = new StreamWindow(streamWindowConfig, retryConfig)
   const controlWindow = new ControlWindow()
 
   let browseWindow: BrowserWindow | null = null

--- a/packages/streamwall/src/main/viewStateMachine.test.ts
+++ b/packages/streamwall/src/main/viewStateMachine.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// viewStateMachine imports electron (directly and via ./loadHTML). Stub the
+// module so the machine can be exercised without an Electron runtime; the
+// electron-touching actions are overridden with no-ops below.
+vi.mock('electron', () => ({
+  BrowserWindow: class {},
+  WebContentsView: class {},
+  WebContents: class {},
+}))
+
+const { createActor, fromPromise, matchesState } = await import('xstate')
+const { default: viewStateMachine, DEFAULT_RETRY_CONFIG } =
+  await import('./viewStateMachine')
+type RetryConfig = import('./viewStateMachine').RetryConfig
+
+const noop = () => {}
+
+// A fast retry config so timers advance quickly and the backoff formula is easy
+// to reason about in assertions.
+function makeRetry(overrides: Partial<RetryConfig> = {}): RetryConfig {
+  return {
+    enabled: true,
+    delay: 1000,
+    maxDelay: 8000,
+    maxRetries: 5,
+    stalledTimeout: 2000,
+    ...overrides,
+  }
+}
+
+// Replace every electron-touching action and the loadPage actor so only the
+// pure state/context logic under test runs. loadPage resolves immediately,
+// moving loading.navigate -> loading.waitForInit.
+function makeActor(retry: RetryConfig, loadPageImpl?: () => Promise<void>) {
+  const machine = viewStateMachine.provide({
+    actions: {
+      offscreenView: noop,
+      positionView: noop,
+      muteAudio: noop,
+      unmuteAudio: noop,
+      openDevTools: noop,
+      sendViewOptions: noop,
+      logError: noop,
+    },
+    actors: {
+      loadPage: fromPromise(loadPageImpl ?? (async () => {})),
+    },
+  })
+  return createActor(machine, {
+    input: {
+      id: 1,
+      view: {} as never,
+      win: {} as never,
+      offscreenWin: {} as never,
+      retry,
+    },
+  })
+}
+
+const CONTENT = { url: 'https://example.com/stream', kind: 'video' as const }
+const POS = { x: 0, y: 0, width: 100, height: 100, spaces: [0] }
+
+function display(actor: ReturnType<typeof makeActor>) {
+  actor.send({ type: 'DISPLAY', pos: POS, content: CONTENT })
+}
+
+// Drive a freshly-displayed view all the way to the running state. The
+// loadPage actor resolves as a microtask, so flush pending timers/promises to
+// let loading.navigate advance to waitForInit before signalling init/loaded.
+async function reachRunning(actor: ReturnType<typeof makeActor>) {
+  display(actor)
+  await vi.advanceTimersByTimeAsync(0)
+  actor.send({ type: 'VIEW_INIT' })
+  actor.send({ type: 'VIEW_LOADED' })
+}
+
+describe('viewStateMachine error handling and auto-retry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('exposes a default retry config', () => {
+    expect(DEFAULT_RETRY_CONFIG).toMatchObject({
+      enabled: expect.any(Boolean),
+      delay: expect.any(Number),
+      maxDelay: expect.any(Number),
+      maxRetries: expect.any(Number),
+      stalledTimeout: expect.any(Number),
+    })
+  })
+
+  it('records a human-readable reason and enters displaying.error on VIEW_ERROR', () => {
+    const actor = makeActor(makeRetry({ enabled: false }))
+    actor.start()
+    display(actor)
+
+    actor.send({ type: 'VIEW_ERROR', error: new Error('boom') })
+
+    const snapshot = actor.getSnapshot()
+    expect(matchesState('displaying.error', snapshot.value)).toBe(true)
+    expect(snapshot.context.error).toBe('boom')
+  })
+
+  it('stringifies non-Error reasons', () => {
+    const actor = makeActor(makeRetry({ enabled: false }))
+    actor.start()
+    display(actor)
+
+    actor.send({ type: 'VIEW_ERROR', error: 'plain string failure' })
+
+    expect(actor.getSnapshot().context.error).toBe('plain string failure')
+  })
+
+  it('auto-retries from the error state after the backoff delay', () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    display(actor)
+    actor.send({ type: 'VIEW_ERROR', error: new Error('boom') })
+    expect(actor.getSnapshot().context.retryCount).toBe(0)
+
+    vi.advanceTimersByTime(1000) // delay * 2^0
+
+    const snapshot = actor.getSnapshot()
+    expect(matchesState('displaying.loading', snapshot.value)).toBe(true)
+    expect(snapshot.context.retryCount).toBe(1)
+    expect(snapshot.context.error).toBe(null)
+  })
+
+  it('does not retry before the backoff delay elapses', () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    display(actor)
+    actor.send({ type: 'VIEW_ERROR', error: new Error('boom') })
+
+    vi.advanceTimersByTime(999)
+
+    expect(matchesState('displaying.error', actor.getSnapshot().value)).toBe(
+      true,
+    )
+  })
+
+  it('grows the backoff exponentially and caps it at maxDelay', () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    display(actor)
+
+    // 1st error -> retry after delay * 2^0 = 1000
+    actor.send({ type: 'VIEW_ERROR', error: new Error('e0') })
+    vi.advanceTimersByTime(1000)
+    expect(actor.getSnapshot().context.retryCount).toBe(1)
+
+    // 2nd error -> retry after delay * 2^1 = 2000
+    actor.send({ type: 'VIEW_ERROR', error: new Error('e1') })
+    vi.advanceTimersByTime(1999)
+    expect(matchesState('displaying.error', actor.getSnapshot().value)).toBe(
+      true,
+    )
+    vi.advanceTimersByTime(1)
+    expect(actor.getSnapshot().context.retryCount).toBe(2)
+
+    // 3rd error -> retry after delay * 2^2 = 4000
+    actor.send({ type: 'VIEW_ERROR', error: new Error('e2') })
+    vi.advanceTimersByTime(4000)
+    expect(actor.getSnapshot().context.retryCount).toBe(3)
+
+    // 4th error -> delay * 2^3 = 8000 (== maxDelay)
+    actor.send({ type: 'VIEW_ERROR', error: new Error('e3') })
+    vi.advanceTimersByTime(8000)
+    expect(actor.getSnapshot().context.retryCount).toBe(4)
+
+    // 5th error -> delay * 2^4 = 16000 but capped at maxDelay = 8000
+    actor.send({ type: 'VIEW_ERROR', error: new Error('e4') })
+    vi.advanceTimersByTime(8000)
+    expect(actor.getSnapshot().context.retryCount).toBe(5)
+  })
+
+  it('stops retrying once maxRetries is reached', () => {
+    const actor = makeActor(makeRetry({ maxRetries: 2 }))
+    actor.start()
+    display(actor)
+
+    actor.send({ type: 'VIEW_ERROR', error: new Error('e0') })
+    vi.advanceTimersByTime(1000)
+    actor.send({ type: 'VIEW_ERROR', error: new Error('e1') })
+    vi.advanceTimersByTime(2000)
+    expect(actor.getSnapshot().context.retryCount).toBe(2)
+
+    // Third failure: budget exhausted, stays terminal.
+    actor.send({ type: 'VIEW_ERROR', error: new Error('e2') })
+    vi.advanceTimersByTime(60000)
+
+    const snapshot = actor.getSnapshot()
+    expect(matchesState('displaying.error', snapshot.value)).toBe(true)
+    expect(snapshot.context.retryCount).toBe(2)
+  })
+
+  it('does not auto-retry when retry is disabled', () => {
+    const actor = makeActor(makeRetry({ enabled: false }))
+    actor.start()
+    display(actor)
+    actor.send({ type: 'VIEW_ERROR', error: new Error('boom') })
+
+    vi.advanceTimersByTime(60000)
+
+    expect(matchesState('displaying.error', actor.getSnapshot().value)).toBe(
+      true,
+    )
+    expect(actor.getSnapshot().context.retryCount).toBe(0)
+  })
+
+  it('resets retry state and clears the error once running is reached', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    display(actor)
+    actor.send({ type: 'VIEW_ERROR', error: new Error('boom') })
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(actor.getSnapshot().context.retryCount).toBe(1)
+
+    actor.send({ type: 'VIEW_INIT' })
+    actor.send({ type: 'VIEW_LOADED' })
+
+    const snapshot = actor.getSnapshot()
+    expect(matchesState('displaying.running', snapshot.value)).toBe(true)
+    expect(snapshot.context.retryCount).toBe(0)
+    expect(snapshot.context.error).toBe(null)
+  })
+
+  it('reloads a stalled view after the stalled watchdog fires', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'VIEW_STALLED' })
+    expect(
+      matchesState(
+        'displaying.running.playback.stalled',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+
+    vi.advanceTimersByTime(2000) // stalledTimeout
+
+    const snapshot = actor.getSnapshot()
+    expect(matchesState('displaying.loading', snapshot.value)).toBe(true)
+    expect(snapshot.context.retryCount).toBe(1)
+  })
+
+  it('does not reload a stalled view when retry is disabled', async () => {
+    const actor = makeActor(makeRetry({ enabled: false }))
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'VIEW_STALLED' })
+
+    vi.advanceTimersByTime(60000)
+
+    expect(
+      matchesState(
+        'displaying.running.playback.stalled',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+  })
+
+  it('resets the retry budget on a manual RELOAD', () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    display(actor)
+    actor.send({ type: 'VIEW_ERROR', error: new Error('boom') })
+    vi.advanceTimersByTime(1000)
+    expect(actor.getSnapshot().context.retryCount).toBe(1)
+
+    actor.send({ type: 'RELOAD' })
+
+    const snapshot = actor.getSnapshot()
+    expect(matchesState('displaying.loading', snapshot.value)).toBe(true)
+    expect(snapshot.context.retryCount).toBe(0)
+    expect(snapshot.context.error).toBe(null)
+  })
+
+  it('surfaces a reason when the loading phase times out', () => {
+    const actor = makeActor(
+      makeRetry({ enabled: false }),
+      () => new Promise<void>(() => {}), // loadPage never resolves
+    )
+    actor.start()
+    display(actor)
+
+    // LOADING_TIMEOUT is 45s.
+    vi.advanceTimersByTime(45 * 1000)
+
+    const snapshot = actor.getSnapshot()
+    expect(matchesState('displaying.error', snapshot.value)).toBe(true)
+    expect(snapshot.context.error).toMatch(/timed out/i)
+  })
+})

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -20,6 +20,47 @@ import { loadHTML } from './loadHTML'
 // healthy streams are not cut off; only trips when the renderer never responds at all.
 const LOADING_TIMEOUT = 45 * 1000
 
+/**
+ * Tunables for automatically recovering views that fail to load or stall. A
+ * failed/stalled view is reloaded after an exponentially growing delay until it
+ * recovers or the attempt budget is exhausted, at which point it stays in the
+ * terminal error state (surfaced on the wall and in the control UI).
+ */
+export interface RetryConfig {
+  /** Whether error/stalled views are reloaded automatically at all. */
+  enabled: boolean
+  /** Base backoff before the first retry, in milliseconds. */
+  delay: number
+  /** Upper bound for the backoff, in milliseconds. */
+  maxDelay: number
+  /** Maximum number of automatic reloads before giving up. */
+  maxRetries: number
+  /** How long a view may stay stalled before it is reloaded, in milliseconds. */
+  stalledTimeout: number
+}
+
+export const DEFAULT_RETRY_CONFIG: RetryConfig = {
+  enabled: true,
+  delay: 5 * 1000,
+  maxDelay: 60 * 1000,
+  maxRetries: 5,
+  stalledTimeout: 30 * 1000,
+}
+
+/**
+ * Turns an arbitrary thrown value into a short, serializable reason that can be
+ * shown on the wall overlay and in the control UI.
+ */
+function formatError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+  if (typeof error === 'string') {
+    return error
+  }
+  return String(error)
+}
+
 const viewStateMachine = setup({
   types: {
     input: {} as {
@@ -27,6 +68,7 @@ const viewStateMachine = setup({
       view: WebContentsView
       win: BrowserWindow
       offscreenWin: BrowserWindow
+      retry: RetryConfig
     },
 
     context: {} as {
@@ -38,6 +80,11 @@ const viewStateMachine = setup({
       content: ViewContent | null
       options: ContentDisplayOptions | null
       info: ContentViewInfo | null
+      retry: RetryConfig
+      // Human-readable reason for the current error, or null when healthy.
+      error: string | null
+      // Number of automatic reloads already spent on the current failure streak.
+      retryCount: number
     },
 
     events: {} as
@@ -66,6 +113,26 @@ const viewStateMachine = setup({
     logError: (_, params: { error: unknown }) => {
       console.warn(params.error)
     },
+
+    // Store a serializable reason for the current failure so it can be surfaced
+    // on the wall overlay and in the control UI.
+    setError: assign({
+      error: (_, params: { error: unknown }) => formatError(params.error),
+    }),
+
+    // Begin another automatic reload: spend one attempt and clear the stale
+    // reason while the view loads again.
+    incrementRetry: assign({
+      retryCount: ({ context }) => context.retryCount + 1,
+      error: null,
+    }),
+
+    // Forget any prior failure streak: used when a view starts fresh (new
+    // content, manual reload) or recovers into the running state.
+    resetRetryState: assign({
+      retryCount: 0,
+      error: null,
+    }),
 
     muteAudio: ({ context }) => {
       context.view.webContents.audioMuted = true
@@ -141,6 +208,22 @@ const viewStateMachine = setup({
     ) => {
       return !isEqual(context.options, params.options)
     },
+
+    // Whether the view is still allowed to reload itself automatically.
+    canRetry: ({ context }) =>
+      context.retry.enabled && context.retryCount < context.retry.maxRetries,
+  },
+
+  delays: {
+    // Exponential backoff, capped, computed from how many attempts have already
+    // been spent on the current failure streak.
+    retryBackoff: ({ context }) =>
+      Math.min(
+        context.retry.delay * 2 ** context.retryCount,
+        context.retry.maxDelay,
+      ),
+
+    stalledTimeout: ({ context }) => context.retry.stalledTimeout,
   },
 
   actors: {
@@ -183,7 +266,7 @@ const viewStateMachine = setup({
 }).createMachine({
   id: 'view',
   initial: 'empty',
-  context: ({ input: { id, view, win, offscreenWin } }) => ({
+  context: ({ input: { id, view, win, offscreenWin, retry } }) => ({
     id,
     view,
     win,
@@ -192,6 +275,9 @@ const viewStateMachine = setup({
     content: null,
     options: null,
     info: null,
+    retry,
+    error: null,
+    retryCount: 0,
   }),
   on: {
     DISPLAY: {
@@ -207,7 +293,8 @@ const viewStateMachine = setup({
     displaying: {
       id: 'displaying',
       initial: 'loading',
-      entry: 'offscreenView',
+      // New content starts with a clean slate: no prior reason, full retry budget.
+      entry: ['offscreenView', 'resetRetryState'],
       on: {
         DISPLAY: {
           actions: assign({
@@ -233,7 +320,12 @@ const viewStateMachine = setup({
             params: ({ event: { options } }) => ({ options }),
           },
         },
-        RELOAD: '.loading',
+        // A manual reload is an operator override: reset the automatic retry
+        // budget so the view gets a fresh streak.
+        RELOAD: {
+          target: '.loading',
+          actions: 'resetRetryState',
+        },
         DEVTOOLS: {
           actions: {
             type: 'openDevTools',
@@ -242,10 +334,16 @@ const viewStateMachine = setup({
         },
         VIEW_ERROR: {
           target: '.error',
-          actions: {
-            type: 'logError',
-            params: ({ event: { error } }) => ({ error }),
-          },
+          actions: [
+            {
+              type: 'logError',
+              params: ({ event: { error } }) => ({ error }),
+            },
+            {
+              type: 'setError',
+              params: ({ event: { error } }) => ({ error }),
+            },
+          ],
         },
         VIEW_INFO: {
           actions: assign({
@@ -261,10 +359,16 @@ const viewStateMachine = setup({
           after: {
             [LOADING_TIMEOUT]: {
               target: '#view.displaying.error',
-              actions: {
-                type: 'logError',
-                params: { error: 'Timed out waiting for view to load' },
-              },
+              actions: [
+                {
+                  type: 'logError',
+                  params: { error: 'Timed out waiting for view to load' },
+                },
+                {
+                  type: 'setError',
+                  params: { error: 'Timed out waiting for view to load' },
+                },
+              ],
             },
           },
           states: {
@@ -277,10 +381,16 @@ const viewStateMachine = setup({
                 },
                 onError: {
                   target: '#view.displaying.error',
-                  actions: {
-                    type: 'logError',
-                    params: ({ event: { error } }) => ({ error }),
-                  },
+                  actions: [
+                    {
+                      type: 'logError',
+                      params: ({ event: { error } }) => ({ error }),
+                    },
+                    {
+                      type: 'setError',
+                      params: ({ event: { error } }) => ({ error }),
+                    },
+                  ],
                 },
               },
             },
@@ -298,7 +408,9 @@ const viewStateMachine = setup({
         },
         running: {
           type: 'parallel',
-          entry: 'positionView',
+          // Reaching running means the view recovered: clear any error streak so
+          // the next failure starts its backoff from scratch.
+          entry: ['positionView', 'resetRetryState'],
           on: {
             DISPLAY: [
               // Noop if nothing changed.
@@ -331,7 +443,18 @@ const viewStateMachine = setup({
               },
               states: {
                 playing: {},
-                stalled: {},
+                stalled: {
+                  // A view that stays stalled past the watchdog is reloaded
+                  // (as long as it still has retry budget). A stall that clears
+                  // on its own (VIEW_LOADED -> playing) simply cancels this.
+                  after: {
+                    stalledTimeout: {
+                      target: '#view.displaying.loading',
+                      guard: 'canRetry',
+                      actions: 'incrementRetry',
+                    },
+                  },
+                },
               },
             },
             audio: {
@@ -371,7 +494,17 @@ const viewStateMachine = setup({
             },
           },
         },
-        error: {},
+        error: {
+          // Automatically reload after the backoff delay until the retry budget
+          // is spent; then this is a terminal state surfaced to the operator.
+          after: {
+            retryBackoff: {
+              target: '#view.displaying.loading',
+              guard: 'canRetry',
+              actions: 'incrementRetry',
+            },
+          },
+        },
       },
     },
   },

--- a/packages/streamwall/src/renderer/overlay.tsx
+++ b/packages/streamwall/src/renderer/overlay.tsx
@@ -3,6 +3,7 @@ import { render } from 'preact'
 import { useEffect, useState } from 'preact/hooks'
 import { useHotkeys } from 'react-hotkeys-hook'
 import {
+  FaExclamationTriangle,
   FaFacebook,
   FaInstagram,
   FaMapMarkerAlt,
@@ -39,10 +40,10 @@ function Overlay({
   streams,
 }: Pick<StreamwallState, 'config' | 'views' | 'streams'>) {
   const { width, height, activeColor } = config
-  const activeViews = views.filter(
-    ({ state }) =>
-      matchesState('displaying', state) &&
-      !matchesState('displaying.error', state),
+  // Keep error views on the wall (instead of leaving a silent black cell) so the
+  // failure and its reason are visible; they are rendered as an error tile below.
+  const activeViews = views.filter(({ state }) =>
+    matchesState('displaying', state),
   )
   const overlays = streams.filter((s) => s.kind === 'overlay')
   return (
@@ -55,6 +56,7 @@ function Overlay({
         }
 
         const data = streams.find((d) => content.url === d.link)
+        const isError = matchesState('displaying.error', state)
         const isListening = matchesState(
           'displaying.running.audio.listening',
           state,
@@ -72,6 +74,7 @@ function Overlay({
           matchesState('displaying.running.playback.stalled', state)
         const hasTitle = data && (data.label || data.source)
         const position = data?.labelPosition ?? 'top-left'
+        const label = data?.label || data?.source
         return (
           <SpaceBorder
             pos={pos}
@@ -79,28 +82,44 @@ function Overlay({
             windowHeight={height}
             activeColor={activeColor}
             isListening={isListening}
+            isError={isError}
           >
-            <FilterCover isBlurred={isBlurred} isDesaturated={isLoading} />
-            {hasTitle && (
-              <StreamTitle
-                position={position}
-                activeColor={activeColor}
-                isListening={isListening}
-              >
-                <StreamIcon url={content.url} />
-                <span>{data.label ? data.label : <>{data.source}</>}</span>
-                {(isListening || isBackgroundListening) && <FaVolumeUp />}
-              </StreamTitle>
+            {isError ? (
+              <ErrorCover>
+                <ErrorIcon>
+                  <FaExclamationTriangle />
+                </ErrorIcon>
+                <ErrorHeading>
+                  <StreamIcon url={content.url} />
+                  <span>{label ?? 'Stream error'}</span>
+                </ErrorHeading>
+                {context.error && <ErrorReason>{context.error}</ErrorReason>}
+              </ErrorCover>
+            ) : (
+              <>
+                <FilterCover isBlurred={isBlurred} isDesaturated={isLoading} />
+                {hasTitle && (
+                  <StreamTitle
+                    position={position}
+                    activeColor={activeColor}
+                    isListening={isListening}
+                  >
+                    <StreamIcon url={content.url} />
+                    <span>{data.label ? data.label : <>{data.source}</>}</span>
+                    {(isListening || isBackgroundListening) && <FaVolumeUp />}
+                  </StreamTitle>
+                )}
+                {data?.city && (
+                  <StreamLocation>
+                    <FaMapMarkerAlt />
+                    <span>
+                      {data.city} {data.state}
+                    </span>
+                  </StreamLocation>
+                )}
+                <LoadingSpinner isVisible={isLoading} />
+              </>
             )}
-            {data?.city && (
-              <StreamLocation>
-                <FaMapMarkerAlt />
-                <span>
-                  {data.city} {data.state}
-                </span>
-              </StreamLocation>
-            )}
-            <LoadingSpinner isVisible={isLoading} />
           </SpaceBorder>
         )
       })}
@@ -198,6 +217,7 @@ const SpaceBorder = styled.div.attrs<{
   windowHeight: number
   activeColor: string
   isListening: boolean
+  isError?: boolean
   borderWidth?: number
 }>(() => ({
   borderWidth: 2,
@@ -209,7 +229,7 @@ const SpaceBorder = styled.div.attrs<{
   top: ${({ pos }) => pos.y}px;
   width: ${({ pos }) => pos.width}px;
   height: ${({ pos }) => pos.height}px;
-  border: 0 solid black;
+  border: 0 solid ${({ isError }) => (isError ? 'red' : 'black')};
   border-left-width: ${({ pos, borderWidth }) =>
     pos.x === 0 ? 0 : borderWidth}px;
   border-right-width: ${({ pos, borderWidth, windowWidth }) =>
@@ -342,6 +362,76 @@ const FilterCover = styled.div<{ isBlurred: boolean; isDesaturated: boolean }>`
     [isBlurred ? 'blur(30px)' : '', isDesaturated ? 'grayscale(75%)' : ''].join(
       ' ',
     )};
+`
+
+const ErrorCover = styled.div`
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px;
+  box-sizing: border-box;
+  text-align: center;
+  color: white;
+  background: ${Color('#300').alpha(0.55).toString()};
+  backdrop-filter: blur(4px) grayscale(80%);
+`
+
+const ErrorIcon = styled.div`
+  display: flex;
+  color: #ff5a5a;
+  filter: drop-shadow(0 0 6px black);
+
+  svg {
+    width: 44px;
+    height: 44px;
+  }
+`
+
+const ErrorHeading = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  max-width: 100%;
+  font-weight: 700;
+  font-size: 22px;
+  letter-spacing: -0.025em;
+  text-shadow: 0 0 4px black;
+
+  span {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+
+  svg {
+    width: 1.1em;
+    height: 1.1em;
+    flex-shrink: 0;
+    filter: drop-shadow(0 0 4px black);
+
+    path {
+      fill: white;
+    }
+  }
+`
+
+const ErrorReason = styled.div`
+  max-width: 100%;
+  font-size: 15px;
+  font-weight: 500;
+  line-height: 1.3;
+  opacity: 0.9;
+  text-shadow: 0 0 4px black;
+  overflow-wrap: anywhere;
+
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 `
 
 const VersionText = styled.div<{ isShowing: boolean }>`


### PR DESCRIPTION
## Problem

When a view entered `displaying.error` the overlay filtered it out entirely, leaving a silent black cell. The `error` state was terminal (no auto-retry), and the `stalled` playback state had no watchdog, so a transient network blip permanently lost a cell until an operator manually reloaded it. The only failure signal in the control UI was a red border, with no reason.

Closes #75.

## Solution

**State machine (`viewStateMachine.ts`)**
- Records a human-readable `error` reason in context (via a new `setError` action + `formatError` helper), cleared on a fresh load/recovery.
- Auto-retries `error` and `stalled` views on an exponentially growing, capped backoff (`min(delay · 2^n, maxDelay)`) via xstate delayed transitions, guarded by a `canRetry` guard (`enabled && retryCount < maxRetries`).
- Adds a watchdog to the `stalled` state so a view that outlasts `stalledTimeout` is reloaded.
- Resets the retry budget when the view reaches `running` (recovery) or on a manual `RELOAD`.

**Wiring**
- `ViewState.context` now carries `error`, serialized by `StreamWindow.emitState()`; `ViewStateValue` also gains the previously-missing `running.playback` sub-state.
- New `[retry]` config section (`enabled`, `delay`, `max-delay`, `max-retries`, `stalled-timeout`) plumbed through yargs, the zod validation schema, and `StreamWindow` (seconds in config → ms in the machine; sensible defaults, retry on by default).

**UI**
- Overlay: error views are no longer filtered out — they render an error tile (warning icon, stream label, failure reason, red border).
- Control UI: adds a warning badge with the reason (full reason as tooltip; icon-only on small cells) alongside the existing red border.

## Architecture decisions

- Backoff lives in the state machine as delayed transitions so retry state is per-view, self-cancelling on recovery/content-change, and unit-testable with fake timers.
- The `displaying.error → displaying.loading` retry is an internal transition (LCA `displaying`), so the `displaying` entry reset does **not** clobber the incremented `retryCount`; a content change re-targets `.displaying` and *does* reset. Both paths are covered by tests.
- Retry config passed to `StreamWindow` as an optional second constructor arg (defaulting to `DEFAULT_RETRY_CONFIG`) rather than folded into `StreamWindowConfig`, to avoid leaking retry internals into the broadcast client state.

## Testing

- `viewStateMachine.test.ts` (new, 13 cases): error reason capture, non-Error stringification, backoff timing/growth/cap, `maxRetries` exhaustion, retry-disabled, running/reload reset, stalled watchdog (on and disabled), loading-timeout reason.
- `config.test.ts`: extended fixture + cases for retry validation (disabled/zeroed, negative delay, fractional max-retries).
- Full gate green locally: `format:check`, `lint`, `typecheck`, `test` (all workspaces), and the control-client build.

## Risks / breaking changes

- No breaking changes. Retry defaults to on; operators can disable it or tune timings via `[retry]`. The added `[retry]` config section is validated at startup (documented in `example.config.toml`).