### PR TITLE
fix(electron): hide window on macOS close and flush storage before quit

### DIFF
--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -1,5 +1,11 @@
 import assert from 'assert'
-import { BrowserWindow, ipcMain, WebContents, WebContentsView } from 'electron'
+import {
+  BrowserWindow,
+  Event as ElectronEvent,
+  ipcMain,
+  WebContents,
+  WebContentsView,
+} from 'electron'
 import EventEmitter from 'events'
 import intersection from 'lodash/intersection'
 import isEqual from 'lodash/isEqual'
@@ -35,7 +41,7 @@ function getDisplayOptions(stream: StreamData): ContentDisplayOptions {
 
 export interface StreamWindowEventMap {
   load: []
-  close: []
+  close: [ElectronEvent]
   state: [ViewState[]]
   resize: []
 }
@@ -71,7 +77,7 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
     })
     win.removeMenu()
     win.loadURL('about:blank')
-    win.on('close', () => this.emit('close'))
+    win.on('close', (event) => this.emit('close', event))
 
     win.once('ready-to-show', () => {
       win.show()

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -37,10 +37,11 @@ import {
 import { applyGridResize } from './gridResize'
 import { denyWindowOpen } from './navigationSecurity'
 import { BROWSE_PARTITION, hardenSession } from './partitions'
-import { loadStorage } from './storage'
+import { flushStorage, loadStorage } from './storage'
 import StreamdelayClient from './StreamdelayClient'
 import StreamWindow from './StreamWindow'
 import TwitchBot from './TwitchBot'
+import { shouldHideInsteadOfQuit } from './windowCloseBehavior'
 
 const SENTRY_DSN =
   'https://e630a21dcf854d1a9eb2a7a8584cbd0b@o459879.ingest.sentry.io/5459505'
@@ -436,15 +437,13 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     }
   }
 
-  stateDoc.on(
-    'update',
-    throttle(() => {
-      db.update((data) => {
-        const fullDoc = Y.encodeStateAsUpdate(stateDoc)
-        data.stateDoc = Buffer.from(fullDoc).toString('base64')
-      })
-    }, 1000),
-  )
+  const persistStateDoc = throttle(() => {
+    db.update((data) => {
+      const fullDoc = Y.encodeStateAsUpdate(stateDoc)
+      data.stateDoc = Buffer.from(fullDoc).toString('base64')
+    })
+  }, 1000)
+  stateDoc.on('update', persistStateDoc)
 
   stateDoc.transact(() => {
     for (let i = 0; i < argv.grid.cols * argv.grid.rows; i++) {
@@ -614,9 +613,42 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   controlWindow.on('ydoc', (update) => Y.applyUpdate(stateDoc, update))
   controlWindow.on('command', (command) => onCommand(command, 'local'))
 
-  // TODO: Hide on macOS, allow reopening from dock
-  streamWindow.on('close', () => {
-    process.exit(0)
+  // Closing the stream window quits the app, except on macOS where the
+  // convention is to hide the window and keep the app (and its dock icon)
+  // running until the user explicitly quits.
+  let isQuitting = false
+  let storageFlushed = false
+  app.on('before-quit', () => {
+    isQuitting = true
+  })
+  app.on('activate', () => {
+    streamWindow.win.show()
+  })
+  streamWindow.on('close', (event) => {
+    if (shouldHideInsteadOfQuit(process.platform, isQuitting)) {
+      event.preventDefault()
+      streamWindow.win.hide()
+      return
+    }
+    app.quit()
+  })
+
+  // The throttled stateDoc persist above may still have a pending write when
+  // the app quits, so flush it and wait for storage to hit disk before the
+  // process actually exits (otherwise recent grid/view changes are lost).
+  app.on('before-quit', (event) => {
+    if (storageFlushed) {
+      return
+    }
+    event.preventDefault()
+    flushStorage(db, () => persistStateDoc.flush())
+      .catch((err) => {
+        console.error('Failed to flush storage before quit', err)
+      })
+      .finally(() => {
+        storageFlushed = true
+        app.quit()
+      })
   })
 
   if (

--- a/packages/streamwall/src/main/storage.test.ts
+++ b/packages/streamwall/src/main/storage.test.ts
@@ -1,0 +1,53 @@
+import { Low, Memory } from 'lowdb'
+import { describe, expect, it, vi } from 'vitest'
+import { flushStorage, StorageDB, StreamwallStoredData } from './storage'
+
+function makeDB(initial: Partial<StreamwallStoredData> = {}): StorageDB {
+  return new Low<StreamwallStoredData>(new Memory(), {
+    stateDoc: '',
+    localStreamData: [],
+    ...initial,
+  })
+}
+
+describe('flushStorage', () => {
+  it('forces a pending throttled write to run before persisting', async () => {
+    const db = makeDB()
+    // Simulate lodash's throttle: the trailing update hasn't run yet, so
+    // db.data still holds the stale value until flush() is called.
+    let pendingUpdateRan = false
+    const flushPendingUpdate = vi.fn(() => {
+      pendingUpdateRan = true
+      db.data.stateDoc = 'latest-update'
+    })
+
+    await flushStorage(db, flushPendingUpdate)
+
+    expect(flushPendingUpdate).toHaveBeenCalledOnce()
+    expect(pendingUpdateRan).toBe(true)
+    expect(db.data.stateDoc).toBe('latest-update')
+  })
+
+  it('persists whatever is in db.data even without a pending update', async () => {
+    const db = makeDB({ stateDoc: 'already-current' })
+    const flushPendingUpdate = vi.fn()
+
+    await flushStorage(db, flushPendingUpdate)
+
+    expect(db.data.stateDoc).toBe('already-current')
+  })
+
+  it('writes the current db.data to the adapter', async () => {
+    const db = makeDB()
+    db.data.localStreamData = [
+      { _id: 'a', kind: 'video', link: 'https://example.test' },
+    ]
+
+    await flushStorage(db, () => {})
+
+    const persisted = await db.adapter.read()
+    expect(persisted?.localStreamData).toEqual([
+      { _id: 'a', kind: 'video', link: 'https://example.test' },
+    ])
+  })
+})

--- a/packages/streamwall/src/main/storage.ts
+++ b/packages/streamwall/src/main/storage.ts
@@ -30,3 +30,20 @@ export async function loadStorage(dbPath: string) {
 
   return db
 }
+
+/**
+ * Guarantees the latest state is on disk before the app quits.
+ *
+ * Writes that go through a throttled updater (e.g. the Yjs stateDoc persist)
+ * can have a trailing call still pending when the app quits, so `db.data`
+ * may not yet hold the latest value. `flushPendingUpdate` should synchronously
+ * force that pending call to run (e.g. lodash's `throttled.flush()`) before
+ * this writes `db.data` to the adapter.
+ */
+export async function flushStorage(
+  db: StorageDB,
+  flushPendingUpdate: () => void,
+): Promise<void> {
+  flushPendingUpdate()
+  await db.write()
+}

--- a/packages/streamwall/src/main/windowCloseBehavior.test.ts
+++ b/packages/streamwall/src/main/windowCloseBehavior.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { shouldHideInsteadOfQuit } from './windowCloseBehavior'
+
+describe('shouldHideInsteadOfQuit', () => {
+  it('hides the window on macOS when the app is not quitting', () => {
+    expect(shouldHideInsteadOfQuit('darwin', false)).toBe(true)
+  })
+
+  it('lets the window close on macOS once the app is quitting', () => {
+    expect(shouldHideInsteadOfQuit('darwin', true)).toBe(false)
+  })
+
+  it('lets the window close on Windows regardless of quitting state', () => {
+    expect(shouldHideInsteadOfQuit('win32', false)).toBe(false)
+    expect(shouldHideInsteadOfQuit('win32', true)).toBe(false)
+  })
+
+  it('lets the window close on Linux regardless of quitting state', () => {
+    expect(shouldHideInsteadOfQuit('linux', false)).toBe(false)
+    expect(shouldHideInsteadOfQuit('linux', true)).toBe(false)
+  })
+})

--- a/packages/streamwall/src/main/windowCloseBehavior.ts
+++ b/packages/streamwall/src/main/windowCloseBehavior.ts
@@ -1,0 +1,12 @@
+/**
+ * On macOS the convention is that closing a window hides it rather than
+ * quitting the app -- the app stays in the dock and reopens the window on
+ * "activate" (dock icon click). Every other platform quits when its main
+ * window closes.
+ */
+export function shouldHideInsteadOfQuit(
+  platform: NodeJS.Platform,
+  isQuitting: boolean,
+): boolean {
+  return platform === 'darwin' && !isQuitting
+}


### PR DESCRIPTION
## Problem

Closing the stream window hard-exited via `streamWindow.on('close', () => process.exit(0))`:

- On macOS this skips the platform convention: closing the main window should hide it and keep the app running in the dock, reopening on activate (dock icon click).
- `process.exit(0)` bypasses the app's quit sequence entirely, so a pending throttled `stateDoc` write (persisted at most once per second, see the `throttle(..., 1000)` around the storage persist) can still be in-flight and never reaches disk -- recent grid/view changes are silently lost.

## Solution

- Extracted the hide-vs-quit decision into a pure, unit-tested `shouldHideInsteadOfQuit(platform, isQuitting)` helper (`windowCloseBehavior.ts`): hide the window on macOS unless the app is actually quitting; quit on every other platform (and on macOS once quitting has started).
- Wired an app-level `activate` handler to reshow the stream window from the dock, matching the standard Electron single-window pattern.
- Added `flushStorage(db, flushPendingUpdate)` to `storage.ts`: it synchronously forces the pending throttled update to run and then awaits `db.write()`, guaranteeing the latest state is actually on disk before the process exits.
- Hooked the flush into `before-quit` (deferring the real quit with `event.preventDefault()` until the flush settles, guarded by a one-shot flag), so it covers every quit path -- the stream window's close button, Cmd+Q, and the app menu -- not just the single spot the old code handled.

## Testing performed

- `windowCloseBehavior.test.ts`: covers hide-on-macOS-while-running, quit-on-macOS-while-quitting, and quit on Windows/Linux regardless of quitting state.
- `storage.test.ts`: covers forcing a pending throttled update to run before persisting, persisting already-current data, and that `db.data` is actually written to the adapter.
- Full workspace quality gate run locally: `format:check`, `lint`, `typecheck` (all workspaces), `npm test` (all workspaces, 153 tests in the `streamwall` package), and the control-client build -- all green.
- Manual verification of the actual Electron app run wasn't performed in this sandboxed environment (no GUI); behavior is covered by the extracted unit tests plus code review of the Electron API usage (`BrowserWindow.hide()`/`show()`, `app.on('activate'|'before-quit')`, `event.preventDefault()`).

## Risks / breaking changes

None expected. Behavior on Windows/Linux is unchanged (window close still quits the app), except storage is now guaranteed to flush first. On macOS, closing the window no longer quits the app -- this is the desired convention change requested by the issue, but it is a user-visible behavior change worth calling out.

Closes #88