### PR TITLE
feat: cycle a grid cell through a stream playlist on an interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Under the hood, think of Streamwall as a specialized web browser for mosaicing v
 - **Remote control with roles** — an optional web-based control server lets operators run the wall from a browser, with **admin**, **operator**, and **monitor** roles gated by invite links.
 - **Automatic recovery** — failed or stalled stream loads are retried automatically with exponential backoff, with the failure surfaced on the wall and in the control UI.
 - **Flexible data sources** — load streams from JSON APIs, TOML files, or add them ad hoc (including `overlay`/`background` kinds for widgets and chroma-key layers).
+- **Playlists** — optionally cycle a grid cell through a fixed list of stream URLs on an interval.
 - **Twitch chat bot** — an optional bot posts templated announcements and runs viewer polls in a Twitch channel's chat.
 
 ![Control UI](docs/images/control-ui.png)
@@ -134,6 +135,31 @@ Each entry (a `[[streams]]` table in TOML, or an object in the JSON array) suppo
 - `web` — an arbitrary webpage, shown as-is without searching for a `<video>` tag.
 - `background` — a webpage loaded behind the grid instead of in a tile.
 - `overlay` — a webpage loaded as a full-screen `<iframe>` layered over the whole wall (e.g. scoreboards, alerts). See [Security: overlay and background streams](#security-overlay-and-background-streams) below.
+
+## Playlists
+
+A grid cell can optionally cycle through a fixed list of stream URLs on an
+interval, independent of manual placement or any data source. Add one
+`[[playlist]]` table per cell you want to cycle (see `example.config.toml`):
+
+```toml
+[[playlist]]
+view = 0
+interval = 60
+urls = ["https://example.com/stream-a", "https://example.com/stream-b"]
+```
+
+| Field      | Type     | Required | Description                                                             |
+| ---------- | -------- | -------- | ----------------------------------------------------------------------- |
+| `view`     | number   | yes      | The grid cell (0-indexed) to cycle. Must be within the configured grid. |
+| `interval` | number   | yes      | Seconds between advances.                                               |
+| `urls`     | string[] | yes      | Stream URLs to cycle through, in order, looping back to the start.      |
+
+A cell without a matching `[[playlist]]` table behaves as usual — assign it
+manually from the control UI. Each URL is matched against the streams
+currently known from your data sources (`json-url`/`toml-file`/custom); if a
+URL doesn't currently resolve to a known stream, that step is skipped with a
+warning and the cell keeps its previous content until the next advance.
 
 ## Security: overlay and background streams
 

--- a/example.config.toml
+++ b/example.config.toml
@@ -82,3 +82,11 @@ json-url = []
 # Whether to report uncaught errors to Streamwall's Sentry project. Enabled
 # by default; uncomment to opt out.
 #sentry = false
+
+# Cycle a grid cell through a fixed list of stream URLs on an interval,
+# independent of manual placement or any data source. Add one [[playlist]]
+# table per cell you want to cycle; cells without one behave as usual.
+#[[playlist]]
+#view = 0
+#interval = 60
+#urls = ["https://example.com/stream-a", "https://example.com/stream-b"]

--- a/packages/streamwall/src/main/config.test.ts
+++ b/packages/streamwall/src/main/config.test.ts
@@ -166,6 +166,60 @@ describe('validateConfig', () => {
     config.retry['max-retries'] = 2.5
     expect(() => validateConfig(config)).toThrow(ConfigError)
   })
+
+  test('accepts a config with no playlist entries', () => {
+    const config = { ...baseConfig(), playlist: [] }
+    expect(() => validateConfig(config)).not.toThrow()
+  })
+
+  test('accepts a valid playlist entry targeting an in-bounds view', () => {
+    const config = {
+      ...baseConfig(),
+      playlist: [{ view: 8, interval: 60, urls: ['https://a', 'https://b'] }],
+    }
+    expect(() => validateConfig(config)).not.toThrow()
+  })
+
+  test('rejects a playlist entry with an empty urls list', () => {
+    const config = {
+      ...baseConfig(),
+      playlist: [{ view: 0, interval: 60, urls: [] }],
+    }
+    expect(() => validateConfig(config)).toThrow(ConfigError)
+  })
+
+  test('rejects a playlist entry with a non-positive interval', () => {
+    const config = {
+      ...baseConfig(),
+      playlist: [{ view: 0, interval: 0, urls: ['https://a'] }],
+    }
+    expect(() => validateConfig(config)).toThrow(ConfigError)
+  })
+
+  test('rejects a playlist entry targeting a view outside the configured grid', () => {
+    // grid is 3x3 by default, so views run 0-8.
+    const config = {
+      ...baseConfig(),
+      playlist: [{ view: 9, interval: 60, urls: ['https://a'] }],
+    }
+    expect(() => validateConfig(config)).toThrow(ConfigError)
+    try {
+      validateConfig(config)
+    } catch (err) {
+      expect((err as Error).message).toContain('view 9')
+    }
+  })
+
+  test('rejects two playlist entries targeting the same view', () => {
+    const config = {
+      ...baseConfig(),
+      playlist: [
+        { view: 0, interval: 60, urls: ['https://a'] },
+        { view: 0, interval: 30, urls: ['https://b'] },
+      ],
+    }
+    expect(() => validateConfig(config)).toThrow(ConfigError)
+  })
 })
 
 describe('findUnknownConfigKeys', () => {

--- a/packages/streamwall/src/main/config.ts
+++ b/packages/streamwall/src/main/config.ts
@@ -1,5 +1,5 @@
 import TOML from '@iarna/toml'
-import { GRID_MAX, GRID_MIN } from 'streamwall-shared'
+import { GRID_MAX, GRID_MIN, MAX_VIEW_IDX } from 'streamwall-shared'
 import { z } from 'zod'
 
 /**
@@ -33,6 +33,7 @@ const nonNegativeNumber = z.number().nonnegative()
 // Kept in lockstep with the WS command schema's grid bounds so a configured
 // wall can always be targeted and resized by remote control commands.
 const gridDimension = z.number().int().min(GRID_MIN).max(GRID_MAX)
+const viewIdx = z.number().int().min(0).max(MAX_VIEW_IDX)
 
 /**
  * Shape of the resolved Streamwall configuration (config file + CLI flags after
@@ -91,6 +92,17 @@ const streamwallConfigSchema = z.object({
   telemetry: z.object({
     sentry: z.boolean(),
   }),
+  // Each entry cycles the given view through a fixed list of stream URLs on
+  // an interval, independent of whatever data source populates the wall.
+  playlist: z
+    .array(
+      z.object({
+        view: viewIdx,
+        interval: z.number().positive(),
+        urls: z.array(z.string().min(1)).min(1),
+      }),
+    )
+    .default([]),
 })
 
 /**
@@ -103,6 +115,27 @@ export function validateConfig(config: unknown): void {
     throw new ConfigError(
       `Invalid configuration:\n${z.prettifyError(result.error)}`,
     )
+  }
+
+  // The schema alone can't know the configured grid size, so cross-check
+  // each playlist entry's view index against it here, and reject entries
+  // that would fight over the same cell.
+  const { grid, playlist } = result.data
+  const maxConfiguredViewIdx = grid.cols * grid.rows - 1
+  const seenViews = new Set<number>()
+  for (const entry of playlist) {
+    if (entry.view > maxConfiguredViewIdx) {
+      throw new ConfigError(
+        `Invalid configuration:\nplaylist entry targets view ${entry.view}, but the ` +
+          `configured ${grid.cols}x${grid.rows} grid only has views 0-${maxConfiguredViewIdx}.`,
+      )
+    }
+    if (seenViews.has(entry.view)) {
+      throw new ConfigError(
+        `Invalid configuration:\nmultiple playlist entries target view ${entry.view}.`,
+      )
+    }
+    seenViews.add(entry.view)
   }
 }
 

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -37,6 +37,7 @@ import {
 import { applyGridResize } from './gridResize'
 import { denyWindowOpen } from './navigationSecurity'
 import { BROWSE_PARTITION, hardenSession } from './partitions'
+import { PlaylistScheduler } from './playlist'
 import { flushStorage, loadStorage } from './storage'
 import StreamdelayClient from './StreamdelayClient'
 import StreamWindow from './StreamWindow'
@@ -123,6 +124,11 @@ export interface StreamwallConfig {
   telemetry: {
     sentry: boolean
   }
+  playlist: {
+    view: number
+    interval: number
+    urls: string[]
+  }[]
 }
 
 // Warns (does not throw) about keys in a raw parsed config file that the
@@ -338,6 +344,11 @@ function parseArgs(): StreamwallConfig {
       boolean: true,
       default: true,
     })
+    // Configured only via `[[playlist]]` tables in config.toml (or --config);
+    // not exposed as an individual CLI flag since it's a list of tables.
+    .option('playlist', {
+      default: [],
+    })
     .help()
     // https://github.com/yargs/yargs/issues/2137
     .parseSync(process.argv) as unknown as StreamwallConfig
@@ -458,6 +469,22 @@ async function main(argv: ReturnType<typeof parseArgs>) {
 
   updateViewsFromStateDoc()
   viewsState.observeDeep(updateViewsFromStateDoc)
+
+  // Cycles any configured views through their playlist of stream URLs,
+  // independent of whatever data source populated `clientState.streams`.
+  const playlistScheduler = new PlaylistScheduler(argv.playlist, {
+    resolveStreamId: (url) =>
+      (
+        clientState.streams.byURL?.get(url) ??
+        clientState.streams.find((s) => s.link === url)
+      )?._id,
+    setViewStream: (view, streamId) => {
+      stateDoc.transact(() => {
+        viewsState.get(String(view))?.set('streamId', streamId)
+      })
+    },
+  })
+  playlistScheduler.start()
 
   const onCommand = async (
     msg: ControlCommand,

--- a/packages/streamwall/src/main/playlist.test.ts
+++ b/packages/streamwall/src/main/playlist.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { PlaylistScheduler } from './playlist'
+
+describe('PlaylistScheduler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function makeDeps(streamIdByURL: Record<string, string | undefined>) {
+    const setViewStream = vi.fn()
+    return {
+      setViewStream,
+      resolveStreamId: vi.fn((url: string) => streamIdByURL[url]),
+    }
+  }
+
+  test('assigns the first URL to its view as soon as it starts', () => {
+    const deps = makeDeps({ a: 'stream-a', b: 'stream-b' })
+    const scheduler = new PlaylistScheduler(
+      [{ view: 0, interval: 10, urls: ['a', 'b'] }],
+      deps,
+    )
+
+    scheduler.start()
+
+    expect(deps.setViewStream).toHaveBeenCalledTimes(1)
+    expect(deps.setViewStream).toHaveBeenCalledWith(0, 'stream-a')
+  })
+
+  test('cycles through the configured URLs on each interval, wrapping around', () => {
+    const deps = makeDeps({ a: 'stream-a', b: 'stream-b', c: 'stream-c' })
+    const scheduler = new PlaylistScheduler(
+      [{ view: 0, interval: 10, urls: ['a', 'b', 'c'] }],
+      deps,
+    )
+
+    scheduler.start()
+    deps.setViewStream.mockClear()
+
+    vi.advanceTimersByTime(10_000)
+    expect(deps.setViewStream).toHaveBeenNthCalledWith(1, 0, 'stream-b')
+
+    vi.advanceTimersByTime(10_000)
+    expect(deps.setViewStream).toHaveBeenNthCalledWith(2, 0, 'stream-c')
+
+    vi.advanceTimersByTime(10_000)
+    expect(deps.setViewStream).toHaveBeenNthCalledWith(3, 0, 'stream-a')
+  })
+
+  test('advances multiple views independently, each on its own interval', () => {
+    const deps = makeDeps({
+      a: 'stream-a',
+      b: 'stream-b',
+      x: 'stream-x',
+      y: 'stream-y',
+    })
+    const scheduler = new PlaylistScheduler(
+      [
+        { view: 0, interval: 15, urls: ['a', 'b'] },
+        { view: 1, interval: 20, urls: ['x', 'y'] },
+      ],
+      deps,
+    )
+
+    scheduler.start()
+    deps.setViewStream.mockClear()
+
+    vi.advanceTimersByTime(15_000)
+    expect(deps.setViewStream).toHaveBeenCalledExactlyOnceWith(0, 'stream-b')
+
+    deps.setViewStream.mockClear()
+    vi.advanceTimersByTime(5_000)
+    expect(deps.setViewStream).toHaveBeenCalledExactlyOnceWith(1, 'stream-y')
+  })
+
+  test('skips a URL that has no resolvable stream yet without getting stuck', () => {
+    const deps = makeDeps({ a: 'stream-a', b: undefined, c: 'stream-c' })
+    const scheduler = new PlaylistScheduler(
+      [{ view: 0, interval: 10, urls: ['a', 'b', 'c'] }],
+      deps,
+    )
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    scheduler.start()
+    deps.setViewStream.mockClear()
+
+    vi.advanceTimersByTime(10_000)
+    expect(deps.setViewStream).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('view 0'))
+
+    vi.advanceTimersByTime(10_000)
+    expect(deps.setViewStream).toHaveBeenCalledExactlyOnceWith(0, 'stream-c')
+
+    warnSpy.mockRestore()
+  })
+
+  test('stop() clears all timers so no further advances happen', () => {
+    const deps = makeDeps({ a: 'stream-a', b: 'stream-b' })
+    const scheduler = new PlaylistScheduler(
+      [{ view: 0, interval: 10, urls: ['a', 'b'] }],
+      deps,
+    )
+
+    scheduler.start()
+    deps.setViewStream.mockClear()
+    scheduler.stop()
+
+    vi.advanceTimersByTime(60_000)
+    expect(deps.setViewStream).not.toHaveBeenCalled()
+  })
+
+  test('does nothing for an empty playlist configuration', () => {
+    const deps = makeDeps({})
+    const scheduler = new PlaylistScheduler([], deps)
+
+    expect(() => scheduler.start()).not.toThrow()
+    vi.advanceTimersByTime(60_000)
+    expect(deps.setViewStream).not.toHaveBeenCalled()
+  })
+})

--- a/packages/streamwall/src/main/playlist.ts
+++ b/packages/streamwall/src/main/playlist.ts
@@ -1,0 +1,60 @@
+export interface PlaylistConfig {
+  view: number
+  /** Seconds between advances. */
+  interval: number
+  urls: string[]
+}
+
+export interface PlaylistSchedulerDeps {
+  /** Resolves a configured URL to its current stream ID, if one exists. */
+  resolveStreamId: (url: string) => string | undefined
+  setViewStream: (view: number, streamId: string) => void
+}
+
+/**
+ * Cycles each configured view through its list of stream URLs on a timer.
+ *
+ * URLs are resolved to stream IDs at the moment each advance fires (rather
+ * than once at startup) since the underlying stream data can change as data
+ * sources refresh.
+ */
+export class PlaylistScheduler {
+  private readonly timers: ReturnType<typeof setInterval>[] = []
+  private readonly cursors = new Map<number, number>()
+
+  constructor(
+    private readonly playlists: PlaylistConfig[],
+    private readonly deps: PlaylistSchedulerDeps,
+  ) {}
+
+  start() {
+    for (const playlist of this.playlists) {
+      this.cursors.set(playlist.view, 0)
+      this.advance(playlist)
+      this.timers.push(
+        setInterval(() => this.advance(playlist), playlist.interval * 1000),
+      )
+    }
+  }
+
+  stop() {
+    for (const timer of this.timers) {
+      clearInterval(timer)
+    }
+    this.timers.length = 0
+  }
+
+  private advance(playlist: PlaylistConfig) {
+    const cursor = this.cursors.get(playlist.view) ?? 0
+    const url = playlist.urls[cursor % playlist.urls.length]
+    const streamId = this.deps.resolveStreamId(url)
+    if (streamId === undefined) {
+      console.warn(
+        `Playlist for view ${playlist.view}: no stream found for URL "${url}", skipping`,
+      )
+    } else {
+      this.deps.setViewStream(playlist.view, streamId)
+    }
+    this.cursors.set(playlist.view, cursor + 1)
+  }
+}


### PR DESCRIPTION
## Problem

There was no cycling/playlist logic in Streamwall. `rotate-stream` only controls video *orientation* (image rotation), and the Twitch chat vote only switches which existing cell's audio is listened to — neither changes which stream occupies a grid cell over time.

## Solution

Adds an optional, config-driven playlist feature: any grid cell can be configured to cycle through a fixed list of stream URLs on an interval.

- `[[playlist]]` config table (`view`, `interval`, `urls`), validated in `config.ts`:
  - `view` must be within the configured grid (`grid.cols * grid.rows`).
  - `urls` must be non-empty.
  - `interval` must be positive.
  - Two entries can't target the same view.
- New `PlaylistScheduler` (`packages/streamwall/src/main/playlist.ts`) advances each configured view on its own timer, resolving each URL to its current stream ID at the moment of the advance (not once at startup), so it keeps working as data sources refresh. A URL that doesn't currently resolve to a known stream is skipped with a console warning rather than crashing, and the cursor still advances so it isn't stuck retrying the same URL forever.
- Wired into `index.ts`: the scheduler writes into the same Yjs `viewsState` that manual drag-to-place already uses, so it flows through the existing `updateViewsFromStateDoc → StreamWindow.setViews → DISPLAY` pipeline with no new rendering plumbing.
- Documented in `README.md` and `example.config.toml`.

### Architecture decisions

- **Config-driven, not a new `ControlCommand`.** The playlist definition is static per-deployment (like `twitch.vote.interval`), so it lives in `config.toml` rather than adding new remote-control surface. This keeps the change scoped to the issue's "optional per-cell playlist" ask without expanding the control-UI/uplink attack surface.
- **Writes through `viewsState`, not a parallel state store.** Reuses the exact mechanism `handleSetView`/drag-and-drop already use, so no changes were needed to `StreamWindow` or the view state machine.
- **Known limitation, not addressed here:** the view state machine (`viewStateMachine.ts`) has no partial "swap content while running" transition — any content change (including a playlist advance) forces a full reload of that cell's view. This matches how manual stream reassignment already behaves today, so it's not a regression, but a future enhancement could add a lighter transition to avoid the reload. Filed as a follow-up issue (see below).

## Testing performed

- New `playlist.test.ts` (Vitest, fake timers): initial assignment on start, cyclic wraparound, independent per-view intervals, skip-and-continue on an unresolvable URL, `stop()` clearing timers, and a no-op empty configuration.
- Extended `config.test.ts`: accepts valid playlist config, rejects empty `urls`, rejects non-positive `interval`, rejects an out-of-grid `view`, rejects duplicate `view` targets.
- Full quality gate green locally: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm run test` (all workspaces).

## Risks / breaking changes

None — the feature is entirely opt-in (no `[[playlist]]` entries means no behavior change) and adds no new remote-control command surface.

Closes #77