### PR TITLE
docs: document full stream data schema (labelPosition, rotation, kind, overlay)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,31 @@ Streamwall can load stream data from both JSON APIs and TOML files. Data sources
 npm run start:app -- --data.json-url="https://your-site/api/streams.json" --data.toml-file="./streams.toml"
 ```
 
+Each entry (a `[[streams]]` table in TOML, or an object in the JSON array) supports the following fields. See `example.streams.toml` for examples.
+
+| Field           | Type                                                                 | Required | Description                                                                                      |
+| --------------- | -------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `link`          | string                                                               | yes      | URL of the stream page. For `overlay` streams, this is the URL loaded in the overlay `<iframe>`. |
+| `kind`          | `"video"` \| `"audio"` \| `"web"` \| `"background"` \| `"overlay"`   | no       | Defaults to `"video"`. See kind reference below.                                                 |
+| `label`         | string                                                               | no       | Short title shown on the wall overlay.                                                           |
+| `labelPosition` | `"top-left"` \| `"top-right"` \| `"bottom-right"` \| `"bottom-left"` | no       | Corner where the label is drawn. Defaults to `"top-left"`.                                       |
+| `source`        | string                                                               | no       | Attribution shown on the wall when `label` is absent.                                            |
+| `notes`         | string                                                               | no       | Free-text notes shown in the control UI (not on the wall overlay).                               |
+| `status`        | string                                                               | no       | Free-text status shown in the control UI.                                                        |
+| `city`          | string                                                               | no       | Shown under the stream label on the wall overlay.                                                |
+| `state`         | string                                                               | no       | Shown alongside `city` on the wall overlay.                                                      |
+| `orientation`   | `"V"` \| `"H"`                                                       | no       | Vertical or horizontal video orientation, used by the control UI.                                |
+| `rotation`      | number (0–360)                                                       | no       | Degrees to rotate the loaded page, e.g. for phone streams held sideways.                         |
+| `addedDate`     | string                                                               | no       | Free-text date, shown in the control UI.                                                         |
+
+### `kind` reference
+
+- `video` (default) — a normal livestream page; Streamwall finds the `<video>` tag and fills the tile with it.
+- `audio` — like `video`, but the tile is treated as audio-only.
+- `web` — an arbitrary webpage, shown as-is without searching for a `<video>` tag.
+- `background` — a webpage loaded behind the grid instead of in a tile.
+- `overlay` — a webpage loaded as a full-screen `<iframe>` layered over the whole wall (e.g. scoreboards, alerts). See [Security: overlay and background streams](#security-overlay-and-background-streams) below.
+
 ## Security: overlay and background streams
 
 Streams added with the `overlay` or `background` kind are loaded as live web

--- a/example.streams.toml
+++ b/example.streams.toml
@@ -9,3 +9,21 @@ source = "woke.net"
 kind  = "web"
 label = "zombocom"
 link  = "https://html5zombo.com"
+
+[[streams]]
+# A phone stream held sideways: rotate it upright and label the bottom-right
+# corner instead of the default top-left.
+city          = "Portland"
+state         = "OR"
+label         = "on the ground"
+labelPosition = "bottom-right"
+link          = "https://twitch.tv/example-mobile-stream"
+rotation      = 90
+source        = "example.net"
+
+[[streams]]
+# An "overlay" stream is loaded as a full-screen <iframe> layered over the
+# whole wall (e.g. a scoreboard or alert widget) instead of a grid tile.
+# See "Security: overlay and background streams" in the README.
+kind = "overlay"
+link = "https://example.com/scoreboard-widget"


### PR DESCRIPTION
## Problem

`example.streams.toml` only showed `city/label/link/notes/source/kind`, but the real stream-data schema (`packages/streamwall-shared/src/schemas.ts`, `packages/streamwall-shared/src/types.ts`) also supports `labelPosition` (4 corners, used in `overlay.tsx`), `rotation`, `state`, `orientation`, `status`, `addedDate`, and a `kind` enum of `video | audio | web | background | overlay`. Overlay iframes (`overlay.tsx`) were undocumented in the README's data-sources section.

## Solution

- Added a field-reference table to the README's "Data sources" section, covering every field in `streamMetaFields`/`streamDataInputSchema` (`packages/streamwall-shared/src/schemas.ts`), plus a `kind` reference describing each of the five kinds (including `audio` and `overlay`, which weren't mentioned in the original issue text but are part of the real schema).
- Extended `example.streams.toml` with a `labelPosition` + `rotation` example (a sideways phone stream) and an `overlay` entry, linking to the existing "Security: overlay and background streams" section.

## Testing

Docs-only change with no testable behavior — no tests added, per the TDD exception for documentation changes. Ran `npm run lint` and `npm run format:check`, both green.

## Risks / breaking changes

None — documentation only, no code changes.

Closes #72