### PR TITLE
docs: correct hotkey list to match all 20 triggers and overlay devtools

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,17 @@ supported by design.
 
 ## Hotkeys
 
-The following hotkeys are available with the "control" webpage focused:
+The following hotkeys are available with a "control" webpage focused, whether
+that's the Electron control UI or the standalone web control client:
 
-- **alt+[1...9]**: Listen to the numbered stream
-- **alt+shift+[1...9]**: Toggle blur on the numbered stream
+- **alt+[1...9,0,q,w,e,r,t,y,u,i,o,p]**: Listen to the corresponding stream
+  (20 grid positions, in that key order)
+- **alt+shift+[1...9,0,q,w,e,r,t,y,u,i,o,p]**: Toggle blur on the
+  corresponding stream
 - **alt+s**: Select the currently focused stream box to be swapped
 - **alt+c**: Activate [Streamdelay](https://github.com/chromakode/streamdelay) censor mode
 - **alt+shift+c**: Deactivate [Streamdelay](https://github.com/chromakode/streamdelay) censor mode
+
+The overlay window has its own hotkey:
+
+- **ctrl+shift+i**: Open devtools for the overlay


### PR DESCRIPTION
## Summary

- The README `## Hotkeys` section only documented `alt+[1...9]` / `alt+shift+[1...9]`, but the code defines 20 hotkey triggers: `1-9,0,q,w,e,r,t,y,u,i,o,p` (`packages/streamwall-control-ui/src/index.tsx:83-104`).
- The doc did not mention that the same hotkeys apply to both the Electron control UI and the standalone web control client (`packages/streamwall-control-client` renders the same shared `<ControlUI>` component).
- The `ctrl+shift+i` overlay devtools hotkey (`packages/streamwall/src/renderer/overlay.tsx:148`) was undocumented entirely.

## Technical solution

Rewrote the `## Hotkeys` section in `README.md`:
- Listed the full 20-key trigger set for `alt+[...]` (listen) and `alt+shift+[...]` (blur), in the actual key order used by `hotkeyTriggers`.
- Clarified the hotkeys apply to both control surfaces (Electron control UI and web control client), since both render the shared `ControlUI` component.
- Added the `ctrl+shift+i` overlay devtools hotkey as a separate entry, since it belongs to the overlay window rather than the control page.

## Testing performed

Docs-only change with no testable behavior — no tests added, per the TDD exception for pure documentation changes. Verified `npx prettier --check README.md` passes.

## Risks / breaking changes

None — documentation only, no code changes.

Closes #73