### PR TITLE
fix(security): revalidate redirects and sub-resources at the session network layer

### DIFF
--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -16,7 +16,7 @@ import {
   ViewState,
 } from 'streamwall-shared'
 import { createActor, EventFrom, SnapshotFrom } from 'xstate'
-import { loadHTML } from './loadHTML'
+import { devServerOrigin, loadHTML } from './loadHTML'
 import { secureStreamView } from './navigationSecurity'
 import { allocateViewPartition, hardenSession } from './partitions'
 import viewStateMachine, {
@@ -188,7 +188,12 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
         partition: allocateViewPartition(),
       },
     })
-    hardenSession(view.webContents.session)
+    hardenSession(view.webContents.session, {
+      // In development the HLS renderer page and its assets are served from the
+      // Vite dev server on loopback; allow that origin so the SSRF request guard
+      // does not cancel them.
+      allowedOrigins: [devServerOrigin()].filter((o) => o !== undefined),
+    })
     view.setBackgroundColor(backgroundColor)
 
     const viewId = view.webContents.id

--- a/packages/streamwall/src/main/loadHTML.ts
+++ b/packages/streamwall/src/main/loadHTML.ts
@@ -2,6 +2,24 @@ import { WebContents } from 'electron'
 import path from 'path'
 import querystring from 'querystring'
 
+/**
+ * Origin of the Vite dev server that serves the renderer HTML pages during
+ * development, or undefined in a packaged build (where those pages are loaded
+ * from disk via file://). The dev server lives on loopback, so the SSRF request
+ * guard must allow this origin explicitly or it would cancel the HLS renderer
+ * page and its bundled assets while developing.
+ */
+export function devServerOrigin(): string | undefined {
+  if (!MAIN_WINDOW_VITE_DEV_SERVER_URL) {
+    return undefined
+  }
+  try {
+    return new URL(MAIN_WINDOW_VITE_DEV_SERVER_URL).origin
+  } catch {
+    return undefined
+  }
+}
+
 export function loadHTML(
   webContents: WebContents,
   name: 'background' | 'overlay' | 'playHLS' | 'control',

--- a/packages/streamwall/src/main/partitions.test.ts
+++ b/packages/streamwall/src/main/partitions.test.ts
@@ -5,7 +5,13 @@ import {
   BROWSE_PARTITION,
   createPartitionAllocator,
   hardenSession,
+  installRequestSSRFGuard,
 } from './partitions'
+
+type RequestListener = (
+  details: { url: string },
+  callback: (response: { cancel: boolean }) => void,
+) => void
 
 type PermissionHandler = (
   webContents: unknown,
@@ -15,9 +21,15 @@ type PermissionHandler = (
 
 function fakeSession() {
   let handler: PermissionHandler | null = null
+  let requestListener: RequestListener | null = null
   return {
     setPermissionRequestHandler(next: PermissionHandler | null) {
       handler = next
+    },
+    webRequest: {
+      onBeforeRequest(listener: RequestListener) {
+        requestListener = listener
+      },
     },
     request(permission: string): boolean {
       assert.ok(handler, 'a permission request handler must be registered')
@@ -27,6 +39,18 @@ function fakeSession() {
       })
       assert.notEqual(granted, undefined, 'handler must invoke the callback')
       return granted!
+    },
+    async requestURL(url: string): Promise<boolean> {
+      assert.ok(requestListener, 'a request listener must be registered')
+      let cancel: boolean | undefined
+      await new Promise<void>((resolve) => {
+        requestListener!({ url }, (response) => {
+          cancel = response.cancel
+          resolve()
+        })
+      })
+      assert.notEqual(cancel, undefined, 'listener must invoke the callback')
+      return cancel!
     },
   }
 }
@@ -109,4 +133,74 @@ test('hardened session rejects every permission request', () => {
       `permission "${permission}" must be denied`,
     )
   }
+})
+
+test('hardenSession also installs the network-layer SSRF guard', async () => {
+  const session = fakeSession()
+  hardenSession(session)
+  assert.equal(
+    await session.requestURL('http://169.254.169.254/latest/meta-data/'),
+    true,
+    'a request to the cloud-metadata endpoint must be cancelled',
+  )
+  assert.equal(
+    await session.requestURL('https://cdn.twitch.tv/'),
+    false,
+    'a public request must be allowed',
+  )
+})
+
+// A resolver stub keeps the guard tests off the network and deterministic.
+const guardWith = (
+  reasons: Record<string, string | null>,
+  allowedOrigins?: readonly string[],
+) => {
+  const session = fakeSession()
+  installRequestSSRFGuard(session, {
+    allowedOrigins,
+    findBlockReason: async (url) => reasons[url] ?? null,
+  })
+  return session
+}
+
+test('installRequestSSRFGuard cancels requests the reason lookup flags', async () => {
+  const session = guardWith({
+    'http://segments.evil.example/0.ts': 'resolves to private address 10.0.0.5',
+  })
+  assert.equal(
+    await session.requestURL('http://segments.evil.example/0.ts'),
+    true,
+  )
+})
+
+test('installRequestSSRFGuard allows requests the reason lookup clears', async () => {
+  const session = guardWith({ 'https://cdn.example/0.ts': null })
+  assert.equal(await session.requestURL('https://cdn.example/0.ts'), false)
+})
+
+test('installRequestSSRFGuard allows an explicitly allowed origin without consulting the reason lookup', async () => {
+  // The dev server lives on loopback; it must stay reachable for the HLS
+  // renderer page even though findBlockReason would otherwise flag it.
+  const session = guardWith(
+    { 'http://localhost:5173/src/renderer/playHLS.html': 'loopback host' },
+    ['http://localhost:5173'],
+  )
+  assert.equal(
+    await session.requestURL('http://localhost:5173/src/renderer/playHLS.html'),
+    false,
+  )
+})
+
+test('installRequestSSRFGuard fails open if the reason lookup itself throws', async () => {
+  const session = fakeSession()
+  installRequestSSRFGuard(session, {
+    findBlockReason: async () => {
+      throw new Error('boom')
+    },
+  })
+  assert.equal(
+    await session.requestURL('https://cdn.example/0.ts'),
+    false,
+    'an internal guard error must not cancel legitimate traffic',
+  )
 })

