### PR TITLE
fix(config): warn on unknown keys in config.toml

### DIFF
--- a/packages/streamwall/src/main/config.test.ts
+++ b/packages/streamwall/src/main/config.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'vitest'
-import { ConfigError, parseConfigToml, validateConfig } from './config'
+import {
+  ConfigError,
+  findUnknownConfigKeys,
+  parseConfigToml,
+  validateConfig,
+} from './config'
 
 /** A structurally-complete config, as produced by yargs after defaults. */
 function baseConfig() {
@@ -160,5 +165,58 @@ describe('validateConfig', () => {
     const config = baseConfig()
     config.retry['max-retries'] = 2.5
     expect(() => validateConfig(config)).toThrow(ConfigError)
+  })
+})
+
+describe('findUnknownConfigKeys', () => {
+  test('returns nothing for a raw config using only known keys', () => {
+    expect(
+      findUnknownConfigKeys({
+        grid: { cols: 4, rows: 3 },
+        window: { width: 1920 },
+      }),
+    ).toEqual([])
+  })
+
+  test('names a top-level unknown key', () => {
+    expect(findUnknownConfigKeys({ grid: { cols: 4 }, cert: {} })).toEqual([
+      'cert',
+    ])
+  })
+
+  test('names a removed nested key, e.g. the old grid.count', () => {
+    expect(findUnknownConfigKeys({ grid: { count: 3 } })).toEqual([
+      'grid.count',
+    ])
+  })
+
+  test('names a misspelled nested key', () => {
+    expect(findUnknownConfigKeys({ grid: { colls: 4 } })).toEqual([
+      'grid.colls',
+    ])
+  })
+
+  test('reports multiple unknown keys across sections', () => {
+    expect(
+      findUnknownConfigKeys({
+        grid: { cols: 4, count: 3 },
+        twitch: { announce: { tempalte: 't' } },
+      }),
+    ).toEqual(['grid.count', 'twitch.announce.tempalte'])
+  })
+
+  test('does not descend into a key whose value is not a config section', () => {
+    // grid.cols is a number in the schema, not an object — an operator
+    // accidentally nesting a table under it should be reported once, not
+    // walked into.
+    expect(findUnknownConfigKeys({ grid: { cols: { nested: true } } })).toEqual(
+      [],
+    )
+  })
+
+  test('ignores the CLI-only help flag and non-object input', () => {
+    expect(findUnknownConfigKeys({ help: true })).toEqual([])
+    expect(findUnknownConfigKeys(null)).toEqual([])
+    expect(findUnknownConfigKeys('not an object')).toEqual([])
   })
 })

--- a/packages/streamwall/src/main/config.ts
+++ b/packages/streamwall/src/main/config.ts
@@ -105,3 +105,46 @@ export function validateConfig(config: unknown): void {
     )
   }
 }
+
+/**
+ * Recursively finds keys in a raw parsed config object that don't exist in
+ * the schema, returning their dotted paths (e.g. "grid.count"). Meant to run
+ * against the raw TOML tables read from a config file — not the yargs-merged
+ * argv, which carries CLI-only additions (camelCase aliases, `_`, `$0`) that
+ * are never mistakes.
+ *
+ * A key whose schema type isn't an object is treated as a leaf: its value is
+ * never walked into, even if the operator nested a table under it by mistake
+ * (e.g. `[grid.cols]`) — the type check in validateConfig already covers that.
+ */
+export function findUnknownConfigKeys(raw: unknown): string[] {
+  return collectUnknownKeys(raw, streamwallConfigSchema, [])
+}
+
+function collectUnknownKeys(
+  raw: unknown,
+  schema: z.ZodTypeAny,
+  path: string[],
+): string[] {
+  if (
+    typeof raw !== 'object' ||
+    raw === null ||
+    Array.isArray(raw) ||
+    !(schema instanceof z.ZodObject)
+  ) {
+    return []
+  }
+
+  const shape = schema.shape
+  const unknown: string[] = []
+  for (const [key, value] of Object.entries(raw)) {
+    const fieldSchema = shape[key]
+    const keyPath = [...path, key]
+    if (fieldSchema === undefined) {
+      unknown.push(keyPath.join('.'))
+    } else {
+      unknown.push(...collectUnknownKeys(value, fieldSchema, keyPath))
+    }
+  }
+  return unknown
+}

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -19,7 +19,12 @@ import WebSocket from 'ws'
 import yargs from 'yargs'
 import * as Y from 'yjs'
 import { createSessionHostResolver, ensureValidURL } from '../util'
