### PR TITLE
feat: add undo/redo for grid edits via Y.UndoManager

### DIFF
--- a/packages/streamwall-control-client/src/dev.tsx
+++ b/packages/streamwall-control-client/src/dev.tsx
@@ -166,9 +166,11 @@ const demoState: StreamwallState = {
 }
 
 function useMockConnection(): StreamwallConnection {
-  const { docValue: sharedState, doc: stateDoc } = useYDoc<CollabData>([
-    'views',
-  ])
+  const {
+    docValue: sharedState,
+    doc: stateDoc,
+    undoManager,
+  } = useYDoc<CollabData>(['views'])
   const appState = useStreamwallState(demoState)
 
   useEffect(() => {
@@ -191,6 +193,7 @@ function useMockConnection(): StreamwallConnection {
     send: (msg) => console.debug('[mock send]', msg),
     sharedState,
     stateDoc,
+    undoManager,
   }
 }
 

--- a/packages/streamwall-control-client/src/index.tsx
+++ b/packages/streamwall-control-client/src/index.tsx
@@ -29,7 +29,8 @@ function useStreamwallWebsocketConnection(
     docValue: sharedState,
     doc: stateDoc,
     setDoc: setStateDoc,
-  } = useYDoc<CollabData>(['views'])
+    undoManager,
+  } = useYDoc<CollabData>(['views'], 'server')
   const [streamwallState, setStreamwallState] = useState<StreamwallState>()
   const appState = useStreamwallState(streamwallState)
 
@@ -133,6 +134,7 @@ function useStreamwallWebsocketConnection(
     send,
     sharedState,
     stateDoc,
+    undoManager,
   }
 }
 

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -61,6 +61,7 @@ import { isPrimaryButton, resolveMoveTarget } from './gestures'
 import './index.css'
 import { LazyChangeInput } from './LazyChangeInput.tsx'
 import { resolveTargetViewIdx, resolveWriteStreamId } from './viewPlacement.ts'
+import { createSharedUndoManager } from './yUndo.ts'
 
 // `import Color from 'color'` binds only the value; alias the instance type
 // (as returned by the Color factory) for use in styled-component prop types.
@@ -424,10 +425,20 @@ function filterStreams(
   return [wallStreams, liveStreams, otherStreams]
 }
 