--- a/packages/streamwall/src/main/partitions.ts
+++ b/packages/streamwall/src/main/partitions.ts
@@ -16,6 +16,7 @@
  */
 
 import type { Session } from 'electron'
+import { findRequestBlockReason } from '../util'
 
 const VIEW_PARTITION_PREFIX = 'view-'
 
@@ -46,17 +47,95 @@ export const allocateViewPartition = createPartitionAllocator(
   VIEW_PARTITION_PREFIX,
 )
 
+// Minimal structural view of the request-filtering surface a session exposes,
+// so the guard can be exercised without a running Electron app.
+type RequestListener = (
+  details: { url: string },
+  callback: (response: { cancel: boolean }) => void,
+) => void
+
+interface RequestFilteringSession {
+  webRequest: {
+    onBeforeRequest(listener: RequestListener): void
+  }
+}
+
+export interface RequestGuardOptions {
+  /**
+   * Origins that bypass the address check entirely (e.g. the Vite dev server on
+   * loopback, which serves the HLS renderer page). Empty in a packaged build.
+   */
+  allowedOrigins?: readonly string[]
+  /** Overridable for tests; defaults to the real address classifier. */
+  findBlockReason?: (url: string) => Promise<string | null>
+}
+
 /**
- * Applies baseline hardening to a session by denying every permission request
- * (camera, microphone, geolocation, notifications, etc.) from web content.
+ * Enforces the non-public-address policy at the network layer of a session, so
+ * that *every* request it issues is checked — not just the initial URL string.
+ * This closes the SSRF vectors a single up-front check structurally cannot
+ * cover: HTTP 3xx redirects (Chromium re-enters `onBeforeRequest` for each hop)
+ * and sub-resources named inside loaded content (e.g. HLS variant/segment URIs
+ * fetched by hls.js), both of which are issued *after* `ensureValidURL` has run.
  *
- * Permission handlers are per-session in Electron, so this must be called for
- * each isolated partition rather than once for a shared one.
+ * Blocked requests are cancelled; a cancelled main-frame navigation surfaces as
+ * a view error on the wall via the existing `did-fail-load` handler.
+ */
+export function installRequestSSRFGuard(
+  session: RequestFilteringSession,
+  {
+    allowedOrigins = [],
+    findBlockReason = findRequestBlockReason,
+  }: RequestGuardOptions = {},
+): void {
+  const allowed = new Set(allowedOrigins.filter(Boolean))
+  session.webRequest.onBeforeRequest((details, callback) => {
+    void (async () => {
+      try {
+        let origin: string | undefined
+        try {
+          origin = new URL(details.url).origin
+        } catch {
+          origin = undefined
+        }
+        if (origin !== undefined && allowed.has(origin)) {
+          callback({ cancel: false })
+          return
+        }
+        const reason = await findBlockReason(details.url)
+        if (reason !== null) {
+          console.warn(reason)
+          callback({ cancel: true })
+          return
+        }
+        callback({ cancel: false })
+      } catch (err) {
+        // Fail open on an internal guard error: the up-front ensureValidURL
+        // already vetted the top-level URL, and cancelling here would break
+        // legitimate traffic on an unexpected fault.
+        console.warn('SSRF request guard error:', err)
+        callback({ cancel: false })
+      }
+    })()
+  })
+}
+
+/**
+ * Applies baseline hardening to a session: denies every permission request
+ * (camera, microphone, geolocation, notifications, etc.) from web content and
+ * installs the network-layer SSRF guard so redirects and sub-resources are
+ * revalidated against the same non-public-address policy.
+ *
+ * Both handlers are per-session in Electron, so this must be called for each
+ * isolated partition rather than once for a shared one.
  */
 export function hardenSession(
-  session: Pick<Session, 'setPermissionRequestHandler'>,
+  session: Pick<Session, 'setPermissionRequestHandler'> &
+    RequestFilteringSession,
+  options: RequestGuardOptions = {},
 ): void {
   session.setPermissionRequestHandler((_webContents, _permission, callback) => {
     callback(false)
   })
+  installRequestSSRFGuard(session, options)
 }

