### PR TITLE
docs: remove dead [cert]/Let's Encrypt section from example.config.toml

### DIFF
--- a/example.config.toml
+++ b/example.config.toml
@@ -69,19 +69,10 @@ json-url = []
     #template = "Switching to #<%- selectedIdx %> (with <%- voteCount %> votes)"
     #interval = 15
 
-[cert]
-# SSL certificates (optional)
-# If you specify an https:// URL for the "webserver" option, a certificate will be automatically generated and signed by Let's Encrypt.
-# For this to work, Streamwall must be accessible from both ports 80 and 443.
-
-# Uncomment to obtain a real certificate (otherwise a testing cert will be generated)
-#production = true
-
-# Email address to use when registering SSL certificate with Let's Encrypt
-#email = "you@example.com"
-
-# Directory to store certificate
-#dir = "../streamwall-cert"
+# Streamwall and streamwall-control-server speak plain HTTP/WebSocket only —
+# neither terminates TLS itself. For a remote `wss://` control endpoint, put a
+# reverse proxy (e.g. nginx, Caddy) in front to handle certificates and
+# forward to the plain-http server.
 
 [streamdelay]
 #endpoint = "http://localhost:8404"


### PR DESCRIPTION
## Problem

`example.config.toml` documented a `[cert]` section promising automatic Let's Encrypt certificate generation for an `https://` "webserver" option. Neither exists: there is no `cert` key in `StreamwallConfig` (`packages/streamwall/src/main/index.ts`), and no ACME/greenlock code anywhere in the codebase. `streamwall-control-server` also only ever `listen()`s over plain HTTP (`packages/streamwall-control-server/src/index.ts`) — it does not terminate TLS.

## Solution

Removed the dead `[cert]` section and replaced it with a short note clarifying that neither Streamwall nor `streamwall-control-server` terminate TLS themselves, and that a `wss://` control endpoint needs a reverse proxy (nginx, Caddy, etc.) in front to handle certificates.

This is consistent with the README, which already requires `wss://` (or loopback `ws://`) for the control endpoint and documents no TLS-termination option in Streamwall itself.

## Testing performed

Doc-only change, no testable behavior — no tests added (per the resolve-issue TDD exception for docs changes). Verified:
- `grep` confirms no remaining references to `[cert]`, `greenlock`, or Let's Encrypt anywhere in the repo.
- `npm run format:check` passes.

## Risks / breaking changes

None — this only removes inaccurate documentation.

Closes #68