### PR TITLE
fix(test): resolve react-icons and styled-components to preact/compat in tests

### DIFF
--- a/packages/streamwall-control-ui/src/GridPreviewBox.test.tsx
+++ b/packages/streamwall-control-ui/src/GridPreviewBox.test.tsx
@@ -1,20 +1,8 @@
 import Color from 'color'
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
-import { afterEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, describe, expect, test } from 'vitest'
 import { GridPreviewBox } from './index.tsx'
-
-// react-icons renders through preact/compat's Context.Consumer, which
-// currently crashes under this package's happy-dom test environment
-// (unrelated to the markup under test here) - stub the icon out so the
-// component's own rendering logic can be exercised in isolation.
-vi.mock('react-icons/fa', () => ({
-  FaExclamationTriangle: () => <i data-icon="warning" />,
-}))
-vi.mock('react-icons/md', () => ({
-  MdOutlineStayCurrentLandscape: () => null,
-  MdOutlineStayCurrentPortrait: () => null,
-}))
 
 let container: HTMLDivElement | undefined
 
@@ -62,7 +50,8 @@ describe('GridPreviewBox', () => {
       errorReason: 'Connection lost',
     })
 
-    const badge = box.querySelector('[data-icon="warning"]')?.parentElement
+    const badge = box.querySelector('svg')?.parentElement
+    expect(badge?.tagName).toBe('DIV')
     expect(badge?.textContent).toContain('Connection lost')
     expect(badge?.getAttribute('title')).toBe('Connection lost')
   })
@@ -73,7 +62,7 @@ describe('GridPreviewBox', () => {
       errorReason: null,
     })
 
-    const badge = box.querySelector('[data-icon="warning"]')?.parentElement
+    const badge = box.querySelector('svg')?.parentElement
     expect(badge?.textContent).toContain('Stream error')
     expect(badge?.hasAttribute('title')).toBe(false)
   })
