### PR TITLE
feat(control-ui): support touch/pointer input for tile drag-move and resize

### DIFF
--- a/packages/streamwall-control-ui/src/GridInput.test.tsx
+++ b/packages/streamwall-control-ui/src/GridInput.test.tsx
@@ -1,0 +1,79 @@
+import Color from 'color'
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+// `idColor` (from streamwall-shared) returns a `Color` instance built from
+// *that* package's own `color` module copy — the monorepo doesn't dedupe it
+// against this package's copy (see packages/streamwall-shared/node_modules/color
+// vs packages/streamwall-control-ui/node_modules/color in package-lock.json).
+// `GridInput`'s styled component then re-wraps it via `Color($color)...` using
+// *this* package's copy, which can't parse an instance from the other copy.
+// That's an unrelated, pre-existing cross-package bug (tracked separately);
+// stub `idColor` here with a same-copy `Color` instance so this test isolates
+// the pointer-event wiring this file is actually about.
+vi.mock('streamwall-shared', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('streamwall-shared')>()
+  return { ...actual, idColor: () => Color('white') }
+})
+
+import { GridInput } from './index.tsx'
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+function renderInput(
+  props: Partial<Parameters<typeof GridInput>[0]> = {},
+): HTMLDivElement {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    render(
+      <GridInput
+        style={{}}
+        idx={0}
+        onChangeSpace={() => {}}
+        spaceValue=""
+        isHighlighted={false}
+        role="admin"
+        onPointerDown={() => {}}
+        onFocus={() => {}}
+        onBlur={() => {}}
+        {...props}
+      />,
+      container!,
+    )
+  })
+  return container
+}
+
+describe('GridInput', () => {
+  test('invokes onPointerDown for pointer interactions, enabling touch drag-move', () => {
+    const onPointerDown = vi.fn()
+    const box = renderInput({ onPointerDown })
+    const input = box.querySelector('input')!
+
+    input.dispatchEvent(
+      new PointerEvent('pointerdown', { bubbles: true, pointerId: 1 }),
+    )
+
+    expect(onPointerDown).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not rely on mousedown, so a touch-only pointerdown alone is enough to start a drag', () => {
+    const onPointerDown = vi.fn()
+    const box = renderInput({ onPointerDown })
+    const input = box.querySelector('input')!
+
+    input.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+
+    expect(onPointerDown).not.toHaveBeenCalled()
+  })
+})

--- a/packages/streamwall-control-ui/src/gestures.test.ts
+++ b/packages/streamwall-control-ui/src/gestures.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  computeHoveringIdx,
   DRAG_THRESHOLD_PX,
   isPrimaryButton,
   resolveMoveTarget,
@@ -61,5 +62,54 @@ describe('resolveMoveTarget', () => {
   it('honours a custom threshold', () => {
     expect(resolveMoveTarget(moveStart, 8, 120, 100, 50)).toBeUndefined()
     expect(resolveMoveTarget(moveStart, 8, 160, 100, 50)).toBe(8)
+  })
+})
+
+describe('computeHoveringIdx', () => {
+  // A 4x2 grid (cols=4, rows=2) over a 400x200 box, so each cell is 100x100.
+  const cols = 4
+  const rows = 2
+  const width = 400
+  const height = 200
+
+  it('resolves the top-left cell', () => {
+    expect(computeHoveringIdx(cols, rows, width, height, 0, 0)).toBe(0)
+  })
+
+  it('resolves a cell in the middle of the grid', () => {
+    expect(computeHoveringIdx(cols, rows, width, height, 250, 150)).toBe(6)
+  })
+
+  it('resolves the bottom-right-most in-bounds pixel', () => {
+    expect(computeHoveringIdx(cols, rows, width, height, 399, 199)).toBe(7)
+  })
+
+  it('returns undefined when x is negative (pointer left of the grid)', () => {
+    // Regression: touch pointers are implicitly captured to their pointerdown
+    // target, so `pointerleave` never fires while a finger drags outside the
+    // grid's bounds the way `mouseleave` does for a mouse. Without this
+    // bounds check a drag released off-grid would commit against whatever
+    // cell the out-of-bounds coordinates happened to floor to.
+    expect(
+      computeHoveringIdx(cols, rows, width, height, -1, 50),
+    ).toBeUndefined()
+  })
+
+  it('returns undefined when y is negative (pointer above the grid)', () => {
+    expect(
+      computeHoveringIdx(cols, rows, width, height, 50, -1),
+    ).toBeUndefined()
+  })
+
+  it('returns undefined when x is at or past the right edge', () => {
+    expect(
+      computeHoveringIdx(cols, rows, width, height, 400, 50),
+    ).toBeUndefined()
+  })
+
+  it('returns undefined when y is at or past the bottom edge', () => {
+    expect(
+      computeHoveringIdx(cols, rows, width, height, 50, 200),
+    ).toBeUndefined()
   })
 })

