### PR TITLE
fix(security): classify ws:/wss: requests in the network-layer SSRF guard

### DIFF
--- a/packages/streamwall/src/main/partitions.test.ts
+++ b/packages/streamwall/src/main/partitions.test.ts
@@ -191,6 +191,25 @@ test('installRequestSSRFGuard allows an explicitly allowed origin without consul
   )
 })
 
+test('installRequestSSRFGuard allows a ws: request to the allow-listed dev server host', async () => {
+  // The Vite HMR socket connects over ws: to the same host:port the dev
+  // server's http: origin is allow-listed for; the allow-list must match by
+  // host so this is not treated as a different, unlisted origin.
+  const session = guardWith(
+    { 'ws://localhost:5173/vite-hmr': 'loopback host' },
+    ['http://localhost:5173'],
+  )
+  assert.equal(await session.requestURL('ws://localhost:5173/vite-hmr'), false)
+})
+
+test('installRequestSSRFGuard still blocks a ws: request to a different, non-allow-listed host', async () => {
+  const session = guardWith(
+    { 'ws://169.254.169.254/': 'blocking request to private-network address' },
+    ['http://localhost:5173'],
+  )
+  assert.equal(await session.requestURL('ws://169.254.169.254/'), true)
+})
+
 test('installRequestSSRFGuard fails open if the reason lookup itself throws', async () => {
   const session = fakeSession()
   installRequestSSRFGuard(session, {

--- a/packages/streamwall/src/main/partitions.ts
+++ b/packages/streamwall/src/main/partitions.ts
@@ -63,20 +63,32 @@ interface RequestFilteringSession {
 export interface RequestGuardOptions {
   /**
    * Origins that bypass the address check entirely (e.g. the Vite dev server on
-   * loopback, which serves the HLS renderer page). Empty in a packaged build.
+   * loopback, which serves the HLS renderer page). Matched by host (hostname
+   * plus port), not full origin, so the dev server's ws: HMR socket is covered
+   * by the same entry as its http: origin. Empty in a packaged build.
    */
   allowedOrigins?: readonly string[]
   /** Overridable for tests; defaults to the real address classifier. */
   findBlockReason?: (url: string) => Promise<string | null>
 }
 
+/** Extracts the `host` (hostname[:port]) from an origin string, or undefined if unparseable. */
+function hostOf(origin: string): string | undefined {
+  try {
+    return new URL(origin).host
+  } catch {
+    return undefined
+  }
+}
+
 /**
  * Enforces the non-public-address policy at the network layer of a session, so
  * that *every* request it issues is checked — not just the initial URL string.
  * This closes the SSRF vectors a single up-front check structurally cannot
- * cover: HTTP 3xx redirects (Chromium re-enters `onBeforeRequest` for each hop)
- * and sub-resources named inside loaded content (e.g. HLS variant/segment URIs
- * fetched by hls.js), both of which are issued *after* `ensureValidURL` has run.
+ * cover: HTTP 3xx redirects (Chromium re-enters `onBeforeRequest` for each hop),
+ * sub-resources named inside loaded content (e.g. HLS variant/segment URIs
+ * fetched by hls.js), and WebSockets opened by script inside the loaded page —
+ * all of which are issued *after* `ensureValidURL` has run.
  *
  * Blocked requests are cancelled; a cancelled main-frame navigation surfaces as
  * a view error on the wall via the existing `did-fail-load` handler.
@@ -88,17 +100,22 @@ export function installRequestSSRFGuard(
     findBlockReason = findRequestBlockReason,
   }: RequestGuardOptions = {},
 ): void {
-  const allowed = new Set(allowedOrigins.filter(Boolean))
+  const allowedHosts = new Set(
+    allowedOrigins
+      .filter(Boolean)
+      .map(hostOf)
+      .filter((host): host is string => host !== undefined),
+  )
   session.webRequest.onBeforeRequest((details, callback) => {
     void (async () => {
       try {
-        let origin: string | undefined
+        let host: string | undefined
         try {
-          origin = new URL(details.url).origin
+          host = new URL(details.url).host
         } catch {
-          origin = undefined
+          host = undefined
         }
-        if (origin !== undefined && allowed.has(origin)) {
+        if (host !== undefined && allowedHosts.has(host)) {
           callback({ cancel: false })
           return
         }

--- a/packages/streamwall/src/util.test.ts
+++ b/packages/streamwall/src/util.test.ts
@@ -280,3 +280,49 @@ test('findRequestBlockReason allows a public IPv6-literal request', async () => 
     null,
   )
 })
+
+// A page loaded into a view can open a WebSocket from script (e.g.
+// `new WebSocket('ws://169.254.169.254/')`), which is the same class of
+// loopback/LAN/cloud-metadata SSRF as an http(s) sub-resource fetch. The
+// guard must classify ws:/wss: targets the same way.
+
+test('findRequestBlockReason blocks a ws: request to the cloud-metadata address', async () => {
+  assert.match(
+    String(
+      await findRequestBlockReason('ws://169.254.169.254/latest/meta-data/'),
+    ),
+    /private-network/,
+  )
+})
+
+test('findRequestBlockReason blocks a wss: request to a loopback hostname', async () => {
+  assert.match(
+    String(await findRequestBlockReason('wss://localhost:8404/')),
+    /loopback/,
+  )
+})
+
+test('findRequestBlockReason blocks a ws: request to a public host resolving to a private address', async () => {
+  const reason = await findRequestBlockReason(
+    'ws://ws.evil.example/socket',
+    resolvesTo('10.1.2.3'),
+  )
+  assert.match(String(reason), /private-network/)
+})
+
+test('findRequestBlockReason allows a wss: request to a public host resolving to a public address', async () => {
+  assert.equal(
+    await findRequestBlockReason(
+      'wss://ws.example.com/socket',
+      resolvesTo('93.184.216.34'),
+    ),
+    null,
+  )
+})
+
+test('findRequestBlockReason fails open for a ws: request when the host does not resolve', async () => {
+  assert.equal(
+    await findRequestBlockReason('ws://cdn.example/socket', resolveFails),
+    null,
+  )
+})

--- a/packages/streamwall/src/util.ts
+++ b/packages/streamwall/src/util.ts
@@ -117,9 +117,12 @@ export async function ensureValidURL(
  *
  * It reuses the same non-public-address classification but differs from
  * `ensureValidURL` in two deliberate ways that suit a per-request hook:
- *   - Only http(s) is governed. Other schemes (file:, data:, blob:, devtools:,
- *     ws:, …) are the app's own machinery and are always allowed; an
+ *   - Only http(s)/ws(s) are governed. Other schemes (file:, data:, blob:,
+ *     devtools:, …) are the app's own machinery and are always allowed; an
  *     unparseable URL is likewise left for the network stack to reject.
+ *     ws:/wss: is included because a page loaded into a view can open a
+ *     WebSocket to an internal host from script, the same class of SSRF as an
+ *     http(s) sub-resource fetch.
  *   - It fails *open* on a resolution failure. Only a positive match — a
  *     loopback hostname or an address that classifies as non-public — blocks a
  *     request, so a transient DNS hiccup on a legitimate public host does not
@@ -136,7 +139,12 @@ export async function findRequestBlockReason(
     return null
   }
 
-  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+  if (
+    url.protocol !== 'http:' &&
+    url.protocol !== 'https:' &&
+    url.protocol !== 'ws:' &&
+    url.protocol !== 'wss:'
+  ) {
     return null
   }
 


### PR DESCRIPTION
## Problem

Follow-up to #106/#170. The network-layer SSRF guard (`installRequestSSRFGuard` / `findRequestBlockReason`) revalidates every request a view/browse session issues, but `findRequestBlockReason` only classified `http:`/`https:` targets — every other scheme, including `ws:`/`wss:`, was passed through unconditionally.

A page loaded into a `WebContentsView` (a compromised/hostile stream page, or content reached via an allowed redirect) can open a WebSocket to an internal host from script:

```js
new WebSocket('ws://169.254.169.254/')
```

That handshake is surfaced to `onBeforeRequest` as a `ws://` URL and was let through, the same class of loopback/LAN/cloud-metadata SSRF as the already-covered http(s) redirect/sub-resource vectors.

## Solution

- `findRequestBlockReason` (`packages/streamwall/src/util.ts`) now also classifies `ws:`/`wss:` targets with the same non-public-address rules used for `http:`/`https:` (loopback hostname fast-path, IP-literal check, DNS resolution + fail-open-on-unresolvable).
- The dev-server allow-list in `installRequestSSRFGuard` (`packages/streamwall/src/main/partitions.ts`) previously matched by full origin (scheme+host+port). Since the Vite HMR socket connects over `ws://localhost:<port>` while the allow-listed entry is the dev server's `http://localhost:<port>` origin, those origins never matched and the HMR socket would have been cancelled once `ws:` became a governed scheme. Switched the match to compare by **host** (hostname+port) instead, so one allow-list entry covers both the `http:` origin and its `ws:` counterpart on the same host — as suggested in the issue.

## Testing

TDD: added failing tests first, then implemented.

- `packages/streamwall/src/util.test.ts`: `findRequestBlockReason` now has ws:/wss: coverage — blocks the cloud-metadata literal, blocks a loopback hostname, blocks a public host resolving to a private address, allows a public host resolving to a public address, and fails open on an unresolvable host (mirrors the existing http(s) test matrix).
- `packages/streamwall/src/main/partitions.test.ts`: `installRequestSSRFGuard` now has coverage for the host-based allow-list — a `ws:` request to the allow-listed dev-server host is let through without consulting the reason lookup, while a `ws:` request to a different, non-allow-listed host is still blocked.
- Full quality gate run locally: prettier, eslint, `tsc --noEmit` (all workspaces), and the full test suite (`packages/streamwall` 126/126, `streamwall-control-server` 73/73, `streamwall-control-ui` 22/22) — all green.

## Risks / breaking changes

None expected. This only tightens an existing security guard to cover a scheme it previously ignored; legitimate `ws:`/`wss:` traffic to public hosts (and the dev-server's own HMR socket) continues to work.

Closes #168