-import { ConfigError, parseConfigToml, validateConfig } from './config'
+import {
+  ConfigError,
+  findUnknownConfigKeys,
+  parseConfigToml,
+  validateConfig,
+} from './config'
 import ControlWindow from './ControlWindow'
 import {
   LocalStreamData,
@@ -119,6 +124,16 @@ export interface StreamwallConfig {
   }
 }
 
+// Warns (does not throw) about keys in a raw parsed config file that the
+// schema doesn't recognize — typos and stale keys (e.g. the removed
+// `grid.count`) that would otherwise be silently dropped and fall back to
+// defaults with no indication anything was wrong.
+function warnUnknownConfigKeys(raw: unknown, source: string) {
+  for (const key of findUnknownConfigKeys(raw)) {
+    console.warn(`Unknown config key "${key}" in "${source}" is ignored.`)
+  }
+}
+
 function parseArgs(): StreamwallConfig {
   // Load config from user data dir, if it exists
   const configPath = join(app.getPath('userData'), 'config.toml')
@@ -133,11 +148,21 @@ function parseArgs(): StreamwallConfig {
     }
   }
 
+  const homeConfig = configText ? parseConfigToml(configText, configPath) : {}
+  if (configText) {
+    warnUnknownConfigKeys(homeConfig, configPath)
+  }
+
   const argv = yargs()
-    .config(configText ? parseConfigToml(configText, configPath) : {})
-    .config('config', (configFilePath) =>
-      parseConfigToml(fs.readFileSync(configFilePath, 'utf-8'), configFilePath),
-    )
+    .config(homeConfig)
+    .config('config', (configFilePath) => {
+      const config = parseConfigToml(
+        fs.readFileSync(configFilePath, 'utf-8'),
+        configFilePath,
+      )
+      warnUnknownConfigKeys(config, configFilePath)
+      return config
+    })
     .group(['grid.cols', 'grid.rows'], 'Grid dimensions')
     .option('grid.cols', {
       number: true,


### PR DESCRIPTION
## Problem

The Zod config schema (`packages/streamwall/src/main/config.ts`) type- and range-checks the *known* keys, but unknown keys are silently dropped. A misspelled or obsolete key (e.g. the now-removed `grid.count`, or a typo like `grid.colls`) is ignored without any feedback, and the operator silently gets defaults instead of the intended value.

## Solution

- Added `findUnknownConfigKeys(raw)` in `config.ts`, which recursively walks a raw parsed config object against the schema's `z.ZodObject` shapes and returns dotted paths (e.g. `grid.count`, `twitch.announce.tempalte`) for anything the schema doesn't recognize. A key whose schema type isn't itself an object is treated as a leaf and never descended into (that mismatch is already caught by `validateConfig`'s type checking).
- Wired it into `parseArgs()` in `index.ts`: after parsing the home `config.toml` and any file passed via `--config`, each raw parsed object is checked and a `console.warn` is logged per unknown key, naming both the file and the key path.
- Deliberately runs against the **raw parsed TOML**, not the yargs-merged `argv` — yargs injects camelCase aliases, `_`, and `$0` into argv, which would otherwise be misreported as unknown keys.
- This is a warning, not a hard error, to preserve forward/backward compatibility with configs carrying extra annotations.

## Architecture decisions

- Kept the detection logic pure and side-effect free in `config.ts` (testable in isolation), with the `console.warn` + file-naming glue living in `index.ts` next to the other startup logging.
- Reused the existing `streamwallConfigSchema` as the single source of truth for known keys, rather than maintaining a separate allowlist that could drift.

## Testing performed

- New `describe('findUnknownConfigKeys', …)` block in `config.test.ts`: no false positives on a fully valid config, top-level unknown key, removed nested key (`grid.count`), misspelled nested key, multiple unknown keys across sections, no descent into an object value nested under a leaf schema key, and CLI-only/non-object input handling.
- Full quality gate run locally: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` (all workspaces), and `npm -w streamwall-control-client run build` — all green.
- No manual index.ts test exists (it's Electron-app wiring, consistent with the rest of that file); the pure logic it calls is fully covered.

## Risks / breaking changes

None. Purely additive logging; behavior for valid configs is unchanged, and unknown keys still fall back to defaults exactly as before — they're now just visible in the log.

Closes #148