### PR TITLE
chore(tsconfig): modernize module resolution to bundler, drop baseUrl

### DIFF
--- a/packages/streamwall-control-ui/tsconfig.json
+++ b/packages/streamwall-control-ui/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "compilerOptions": {
-    // baseUrl + moduleResolution:node are flagged as deprecated under TS 6 but
-    // are still required here; silence until module resolution is modernized.
-    "ignoreDeprecations": "6.0",
     "target": "ES2024",
-    "module": "commonjs",
+    "module": "esnext",
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -18,9 +15,8 @@
       "react-dom": ["../../node_modules/preact/compat"]
     },
     "lib": ["ES2024", "DOM", "DOM.iterable"],
-    "baseUrl": ".",
     "outDir": "dist",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     // tsc here only type-checks (Vite does the build), so allow the .ts import
     // extensions the shared package requires.

--- a/packages/streamwall/tsconfig.json
+++ b/packages/streamwall/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
-    // baseUrl + moduleResolution:node are flagged as deprecated under TS 6 but
-    // are still required by the Electron/CommonJS build; silence until the
-    // module-resolution modernization is done separately.
-    "ignoreDeprecations": "6.0",
     "target": "ES2024",
-    "module": "commonjs",
+    "module": "esnext",
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -19,9 +15,8 @@
       "react-dom": ["../../node_modules/preact/compat"]
     },
     "lib": ["ES2024", "DOM", "DOM.iterable"],
-    "baseUrl": ".",
     "outDir": "dist",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     // tsc here only type-checks (Vite/Electron Forge does the build), so allow
     // the .ts import extensions the shared package requires.


### PR DESCRIPTION
## Problem

`packages/streamwall/tsconfig.json` and `packages/streamwall-control-ui/tsconfig.json` used the TS6-deprecated `baseUrl: "."` + `moduleResolution: "node"` combo, silenced with `ignoreDeprecations: "6.0"`. This was deliberately deferred follow-up work from #57/#58.

## Solution

- Dropped `baseUrl` and switched both configs to `moduleResolution: "bundler"`.
- Bundler resolution requires a modern `module` setting, so `module` changed from `"commonjs"` to `"esnext"` in both configs — this only affects `tsc`'s type-checking; the actual build output is produced by Vite/Electron Forge/esbuild, which are unaffected.
- `paths` (react/react-dom → preact/compat) continues to resolve correctly without `baseUrl` under `bundler` resolution.
- Removed the `ignoreDeprecations: "6.0"` escape hatch and its explanatory comment, since the deprecated combo is gone.

## Testing performed

No behavior change / no new tests needed (config-only change with no testable runtime behavior) — verified via the full quality gate instead:
- `npm run typecheck` — clean across all 5 packages
- `npm run lint` — clean
- `npm run test` — all existing suites pass (control-server: 73/73, control-ui: 30/30)
- `npm run package -w packages/streamwall` — Electron Forge package build succeeds (Vite bundling unaffected)
- `npm run build` in `streamwall-control-client` — succeeds

## Risks / breaking changes

None expected — this is a type-checker-only configuration change; no runtime code or build tooling behavior changes.

Closes #145