### PR TITLE
docs: document the Sentry telemetry default and how to opt out

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ Configuration precedence is:
 
 See `example.config.toml` for an example.
 
+### Telemetry
+
+Streamwall reports uncaught errors to a Sentry project run by the maintainers
+(`telemetry.sentry`, default `true`). To opt out, set `sentry = false` under
+`[telemetry]` in your config file (see `example.config.toml`) or pass
+`--telemetry.sentry=false` on the command line.
+
 ## Remote control server
 
 For multi-operator setups, `streamwall-control-server` lets you control the

--- a/example.config.toml
+++ b/example.config.toml
@@ -86,3 +86,8 @@ json-url = []
 [streamdelay]
 #endpoint = "http://localhost:8404"
 #key = "super-secret"
+
+[telemetry]
+# Whether to report uncaught errors to Streamwall's Sentry project. Enabled
+# by default; uncomment to opt out.
+#sentry = false


### PR DESCRIPTION
## Problem

`telemetry.sentry` defaults to `true` with a hardcoded DSN (`packages/streamwall/src/main/index.ts:40-41`, `:717-718`), so error reports go to a third-party Sentry project by default. This was undocumented — neither `example.config.toml` nor the README mentioned the option or how to opt out.

## Solution

- Added a commented `[telemetry]` section with `#sentry = false` to `example.config.toml`, matching the existing style of documented-but-commented-out options.
- Added a short "Telemetry" subsection to the README's Configuration section stating the default and both ways to disable it (config file or `--telemetry.sentry=false` CLI flag).

## Testing

Docs-only change, no testable behavior — verified the `[telemetry]`/`sentry` key names against the actual zod schema in `packages/streamwall/src/main/config.ts:90-92` and the yargs option definition in `packages/streamwall/src/main/index.ts:308-313` to make sure the documented option name and default match the code. Ran \`prettier --check README.md\` (TOML isn't prettier-covered in this repo).

## Risks / breaking changes

None — documentation only.

Closes #71