### PR TITLE
fix(control-server): run test files sequentially to avoid contention

### DIFF
--- a/packages/streamwall-control-server/package.json
+++ b/packages/streamwall-control-server/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "tsx ./src/index.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "test": "node --import tsx --test --test-force-exit --test-timeout=20000 \"src/**/*.test.ts\""
+    "test": "node --import tsx --test --test-concurrency=1 --test-force-exit --test-timeout=20000 \"src/**/*.test.ts\""
   },
   "repository": "github:NilsR0711/streamwall",
   "author": "Nils Reeh <info@nilsreeh.de>",


### PR DESCRIPTION
## Problem

`packages/streamwall-control-server/src/wsValidation.test.ts` intermittently timed out (`testTimeoutFailure`, 20000ms) when the full workspace test suite ran via the root `npm run test`, while `npm -w packages/streamwall-control-server run test` run standalone always passed.

## Root cause

Node's test runner executes matched test files **concurrently by default** (`--test-concurrency`, defaulting to a value derived from CPU count). Six of the eleven files in `streamwall-control-server` (`helmet.test.ts`, `inviteExchange.test.ts`, `rateLimit.test.ts`, `uplinkAuth.test.ts`, `wsRateLimit.test.ts`, `wsValidation.test.ts`) each boot a real Fastify server on an ephemeral port and open real WebSocket connections, then await real timers (a 150ms state-sync delay, 2000ms `waitFor` calls, a 3000ms close-event wait).

When several of these listener-heavy files run truly in parallel, on a CPU-constrained runner (GitHub Actions' `ubuntu-latest`/`windows-latest`/`macos-latest` runners have limited cores) the resulting event-loop/CPU contention can push one of those awaits past its timeout, producing the observed intermittent failure — reproducible only under contention, never in isolation.

This isn't about `npm run test --workspaces` running workspaces in parallel (it runs them sequentially by default, confirmed empirically); the concurrency causing contention is at the test-*file* level within the single `node --test` invocation for `streamwall-control-server`.

## Fix

Add `--test-concurrency=1` to `streamwall-control-server`'s `test` script so files run one at a time, eliminating the contention between listener-heavy files.

## Testing performed

- Ran the full root `npm run test` three consecutive times — all green, ~30s wall time each (well within the CI job's 20-minute budget; individual `streamwall-control-server` run went from ~4.4s to ~11.9s, still far under the file's 20000ms per-test timeout).
- `npm run format:check`, `npm run lint`, `npm run typecheck`, and `npm -w streamwall-control-client run build` all pass.
- No test changes: this is a test-runner configuration fix, not an application behavior change, so no new tests were added per the TDD no-testable-behavior exception.

## Risks / breaking changes

None — this only affects local test-run parallelism within one workspace; no production code changed.

Closes #174