### PR TITLE
docs(control-ui): translate remaining German UI strings to English

### DIFF
--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -373,7 +373,7 @@ export function ThemeToggle() {
   ]
 
   return (
-    <StyledThemeToggle role="group" aria-label="Farbschema">
+    <StyledThemeToggle role="group" aria-label="Color scheme">
       {opts.map(({ key, label, icon }) => (
         <button
           key={key}
@@ -1738,7 +1738,7 @@ function GridSizeControls({
         </button>
       ))}
       <label>
-        Spalten
+        Columns
         <input
           type="number"
           min={GRID_MIN}
@@ -1751,7 +1751,7 @@ function GridSizeControls({
         />
       </label>
       <label>
-        Zeilen
+        Rows
         <input
           type="number"
           min={GRID_MIN}


### PR DESCRIPTION
## Problem

`packages/streamwall-control-ui/src/index.tsx` had three untranslated German labels mixed into the otherwise English UI, found while working on #74:

- Line 376: `aria-label="Farbschema"` on the theme-toggle group
- Line 1741: `Spalten` (grid column-count label)
- Line 1754: `Zeilen` (grid row-count label)

## Solution

Translated the three strings to English to match the rest of the UI and the repo's English-only convention:

- `"Farbschema"` → `"Color scheme"`
- `"Spalten"` → `"Columns"`
- `"Zeilen"` → `"Rows"`

No other German strings were found elsewhere in `streamwall-control-ui` or `streamwall-control-client`.

## Testing

Pure copy change with no behavioral impact, so no new tests were added (per the repo's TDD exception for non-testable changes). Verified via the full quality gate:

- `prettier --check` — clean
- `tsc --noEmit` (control-ui) — clean
- `eslint` on the changed file — clean
- `npm run test -w packages/streamwall-control-ui` — 22/22 passing
- `npm run build -w packages/streamwall-control-client` (consumes control-ui via a Vite alias) — succeeds

## Risks / breaking changes

None. Text-only change; no functional or accessibility-tree structure change beyond the aria-label's text content.

Closes #166