@@ -81,7 +70,7 @@ describe('GridPreviewBox', () => {
   test('does not render the error badge for a non-error view', () => {
     const box = renderBox({ isError: false })
 
-    expect(box.querySelector('[data-icon="warning"]')).toBeNull()
+    expect(box.querySelector('svg')).toBeNull()
   })
 
   test('marks the info panel as small so the reason text collapses on small cells', () => {

--- a/packages/streamwall-control-ui/src/preactCompatInterop.test.tsx
+++ b/packages/streamwall-control-ui/src/preactCompatInterop.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment happy-dom
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { FaExclamationTriangle } from 'react-icons/fa'
+import styled from 'styled-components'
+import { afterEach, describe, expect, test } from 'vitest'
+
+// Regression test for https://github.com/NilsR0711/streamwall/issues/177:
+// react-icons and styled-components must resolve `react` to `preact/compat`
+// (see vitest.config.ts) rather than the real `react` package that npm
+// installs as their peer dependency, or rendering either throws / produces
+// the wrong DOM tag.
+
+const Box = styled.div`
+  color: red;
+`
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+function mount(vnode: preact.ComponentChild) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => render(vnode, container!))
+  return container
+}
+
+describe('preact/compat interop', () => {
+  test('renders a react-icons icon as a real svg', () => {
+    const tile = mount(<FaExclamationTriangle />)
+    expect(tile.querySelector('svg')).not.toBeNull()
+  })
+
+  test('renders a styled-components element with its real DOM tag', () => {
+    const tile = mount(<Box />)
+    expect(tile.firstElementChild?.tagName).toBe('DIV')
+  })
+})

--- a/packages/streamwall-control-ui/vitest.config.ts
+++ b/packages/streamwall-control-ui/vitest.config.ts
@@ -5,12 +5,25 @@ import { defineConfig } from 'vitest/config'
 // a DOM. `preact/compat` is aliased for `react`, matching how react-icons and
 // react-hotkeys-hook resolve at runtime, and is loaded in the setup file so
 // `onChange` fires on input (React-style), exactly as it does in the app.
+//
+// `react-icons` and `styled-components` ship both a CJS build (whose internal
+// `require('react')` bypasses the alias above under Vitest's SSR-like module
+// runner) and an ESM build (whose `import ... from 'react'` resolves through
+// Vite's resolver, honoring the alias). `mainFields` prefers their ESM/browser
+// builds, and `deps.inline` forces both through Vite's transform pipeline
+// instead of being loaded as opaque external CJS modules - without both, they
+// resolve the real `react` package instead of `preact/compat`, which crashes
+// react-icons (`Cannot add property __, object is not extensible`, a frozen
+// React element hitting Preact's reconciler) and makes styled-components
+// render elements with their generated class name as the tag instead of the
+// real DOM tag.
 export default defineConfig({
   esbuild: {
     jsx: 'automatic',
     jsxImportSource: 'preact',
   },
   resolve: {
+    mainFields: ['browser', 'module', 'main'],
     alias: {
       react: 'preact/compat',
       'react-dom': 'preact/compat',
@@ -19,5 +32,10 @@ export default defineConfig({
   test: {
     environment: 'happy-dom',
     setupFiles: ['./src/test-setup.ts'],
+    server: {
+      deps: {
+        inline: [/react-icons/, /styled-components/],
+      },
+    },
   },
 })

--- a/packages/streamwall/src/renderer/OverlayViewTile.test.tsx
+++ b/packages/streamwall/src/renderer/OverlayViewTile.test.tsx
@@ -5,23 +5,14 @@ import type { StreamData } from 'streamwall-shared'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { OverlayViewTile } from './OverlayViewTile'
 
-// react-icons renders through preact/compat's Context.Consumer, which
-// currently crashes under the happy-dom test environment (unrelated to the
-// markup under test here) - stub the icons out so the tile's own rendering
-// logic can be exercised in isolation.
-vi.mock('react-icons/fa', () => ({
-  FaExclamationTriangle: () => <i data-icon="warning" />,
-  FaFacebook: () => null,
-  FaInstagram: () => null,
-  FaMapMarkerAlt: () => null,
-  FaTiktok: () => null,
-  FaTwitch: () => null,
-  FaVolumeUp: () => null,
-  FaYoutube: () => null,
-}))
-vi.mock('react-icons/ri', () => ({
-  RiKickFill: () => null,
-  RiTwitterXFill: () => null,
+// Unlike react-icons and styled-components (see vitest.config.ts),
+// svg-loaders-react ships CJS only, so it has no ESM build for Vite's
+// resolver to route through the `react` -> `preact/compat` alias - it always
+// resolves the real `react` package, which crashes when preact/compat's
+// forwardRef-wrapped `styled(TailSpin)` renders it. Stub it out so the
+// tile's own rendering logic can be exercised in isolation.
+vi.mock('svg-loaders-react', () => ({
+  TailSpin: () => null,
 }))
 
 let container: HTMLDivElement | undefined
@@ -77,7 +68,7 @@ describe('OverlayViewTile', () => {
 
     expect(tile.textContent).toContain('Example Stream')
     expect(tile.textContent).toContain('Stream unavailable')
-    expect(tile.querySelector('[data-icon="warning"]')).not.toBeNull()
+    expect(tile.querySelector('svg')).not.toBeNull()
   })
 
   test('falls back to a generic label when the errored stream has no title', () => {
@@ -110,6 +101,6 @@ describe('OverlayViewTile', () => {
     expect(tile.textContent).not.toContain('Stream error')
     expect(tile.textContent).not.toContain('Stream unavailable')
     expect(tile.textContent).toContain('Example Stream')
-    expect(tile.querySelector('[data-icon="warning"]')).toBeNull()
+    expect(tile.querySelector('svg')).toBeNull()
   })
 })

--- a/packages/streamwall/vitest.config.ts
+++ b/packages/streamwall/vitest.config.ts
@@ -4,15 +4,38 @@ import { defineConfig } from 'vitest/config'
 // components. Component tests opt into a DOM via `// @vitest-environment
 // happy-dom` per file. `preact/compat` is aliased for `react`/`react-dom`,
 // matching how react-icons and react-hotkeys-hook resolve at runtime.
+//
+// `react-icons` and `styled-components` ship both a CJS build (whose internal
+// `require('react')` bypasses the alias above under Vitest's SSR-like module
+// runner) and an ESM build (whose `import ... from 'react'` resolves through
+// Vite's resolver, honoring the alias). `mainFields` prefers their ESM/browser
+// builds, and `deps.inline` forces both through Vite's transform pipeline
+// instead of being loaded as opaque external CJS modules - without both, they
+// resolve the real `react` package instead of `preact/compat`, which crashes
+// react-icons (`Cannot add property __, object is not extensible`, a frozen
+// React element hitting Preact's reconciler) and makes styled-components
+// render elements with their generated class name as the tag instead of the
+// real DOM tag. `svg-loaders-react` (used via `styled(TailSpin)` in
+// OverlayViewTile) has no ESM build, so this fix doesn't reach it - see the
+// `vi.mock('svg-loaders-react', ...)` in OverlayViewTile.test.tsx for the
+// remaining workaround.
 export default defineConfig({
   esbuild: {
     jsx: 'automatic',
     jsxImportSource: 'preact',
   },
   resolve: {
+    mainFields: ['browser', 'module', 'main'],
     alias: {
       react: 'preact/compat',
       'react-dom': 'preact/compat',
+    },
+  },
+  test: {
+    server: {
+      deps: {
+        inline: [/react-icons/, /styled-components/],
+      },
     },
   },
 })


### PR DESCRIPTION
## Problem

`react-icons` and `styled-components` break when rendered directly under this repo's `vitest` + `preact` (non-React) + `happy-dom` component test stack:

- `react-icons` (e.g. `FaExclamationTriangle`) throws `TypeError: Cannot add property __, object is not extensible` from Preact's reconciler.
- `styled-components` (e.g. `styled.div`) renders elements with their generated CSS class name as the DOM tag (`.sc-bdvvNz`) instead of the real tag (`DIV`).

Neither reproduces in the real Electron/browser app - only under this test harness. The tests added in #176 worked around both by mocking `react-icons` and avoiding tag-based DOM queries.

## Root cause

`vitest.config.ts` aliases `react`/`react-dom` to `preact/compat` so these libraries pick up Preact instead of React at runtime. But `react-icons` and `styled-components` each ship both a CJS build and an ESM build:

- Their **CJS build**'s internal `require('react')` is resolved as an opaque external module by vitest's SSR-like module runner, which bypasses `resolve.alias` entirely.
- Their **ESM build**'s `import ... from 'react'` goes through Vite's resolver, which correctly honors the alias.

Under the existing config, vitest was loading the CJS build for both packages, so they resolved the real `react` package - installed automatically as their npm peer dependency - instead of `preact/compat`. That's what caused the crash (a frozen React element hitting Preact's non-compat reconciler) and the wrong-tag rendering (styled-components' `forwardRef`/`$$typeof` interop checks - see [styled-components#5736](https://github.com/styled-components/styled-components/pull/5736) - never got a chance to run against a `preact/compat`-shaped component).

## Fix

In both `packages/streamwall/vitest.config.ts` and `packages/streamwall-control-ui/vitest.config.ts`:

- `resolve.mainFields: ['browser', 'module', 'main']` makes Vite prefer `react-icons`'/`styled-components`' ESM/browser builds.
- `test.server.deps.inline: [/react-icons/, /styled-components/]` forces both through Vite's transform pipeline instead of being loaded as opaque external CJS modules, so their ESM `import` specifiers actually resolve through the `react` alias.

One residual gap: `svg-loaders-react` (used via `styled(TailSpin)` in `OverlayViewTile`, for the loading spinner) ships CJS only, with no ESM build for this fix to route through - it still resolves real `react` and still crashes. It's mocked in `OverlayViewTile.test.tsx` the same way `react-icons` used to be, since there's no ESM build to redirect through the alias.

## Testing

- Added `packages/streamwall-control-ui/src/preactCompatInterop.test.tsx`, a focused regression test that renders a real (unmocked) `react-icons` icon and a real `styled-components` element and asserts the actual rendered DOM (a real `<svg>`, and the real `DIV` tag) - verified red (fails without the config fix) before green (passes with it).
- Removed the `vi.mock('react-icons/...')` workarounds from `GridPreviewBox.test.tsx` and `OverlayViewTile.test.tsx` now that the underlying resolution is fixed, switching their assertions from a mock-only `data-icon` attribute to querying the real rendered `<svg>` / DOM tag - this also gives the styled-components error badge wrapper a genuine tag-name assertion, which wasn't previously possible per the issue.
- Full workspace test suite (`npm run test --workspaces`), `npm run typecheck --workspaces`, and `npm run lint` all pass.

## Risks / breaking changes

None expected - this is test-tooling only (`vitest.config.ts` in the two Preact packages, plus the two test files); no production code paths change.

Closes #177