### PR TITLE
docs: add a Features section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,22 @@ It's a cross-platform desktop app built with Electron and TypeScript. Streams ar
 
 Under the hood, think of Streamwall as a specialized web browser for mosaicing video streams. It uses [Electron](https://www.electronjs.org) to create a grid of web browser views, loading the specified webpages into them. Once the page loads, Streamwall finds the `<video>` tag and reformats the page so that the video fills the space. This works for a wide variety of web pages without specialized scrapers.
 
+<!-- TODO(screenshots): the wall and control UI don't have images here yet.
+     See #165 to add real screenshots once captured on a machine with a
+     display. -->
+
+## Features
+
+- **Resizable grid** — arrange streams in an NxN grid; resize it at runtime from the control UI (column/row presets or exact counts), no restart required.
+- **Drag-to-place layout** — drag a tile onto another to swap their positions, or drop a stream from the list straight onto a grid cell.
+- **Per-tile audio** — listen to any single tile's audio at a time, switchable with a click or hotkey.
+- **Blur/censor** — blur individual tiles, or trigger a wall-wide [Streamdelay](https://github.com/chromakode/streamdelay) censor mode.
+- **Dark mode** — light, dark, or system-matched theme in the control UI.
+- **Remote control with roles** — an optional web-based control server lets operators run the wall from a browser, with **admin**, **operator**, and **monitor** roles gated by invite links.
+- **Automatic recovery** — failed or stalled stream loads are retried automatically with exponential backoff, with the failure surfaced on the wall and in the control UI.
+- **Flexible data sources** — load streams from JSON APIs, TOML files, or add them ad hoc (including `overlay`/`background` kinds for widgets and chroma-key layers).
+- **Twitch chat bot** — an optional bot posts templated announcements and runs viewer polls in a Twitch channel's chat.
+
 ## Configuration
 
 Streamwall has a growing number of configuration options. To get a summary run:


### PR DESCRIPTION
## Problem

The README had no feature overview and no images, and the person filing the issue expected screenshots pulled from the local (gitignored) `design/` folder — which was never committed and doesn't exist in this checkout. The "still opens with v2.0 work-in-progress" part of the issue is already stale: that framing was removed in an earlier consolidation pass, so the README currently reads as a normal, standalone project description.

## Solution

Added a `## Features` section listing what the app actually does today, verified against the source rather than assumed:

- Resizable grid — runtime column/row resize in the control UI (`GRID_MIN`/`GRID_MAX`, presets and numeric inputs), not just a config-time setting.
- Drag-to-place layout — tile swap/drop gestures (`gestures.ts`).
- Per-tile audio, blur/censor (including wall-wide Streamdelay censor mode).
- Dark/light/system theme toggle.
- Role-based remote control (admin/operator/monitor via the control server's invite tokens).
- Automatic retry/backoff for failed or stalled stream loads.
- Flexible data sources (JSON/TOML, `overlay`/`background` stream kinds).
- Twitch chat bot.

Screenshots are intentionally **not** included in this PR — this environment has no display (`screencapture` fails), so any image would have to be captured on a different machine or fabricated, and I didn't want to guess at what the actual UI looks like. That's split off into #165, referenced via a `TODO(screenshots)` comment in the README.

## Testing performed

Docs-only change; no testable behavior. Ran `npx prettier --check README.md` — passes. No lint/typecheck/test suite applies to a Markdown-only diff.

## Risks / breaking changes

None — README only.

## Follow-ups

- #165 — capture and add real screenshots of the wall and control UI once a display is available.
- #166 — three leftover German UI strings found in `streamwall-control-ui/src/index.tsx` while researching the feature list (`Spalten`, `Zeilen`, `Farbschema`).

Closes #74