### PR TITLE
build(eslint): enable react-hooks/exhaustive-deps for the Preact packages

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@
 // Replaces the legacy .eslintrc.json, which ESLint 9+ no longer reads.
 import js from '@eslint/js'
 import importX from 'eslint-plugin-import-x'
+import reactHooks from 'eslint-plugin-react-hooks'
 import globals from 'globals'
 import tseslint from 'typescript-eslint'
 
@@ -54,6 +55,28 @@ export default tseslint.config(
     files: ['**/*.test.{ts,tsx}'],
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
+    },
+  },
+  {
+    // Preact mirrors the React hooks API via `preact/hooks`, so the React
+    // Hooks rules apply to these Preact-based packages. Scoped to
+    // rules-of-hooks/exhaustive-deps only (not the plugin's full
+    // "recommended" set), since v7's recommended config also pulls in
+    // React Compiler-oriented rules (e.g. purity, immutability, gating)
+    // that don't apply here — this project doesn't use the React Compiler.
+    files: [
+      'packages/streamwall-control-ui/src/**/*.{ts,tsx}',
+      'packages/streamwall-control-client/src/**/*.{ts,tsx}',
+      'packages/streamwall/src/renderer/**/*.{ts,tsx}',
+    ],
+    plugins: {
+      'react-hooks': reactHooks,
+    },
+    rules: {
+      'react-hooks/rules-of-hooks': 'error',
+      // Start at warn to land the tooling without blocking CI; promote to
+      // error once the existing violations it surfaces are cleared.
+      'react-hooks/exhaustive-deps': 'warn',
     },
   },
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "eslint": "^10.7.0",
         "eslint-import-resolver-typescript": "^4.4.5",
         "eslint-plugin-import-x": "^4.17.1",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "globals": "^17.7.0",
         "prettier": "^3.9.5",
         "prettier-plugin-organize-imports": "^4.3.0",
@@ -8071,6 +8072,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -9310,6 +9331,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/EvanHahn"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/hls.js": {
@@ -14749,6 +14787,19 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
     "packages/streamwall": {
       "version": "2.0.0-pre2",
       "license": "MIT",
@@ -14799,6 +14850,7 @@
         "@types/ws": "^8.18.1",
         "@types/yargs": "^17.0.35",
         "electron": "^43.1.0",
+        "happy-dom": "^20.10.6",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.3",
         "vite": "^8.1.3",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint": "^10.7.0",
     "eslint-import-resolver-typescript": "^4.4.5",
     "eslint-plugin-import-x": "^4.17.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "globals": "^17.7.0",
     "prettier": "^3.9.5",
     "prettier-plugin-organize-imports": "^4.3.0",

--- a/packages/streamwall-control-client/src/index.tsx
+++ b/packages/streamwall-control-client/src/index.tsx
@@ -77,7 +77,7 @@ function useStreamwallWebsocketConnection(
       }
     })
     wsRef.current = { ws, msgId: 0, responseMap: new Map() }
-  }, [])
+  }, [setStateDoc, wsEndpoint])
 
   const send = useCallback(
     (msg: ControlCommand, cb?: (msg: unknown) => void) => {

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -444,6 +444,10 @@ export function useYDoc<T>(keys: string[]): {
     return () => {
       doc.off('update', updateDocValue)
     }
+    // `keys` is deliberately omitted: every caller passes a literal array,
+    // so including it would re-subscribe the listener on every render
+    // without any behavioral benefit.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [doc])
   return { docValue, doc, setDoc }
 }
@@ -847,7 +851,7 @@ export function ControlUI({
         rotation: ((stream.rotation || 0) + 90) % 360,
       })
     },
-    [streams],
+    [streams, send],
   )
 
   const handleBrowse = useCallback(
@@ -861,7 +865,7 @@ export function ControlUI({
         url: stream.link,
       })
     },
-    [streams],
+    [streams, send],
   )
 
   const handleDevTools = useCallback(
@@ -956,15 +960,18 @@ export function ControlUI({
         },
       )
     },
-    [],
+    [send],
   )
 
-  const handleDeleteToken = useCallback((tokenId: string) => {
-    send({
-      type: 'delete-token',
-      tokenId,
-    })
-  }, [])
+  const handleDeleteToken = useCallback(
+    (tokenId: string) => {
+      send({
+        type: 'delete-token',
+        tokenId,
+      })
+    },
+    [send],
+  )
 
   const preventLinkClick = useCallback((ev: Event) => {
     ev.preventDefault()
@@ -2557,7 +2564,7 @@ function AuthTokenLine({
 }) {
   const handleDeleteClick = useCallback(() => {
     onDelete(id)
-  }, [id])
+  }, [id, onDelete])
   return (
     <div>
       <strong>{name}</strong>: {role}{' '}


### PR DESCRIPTION
## Problem

The bug fixed in #134 (Closes #30) was a classic stale-closure defect: `handleClickId` omitted `handleSetView` from its `useCallback` dependency array, so it kept invoking a stale callback whose captured `streams` lacked a newly appeared stream.

The React Hooks `exhaustive-deps` rule catches exactly this class of bug at lint time, but `eslint-plugin-react-hooks` was never installed or wired into the flat ESLint config.

## Solution

- Add `eslint-plugin-react-hooks@^7.1.1` as a root dev dependency (its peer range covers ESLint 10).
- In `eslint.config.mjs`, add a scoped config block for the Preact packages (`streamwall-control-ui`, `streamwall-control-client`, and the Electron renderer entry points under `packages/streamwall/src/renderer`) enabling:
  - `react-hooks/rules-of-hooks`: `error`
  - `react-hooks/exhaustive-deps`: `warn` (per the issue's suggestion, to land the tooling without blocking CI)

Preact is used via `preact/compat`/`preact/hooks`, which mirror the React hooks API, so the plugin applies even though this isn't a React project.

### Scope: two rules, not the plugin's "recommended" set

`eslint-plugin-react-hooks` v7's `recommended` config also pulls in several React Compiler-oriented rules (`purity`, `immutability`, `gating`, `set-state-in-render`, etc.). This project doesn't use the React Compiler, so those rules would add noise unrelated to the stale-closure bug class this issue targets. Scoped to `rules-of-hooks` + `exhaustive-deps` only, matching the issue's "at minimum `react-hooks/exhaustive-deps`" ask.

### Violations found and fixed

The first lint run surfaced 7 warnings. All were triaged:

- **6 genuine fixes** — added missing dependencies (`send`, `onDelete`, `setStateDoc`, `wsEndpoint`). All are stable across the component's lifetime (`useState` setters, or values coming from a `useCallback` with `[]` deps upstream), so no added re-renders.
- **1 deliberate omission** — `useYDoc`'s internal effect omits `keys` from its dependency array. Every current caller passes a literal array, so including it would re-subscribe the Yjs listener on every render with no correctness benefit. Marked with a targeted `eslint-disable-next-line react-hooks/exhaustive-deps` and an explanatory comment, per the issue's own triage guidance.

## Testing performed

No dedicated tests were added — this is a lint tooling/config change with no testable application behavior (consistent with how #150 wired up `eslint-plugin-import-x`).

Verified by:
- `npm run lint` before the fixes: 7 warnings. After: 0.
- Full quality gate green: `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run test` (all workspaces), and `npm -w streamwall-control-client run build`.

## Risks / breaking changes

None expected. All dependency additions are to values that are referentially stable in practice, so no behavioral or performance regressions.

Closes #138