### PR TITLE
fix(control-ui): replace no-op v3 hotkeys filter option with enableOnFormTags

### DIFF
--- a/packages/streamwall-control-ui/src/hotkeysOptions.test.tsx
+++ b/packages/streamwall-control-ui/src/hotkeysOptions.test.tsx
@@ -1,0 +1,95 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import type { StreamDelayStatus } from 'streamwall-shared'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import * as Y from 'yjs'
+import type { StreamwallConnection } from './index.tsx'
+import { ControlUI } from './index.tsx'
+
+// react-icons renders through preact/compat's Context.Consumer, which
+// currently crashes under this package's happy-dom test environment
+// (unrelated to the hotkey wiring under test here) - stub the icons out so
+// the component can render far enough to register its hotkeys.
+vi.mock('react-icons/fa', () => ({
+  FaExchangeAlt: () => null,
+  FaExclamationTriangle: () => null,
+  FaRedoAlt: () => null,
+  FaRegLifeRing: () => null,
+  FaRegWindowMaximize: () => null,
+  FaSyncAlt: () => null,
+  FaVideoSlash: () => null,
+  FaVolumeUp: () => null,
+}))
+vi.mock('react-icons/md', () => ({
+  MdOutlineStayCurrentLandscape: () => null,
+  MdOutlineStayCurrentPortrait: () => null,
+}))
+
+const useHotkeysMock = vi.hoisted(() => vi.fn())
+vi.mock('react-hotkeys-hook', () => ({
+  useHotkeys: useHotkeysMock,
+}))
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+  useHotkeysMock.mockClear()
+})
+
+function renderControlUI(): HTMLDivElement {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+
+  const delayState: StreamDelayStatus = {
+    isConnected: true,
+    delaySeconds: 0,
+    restartSeconds: 0,
+    isCensored: false,
+    isStreamRunning: true,
+    startTime: 0,
+    state: 'idle',
+  }
+
+  const connection: StreamwallConnection = {
+    isConnected: true,
+    role: 'operator',
+    send: () => {},
+    sharedState: { views: {} },
+    stateDoc: new Y.Doc(),
+    config: undefined,
+    streams: [],
+    customStreams: [],
+    views: [],
+    stateIdxMap: new Map(),
+    delayState,
+    authState: undefined,
+  }
+
+  act(() => {
+    render(<ControlUI connection={connection} />, container!)
+  })
+  return container
+}
+
+describe('alt+<n> listen-toggle hotkey', () => {
+  test('enables the hotkey while a grid input is focused via the v5 enableOnFormTags option', () => {
+    renderControlUI()
+
+    const listenToggleCall = useHotkeysMock.mock.calls.find(
+      ([keys]) =>
+        typeof keys === 'string' &&
+        keys
+          .split(',')
+          .every((k) => k.startsWith('alt+') && !k.includes('shift')),
+    )
+
+    expect(listenToggleCall).toBeDefined()
+    const options = listenToggleCall?.[2]
+    expect(options).toEqual({ enableOnFormTags: true })
+  })
+})

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -993,8 +993,8 @@ export function ControlUI({
       const isListening = stateIdxMap.get(idx)?.isListening ?? false
       handleSetListening(idx, !isListening)
     },
-    // This enables hotkeys when input elements are focused, and affects all hotkeys, not just this one.
-    { filter: () => true },
+    // This enables the hotkey while a grid input is focused.
+    { enableOnFormTags: true },
     [stateIdxMap],
   )
   useHotkeys(


### PR DESCRIPTION
## Problem

`packages/streamwall-control-ui/src/index.tsx` passed `{ filter: () => true }`
to `useHotkeys` for the `alt+<n>` listen-toggle hotkey, with a comment saying
it "enables hotkeys when input elements are focused."

`filter` was a `react-hotkeys-hook` v3 option. The package is on v5
(`react-hotkeys-hook@^5.3.3`), whose `Options` type no longer has `filter` —
the equivalent is `enableOnFormTags`. The object still type-checks (it matches
the `Options` branch of the `Options | DependencyList` union), but the
`filter` key is ignored at runtime, so the hotkey stopped firing while a grid
input was focused.

## Solution

Replace `{ filter: () => true }` with `{ enableOnFormTags: true }` for the
`alt+<n>` listen-toggle hotkey and drop the comment referencing the removed
option.

## Testing

Added `hotkeysOptions.test.tsx`, which mocks `react-hotkeys-hook` to capture
the arguments `ControlUI` passes to `useHotkeys` and asserts the listen-toggle
call receives `{ enableOnFormTags: true }` (not the removed `filter` option).
Verified the test fails against the old code (wrong option object) and passes
against the fix.

Full quality gate run locally: `format:check`, `lint`, `typecheck`, `test`
(all workspaces), and the control-client build — all green.

## Risks / breaking changes

None. Behavior-preserving bug fix restoring the intended v3 behavior under v5.

Closes #137