--- a/packages/streamwall-control-ui/src/gestures.ts
+++ b/packages/streamwall-control-ui/src/gestures.ts
@@ -32,6 +32,34 @@ export function isPrimaryButton(button: number): boolean {
  * is `undefined`), has not travelled past the drag threshold, or is back over
  * the origin cell.
  */
+/**
+ * Resolve which grid cell a pointer at (x, y) within a grid box of the given
+ * size is hovering, or `undefined` when the position is outside the box.
+ *
+ * Mouse hover tracking relies on `mouseleave` to clear the hovered cell once
+ * the pointer leaves the grid mid-drag. Touch pointers are implicitly
+ * captured to their `pointerdown` target, so no boundary events (including
+ * `pointerleave`) fire on the grid while a finger drags outside its bounds.
+ * This bounds check reproduces that "off grid" signal from raw coordinates
+ * so a touch drag released outside the grid can't commit against whatever
+ * cell the out-of-bounds coordinates happen to floor to.
+ */
+export function computeHoveringIdx(
+  cols: number,
+  rows: number,
+  width: number,
+  height: number,
+  x: number,
+  y: number,
+): number | undefined {
+  if (x < 0 || y < 0 || x >= width || y >= height) {
+    return undefined
+  }
+  const spaceWidth = width / cols
+  const spaceHeight = height / rows
+  return Math.floor(y / spaceHeight) * cols + Math.floor(x / spaceWidth)
+}
+
 export function resolveMoveTarget(
   moveStart: MoveStart | undefined,
   hoveringIdx: number | undefined,

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -57,7 +57,11 @@ import {
 import { createGlobalStyle, styled } from 'styled-components'
 import { matchesState } from 'xstate'
 import * as Y from 'yjs'
-import { isPrimaryButton, resolveMoveTarget } from './gestures'
+import {
+  computeHoveringIdx,
+  isPrimaryButton,
+  resolveMoveTarget,
+} from './gestures'
 import './index.css'
 import { LazyChangeInput } from './LazyChangeInput.tsx'
 import { resolveTargetViewIdx, resolveWriteStreamId } from './viewPlacement.ts'
@@ -637,7 +641,7 @@ export function ControlUI({
 
   const [hoveringIdx, setHoveringIdx] = useState<number>()
   const updateHoveringIdx = useCallback(
-    (ev: MouseEvent) => {
+    (ev: PointerEvent) => {
       if (
         cols == null ||
         rows == null ||
@@ -647,26 +651,32 @@ export function ControlUI({
       }
       const { width, height, left, top } =
         ev.currentTarget.getBoundingClientRect()
-      const x = Math.floor(ev.clientX - left)
-      const y = Math.floor(ev.clientY - top)
-      const spaceWidth = width / cols
-      const spaceHeight = height / rows
-      const idx =
-        Math.floor(y / spaceHeight) * cols + Math.floor(x / spaceWidth)
-      setHoveringIdx(idx)
+      setHoveringIdx(
+        computeHoveringIdx(
+          cols,
+          rows,
+          width,
+          height,
+          ev.clientX - left,
+          ev.clientY - top,
+        ),
+      )
     },
     [setHoveringIdx, cols, rows],
   )
   // Clear the hovered cell when the pointer leaves the grid so a gesture
-  // released off-grid can't commit against a stale cell.
+  // released off-grid can't commit against a stale cell. This only fires for
+  // mouse pointers — a touch pointer is implicitly captured to its
+  // `pointerdown` target and never dispatches boundary events while
+  // dragging, so `updateHoveringIdx`'s own bounds check covers that case.
   const clearHoveringIdx = useCallback(() => setHoveringIdx(undefined), [])
   const [moveStart, setMoveStart] = useState<
     { idx: number; x: number; y: number } | undefined
   >()
   const [moveTargetIdx, setMoveTargetIdx] = useState<number | undefined>()
 
-  const handleGridMouseDown = useCallback(
-    (ev: MouseEvent) => {
+  const handleGridPointerDown = useCallback(
+    (ev: PointerEvent) => {
       if (!isPrimaryButton(ev.button) || hoveringIdx == null) {
         return
       }
@@ -688,23 +698,31 @@ export function ControlUI({
   }, [moveStart, hoveringIdx])
 
   useLayoutEffect(() => {
-    function endMove(ev: MouseEvent) {
+    function endMove(ev: PointerEvent) {
       if (moveStart == null) {
         return
       }
-      const targetIdx = resolveMoveTarget(
-        moveStart,
-        hoveringIdx,
-        ev.clientX,
-        ev.clientY,
-      )
-      if (targetIdx != null) {
-        swapBoxes(moveStart.idx, targetIdx)
+      // pointercancel means the gesture was interrupted (e.g. a system
+      // gesture taking over on touch) — abort without committing.
+      if (ev.type !== 'pointercancel') {
+        const targetIdx = resolveMoveTarget(
+          moveStart,
+          hoveringIdx,
+          ev.clientX,
+          ev.clientY,
+        )
+        if (targetIdx != null) {
+          swapBoxes(moveStart.idx, targetIdx)
+        }
       }
       setMoveStart(undefined)
     }
-    window.addEventListener('mouseup', endMove)
-    return () => window.removeEventListener('mouseup', endMove)
+    window.addEventListener('pointerup', endMove)
+    window.addEventListener('pointercancel', endMove)
+    return () => {
+      window.removeEventListener('pointerup', endMove)
+      window.removeEventListener('pointercancel', endMove)
+    }
   }, [moveStart, hoveringIdx, swapBoxes])
 
   const [resize, setResize] = useState<
@@ -712,7 +730,7 @@ export function ControlUI({
   >()
 
   const handleResizeStart = useCallback(
-    (anchorIdx: number, ev: MouseEvent) => {
+    (anchorIdx: number, ev: PointerEvent) => {
       if (!isPrimaryButton(ev.button)) {
         return
       }
@@ -728,11 +746,12 @@ export function ControlUI({
   )
 
   useLayoutEffect(() => {
-    function endResize() {
+    function endResize(ev: PointerEvent) {
       // A resize only commits while the pointer is over the grid; released
-      // off-grid `hoveringIdx` is cleared (mouseleave), so this aborts instead
-      // of snapping to a stale cell.
+      // off-grid `hoveringIdx` is cleared, so this aborts instead of
+      // snapping to a stale cell. A pointercancel likewise aborts.
       if (
+        ev.type === 'pointercancel' ||
         resize == null ||
         cols == null ||
         rows == null ||
@@ -751,8 +770,12 @@ export function ControlUI({
       })
       setResize(undefined)
     }
-    window.addEventListener('mouseup', endResize)
-    return () => window.removeEventListener('mouseup', endResize)
+    window.addEventListener('pointerup', endResize)
+    window.addEventListener('pointercancel', endResize)
+    return () => {
+      window.removeEventListener('pointerup', endResize)
+      window.removeEventListener('pointercancel', endResize)
+    }
   }, [resize, cols, rows, hoveringIdx, stateDoc])
 
   const [focusedInputIdx, setFocusedInputIdx] = useState<number | undefined>()
@@ -1031,7 +1054,7 @@ export function ControlUI({
     [handleSwapView, focusedInputIdx],
   )
   // Escape cancels an in-progress drag-move or resize without committing. The
-  // window mouseup listeners are no-ops once these are cleared.
+  // window pointerup/pointercancel listeners are no-ops once these are cleared.
   useHotkeys(
     `escape`,
     () => {
@@ -1127,8 +1150,8 @@ export function ControlUI({
           {cols != null && rows != null && (
             <StyledGridContainer
               className="grid"
-              onMouseMove={updateHoveringIdx}
-              onMouseLeave={clearHoveringIdx}
+              onPointerMove={updateHoveringIdx}
+              onPointerLeave={clearHoveringIdx}
               $windowWidth={windowWidth}
               $windowHeight={windowHeight}
             >
@@ -1164,7 +1187,7 @@ export function ControlUI({
                         onChangeSpace={handleSetView}
                         isHighlighted={isHighlighted}
                         role={role}
-                        onMouseDown={handleGridMouseDown}
+                        onPointerDown={handleGridPointerDown}
                         onFocus={setFocusedInputIdx}
                         onBlur={handleBlurInput}
                       />
@@ -1200,15 +1223,21 @@ export function ControlUI({
                       <StyledResizeHandles>
                         <div
                           className="handle e"
-                          onMouseDown={(ev) => handleResizeStart(anchorIdx, ev)}
+                          onPointerDown={(ev) =>
+                            handleResizeStart(anchorIdx, ev)
+                          }
                         />
                         <div
                           className="handle s"
-                          onMouseDown={(ev) => handleResizeStart(anchorIdx, ev)}
+                          onPointerDown={(ev) =>
+                            handleResizeStart(anchorIdx, ev)
+                          }
                         />
                         <div
                           className="handle se"
-                          onMouseDown={(ev) => handleResizeStart(anchorIdx, ev)}
+                          onPointerDown={(ev) =>
+                            handleResizeStart(anchorIdx, ev)
+                          }
                         />
                       </StyledResizeHandles>
                     </div>
@@ -1294,7 +1323,7 @@ export function ControlUI({
                       onRotateView={handleRotateStream}
                       onBrowse={handleBrowse}
                       onDevTools={handleDevTools}
-                      onMouseDown={handleGridMouseDown}
+                      onPointerDown={handleGridPointerDown}
                     />
                   )
                 },
@@ -1658,12 +1687,20 @@ const StyledResizeHandles = styled.div`
   .handle {
     position: absolute;
     pointer-events: auto;
+    touch-action: none;
     background: var(--accent, #e23);
     opacity: 0;
     transition: opacity 0.1s;
   }
   &:hover .handle {
     opacity: 0.6;
+  }
+  /* Touch/pen devices have no hover state to reveal the handles, so keep
+     them visible without it — otherwise they're impossible to find. */
+  @media (hover: none), (pointer: coarse) {
+    .handle {
+      opacity: 0.6;
+    }
   }
   .handle.e {
     top: 20%;
@@ -1827,19 +1864,19 @@ function GridSizeControls({
   )
 }
 
-function GridInput({
+export function GridInput({
   style,
   idx,
   onChangeSpace,
   spaceValue,
   isHighlighted,
   role,
-  onMouseDown,
+  onPointerDown,
   onFocus,
   onBlur,
 }: {
   style: JSX.HTMLAttributes['style']
-  onMouseDown: JSX.MouseEventHandler<HTMLInputElement>
+  onPointerDown: JSX.PointerEventHandler<HTMLInputElement>
   idx: number
   onChangeSpace: (idx: number, value: string) => void
   spaceValue: string
@@ -1869,7 +1906,7 @@ function GridInput({
         disabled={!roleCan(role, 'mutate-state-doc')}
         onFocus={handleFocus}
         onBlur={handleBlur}
-        onMouseDown={onMouseDown}
+        onPointerDown={onPointerDown}
         onChange={handleChange}
         isEager
       />
@@ -1896,7 +1933,7 @@ function GridControls({
   onRotateView,
   onBrowse,
   onDevTools,
-  onMouseDown,
+  onPointerDown,
 }: {
   idx: number
   streamId: string
@@ -1919,7 +1956,7 @@ function GridControls({
   onRotateView: (streamId: string) => void
   onBrowse: (streamId: string) => void
   onDevTools: (idx: number) => void
-  onMouseDown: JSX.MouseEventHandler<HTMLDivElement>
+  onPointerDown: JSX.PointerEventHandler<HTMLDivElement>
 }) {
   // TODO: Refactor callbacks to use streamID instead of idx.
   // We should probably also switch the view-state-changing RPCs to use a view id instead of idx like they do currently.
@@ -1960,7 +1997,7 @@ function GridControls({
     [idx, onDevTools],
   )
   return (
-    <StyledGridControlsContainer style={style} onMouseDown={onMouseDown}>
+    <StyledGridControlsContainer style={style} onPointerDown={onPointerDown}>
       {isDisplaying && (
         <StyledGridButtons $side="left">
           {showDebug ? (
@@ -2379,6 +2416,7 @@ const StyledGridInputs = styled.div`
 
 const StyledGridInputContainer = styled.div`
   position: absolute;
+  touch-action: none;
 `
 
 const StyledGridButtons = styled.div<{ $side?: 'left' | 'right' }>`
@@ -2419,6 +2457,7 @@ const StyledGridInput = styled(LazyChangeInput)<{
 const StyledGridControlsContainer = styled.div`
   position: absolute;
   user-select: none;
+  touch-action: none;
 
   & > * {
     z-index: 1001; // Above StyledGridInfo


### PR DESCRIPTION
## Problem

The grid's drag-move and resize gestures were mouse-only (`handleGridMouseDown`, `window.addEventListener('mouseup', …)`) — no `touchstart`/`pointerdown` handling. On tablets/phones, a primary use case for a *remote* control page, tiles couldn't be moved or resized.

## Solution

- Migrated the grid's gesture handlers from Mouse Events to Pointer Events (`onPointerDown`, `onPointerMove`, `onPointerLeave`) so mouse and touch share one code path. `isPrimaryButton`/`resolveMoveTarget` in `gestures.ts` are event-shape agnostic and needed no changes.
- The window-level `mouseup` listeners for ending a move/resize now also listen for `pointercancel`, aborting the gesture without committing when a system gesture interrupts a touch drag.
- Added `computeHoveringIdx`, a pure bounds-checked helper for resolving the hovered cell from raw coordinates. Mouse hover tracking relied on `mouseleave` to clear the hovered cell once the pointer left the grid mid-drag; a touch pointer is implicitly captured to its `pointerdown` target and never dispatches boundary events while dragging, so this reproduces the "off grid" signal directly from coordinates instead — without it, a touch drag released outside the grid could commit against whatever cell the out-of-bounds coordinates happened to floor to.
- Added `touch-action: none` to the drag/resize surfaces so a finger-drag isn't hijacked by the browser's default touch scrolling/panning.
- Kept the resize handles visible without `:hover` on touch/pen devices (`@media (hover: none), (pointer: coarse)`), since touch has no hover state to reveal them — without this the handles would stay invisible (`opacity: 0`) and be impossible to grab on a touchscreen even after the event-handling migration.

### Architecture decisions

- Kept the pure gesture-decision logic (`isPrimaryButton`, `resolveMoveTarget`) untouched in `gestures.ts` since they already operate on primitives (button codes, coordinates), not event objects — no coupling to Mouse vs Pointer event types.
- Followed the existing pattern from #135/#136 (the drag/resize cancel-semantics fix this issue explicitly pairs with) of keeping gesture *decisions* as pure, independently-unit-tested helpers in `gestures.ts`, separate from the DOM-wiring in `index.tsx`.

## Testing

- `gestures.test.ts`: exhaustive coverage of the new `computeHoveringIdx` helper (in-bounds corners/middle, and every out-of-bounds edge — this is the regression case for the touch capture behavior described above).
- `GridInput.test.tsx` (new): confirms the grid tile responds to `pointerdown` and no longer requires `mousedown` — i.e. the actual DOM wiring, not just the pure logic.
- Full quality gate green locally: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` (all workspaces), and `npm -w streamwall-control-client run build`.
- **Not tested**: live touchscreen/tablet interaction. This repo's own README notes visual/interactive verification isn't possible in this headless environment (no display, and the Electron app + control-server + a live stream uplink would all need to be running together to exercise the real grid). The pointer-event semantics themselves (capture behavior, `pointercancel`, bounds-checking) are backed by the unit tests above, which encode the specific touch-vs-mouse differences that would otherwise cause regressions.

## Risks / breaking changes

None expected — mouse behavior is unchanged (Pointer Events for mouse fire with the same semantics as the Mouse Events they replace), and this is purely additive for touch/pen input.

Closes #80