-export function useYDoc<T>(keys: string[]): {
+export function useYDoc<T>(
+  keys: string[],
+  // Origin string used by this connection when applying remote updates to
+  // `doc` (e.g. `'server'` for the websocket client, `'app'` for the
+  // Electron IPC renderer). Passed through to the doc's `Y.UndoManager` so
+  // that remotely-applied changes - notably a destructive grid-shrink remap,
+  // which runs on the main process's doc and only reaches here as a
+  // remote-origin update - are undoable too (issue #79).
+  remoteOrigin?: string,
+): {
   docValue: T | undefined
   doc: Y.Doc
   setDoc: (doc: Y.Doc) => void
+  undoManager: Y.UndoManager | undefined
 } {
   const [doc, setDoc] = useState(new Y.Doc())
   const [docValue, setDocValue] = useState<T>()
@@ -449,7 +460,19 @@ export function useYDoc<T>(keys: string[]): {
     // without any behavioral benefit.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [doc])
-  return { docValue, doc, setDoc }
+
+  const [undoManager, setUndoManager] = useState<Y.UndoManager>()
+  useEffect(() => {
+    const manager = createSharedUndoManager(doc, keys, remoteOrigin)
+    setUndoManager(manager)
+    return () => {
+      manager.destroy()
+    }
+    // `keys` is deliberately omitted for the same reason as above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [doc, remoteOrigin])
+
+  return { docValue, doc, setDoc, undoManager }
 }
 
 export interface CollabData {
@@ -462,6 +485,7 @@ export interface StreamwallConnection {
   send: (msg: ControlCommand, cb?: (msg: unknown) => void) => void
   sharedState: CollabData | undefined
   stateDoc: Y.Doc
+  undoManager?: Y.UndoManager
   config: StreamWindowConfig | undefined
   streams: StreamData[]
   customStreams: StreamData[]
@@ -553,6 +577,7 @@ export function ControlUI({
     send,
     sharedState,
     stateDoc,
+    undoManager,
     config,
     streams,
     customStreams,
@@ -1041,6 +1066,26 @@ export function ControlUI({
     // Also fire while a grid input is focused during a gesture.
     { enableOnFormTags: true },
     [setMoveStart, setResize],
+  )
+  // Undo/redo edits to the shared views doc (drag-move, swap, and destructive
+  // grid-shrink remaps alike - see `useYDoc`'s `remoteOrigin` wiring).
+  // `enableOnFormTags` defaults to false so this doesn't hijack native
+  // undo/redo while a text input (e.g. a grid-size field) is focused.
+  useHotkeys(
+    'mod+z',
+    (ev) => {
+      ev.preventDefault()
+      undoManager?.undo()
+    },
+    [undoManager],
+  )
+  useHotkeys(
+    'mod+shift+z',
+    (ev) => {
+      ev.preventDefault()
+      undoManager?.redo()
+    },
+    [undoManager],
   )
 
   const wallStreamIds = useMemo(

--- a/packages/streamwall-control-ui/src/yUndo.test.ts
+++ b/packages/streamwall-control-ui/src/yUndo.test.ts
@@ -1,0 +1,118 @@
+import { remapGridAssignments } from 'streamwall-shared'
+import { describe, expect, it } from 'vitest'
+import * as Y from 'yjs'
+import { createSharedUndoManager } from './yUndo.ts'
+
+function seedViews(
+  doc: Y.Doc,
+  assignments: Map<number, string | undefined>,
+): void {
+  const views = doc.getMap<Y.Map<string | undefined>>('views')
+  doc.transact(() => {
+    for (const [idx, streamId] of assignments) {
+      const cell = new Y.Map<string | undefined>()
+      cell.set('streamId', streamId)
+      views.set(String(idx), cell)
+    }
+  })
+}
+
+function readViews(doc: Y.Doc): Map<number, string | undefined> {
+  const views = doc.getMap<Y.Map<string | undefined>>('views')
+  const result = new Map<number, string | undefined>()
+  for (const [key, cell] of views) {
+    result.set(Number(key), cell.get('streamId'))
+  }
+  return result
+}
+
+describe('createSharedUndoManager', () => {
+  it('undoes and redoes a local edit (e.g. a drag-move)', () => {
+    const doc = new Y.Doc()
+    seedViews(doc, new Map([[0, undefined]]))
+    const undoManager = createSharedUndoManager(doc, ['views'])
+
+    doc
+      .getMap<Y.Map<string | undefined>>('views')
+      .get('0')
+      ?.set('streamId', 'abc')
+    expect(readViews(doc).get(0)).toBe('abc')
+
+    undoManager.undo()
+    expect(readViews(doc).get(0)).toBeUndefined()
+
+    undoManager.redo()
+    expect(readViews(doc).get(0)).toBe('abc')
+  })
+
+  it('does not track transactions whose origin is not local or the configured remote origin', () => {
+    const doc = new Y.Doc()
+    seedViews(doc, new Map([[0, undefined]]))
+    const undoManager = createSharedUndoManager(doc, ['views'], 'server')
+
+    doc.transact(() => {
+      doc
+        .getMap<Y.Map<string | undefined>>('views')
+        .get('0')
+        ?.set('streamId', 'from-other-origin')
+    }, 'some-other-origin')
+    expect(readViews(doc).get(0)).toBe('from-other-origin')
+
+    undoManager.undo()
+    // Nothing was captured for this origin, so undo is a no-op.
+    expect(readViews(doc).get(0)).toBe('from-other-origin')
+  })
+
+  it('restores assignments dropped by a destructive grid-shrink relayed from the server (issue #79)', () => {
+    // Mirrors the real dataflow: an authoritative doc (main process) applies
+    // `remapGridAssignments` and ships the resulting update to a client doc,
+    // which applies it with a remote origin (`applyUpdate(clientDoc, update,
+    // 'server')`, see streamwall-control-client's `receiveUpdate`).
+    const oldCols = 2
+    const oldAssignments = new Map<number, string | undefined>([
+      [0, 'keep-me'],
+      [1, 'drop-me'], // (x=1, y=0) falls outside a 1x1 grid.
+    ])
+
+    // The authoritative doc lives in the main process; the client doc mirrors
+    // it via an initial full sync and then incremental updates - exactly like
+    // `useYDoc`'s `doc.on('update', ...)` / `Y.applyUpdate(..., 'server')`
+    // wiring in the real connections. Seeding both docs independently (rather
+    // than syncing) would give their items unrelated identities and the
+    // "delete" below wouldn't resolve against the client's copy.
+    const serverDoc = new Y.Doc()
+    seedViews(serverDoc, oldAssignments)
+
+    const clientDoc = new Y.Doc()
+    Y.applyUpdate(clientDoc, Y.encodeStateAsUpdate(serverDoc), 'server')
+    const undoManager = createSharedUndoManager(clientDoc, ['views'], 'server')
+
+    // Simulate the authoritative remap on the server doc, then relay the
+    // resulting update onto the client doc under the 'server' origin.
+    const newAssignments = remapGridAssignments(oldCols, 1, 1, oldAssignments)
+    const stateBefore = Y.encodeStateVector(serverDoc)
+    const serverViews = serverDoc.getMap<Y.Map<string | undefined>>('views')
+    serverDoc.transact(() => {
+      for (const key of [...serverViews.keys()]) {
+        serverViews.delete(key)
+      }
+      for (const [idx, streamId] of newAssignments) {
+        const cell = new Y.Map<string | undefined>()
+        cell.set('streamId', streamId)
+        serverViews.set(String(idx), cell)
+      }
+    })
+    const update = Y.encodeStateAsUpdate(serverDoc, stateBefore)
+    Y.applyUpdate(clientDoc, update, 'server')
+
+    // The shrink dropped the out-of-grid assignment.
+    expect(readViews(clientDoc).get(1)).toBeUndefined()
+    expect([...readViews(clientDoc).keys()]).toEqual([0])
+
+    undoManager.undo()
+
+    const restored = readViews(clientDoc)
+    expect(restored.get(0)).toBe('keep-me')
+    expect(restored.get(1)).toBe('drop-me')
+  })
+})

--- a/packages/streamwall-control-ui/src/yUndo.ts
+++ b/packages/streamwall-control-ui/src/yUndo.ts
@@ -1,0 +1,29 @@
+import * as Y from 'yjs'
+
+/**
+ * Creates a `Y.UndoManager` scoped to the given root map keys of `doc`.
+ *
+ * By default, `Y.UndoManager` only tracks locally-originated transactions
+ * (`origin === null`). Streamwall's control connections apply remote changes
+ * under a fixed origin string (e.g. `'server'` for the websocket client,
+ * `'app'` for the Electron IPC renderer - see `receiveUpdate`/`handleUpdate`
+ * in their respective `index.tsx`/`control.tsx`). Passing that same string as
+ * `remoteOrigin` makes those remote transactions undoable too, which is what
+ * lets Ctrl+Z recover from a destructive grid-shrink remap (issue #79): that
+ * remap runs on the main process's doc and reaches the client purely as a
+ * remote-origin update.
+ */
+export function createSharedUndoManager(
+  doc: Y.Doc,
+  keys: string[],
+  remoteOrigin?: string,
+): Y.UndoManager {
+  const trackedOrigins = new Set<unknown>([null])
+  if (remoteOrigin !== undefined) {
+    trackedOrigins.add(remoteOrigin)
+  }
+  return new Y.UndoManager(
+    keys.map((key) => doc.getMap(key)),
+    { trackedOrigins },
+  )
+}

--- a/packages/streamwall/src/renderer/control.tsx
+++ b/packages/streamwall/src/renderer/control.tsx
@@ -20,9 +20,11 @@ declare global {
 }
 
 function useStreamwallIPCConnection(): StreamwallConnection {
-  const { docValue: sharedState, doc: stateDoc } = useYDoc<CollabData>([
-    'views',
-  ])
+  const {
+    docValue: sharedState,
+    doc: stateDoc,
+    undoManager,
+  } = useYDoc<CollabData>(['views'], 'app')
 
   const [streamwallState, setStreamwallState] = useState<StreamwallState>()
   const appState = useStreamwallState(streamwallState)
@@ -73,6 +75,7 @@ function useStreamwallIPCConnection(): StreamwallConnection {
     send,
     sharedState,
     stateDoc,
+    undoManager,
   }
 }
 


### PR DESCRIPTION
## Problem

No undo/redo existed for grid edits. Drag-move, resize handles, and grid-size
changes were all one-way: a mis-drag or an accidental grid shrink could lose
layout state irrecoverably. Grid shrinks in particular are destructive by
design - `remapGridAssignments` permanently drops any assignment whose (x, y)
no longer fits the new grid.

## Solution

- Added `createSharedUndoManager` (`packages/streamwall-control-ui/src/yUndo.ts`),
  a small wrapper around `Y.UndoManager` scoped to the shared `views` doc.
  By default `Y.UndoManager` only tracks locally-originated transactions, so it
  accepts an optional `remoteOrigin` string to also track remote-applied
  updates sharing that origin.
- `useYDoc` now builds this undo manager for its doc and exposes it on
  `StreamwallConnection`.
- `ControlUI` binds `mod+z` / `mod+shift+z` (Ctrl+Z / Ctrl+Shift+Z on
  Windows/Linux, Cmd+Z / Cmd+Shift+Z on macOS) to `undo()`/`redo()`, following
  the existing `react-hotkeys-hook` pattern used by the other shortcuts.
  `enableOnFormTags` defaults to false, so this doesn't hijack native
  undo/redo while a grid-size input or other text field is focused.
- Each of the three connections (`streamwall-control-client`'s websocket
  client, `streamwall`'s Electron IPC renderer, and the dev mock harness)
  now passes its own remote-update origin string (`'server'`, `'app'`, and
  none, respectively) into `useYDoc`.

### Architecture decision: why the grid-shrink case needed `remoteOrigin`

Drag-move and swap mutate the client's own `stateDoc` directly (local
origin), so a plain `Y.UndoManager` already covers them. A grid-size change
does not: the client sends a `set-grid-size` command over the websocket, the
*main process* applies `applyGridResize` → `remapGridAssignments` on its own
authoritative doc, and only the resulting Yjs update reaches the client - as
a remote-origin update (`Y.applyUpdate(stateDoc, update, 'server'|'app')`).
Without tracking that origin, Ctrl+Z would silently do nothing for the one
case the issue explicitly calls out as needing protection. Tracking the
connection's own remote-update origin (rather than, say, all origins) keeps
undo scoped to changes this client's Streamwall connection actually applied.

## Testing performed

- New unit tests (`packages/streamwall-control-ui/src/yUndo.test.ts`),
  written test-first:
  - undoes/redoes a plain local edit (drag-move-style mutation)
  - ignores transactions from an untracked, unrelated origin
  - restores assignments dropped by a destructive grid-shrink relayed from
    the server, using the real `remapGridAssignments` and the same
    `encodeStateAsUpdate`/`applyUpdate(..., 'server')` relay pattern the
    production code uses - this is the regression test for the issue's
    specific concern
- Full workspace test suite (`npm run test --workspaces`): all packages
  green, including the new tests (control-ui: 33/33)
- `npm run typecheck --workspaces`: clean
- `eslint` / `prettier --check` on all touched files: clean
- `npm run build` (control-client): succeeds
- Manual verification in the browser via the control-client dev harness
  (`vite --config packages/streamwall-control-client/vite.config.ts`,
  `/dev.html`): dragged a stream off the wall, confirmed the cell emptied,
  pressed Ctrl+Z, confirmed the stream reappeared in its original cell.
  Also confirmed Ctrl+Z does not interfere while a grid-size text input is
  focused.

## Risks / breaking changes

None expected. `StreamwallConnection.undoManager` is a new optional field;
existing consumers are unaffected. No config or persisted-data format
changes.

Closes #79
