### PR TITLE
docs: remove stale [cert] section, document TLS via reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ See
 for environment variable configuration (hostname/port, storage location, rate
 limits).
 
+`streamwall-control-server` does not generate or manage TLS certificates —
+for `wss://`/`https://` endpoints, terminate TLS with a reverse proxy (e.g.
+nginx, Caddy) in front of the server and set `STREAMWALL_CONTROL_URL` to the
+public `https://` address.
+
 ## Data sources
 
 Streamwall can load stream data from both JSON APIs and TOML files. Data sources can be specified in a config file (see `example.config.toml` for an example) or the command line:

--- a/example.config.toml
+++ b/example.config.toml
@@ -69,20 +69,6 @@ json-url = []
     #template = "Switching to #<%- selectedIdx %> (with <%- voteCount %> votes)"
     #interval = 15
 
-[cert]
-# SSL certificates (optional)
-# If you specify an https:// URL for the "webserver" option, a certificate will be automatically generated and signed by Let's Encrypt.
-# For this to work, Streamwall must be accessible from both ports 80 and 443.
-
-# Uncomment to obtain a real certificate (otherwise a testing cert will be generated)
-#production = true
-
-# Email address to use when registering SSL certificate with Let's Encrypt
-#email = "you@example.com"
-
-# Directory to store certificate
-#dir = "../streamwall-cert"
-
 [streamdelay]
 #endpoint = "http://localhost:8404"
 #key = "super-secret"


### PR DESCRIPTION
## Problem

The `[cert]` section in `example.config.toml` documented:
- An `https://` value for a `"webserver"` config option that does not exist anywhere in the codebase (`grep -rn "webserver" packages/ --include="*.ts"` returns nothing).
- Automatic Let's Encrypt certificate provisioning that `streamwall-control-server` never implemented — the server only reads its `baseURL` from `STREAMWALL_CONTROL_URL` and expects TLS to be terminated externally.

Found while resolving #67 (PR #153) and filed as #154 for a follow-up decision.

## Solution

Per the direction suggested in the issue and confirmed by the current control-server behavior (`STREAMWALL_CONTROL_URL`'s scheme just selects http/https behavior; the README already requires `wss://` for non-loopback remote endpoints), removed the `[cert]` section entirely and documented externally-terminated TLS (reverse proxy) as the supported approach:

- `example.config.toml`: removed the stale `[cert]` section.
- `README.md`: added a short note under "Remote control server" pointing to reverse-proxy TLS termination (nginx, Caddy, etc.) for `wss://`/`https://` endpoints.

## Testing

Docs-only change; no testable behavior. Verified `npx prettier --check README.md` passes.

## Risks / breaking changes

None — this only corrects documentation to match existing behavior; no code changed.

Closes #154