### PR TITLE
docs: remove dead [cert]/webserver config keys from example.config.toml

### DIFF
--- a/example.config.toml
+++ b/example.config.toml
@@ -69,20 +69,6 @@ json-url = []
     #template = "Switching to #<%- selectedIdx %> (with <%- voteCount %> votes)"
     #interval = 15
 
-[cert]
-# SSL certificates (optional)
-# If you specify an https:// URL for the "webserver" option, a certificate will be automatically generated and signed by Let's Encrypt.
-# For this to work, Streamwall must be accessible from both ports 80 and 443.
-
-# Uncomment to obtain a real certificate (otherwise a testing cert will be generated)
-#production = true
-
-# Email address to use when registering SSL certificate with Let's Encrypt
-#email = "you@example.com"
-
-# Directory to store certificate
-#dir = "../streamwall-cert"
-
 [streamdelay]
 #endpoint = "http://localhost:8404"
 #key = "super-secret"


### PR DESCRIPTION
## Problem

`example.config.toml` contains a `[cert]` section (`production`, `email`, `dir`) documenting automatic Let's Encrypt certificate provisioning tied to a `webserver` config option. Neither `webserver` nor `[cert]` exist in the current config schema (`packages/streamwall/src/main/config.ts`) or CLI options (`packages/streamwall/src/main/index.ts`) — a repo-wide search for `cert`/`webserver` outside this file turns up nothing related. This is leftover documentation from before the control server was split into its own package, the same class of staleness already fixed for `[grid]` count in #149 and for `[control]` in #153.

## Solution

Remove the dead `[cert]` block from `example.config.toml`. No replacement guidance was added since TLS termination for the control server has already been documented separately in #155 (control server setup docs).

## Testing

Docs-only change with no testable behavior — skipped TDD per the resolve-issue workflow. Verified via `git diff` that only the dead block was removed, and confirmed `grep -rn "cert|webserver"` across the config/CLI source has no matches tied to this section.

## Risks / Breaking changes

None — this is a comment/config-example cleanup with no code or runtime impact.

Closes #157