### PR TITLE
fix(security): resolve validated hosts through the loader's own session

### DIFF
--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -18,7 +18,7 @@ import { updateElectronApp } from 'update-electron-app'
 import WebSocket from 'ws'
 import yargs from 'yargs'
 import * as Y from 'yjs'
-import { ensureValidURL } from '../util'
+import { createSessionHostResolver, ensureValidURL } from '../util'
 import { ConfigError, parseConfigToml, validateConfig } from './config'
 import ControlWindow from './ControlWindow'
 import {
@@ -503,7 +503,10 @@ async function main(argv: ReturnType<typeof parseArgs>) {
       if (msg.type === 'browse') {
         console.debug('Attempting to browse URL:', msg.url)
         try {
-          await ensureValidURL(msg.url)
+          await ensureValidURL(
+            msg.url,
+            createSessionHostResolver(browseWindow.webContents.session),
+          )
           browseWindow.loadURL(msg.url)
         } catch (error) {
           console.error('Invalid URL:', msg.url)

--- a/packages/streamwall/src/main/partitions.test.ts
+++ b/packages/streamwall/src/main/partitions.test.ts
@@ -31,6 +31,11 @@ function fakeSession() {
         requestListener = listener
       },
     },
+    // Overridable per test; the default reports every hostname as public so
+    // tests that don't care about DNS classification aren't forced to stub it.
+    resolveHost: async (): Promise<{
+      endpoints: { address: string; family: 'ipv4' | 'ipv6' }[]
+    }> => ({ endpoints: [{ address: '93.184.216.34', family: 'ipv4' }] }),
     request(permission: string): boolean {
       assert.ok(handler, 'a permission request handler must be registered')
       let granted: boolean | undefined
@@ -221,5 +226,34 @@ test('installRequestSSRFGuard fails open if the reason lookup itself throws', as
     await session.requestURL('https://cdn.example/0.ts'),
     false,
     'an internal guard error must not cancel legitimate traffic',
+  )
+})
+
+// The default resolver (i.e. when findBlockReason is not overridden) must be
+// the guarded session's own resolveHost, not an independent DNS lookup — this
+// is what narrows the #169 DNS-rebinding time-of-check/time-of-use gap by
+// sharing the resolver and cache Chromium actually connects through.
+
+test("installRequestSSRFGuard defaults to the guarded session's own resolveHost", async () => {
+  const session = fakeSession()
+  const calls: string[] = []
+  session.resolveHost = async (host: string) => {
+    calls.push(host)
+    return { endpoints: [{ address: '93.184.216.34', family: 'ipv4' }] }
+  }
+  installRequestSSRFGuard(session)
+  assert.equal(await session.requestURL('http://stream.example/0.ts'), false)
+  assert.deepEqual(calls, ['stream.example'])
+})
+
+test('installRequestSSRFGuard blocks a request when the session resolver reports a private address', async () => {
+  const session = fakeSession()
+  session.resolveHost = async () => ({
+    endpoints: [{ address: '10.1.2.3', family: 'ipv4' }],
+  })
+  installRequestSSRFGuard(session)
+  assert.equal(
+    await session.requestURL('http://rebind.evil.example/0.ts'),
+    true,
   )
 })

--- a/packages/streamwall/src/main/partitions.ts
+++ b/packages/streamwall/src/main/partitions.ts
@@ -16,7 +16,7 @@
  */
 
 import type { Session } from 'electron'
-import { findRequestBlockReason } from '../util'
+import { createSessionHostResolver, findRequestBlockReason } from '../util'
 
 const VIEW_PARTITION_PREFIX = 'view-'
 
@@ -58,6 +58,7 @@ interface RequestFilteringSession {
   webRequest: {
     onBeforeRequest(listener: RequestListener): void
   }
+  resolveHost(host: string): Promise<{ endpoints: { address: string }[] }>
 }
 
 export interface RequestGuardOptions {
@@ -68,7 +69,11 @@ export interface RequestGuardOptions {
    * by the same entry as its http: origin. Empty in a packaged build.
    */
   allowedOrigins?: readonly string[]
-  /** Overridable for tests; defaults to the real address classifier. */
+  /**
+   * Overridable for tests; defaults to the real address classifier, resolving
+   * hostnames through the guarded session's own DNS resolver (see
+   * {@link createSessionHostResolver}) rather than an independent lookup.
+   */
   findBlockReason?: (url: string) => Promise<string | null>
 }
 
@@ -97,7 +102,8 @@ export function installRequestSSRFGuard(
   session: RequestFilteringSession,
   {
     allowedOrigins = [],
-    findBlockReason = findRequestBlockReason,
+    findBlockReason = (url) =>
+      findRequestBlockReason(url, createSessionHostResolver(session)),
   }: RequestGuardOptions = {},
 ): void {
   const allowedHosts = new Set(

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -12,7 +12,7 @@ import {
   ContentViewInfo,
 } from 'streamwall-shared/src/types'
 import { Actor, assign, fromPromise, setup } from 'xstate'
-import { ensureValidURL } from '../util'
+import { createSessionHostResolver, ensureValidURL } from '../util'
 import { loadHTML } from './loadHTML'
 
 // Safety net for the whole loading phase (navigate -> waitForInit -> waitForVideo).
@@ -235,8 +235,8 @@ const viewStateMachine = setup({
       }) => {
         assert(content !== null)
 
-        await ensureValidURL(content.url)
         const wc = view.webContents
+        await ensureValidURL(content.url, createSessionHostResolver(wc.session))
         wc.audioMuted = true
         wc.executeJavaScript(`
           Object.defineProperty(document, 'visibilityState', {

--- a/packages/streamwall/src/util.test.ts
+++ b/packages/streamwall/src/util.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict'
 import { test } from 'vitest'
 
-import { ensureValidURL, findRequestBlockReason } from './util'
+import {
+  createSessionHostResolver,
+  ensureValidURL,
+  findRequestBlockReason,
+} from './util'
 
 // Deterministic resolver stubs so the DNS-dependent paths can be exercised
 // without touching the network.
@@ -323,6 +327,93 @@ test('findRequestBlockReason allows a wss: request to a public host resolving to
 test('findRequestBlockReason fails open for a ws: request when the host does not resolve', async () => {
   assert.equal(
     await findRequestBlockReason('ws://cdn.example/socket', resolveFails),
+    null,
+  )
+})
+
+// createSessionHostResolver adapts a session's own DNS resolver (the one
+// Chromium actually uses to connect) into a HostAddressResolver, so
+// ensureValidURL/findRequestBlockReason can be checked against the exact
+// resolution the request will reuse — narrowing the DNS-rebinding
+// time-of-check/time-of-use gap tracked in #169, instead of validating
+// against a second, wholly independent lookup via Node's `dns.lookup`.
+
+const fakeSessionResolving =
+  (...endpoints: { address: string; family: 'ipv4' | 'ipv6' }[]) =>
+  (): {
+    resolveHost: (host: string) => Promise<{ endpoints: typeof endpoints }>
+  } => ({
+    resolveHost: async () => ({ endpoints }),
+  })
+
+test('createSessionHostResolver resolves a hostname via session.resolveHost', async () => {
+  const calls: string[] = []
+  const session = {
+    resolveHost: async (host: string) => {
+      calls.push(host)
+      return {
+        endpoints: [{ address: '93.184.216.34', family: 'ipv4' as const }],
+      }
+    },
+  }
+  const resolve = createSessionHostResolver(session)
+  assert.deepEqual(await resolve('stream.example.com'), ['93.184.216.34'])
+  assert.deepEqual(calls, ['stream.example.com'])
+})
+
+test('createSessionHostResolver flattens every resolved endpoint address', async () => {
+  const session = fakeSessionResolving(
+    { address: '93.184.216.34', family: 'ipv4' },
+    { address: '2606:4700:4700::1111', family: 'ipv6' },
+  )()
+  const resolve = createSessionHostResolver(session)
+  assert.deepEqual(await resolve('stream.example.com'), [
+    '93.184.216.34',
+    '2606:4700:4700::1111',
+  ])
+})
+
+test('createSessionHostResolver resolves to an empty list when the session finds no endpoints', async () => {
+  const resolve = createSessionHostResolver(fakeSessionResolving()())
+  assert.deepEqual(await resolve('empty.example'), [])
+})
+
+test('ensureValidURL rejects a hostname the session resolver reports as private', async () => {
+  const resolve = createSessionHostResolver(
+    fakeSessionResolving({ address: '10.1.2.3', family: 'ipv4' })(),
+  )
+  await assert.rejects(
+    ensureValidURL('http://rebind.example/', resolve),
+    /private-network/,
+  )
+})
+
+test('ensureValidURL allows a hostname the session resolver reports as public', async () => {
+  const resolve = createSessionHostResolver(
+    fakeSessionResolving({ address: '93.184.216.34', family: 'ipv4' })(),
+  )
+  await assert.doesNotReject(
+    ensureValidURL('http://stream.example.com/', resolve),
+  )
+})
+
+test('findRequestBlockReason blocks a sub-resource host the session resolver reports as private', async () => {
+  const resolve = createSessionHostResolver(
+    fakeSessionResolving({ address: '169.254.169.254', family: 'ipv4' })(),
+  )
+  const reason = await findRequestBlockReason(
+    'http://metadata.evil.example/0.ts',
+    resolve,
+  )
+  assert.match(String(reason), /private-network/)
+})
+
+test('findRequestBlockReason allows a sub-resource host the session resolver reports as public', async () => {
+  const resolve = createSessionHostResolver(
+    fakeSessionResolving({ address: '93.184.216.34', family: 'ipv4' })(),
+  )
+  assert.equal(
+    await findRequestBlockReason('http://cdn.example/0.ts', resolve),
     null,
   )
 })

--- a/packages/streamwall/src/util.ts
+++ b/packages/streamwall/src/util.ts
@@ -38,11 +38,45 @@ function isLoopbackHostname(hostname: string): boolean {
   return host === 'localhost' || host.endsWith('.localhost')
 }
 
-type HostAddressResolver = (hostname: string) => Promise<string[]>
+export type HostAddressResolver = (hostname: string) => Promise<string[]>
 
 const resolveHostAddresses: HostAddressResolver = async (hostname) => {
   const results = await lookup(hostname, { all: true })
   return results.map((result) => result.address)
+}
+
+// Structural view of the DNS-resolution surface Electron's `Session` exposes
+// (see `session.resolveHost` in the Electron API), kept independent of the
+// `electron` module so this file — and its tests — stay Electron-free.
+interface HostResolvingSession {
+  resolveHost(host: string): Promise<{ endpoints: { address: string }[] }>
+}
+
+/**
+ * Builds a {@link HostAddressResolver} backed by a session's own DNS resolver
+ * — the same resolver, and same cache, Chromium uses to actually connect —
+ * instead of Node's independent `dns.lookup`. Callers that have a session
+ * available (every real call site does) should pass this to
+ * {@link ensureValidURL} / {@link findRequestBlockReason} so the validated
+ * address is very likely the one still in the session's cache when the real
+ * connection is made moments later, narrowing the DNS-rebinding
+ * time-of-check/time-of-use gap described in #169.
+ *
+ * This narrows the gap; it does not close it. Chromium can still re-resolve
+ * independently if the cache entry it just populated has already expired
+ * (e.g. an attacker serving a TTL of 0), and Electron/Chromium currently
+ * expose no API to pin a single request's connection to a specific,
+ * pre-validated address. The network-layer guard
+ * (`findRequestBlockReason`/`installRequestSSRFGuard`) therefore remains
+ * necessary as defense in depth, not a complete fix on its own.
+ */
+export function createSessionHostResolver(
+  session: HostResolvingSession,
+): HostAddressResolver {
+  return async (hostname) => {
+    const { endpoints } = await session.resolveHost(hostname)
+    return endpoints.map((endpoint) => endpoint.address)
+  }
 }
 
 /**
@@ -52,9 +86,14 @@ const resolveHostAddresses: HostAddressResolver = async (hostname) => {
  * etc.). Hostnames are resolved and every resulting address is checked, so a
  * public domain that maps to a private address is rejected too.
  *
- * Note: DNS is re-resolved by the loader afterwards, so this does not defend
- * against active DNS-rebinding; it blocks statically-malicious and
- * literal-address targets, which is the reported operator SSRF vector.
+ * Note: DNS is re-resolved by the loader afterwards, so passing the default
+ * resolver does not defend against active DNS-rebinding; it blocks
+ * statically-malicious and literal-address targets, which is the reported
+ * operator SSRF vector. Callers should pass a
+ * {@link createSessionHostResolver} bound to the session that will actually
+ * load the URL — this narrows (but, per that function's docs, does not
+ * eliminate) the DNS-rebinding gap by sharing the loader's own resolver and
+ * cache instead of an independent lookup.
  */
 export async function ensureValidURL(
   urlStr: string,


### PR DESCRIPTION
## Problem

Both SSRF layers (`ensureValidURL` and the `#106` network guard,
`findRequestBlockReason`/`installRequestSSRFGuard`) resolved a hostname
themselves — via Node's independent `dns.lookup` — to classify it as
public/private, then handed the *URL string* to Chromium, which re-resolves
it independently to actually connect.

This is a time-of-check/time-of-use gap: an attacker who controls a DNS name
can answer our lookup with a public address and Chromium's later lookup with
a private one (DNS rebinding), reaching loopback/LAN/cloud-metadata despite
both checks passing. #106 explicitly documented this as out of scope; #169
tracks the remaining limitation.

## Solution

Added `createSessionHostResolver` (`packages/streamwall/src/util.ts`), which
builds a `HostAddressResolver` backed by `session.resolveHost(...)` — the
same resolver, and same cache, Chromium itself uses to connect — instead of
Node's independent `dns.lookup`.

Wired it into every call site that has a session available:
- `main/index.ts`: browse-window `ensureValidURL` uses
  `browseWindow.webContents.session`.
- `main/viewStateMachine.ts`: view-load `ensureValidURL` uses
  `view.webContents.session`.
- `main/partitions.ts`: `installRequestSSRFGuard`'s default resolver (used
  by every session `hardenSession` protects) is now bound to the guarded
  session itself, instead of falling back to `findRequestBlockReason`'s
  Node-`dns`-backed default.

### Why this helps, and what it doesn't fix

Sharing the resolver/cache means the address we validate is very likely the
exact one Chromium reuses moments later for the real connection — narrowing
the gap to only a short/zero-TTL adversarial DNS response racing the two
lookups by milliseconds, rather than being wide open on every single
request regardless of TTL (the previous state, where the two lookups used
entirely unrelated resolvers).

It does **not** close the gap outright. Electron/Chromium expose no API to
pin a single request's connection to a pre-validated address — the
command-line `--host-resolver-rules` switch that Chromium's network stack
does honor is static and set once at process launch, so it can't be used to
pin arbitrary, dynamically-supplied operator hostnames discovered at
runtime. This is documented in code (`createSessionHostResolver`'s JSDoc)
so any future change to close the gap further is deliberate, per the
issue's own "at minimum" bar.

The network-layer guard (`findRequestBlockReason`/`installRequestSSRFGuard`)
therefore remains necessary as defense in depth, not a complete fix on its
own.

## Testing

TDD: failing tests written first (`createSessionHostResolver` didn't exist),
confirmed red, then implemented to green.

- `packages/streamwall/src/util.test.ts`: new tests for
  `createSessionHostResolver` (endpoint flattening, empty-endpoint case) and
  for `ensureValidURL`/`findRequestBlockReason` classifying addresses
  reported by a session resolver.
- `packages/streamwall/src/main/partitions.test.ts`: `fakeSession()` now
  exposes a stubbable `resolveHost`; new tests assert
  `installRequestSSRFGuard`'s default resolver is the guarded session's own
  `resolveHost` (not an independent lookup), for both the allow and block
  paths. Also tightened the existing `hardenSession also installs the
  network-layer SSRF guard` test to use the stub instead of relying on a
  real DNS lookup for `cdn.twitch.tv`, removing a hidden network dependency
  from the unit suite.

All existing SSRF/loopback/private-range regression tests still pass
unchanged. Full quality gate green locally: format, lint, typecheck, full
workspace test suite (`npm run test` across all packages), and
`electron-forge package` build.

## Risks / breaking changes

None expected. Purely additive resolver wiring; the classification logic
(`isBlockedAddress`, `isLoopbackHostname`) is unchanged. No behavior change
for callers that don't have a session (none currently — `ensureValidURL` is
called at both real call sites with a session-bound resolver now).

Closes #169