--- a/packages/streamwall/src/util.test.ts
+++ b/packages/streamwall/src/util.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { test } from 'vitest'
 
-import { ensureValidURL } from './util'
+import { ensureValidURL, findRequestBlockReason } from './util'
 
 // Deterministic resolver stubs so the DNS-dependent paths can be exercised
 // without touching the network.
@@ -177,4 +177,106 @@ test('rejects the localhost hostname with a trailing dot', async () => {
 
 test('rejects a *.localhost hostname with a trailing dot', async () => {
   await assert.rejects(ensureValidURL('http://admin.localhost./'), /loopback/)
+})
+
+// findRequestBlockReason is the network-layer counterpart of ensureValidURL:
+// it is applied to *every* request a view's session issues (redirects and
+// sub-resources included), returns a reason string when a request must be
+// cancelled or null when it is allowed, and — unlike ensureValidURL — only
+// governs http(s) and fails *open* on resolution failure (so a transient DNS
+// hiccup on a legitimate public host does not cancel its traffic).
+
+test('findRequestBlockReason allows a public host resolving to a public address', async () => {
+  assert.equal(
+    await findRequestBlockReason(
+      'https://cdn.example/segment0.ts',
+      resolvesTo('93.184.216.34'),
+    ),
+    null,
+  )
+})
+
+test('findRequestBlockReason allows non-http requests (file/data/blob)', async () => {
+  assert.equal(await findRequestBlockReason('file:///app/playHLS.html'), null)
+  assert.equal(await findRequestBlockReason('data:text/plain,hi'), null)
+  assert.equal(await findRequestBlockReason('blob:https://x/abc'), null)
+})
+
+test('findRequestBlockReason allows an unparseable URL', async () => {
+  assert.equal(await findRequestBlockReason('::not a url::'), null)
+})
+
+test('findRequestBlockReason blocks the cloud-metadata literal address', async () => {
+  const reason = await findRequestBlockReason(
+    'http://169.254.169.254/latest/meta-data/',
+  )
+  assert.match(String(reason), /private-network/)
+})
+
+test('findRequestBlockReason blocks a literal loopback address', async () => {
+  assert.match(
+    String(await findRequestBlockReason('http://127.0.0.1/')),
+    /private-network/,
+  )
+})
+
+test('findRequestBlockReason blocks the localhost hostname', async () => {
+  assert.match(
+    String(await findRequestBlockReason('http://localhost:8404/')),
+    /loopback/,
+  )
+})
+
+test('findRequestBlockReason blocks a *.localhost hostname with a trailing dot', async () => {
+  assert.match(
+    String(await findRequestBlockReason('http://admin.localhost./')),
+    /loopback/,
+  )
+})
+
+test('findRequestBlockReason blocks a public host resolving to a private address', async () => {
+  const reason = await findRequestBlockReason(
+    'http://segments.evil.example/0.ts',
+    resolvesTo('10.1.2.3'),
+  )
+  assert.match(String(reason), /private-network/)
+})
+
+test('findRequestBlockReason blocks when any resolved address is private', async () => {
+  const reason = await findRequestBlockReason(
+    'http://mixed.example/0.ts',
+    resolvesTo('93.184.216.34', '169.254.169.254'),
+  )
+  assert.match(String(reason), /private-network/)
+})
+
+test('findRequestBlockReason blocks an IPv4-mapped IPv6 loopback literal', async () => {
+  assert.match(
+    String(await findRequestBlockReason('http://[::ffff:127.0.0.1]/0.ts')),
+    /private-network/,
+  )
+})
+
+test('findRequestBlockReason fails open when the host does not resolve', async () => {
+  // Unlike ensureValidURL (fail-closed for the top-level load), the per-request
+  // hook must not cancel a legitimate public sub-resource on a transient DNS
+  // failure it cannot positively classify as private.
+  assert.equal(
+    await findRequestBlockReason('http://cdn.example/0.ts', resolveFails),
+    null,
+  )
+})
+
+test('findRequestBlockReason fails open when the host resolves to no addresses', async () => {
+  assert.equal(
+    await findRequestBlockReason('http://cdn.example/0.ts', resolvesTo()),
+    null,
+  )
+})
+
+test('findRequestBlockReason allows a public IPv6-literal request', async () => {
+  assert.equal(
+    await findRequestBlockReason('http://[2606:4700:4700::1111]/0.ts'),
+    null,
+  )
 })

--- a/packages/streamwall/src/util.ts
+++ b/packages/streamwall/src/util.ts
@@ -107,3 +107,67 @@ export async function ensureValidURL(
     }
   }
 }
