### PR TITLE
fix(styled-components): make custom props transient to stop DOM prop leakage

### DIFF
--- a/packages/streamwall-control-ui/src/GridPreviewBox.test.tsx
+++ b/packages/streamwall-control-ui/src/GridPreviewBox.test.tsx
@@ -89,4 +89,24 @@ describe('GridPreviewBox', () => {
 
     expect(box.querySelector('.small')).not.toBeNull()
   })
+
+  test('does not leak custom styled-component props onto the DOM node (#152)', () => {
+    const box = renderBox({ isError: true, isListening: true })
+
+    for (const el of box.querySelectorAll('*')) {
+      for (const propName of [
+        'color',
+        'pos',
+        'windowwidth',
+        'windowheight',
+        'islistening',
+        'iserror',
+      ]) {
+        expect(
+          el.hasAttribute(propName),
+          `<${el.tagName.toLowerCase()}> unexpectedly has a "${propName}" attribute`,
+        ).toBe(false)
+      }
+    }
+  })
 })

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -1062,14 +1062,14 @@ export function ControlUI({
 
   return (
     <Stack
-      flex="1"
-      direction="row"
-      gap={16}
+      $flex="1"
+      $direction="row"
+      $gap={16}
       style={{ height: '100vh', minHeight: 0, padding: 16, overflow: 'hidden' }}
     >
       <Stack
         className="grid-container"
-        flex="1"
+        $flex="1"
         style={{ minWidth: 0, minHeight: 0 }}
       >
         <StyledHeader>
@@ -1108,7 +1108,7 @@ export function ControlUI({
           />
         )}
         <StyledDataContainer
-          isConnected={isConnected}
+          $isConnected={isConnected}
           style={{
             flex: 1,
             minHeight: 0,
@@ -1122,8 +1122,8 @@ export function ControlUI({
               className="grid"
               onMouseMove={updateHoveringIdx}
               onMouseLeave={clearHoveringIdx}
-              windowWidth={windowWidth}
-              windowHeight={windowHeight}
+              $windowWidth={windowWidth}
+              $windowHeight={windowHeight}
             >
               <StyledGridInputs>
                 {range(0, rows).map((y) =>
@@ -1314,11 +1314,11 @@ export function ControlUI({
       </Stack>
       <Stack
         className="stream-list"
-        scroll={true}
-        minHeight={200}
+        $scroll={true}
+        $minHeight={200}
         style={{ flex: '0 0 340px' }}
       >
-        <StyledDataContainer isConnected={isConnected}>
+        <StyledDataContainer $isConnected={isConnected}>
           {isConnected ? (
             <div>
               <input
@@ -1417,18 +1417,18 @@ export function ControlUI({
 }
 
 const Stack = styled.div<{
-  direction?: string
-  flex?: string
-  gap?: number
-  scroll?: boolean
-  minHeight?: number
+  $direction?: string
+  $flex?: string
+  $gap?: number
+  $scroll?: boolean
+  $minHeight?: number
 }>`
   display: flex;
-  flex-direction: ${({ direction }) => direction ?? 'column'};
-  flex: ${({ flex }) => flex};
-  ${({ gap }) => gap && `gap: ${gap}px`};
-  ${({ scroll }) => scroll && `overflow-y: auto`};
-  ${({ minHeight }) => minHeight && `min-height: ${minHeight}px`};
+  flex-direction: ${({ $direction }) => $direction ?? 'column'};
+  flex: ${({ $flex }) => $flex};
+  ${({ $gap }) => $gap && `gap: ${$gap}px`};
+  ${({ $scroll }) => $scroll && `overflow-y: auto`};
+  ${({ $minHeight }) => $minHeight && `min-height: ${$minHeight}px`};
 `
 
 function StreamDurationClock({ startTime }: { startTime: number }) {
@@ -1489,7 +1489,7 @@ function StreamDelayBox({
             <span>delay: {delayState.delaySeconds}s</span>
             {delayState.isStreamRunning && (
               <StyledButton
-                isActive={delayState.isCensored}
+                $isActive={delayState.isCensored}
                 onClick={handleToggleStreamCensored}
                 tabIndex={1}
               >
@@ -1567,13 +1567,13 @@ export function GridPreviewBox({
 }) {
   return (
     <StyledGridPreviewBox
-      color={color}
+      $color={color}
       style={style}
-      pos={pos}
-      windowWidth={windowWidth}
-      windowHeight={windowHeight}
-      isListening={isListening}
-      isError={isError}
+      $pos={pos}
+      $windowWidth={windowWidth}
+      $windowHeight={windowHeight}
+      $isListening={isListening}
+      $isError={isError}
     >
       <StyledGridInfo className={isSmall ? 'small' : undefined}>
         <StyledGridLabel>
@@ -1857,8 +1857,8 @@ function GridInput({
     <StyledGridInputContainer style={style}>
       <StyledGridInput
         value={spaceValue}
-        color={idColor(spaceValue)}
-        isHighlighted={isHighlighted}
+        $color={idColor(spaceValue)}
+        $isHighlighted={isHighlighted}
         disabled={!roleCan(role, 'mutate-state-doc')}
         onFocus={handleFocus}
         onBlur={handleBlur}
@@ -1955,7 +1955,7 @@ function GridControls({
   return (
     <StyledGridControlsContainer style={style} onMouseDown={onMouseDown}>
       {isDisplaying && (
-        <StyledGridButtons side="left">
+        <StyledGridButtons $side="left">
           {showDebug ? (
             <>
               {roleCan(role, 'reload-view') && (
@@ -1983,7 +1983,7 @@ function GridControls({
               )}
               {roleCan(role, 'mutate-state-doc') && (
                 <StyledSmallButton
-                  isActive={isSwapping}
+                  $isActive={isSwapping}
                   onClick={handleSwapClick}
                   tabIndex={1}
                 >
@@ -1999,10 +1999,10 @@ function GridControls({
           )}
         </StyledGridButtons>
       )}
-      <StyledGridButtons side="right">
+      <StyledGridButtons $side="right">
         {roleCan(role, 'set-view-blurred') && (
           <StyledButton
-            isActive={isBlurred}
+            $isActive={isBlurred}
             onClick={handleBlurClick}
             tabIndex={1}
           >
@@ -2011,8 +2011,8 @@ function GridControls({
         )}
         {roleCan(role, 'set-listening-view') && (
           <StyledButton
-            isActive={isListening || isBackgroundListening}
-            activeColor={
+            $isActive={isListening || isBackgroundListening}
+            $activeColor={
               isListening ? 'red' : Color('red').desaturate(0.5).hsl().string()
             }
             onClick={handleListeningClick}
@@ -2201,13 +2201,13 @@ const StyledStreamDelayBox = styled.div`
   color: var(--text);
 `
 
-const StyledDataContainer = styled.div<{ isConnected?: boolean }>`
-  opacity: ${({ isConnected }) => (isConnected ? 1 : 0.5)};
+const StyledDataContainer = styled.div<{ $isConnected?: boolean }>`
+  opacity: ${({ $isConnected }) => ($isConnected ? 1 : 0.5)};
 `
 
 const StyledButton = styled.button<{
-  isActive?: boolean
-  activeColor?: string
+  $isActive?: boolean
+  $activeColor?: string
 }>`
   display: flex;
   align-items: center;
@@ -2224,11 +2224,11 @@ const StyledButton = styled.button<{
     border-color: var(--text-faint);
   }
 
-  ${({ isActive, activeColor = 'red' }) =>
-    isActive &&
+  ${({ $isActive, $activeColor = 'red' }) =>
+    $isActive &&
     `
-      border-color: ${Color(activeColor).hsl().string()};
-      background: ${Color(activeColor).hsl().string()};
+      border-color: ${Color($activeColor).hsl().string()};
+      background: ${Color($activeColor).hsl().string()};
       color: #fff;
     `};
 
@@ -2267,42 +2267,42 @@ const StyledGridInfo = styled.div`
 `
 
 const StyledGridPreviewBox = styled.div.attrs<{
-  color: ColorInstance
-  isError: boolean
-  pos: ViewPos
-  windowWidth: number
-  windowHeight: number
-  isListening: boolean
-  borderWidth?: number
+  $color: ColorInstance
+  $isError: boolean
+  $pos: ViewPos
+  $windowWidth: number
+  $windowHeight: number
+  $isListening: boolean
+  $borderWidth?: number
 }>(() => ({
-  borderWidth: 2,
+  $borderWidth: 2,
 }))`
   display: flex;
   align-items: center;
   justify-content: center;
   position: absolute;
-  background: ${({ color }) =>
-    Color(color).lightness(50).hsl().string() || '#333'};
+  background: ${({ $color }) =>
+    Color($color).lightness(50).hsl().string() || '#333'};
   border: 0 solid
-    ${({ isError }) =>
-      isError ? Color('red').hsl().string() : Color('black').hsl().string()};
-  border-left-width: ${({ pos, borderWidth }) =>
-    pos.x === 0 ? 0 : borderWidth}px;
-  border-right-width: ${({ pos, borderWidth, windowWidth }) =>
-    pos.x + pos.width === windowWidth ? 0 : borderWidth}px;
-  border-top-width: ${({ pos, borderWidth }) =>
-    pos.y === 0 ? 0 : borderWidth}px;
-  border-bottom-width: ${({ pos, borderWidth, windowHeight }) =>
-    pos.y + pos.height === windowHeight ? 0 : borderWidth}px;
-  box-shadow: ${({ isListening }) =>
-    isListening ? `0 0 0 4px red inset` : 'none'};
+    ${({ $isError }) =>
+      $isError ? Color('red').hsl().string() : Color('black').hsl().string()};
+  border-left-width: ${({ $pos, $borderWidth }) =>
+    $pos.x === 0 ? 0 : $borderWidth}px;
+  border-right-width: ${({ $pos, $borderWidth, $windowWidth }) =>
+    $pos.x + $pos.width === $windowWidth ? 0 : $borderWidth}px;
+  border-top-width: ${({ $pos, $borderWidth }) =>
+    $pos.y === 0 ? 0 : $borderWidth}px;
+  border-bottom-width: ${({ $pos, $borderWidth, $windowHeight }) =>
+    $pos.y + $pos.height === $windowHeight ? 0 : $borderWidth}px;
+  box-shadow: ${({ $isListening }) =>
+    $isListening ? `0 0 0 4px red inset` : 'none'};
   box-sizing: border-box;
   overflow: hidden;
   user-select: none;
 
   ${StyledGridInfo} {
-    background: ${({ color }) =>
-      Color(color).lightness(50).hsl().string() || '#333'};
+    background: ${({ $color }) =>
+      Color($color).lightness(50).hsl().string() || '#333'};
   }
 `
 
@@ -2374,31 +2374,31 @@ const StyledGridInputContainer = styled.div`
   position: absolute;
 `
 
-const StyledGridButtons = styled.div<{ side?: 'left' | 'right' }>`
+const StyledGridButtons = styled.div<{ $side?: 'left' | 'right' }>`
   display: flex;
   position: absolute;
-  ${({ side }) =>
-    side === 'left' ? 'top: 0; left: 0' : 'bottom: 0; right: 0'};
+  ${({ $side }) =>
+    $side === 'left' ? 'top: 0; left: 0' : 'bottom: 0; right: 0'};
 
   ${StyledButton} {
     margin: 5px;
-    ${({ side }) => (side === 'left' ? 'margin-right: 0' : 'margin-left: 0')};
+    ${({ $side }) => ($side === 'left' ? 'margin-right: 0' : 'margin-left: 0')};
   }
 `
 
 const StyledGridInput = styled(LazyChangeInput)<{
-  color: ColorInstance
-  isHighlighted?: boolean
+  $color: ColorInstance
+  $isHighlighted?: boolean
 }>`
   width: 100%;
   height: 100%;
   outline: 1px solid rgba(0, 0, 0, 0.5);
   border: none;
   padding: 0;
-  background: ${({ color, isHighlighted }) =>
-    isHighlighted
-      ? Color(color).lightness(90).hsl().string()
-      : Color(color).lightness(75).hsl().string()};
+  background: ${({ $color, $isHighlighted }) =>
+    $isHighlighted
+      ? Color($color).lightness(90).hsl().string()
+      : Color($color).lightness(75).hsl().string()};
   font-size: 20px;
   text-align: center;
 
@@ -2419,14 +2419,14 @@ const StyledGridControlsContainer = styled.div`
 `
 
 const StyledGridContainer = styled.div<{
-  windowWidth: number
-  windowHeight: number
+  $windowWidth: number
+  $windowHeight: number
 }>`
   position: relative;
   /* Responsive: keep the wall's aspect ratio but fit the available space
      instead of a hard-coded pixel size, so the layout never overflows. */
-  aspect-ratio: ${({ windowWidth, windowHeight }) =>
-    `${windowWidth} / ${windowHeight}`};
+  aspect-ratio: ${({ $windowWidth, $windowHeight }) =>
+    `${$windowWidth} / ${$windowHeight}`};
   width: 100%;
   max-height: 100%;
   margin: 0 auto;

--- a/packages/streamwall-control-ui/src/transientProps.test.tsx
+++ b/packages/streamwall-control-ui/src/transientProps.test.tsx
@@ -1,0 +1,109 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import type { StreamDelayStatus } from 'streamwall-shared'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import * as Y from 'yjs'
+import type { StreamwallConnection } from './index.tsx'
+import { ControlUI } from './index.tsx'
+
+// react-icons renders through preact/compat's Context.Consumer, which
+// currently crashes under this package's happy-dom test environment
+// (unrelated to the markup under test here) - stub the icons out so the
+// component's own rendering logic can be exercised in isolation.
+vi.mock('react-icons/fa', () => ({
+  FaExchangeAlt: () => null,
+  FaExclamationTriangle: () => null,
+  FaRedoAlt: () => null,
+  FaRegLifeRing: () => null,
+  FaRegWindowMaximize: () => null,
+  FaSyncAlt: () => null,
+  FaVideoSlash: () => null,
+  FaVolumeUp: () => null,
+}))
+vi.mock('react-icons/md', () => ({
+  MdOutlineStayCurrentLandscape: () => null,
+  MdOutlineStayCurrentPortrait: () => null,
+}))
+// react-hotkeys-hook resolves its own copy of `react` (bypassing this
+// package's `react` -> `preact/compat` test alias), which crashes under
+// happy-dom with an "Invalid hook call" error unrelated to the markup under
+// test here - stub it out so the component's own rendering logic can be
+// exercised in isolation.
+vi.mock('react-hotkeys-hook', () => ({
+  useHotkeys: () => {},
+}))
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+// styled-components v6 forwards any non-`$`-prefixed custom prop that isn't a
+// recognized HTML attribute straight onto the DOM node. Each of these is a
+// custom prop consumed by a styled component in this file (see #152) and must
+// never show up as a literal attribute in the rendered markup.
+const leakedPropNames = [
+  'direction',
+  'flex',
+  'gap',
+  'scroll',
+  'minheight',
+  'isconnected',
+  'isactive',
+  'activecolor',
+]
+
+function renderControlUI(): HTMLDivElement {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+
+  const delayState: StreamDelayStatus = {
+    isConnected: true,
+    delaySeconds: 0,
+    restartSeconds: 0,
+    isCensored: false,
+    isStreamRunning: true,
+    startTime: 0,
+    state: 'idle',
+  }
+
+  const connection: StreamwallConnection = {
+    isConnected: true,
+    role: 'operator',
+    send: () => {},
+    sharedState: { views: {} },
+    stateDoc: new Y.Doc(),
+    config: undefined,
+    streams: [],
+    customStreams: [],
+    views: [],
+    stateIdxMap: new Map(),
+    delayState,
+    authState: undefined,
+  }
+
+  act(() => {
+    render(<ControlUI connection={connection} />, container!)
+  })
+  return container
+}
+
+describe('styled-component custom props (transient props)', () => {
+  test('never leak onto rendered DOM elements as literal attributes', () => {
+    const root = renderControlUI()
+
+    for (const el of root.querySelectorAll('*')) {
+      for (const propName of leakedPropNames) {
+        expect(
+          el.hasAttribute(propName),
+          `<${el.tagName.toLowerCase()}> unexpectedly has a "${propName}" attribute`,
+        ).toBe(false)
+      }
+    }
+  })
+})

--- a/packages/streamwall/src/renderer/OverlayViewTile.test.tsx
+++ b/packages/streamwall/src/renderer/OverlayViewTile.test.tsx
@@ -112,4 +112,41 @@ describe('OverlayViewTile', () => {
     expect(tile.textContent).toContain('Example Stream')
     expect(tile.querySelector('[data-icon="warning"]')).toBeNull()
   })
+
+  test('does not leak custom styled-component props onto the DOM nodes (#152)', () => {
+    const data: StreamData = {
+      _id: 'a',
+      _dataSource: 'test',
+      kind: 'video',
+      link: 'https://example.com/stream',
+      source: 'Example',
+      label: 'Example Stream',
+      city: 'Portland',
+      state: 'OR',
+    }
+    const tile = renderTile({
+      data,
+      isError: false,
+      isListening: true,
+      isBlurred: true,
+      isLoading: true,
+      activeColor: '#f00',
+    })
+
+    for (const el of tile.querySelectorAll('*')) {
+      for (const propName of [
+        'position',
+        'islistening',
+        'activecolor',
+        'isvisible',
+        'isblurred',
+        'isdesaturated',
+      ]) {
+        expect(
+          el.hasAttribute(propName),
+          `<${el.tagName.toLowerCase()}> unexpectedly has a "${propName}" attribute`,
+        ).toBe(false)
+      }
+    }
+  })
 })

--- a/packages/streamwall/src/renderer/OverlayViewTile.tsx
+++ b/packages/streamwall/src/renderer/OverlayViewTile.tsx
@@ -58,12 +58,12 @@ export function OverlayViewTile({
 
   return (
     <>
-      <FilterCover isBlurred={isBlurred} isDesaturated={isLoading} />
+      <FilterCover $isBlurred={isBlurred} $isDesaturated={isLoading} />
       {hasTitle && (
         <StreamTitle
-          position={position}
-          activeColor={activeColor}
-          isListening={isListening}
+          $position={position}
+          $activeColor={activeColor}
+          $isListening={isListening}
         >
           <StreamIcon url={url} />
           <span>{data.label ? data.label : <>{data.source}</>}</span>
@@ -78,7 +78,7 @@ export function OverlayViewTile({
           </span>
         </StreamLocation>
       )}
-      <LoadingSpinner isVisible={isLoading} />
+      <LoadingSpinner $isVisible={isLoading} />
     </>
   )
 }
@@ -112,19 +112,19 @@ function StreamIcon({ url }: { url: string }) {
 }
 
 const StreamTitle = styled.div<{
-  position: StreamData['labelPosition']
-  isListening: boolean
-  activeColor: string
+  $position: StreamData['labelPosition']
+  $isListening: boolean
+  $activeColor: string
 }>`
   position: absolute;
-  ${({ position }) => {
-    if (position === 'top-left') {
+  ${({ $position }) => {
+    if ($position === 'top-left') {
       return `top: 0; left: 0;`
-    } else if (position === 'top-right') {
+    } else if ($position === 'top-right') {
       return `top: 0; right: 0;`
-    } else if (position === 'bottom-right') {
+    } else if ($position === 'bottom-right') {
       return `bottom: 0; right: 0;`
-    } else if (position === 'bottom-left') {
+    } else if ($position === 'bottom-left') {
       return `bottom: 0; left: 0;`
     }
   }}
@@ -141,8 +141,8 @@ const StreamTitle = styled.div<{
   color: white;
   text-shadow: 0 0 4px black;
   letter-spacing: -0.025em;
-  background: ${({ isListening, activeColor }) =>
-    Color(isListening ? activeColor : 'black')
+  background: ${({ $isListening, $activeColor }) =>
+    Color($isListening ? $activeColor : 'black')
       .alpha(0.5)
       .toString()};
   border-radius: 4px;
@@ -203,31 +203,35 @@ const StreamLocation = styled.div`
   }
 `
 
-const LoadingSpinner = styled(TailSpin)<{ isVisible: boolean }>`
+const LoadingSpinner = styled(TailSpin)<{ $isVisible: boolean }>`
   position: absolute;
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
   width: 100px;
   height: 100px;
-  opacity: ${({ isVisible }) => (isVisible ? 0.5 : 0)};
+  opacity: ${({ $isVisible }) => ($isVisible ? 0.5 : 0)};
 
   transition:
     opacity 0.5s ease-in-out,
-    visibility 0s ${({ isVisible }) => (isVisible ? '0s' : '0.5s')};
-  visibility: ${({ isVisible }) => (isVisible ? 'visible' : 'hidden')};
+    visibility 0s ${({ $isVisible }) => ($isVisible ? '0s' : '0.5s')};
+  visibility: ${({ $isVisible }) => ($isVisible ? 'visible' : 'hidden')};
 `
 
-const FilterCover = styled.div<{ isBlurred: boolean; isDesaturated: boolean }>`
+const FilterCover = styled.div<{
+  $isBlurred: boolean
+  $isDesaturated: boolean
+}>`
   position: absolute;
   left: 0;
   right: 0;
   top: 0;
   bottom: 0;
-  backdrop-filter: ${({ isBlurred, isDesaturated }) =>
-    [isBlurred ? 'blur(30px)' : '', isDesaturated ? 'grayscale(75%)' : ''].join(
-      ' ',
-    )};
+  backdrop-filter: ${({ $isBlurred, $isDesaturated }) =>
+    [
+      $isBlurred ? 'blur(30px)' : '',
+      $isDesaturated ? 'grayscale(75%)' : '',
+    ].join(' ')};
 `
 
 const ErrorCover = styled.div`

--- a/packages/streamwall/src/renderer/overlay.tsx
+++ b/packages/streamwall/src/renderer/overlay.tsx
@@ -58,12 +58,12 @@ function Overlay({
           matchesState('displaying.running.playback.stalled', state)
         return (
           <SpaceBorder
-            pos={pos}
-            windowWidth={width}
-            windowHeight={height}
-            activeColor={activeColor}
-            isListening={isListening}
-            isError={isError}
+            $pos={pos}
+            $windowWidth={width}
+            $windowHeight={height}
+            $activeColor={activeColor}
+            $isListening={isListening}
+            $isError={isError}
           >
             <OverlayViewTile
               url={content.url}
@@ -129,7 +129,7 @@ function VersionFooter() {
     }
   }, [])
   return (
-    <VersionText isShowing={isShowing}>
+    <VersionText $isShowing={isShowing}>
       <strong>streamwall</strong> {packageInfo.version}
     </VersionText>
   )
@@ -140,40 +140,40 @@ const OverlayContainer = styled.div`
 `
 
 const SpaceBorder = styled.div.attrs<{
-  pos: ViewPos
-  windowWidth: number
-  windowHeight: number
-  activeColor: string
-  isListening: boolean
-  isError?: boolean
-  borderWidth?: number
+  $pos: ViewPos
+  $windowWidth: number
+  $windowHeight: number
+  $activeColor: string
+  $isListening: boolean
+  $isError?: boolean
+  $borderWidth?: number
 }>(() => ({
-  borderWidth: 2,
+  $borderWidth: 2,
 }))`
   display: flex;
   align-items: flex-start;
   position: fixed;
-  left: ${({ pos }) => pos.x}px;
-  top: ${({ pos }) => pos.y}px;
-  width: ${({ pos }) => pos.width}px;
-  height: ${({ pos }) => pos.height}px;
-  border: 0 solid ${({ isError }) => (isError ? 'red' : 'black')};
-  border-left-width: ${({ pos, borderWidth }) =>
-    pos.x === 0 ? 0 : borderWidth}px;
-  border-right-width: ${({ pos, borderWidth, windowWidth }) =>
-    pos.x + pos.width === windowWidth ? 0 : borderWidth}px;
-  border-top-width: ${({ pos, borderWidth }) =>
-    pos.y === 0 ? 0 : borderWidth}px;
-  border-bottom-width: ${({ pos, borderWidth, windowHeight }) =>
-    pos.y + pos.height === windowHeight ? 0 : borderWidth}px;
-  box-shadow: ${({ isListening, activeColor }) =>
-    isListening ? `0 0 10px ${activeColor} inset` : 'none'};
+  left: ${({ $pos }) => $pos.x}px;
+  top: ${({ $pos }) => $pos.y}px;
+  width: ${({ $pos }) => $pos.width}px;
+  height: ${({ $pos }) => $pos.height}px;
+  border: 0 solid ${({ $isError }) => ($isError ? 'red' : 'black')};
+  border-left-width: ${({ $pos, $borderWidth }) =>
+    $pos.x === 0 ? 0 : $borderWidth}px;
+  border-right-width: ${({ $pos, $borderWidth, $windowWidth }) =>
+    $pos.x + $pos.width === $windowWidth ? 0 : $borderWidth}px;
+  border-top-width: ${({ $pos, $borderWidth }) =>
+    $pos.y === 0 ? 0 : $borderWidth}px;
+  border-bottom-width: ${({ $pos, $borderWidth, $windowHeight }) =>
+    $pos.y + $pos.height === $windowHeight ? 0 : $borderWidth}px;
+  box-shadow: ${({ $isListening, $activeColor }) =>
+    $isListening ? `0 0 10px ${$activeColor} inset` : 'none'};
   box-sizing: border-box;
   pointer-events: none;
   user-select: none;
 `
 
-const VersionText = styled.div<{ isShowing: boolean }>`
+const VersionText = styled.div<{ $isShowing: boolean }>`
   position: fixed;
   bottom: 4px;
   right: 4px;
@@ -187,7 +187,7 @@ const VersionText = styled.div<{ isShowing: boolean }>`
   backdrop-filter: blur(30px);
   padding: 1px 4px;
   border-bottom-left-radius: 4px;
-  opacity: ${({ isShowing }) => (isShowing ? '.65' : '.35')};
+  opacity: ${({ $isShowing }) => ($isShowing ? '.65' : '.35')};
   transition: ease-out 500ms all;
 `
 


### PR DESCRIPTION
## Problem

In styled-components v6, non-`$`-prefixed custom props are forwarded to
the underlying DOM element unless they are filtered. Many styled
components in the control UI and overlay renderer took custom props
(`isActive`, `direction`, `flex`, `gap`, `scroll`, `minHeight`,
`isConnected`, `pos`, `windowWidth`, `windowHeight`, `isListening`,
`isError`, `color`, `side`, `isHighlighted`, `activeColor`,
`isShowing`, `position`, `isVisible`, `isBlurred`, `isDesaturated`)
without the `$` prefix, so they leaked onto the DOM as invalid HTML
attributes and produced React unknown-attribute console warnings.

This was pre-existing runtime behavior surfaced (but deliberately left
unchanged) by #151, which added honest TypeScript typings for these
props without altering their names.

## Solution

Renamed every affected custom prop to its `$`-prefixed transient form,
at both the styled-component definition and every call site, across:

- `packages/streamwall-control-ui/src/index.tsx` — `Stack`,
  `StyledDataContainer`, `StyledButton`/`StyledSmallButton`,
  `StyledGridPreviewBox`, `StyledGridButtons`, `StyledGridInput`,
  `StyledGridContainer`
- `packages/streamwall/src/renderer/overlay.tsx` — `SpaceBorder`,
  `VersionText`
- `packages/streamwall/src/renderer/OverlayViewTile.tsx` —
  `StreamTitle`, `LoadingSpinner`, `FilterCover`

This is a pure rename with no behavioral or visual change: every
consuming template-literal interpolation and JSX call site was updated
in lockstep, verified by the regression tests below plus `tsc
--noEmit` (which would fail on any missed prop reference since these
are now typed generics).

`StyledId`'s existing `$color`/`$disabled` props (already correctly
transient) were left untouched.

## Testing

- Extended `packages/streamwall-control-ui/src/GridPreviewBox.test.tsx`
  and `packages/streamwall/src/renderer/OverlayViewTile.test.tsx` with
  assertions that none of the renamed props appear as literal DOM
  attributes on the rendered tree.
- Added `packages/streamwall-control-ui/src/transientProps.test.tsx`,
  which renders `ControlUI` end-to-end (with a minimal fake connection)
  and asserts across the whole subtree that `direction`, `flex`, `gap`,
  `scroll`, `minheight`, `isconnected`, `isactive`, and `activecolor`
  never appear as attributes.
- All three new/extended tests were confirmed red (failing due to real
  leaked attributes) before the rename and green after.
- `SpaceBorder`/`VersionText` in `overlay.tsx` are not independently
  covered by a new test: that module still self-renders
  (`render(<App />, document.body)`) at import time, the same
  constraint that motivated extracting `OverlayViewTile` out of it in
  #176. Extracting further seams there is out of scope for this
  rename; the prop-rename itself is exercised transitively by the
  existing `layerFrameSandbox.sources.test.ts` import of the module and
  verified manually via `tsc --noEmit`.
- Full quality gate green: `npm run format:check`, `npm run lint`,
  `npm run typecheck`, `npm test` (all workspaces).

## Risks / breaking changes

None. Internal prop rename only; no public API, config, or persisted
state is affected.

Closes #152