### PR TITLE
chore: add .prettierignore for build output

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,19 @@
+# Dependencies
+node_modules/
+
+# Build output (mirrors .gitignore entries across all workspaces)
+dist/
+dist-ssr/
+out/
+build/
+.vite/
+.webpack/
+
+# Coverage / logs / caches
+coverage/
+*.log
+.cache/
+.eslintcache
+
+# Package lock (auto-formatted by npm, not by prettier)
+package-lock.json


### PR DESCRIPTION
## Problem

Prettier 3 does not read `.gitignore` — it only honours `.prettierignore`
(plus its built-in `node_modules` ignore). The repo had no
`.prettierignore`, so `npm run format:check` (the documented command and
the CI `checks` step) would lint git-ignored generated build output once it
existed locally, e.g. `packages/streamwall/.vite/**`.

CI passes only by coincidence: the `checks` job runs `format:check` before
`build`, so `.vite/` doesn't exist yet in CI. Any developer running
`format:check` after a local `electron-forge package`/`make` sees spurious
failures, which undermines trust in the command and can mask real
formatting issues.

## Solution

Added a root `.prettierignore` mirroring the generated-output entries from
the workspace `.gitignore` files (`.vite/`, `dist/`, `dist-ssr/`, `out/`,
`build/`, `coverage/`, caches, logs, and `package-lock.json`).

## Testing performed

- Reproduced the bug: ran `electron-forge package` in `packages/streamwall`
  to generate `.vite/`, then ran `npm run format:check` without the new
  file — confirmed 20 files under `.vite/` were flagged.
- Restored `.prettierignore` and re-ran `format:check` — all files pass.
- Removed the generated `.vite/`/`out/` build output before committing.
- Full quality gate (all green): `format:check`, `lint` (all workspaces),
  `typecheck` (all workspaces), `test` (all workspaces — 73 + 30 tests
  passing).

No test file was added — this is a tooling-config change with no
executable behavior (documented per the TDD exception for docs/CI/config
changes).

## Risks / breaking changes

None. Purely a local dev-experience fix; CI behavior is unchanged since
`.vite/` never exists at the point `format:check` runs in CI.

Closes #147