+
+/**
+ * Network-layer counterpart of {@link ensureValidURL}, meant to run on every
+ * request a view's session issues — including HTTP redirects and sub-resources
+ * (e.g. HLS variant/segment fetches) that never pass through the initial
+ * string check. Returns a short reason when the request must be cancelled, or
+ * null when it is allowed.
+ *
+ * It reuses the same non-public-address classification but differs from
+ * `ensureValidURL` in two deliberate ways that suit a per-request hook:
+ *   - Only http(s) is governed. Other schemes (file:, data:, blob:, devtools:,
+ *     ws:, …) are the app's own machinery and are always allowed; an
+ *     unparseable URL is likewise left for the network stack to reject.
+ *   - It fails *open* on a resolution failure. Only a positive match — a
+ *     loopback hostname or an address that classifies as non-public — blocks a
+ *     request, so a transient DNS hiccup on a legitimate public host does not
+ *     cancel its traffic.
+ */
+export async function findRequestBlockReason(
+  urlStr: string,
+  resolveAddresses: HostAddressResolver = resolveHostAddresses,
+): Promise<string | null> {
+  let url: URL
+  try {
+    url = new URL(urlStr)
+  } catch {
+    return null
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return null
+  }
+
+  const hostname = url.hostname.replace(/^\[|\]$/g, '').replace(/\.+$/, '')
+  if (hostname === '') {
+    return null
+  }
+
+  if (isLoopbackHostname(hostname)) {
+    return `blocking request to loopback host '${urlStr}'`
+  }
+
+  if (isIP(hostname) !== 0) {
+    return isBlockedAddress(hostname)
+      ? `blocking request to private-network address '${urlStr}'`
+      : null
+  }
+
+  let addresses: string[]
+  try {
+    addresses = await resolveAddresses(hostname)
+  } catch {
+    // Fail open: an unresolvable host cannot be positively classified as
+    // private, and the network stack will fail the request on its own if the
+    // name is genuinely dead.
+    return null
+  }
+  for (const address of addresses) {
+    if (isBlockedAddress(address)) {
+      return `blocking request to private-network URL '${urlStr}' (${hostname} resolves to ${address})`
+    }
+  }
+  return null
+}


### PR DESCRIPTION
## Problem

`ensureValidURL` (added in #94) only validates the **initial URL string** before it is loaded into a `WebContentsView`. Two SSRF vectors survive because the dangerous request is issued *after* validation (#106):

1. **HTTP redirects.** `wc.loadURL(content.url)` and `browseWindow.loadURL(msg.url)` follow Chromium 3xx redirects with no revalidation. An operator URL that passes the check can `302` to `http://169.254.169.254/…`, loopback, or a LAN host. The existing `will-redirect` guard in `navigationSecurity.ts` deliberately **allows the initial-load redirect** (`currentURL === ''`), so it does not close this vector.
2. **HLS sub-resources.** For `.m3u8`, only the manifest URL is validated; hls.js then fetches the variant/segment URIs named *inside* the manifest, none of which pass through `ensureValidURL`. A public-IP host can serve a playlist whose segments point at internal addresses.

## Solution

Enforce the same non-public-address policy at the **network layer** of every view/browse session, so every request — redirect hops (Chromium re-enters `onBeforeRequest` for each hop) and sub-resources alike — is revalidated:

- **`installRequestSSRFGuard(session, …)`** (`partitions.ts`) registers `session.webRequest.onBeforeRequest` and cancels any request that classifies as non-public. `hardenSession` now installs it alongside the permission handler, so **every** isolated partition (each stream view + the browse window) is covered automatically.
- **`findRequestBlockReason(url)`** (`util.ts`) is the per-request counterpart of `ensureValidURL`, reusing the same address/loopback/blocklist classification. It differs deliberately for a per-request hook:
  - scoped to **http(s)** — other schemes (`file:`, `data:`, `blob:`, `devtools:`, `ws:`) are the app's own machinery and are allowed;
  - **fails open** on DNS resolution failure — only a *positive* private-address match cancels a request, so a transient DNS hiccup on a legitimate public host cannot drop its traffic.
- The **Vite dev-server origin** (loopback) is allow-listed (`devServerOrigin()` → `hardenSession({ allowedOrigins })`) so the HLS renderer page and its assets still load in development.

A cancelled main-frame navigation surfaces as a view error on the wall via the existing `did-fail-load` handler.

## Architecture decisions

- **Reuse over extraction.** The issue suggested optionally moving the classifier to `streamwall-shared`. `streamwall-shared` is also consumed by the Preact renderer/control-ui, and the classifier depends on `node:net`/`node:dns` (main-process only), so extracting it there would break those bundles. The network hook runs in the main process, so it reuses the classifier in place in `util.ts` — one blocklist, no new cross-package coupling.
- **Fold into `hardenSession`.** Registering the guard where sessions are already hardened guarantees no view/browse session can be created without it, which is the whole point of "check every request".
- **Defense in depth, not replacement.** The up-front `ensureValidURL` calls stay: they reject a bad top-level URL immediately with an operator-facing message; the network guard is the backstop for redirects and sub-resources.

## Testing

- `findRequestBlockReason`: public→public allowed; non-http allowed; unparseable allowed; literal metadata/loopback/private blocked; `localhost`(+trailing dot) blocked; public host resolving to private blocked; IPv4-mapped IPv6 loopback blocked; **fail-open** on resolution failure / empty answer; public IPv6 literal allowed.
- `installRequestSSRFGuard` / `hardenSession`: cancels flagged requests, allows cleared ones, honors the dev-origin allow-list without consulting DNS, and fails open on an internal guard error. `hardenSession` is asserted to install the guard (metadata endpoint cancelled, public allowed).
- Full quality gate green locally: `format:check`, `lint`, `typecheck` (all workspaces), `test` (all workspaces — streamwall 119 passing), and the CI build step (`npm -w streamwall-control-client run build`).

The network hook itself can only be exercised end-to-end inside a running Electron session; its logic is verified at the seam (the `onBeforeRequest` listener is invoked with URLs and asserted against cancel decisions).

## Risks / breaking changes

- No API/behavior change for legitimate public streams. In development, the dev-server origin is explicitly allowed so HLS previews keep working.
- Every http(s) sub-resource host is re-resolved in `onBeforeRequest`; `dns.lookup` hits the OS resolver cache, so overhead is bounded. No app-level cache was added (avoids staleness).

## Known limitations / follow-ups

- Active **DNS rebinding** (TOCTOU) is unchanged and out of scope, as documented in #94 — now tracked in #169.
- **WebSocket (`ws`/`wss`)** requests are not yet covered by the guard — tracked in #168.

Closes #106