### PR TITLE
feat: add named layout presets (save/load)

### DIFF
--- a/packages/streamwall-control-client/src/dev.tsx
+++ b/packages/streamwall-control-client/src/dev.tsx
@@ -163,6 +163,7 @@ const demoState: StreamwallState = {
   customStreams: [],
   views: demoViews as unknown as StreamwallState['views'],
   streamdelay: null,
+  layoutPresets: [],
 }
 
 function useMockConnection(): StreamwallConnection {

--- a/packages/streamwall-control-server/src/auth.test.ts
+++ b/packages/streamwall-control-server/src/auth.test.ts
@@ -311,6 +311,9 @@ function makeState(): StreamwallState {
     customStreams: [],
     views: [],
     streamdelay: null,
+    layoutPresets: [
+      { id: 'p1', name: 'My Layout', cols: 2, rows: 2, views: {} },
+    ],
   }
 }
 
@@ -362,6 +365,7 @@ test('StateWrapper.view passes non-sensitive fields through unchanged', () => {
   assert.equal(view.customStreams, state.customStreams)
   assert.equal(view.views, state.views)
   assert.equal(view.streamdelay, state.streamdelay)
+  assert.equal(view.layoutPresets, state.layoutPresets)
 })
 
 test('StateWrapper.info returns an unprivileged (monitor) view with no auth', () => {

--- a/packages/streamwall-control-server/src/auth.ts
+++ b/packages/streamwall-control-server/src/auth.ts
@@ -87,8 +87,15 @@ export class StateWrapper extends EventEmitter {
   }
 
   view(role: StreamwallRole) {
-    const { config, auth, streams, customStreams, views, streamdelay } =
-      this._value
+    const {
+      config,
+      auth,
+      streams,
+      customStreams,
+      views,
+      streamdelay,
+      layoutPresets,
+    } = this._value
 
     const state: StreamwallState = {
       identity: {
@@ -99,6 +106,7 @@ export class StateWrapper extends EventEmitter {
       customStreams,
       views,
       streamdelay,
+      layoutPresets,
     }
     if (role === 'admin') {
       state.auth = auth

--- a/packages/streamwall-control-ui/src/LayoutPresetControls.test.tsx
+++ b/packages/streamwall-control-ui/src/LayoutPresetControls.test.tsx
@@ -1,0 +1,136 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import type { LayoutPreset } from 'streamwall-shared'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { LayoutPresetControls } from './LayoutPresetControls.tsx'
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+const presets: LayoutPreset[] = [
+  { id: 'p1', name: 'News Wall', cols: 2, rows: 2, views: {} },
+  { id: 'p2', name: 'Big Screen', cols: 1, rows: 1, views: {} },
+]
+
+function renderControls(
+  props: Partial<Parameters<typeof LayoutPresetControls>[0]> = {},
+): HTMLDivElement {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    render(
+      <LayoutPresetControls
+        presets={presets}
+        role="operator"
+        onSavePreset={vi.fn()}
+        onLoadPreset={vi.fn()}
+        onDeletePreset={vi.fn()}
+        {...props}
+      />,
+      container!,
+    )
+  })
+  return container
+}
+
+function type(input: HTMLInputElement, value: string): void {
+  act(() => {
+    input.value = value
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+
+function submit(form: HTMLFormElement): void {
+  act(() => {
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+  })
+}
+
+describe('LayoutPresetControls', () => {
+  test('renders a load button for each saved preset', () => {
+    const el = renderControls()
+    const buttons = [...el.querySelectorAll('button.preset')].map(
+      (b) => b.textContent,
+    )
+    expect(buttons).toEqual(['News Wall', 'Big Screen'])
+  })
+
+  test('calls onLoadPreset with the preset id when a preset button is clicked', () => {
+    const onLoadPreset = vi.fn()
+    const el = renderControls({ onLoadPreset })
+    const button = el.querySelector('button.preset') as HTMLButtonElement
+
+    act(() => button.click())
+
+    expect(onLoadPreset).toHaveBeenCalledWith('p1')
+  })
+
+  test('calls onDeletePreset with the preset id when its delete button is clicked', () => {
+    const onDeletePreset = vi.fn()
+    const el = renderControls({ onDeletePreset })
+    const deleteButton = el.querySelector('button.delete') as HTMLButtonElement
+
+    act(() => deleteButton.click())
+
+    expect(onDeletePreset).toHaveBeenCalledWith('p1')
+  })
+
+  test('submits the typed name and clears the input on save', () => {
+    const onSavePreset = vi.fn()
+    const el = renderControls({ onSavePreset })
+    const input = el.querySelector('input') as HTMLInputElement
+    const form = el.querySelector('form') as HTMLFormElement
+
+    type(input, 'My New Layout')
+    submit(form)
+
+    expect(onSavePreset).toHaveBeenCalledWith('My New Layout')
+    expect(input.value).toBe('')
+  })
+
+  test('does not call onSavePreset for a blank or whitespace-only name', () => {
+    const onSavePreset = vi.fn()
+    const el = renderControls({ onSavePreset })
+    const input = el.querySelector('input') as HTMLInputElement
+    const form = el.querySelector('form') as HTMLFormElement
+
+    type(input, '   ')
+    submit(form)
+
+    expect(onSavePreset).not.toHaveBeenCalled()
+  })
+
+  test('disables all controls for a role without save-layout-preset permission', () => {
+    const el = renderControls({ role: 'monitor' })
+
+    const input = el.querySelector('input') as HTMLInputElement
+    const saveButton = el.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement
+    const presetButtons = [...el.querySelectorAll('button.preset')]
+    const deleteButtons = [...el.querySelectorAll('button.delete')]
+
+    expect(input.disabled).toBe(true)
+    expect(saveButton.disabled).toBe(true)
+    for (const button of [...presetButtons, ...deleteButtons]) {
+      expect((button as HTMLButtonElement).disabled).toBe(true)
+    }
+  })
+
+  test('enables all controls for the local role', () => {
+    const el = renderControls({ role: 'local' })
+
+    const input = el.querySelector('input') as HTMLInputElement
+    const presetButton = el.querySelector('button.preset') as HTMLButtonElement
+
+    expect(input.disabled).toBe(false)
+    expect(presetButton.disabled).toBe(false)
+  })
+})

--- a/packages/streamwall-control-ui/src/LayoutPresetControls.tsx
+++ b/packages/streamwall-control-ui/src/LayoutPresetControls.tsx
@@ -1,0 +1,128 @@
+import { type JSX } from 'preact'
+import { useCallback, useState } from 'preact/hooks'
+import {
+  roleCan,
+  type LayoutPreset,
+  type StreamwallRole,
+} from 'streamwall-shared'
+import { styled } from 'styled-components'
+
+const StyledLayoutPresetControls = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+
+  form {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+  input {
+    width: 140px;
+    background: transparent;
+    color: inherit;
+    border: 1px solid var(--border, #444);
+    border-radius: 4px;
+    padding: 2px 4px;
+    font: inherit;
+  }
+  button {
+    padding: 2px 8px;
+    border: 1px solid var(--border, #444);
+    background: transparent;
+    color: inherit;
+    border-radius: 4px;
+    cursor: pointer;
+    font: inherit;
+  }
+  .preset-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+  }
+  button.delete {
+    padding: 2px 6px;
+    color: var(--text-dim, #888);
+  }
+`
+
+/**
+ * Save-current-layout form plus a row of saved presets, each loadable or
+ * deletable in one click. Fits next to `GridSizeControls` in the header, per
+ * issue #78.
+ */
+export function LayoutPresetControls({
+  presets,
+  role,
+  onSavePreset,
+  onLoadPreset,
+  onDeletePreset,
+}: {
+  presets: LayoutPreset[]
+  role: StreamwallRole | null
+  onSavePreset: (name: string) => void
+  onLoadPreset: (id: string) => void
+  onDeletePreset: (id: string) => void
+}) {
+  const disabled = !roleCan(role, 'save-layout-preset')
+
+  const [nameDraft, setNameDraft] = useState('')
+
+  const handleChangeName = useCallback<JSX.InputEventHandler<HTMLInputElement>>(
+    (ev) => {
+      setNameDraft(ev.currentTarget.value)
+    },
+    [],
+  )
+
+  const handleSubmit = useCallback<JSX.SubmitEventHandler<HTMLFormElement>>(
+    (ev) => {
+      ev.preventDefault()
+      const name = nameDraft.trim()
+      if (!name) {
+        return
+      }
+      onSavePreset(name)
+      setNameDraft('')
+    },
+    [nameDraft, onSavePreset],
+  )
+
+  return (
+    <StyledLayoutPresetControls>
+      <form onSubmit={handleSubmit}>
+        <input
+          placeholder="Preset name"
+          value={nameDraft}
+          disabled={disabled}
+          onInput={handleChangeName}
+        />
+        <button type="submit" disabled={disabled}>
+          save layout
+        </button>
+      </form>
+      {presets.map((preset) => (
+        <span className="preset-chip" key={preset.id}>
+          <button
+            type="button"
+            className="preset"
+            disabled={disabled}
+            onClick={() => onLoadPreset(preset.id)}
+          >
+            {preset.name}
+          </button>
+          <button
+            type="button"
+            className="delete"
+            disabled={disabled}
+            aria-label={`Delete preset ${preset.name}`}
+            onClick={() => onDeletePreset(preset.id)}
+          >
+            ×
+          </button>
+        </span>
+      ))}
+    </StyledLayoutPresetControls>
+  )
+}

--- a/packages/streamwall-control-ui/src/hotkeysOptions.test.tsx
+++ b/packages/streamwall-control-ui/src/hotkeysOptions.test.tsx
@@ -68,6 +68,7 @@ function renderControlUI(): HTMLDivElement {
     stateIdxMap: new Map(),
     delayState,
     authState: undefined,
+    layoutPresets: [],
   }
 
   act(() => {

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -43,6 +43,7 @@ import {
   idColor,
   idxInBox,
   inviteLink,
+  type LayoutPreset,
   type LocalStreamData,
   parseGridDimensionInput,
   roleCan,
@@ -63,6 +64,7 @@ import {
   resolveMoveTarget,
 } from './gestures'
 import './index.css'
+import { LayoutPresetControls } from './LayoutPresetControls.tsx'
 import { LazyChangeInput } from './LazyChangeInput.tsx'
 import { resolveTargetViewIdx, resolveWriteStreamId } from './viewPlacement.ts'
 import { createSharedUndoManager } from './yUndo.ts'
@@ -497,6 +499,7 @@ export interface StreamwallConnection {
   stateIdxMap: Map<number, ViewInfo>
   delayState: StreamDelayStatus | null | undefined
   authState?: StreamwallState['auth']
+  layoutPresets: LayoutPreset[]
 }
 
 export function useStreamwallState(state: StreamwallState | undefined) {
@@ -511,6 +514,7 @@ export function useStreamwallState(state: StreamwallState | undefined) {
         stateIdxMap: new Map(),
         delayState: undefined,
         authState: undefined,
+        layoutPresets: [],
       }
     }
 
@@ -521,6 +525,7 @@ export function useStreamwallState(state: StreamwallState | undefined) {
       streams: stateStreams,
       views: stateViews,
       streamdelay,
+      layoutPresets,
     } = state
     const stateIdxMap = new Map()
     const views = []
@@ -567,6 +572,7 @@ export function useStreamwallState(state: StreamwallState | undefined) {
       streams,
       customStreams,
       stateIdxMap,
+      layoutPresets,
     }
   }, [state])
 }
@@ -590,6 +596,7 @@ export function ControlUI({
     delayState,
     authState,
     role,
+    layoutPresets,
   } = connection
   const {
     cols,
@@ -1021,6 +1028,27 @@ export function ControlUI({
     [send],
   )
 
+  const handleSaveLayoutPreset = useCallback(
+    (name: string) => {
+      send({ type: 'save-layout-preset', name })
+    },
+    [send],
+  )
+
+  const handleLoadLayoutPreset = useCallback(
+    (presetId: string) => {
+      send({ type: 'load-layout-preset', presetId })
+    },
+    [send],
+  )
+
+  const handleDeleteLayoutPreset = useCallback(
+    (presetId: string) => {
+      send({ type: 'delete-layout-preset', presetId })
+    },
+    [send],
+  )
+
   const preventLinkClick = useCallback((ev: Event) => {
     ev.preventDefault()
   }, [])
@@ -1162,6 +1190,13 @@ export function ControlUI({
               onSetGridSize={handleSetGridSize}
             />
           )}
+          <LayoutPresetControls
+            presets={layoutPresets}
+            role={role}
+            onSavePreset={handleSaveLayoutPreset}
+            onLoadPreset={handleLoadLayoutPreset}
+            onDeletePreset={handleDeleteLayoutPreset}
+          />
           <div className="spacer" />
           {liveStreams.length > 0 && (
             <div className="livecount">● {liveStreams.length} On Air</div>

--- a/packages/streamwall-control-ui/src/transientProps.test.tsx
+++ b/packages/streamwall-control-ui/src/transientProps.test.tsx
@@ -85,6 +85,7 @@ function renderControlUI(): HTMLDivElement {
     stateIdxMap: new Map(),
     delayState,
     authState: undefined,
+    layoutPresets: [],
   }
 
   act(() => {

--- a/packages/streamwall-shared/src/roles.test.ts
+++ b/packages/streamwall-shared/src/roles.test.ts
@@ -31,6 +31,9 @@ const operatorOnlyActions = [
   'set-stream-running',
   'mutate-state-doc',
   'set-grid-size',
+  'save-layout-preset',
+  'load-layout-preset',
+  'delete-layout-preset',
 ] as const satisfies readonly StreamwallAction[]
 
 // Available to every authenticated role down to monitor.

--- a/packages/streamwall-shared/src/roles.ts
+++ b/packages/streamwall-shared/src/roles.ts
@@ -15,6 +15,9 @@ const operatorActions = [
   'set-stream-running',
   'mutate-state-doc',
   'set-grid-size',
+  'save-layout-preset',
+  'load-layout-preset',
+  'delete-layout-preset',
 ] as const
 
 const monitorActions = ['set-view-blurred', 'set-stream-censored'] as const

--- a/packages/streamwall-shared/src/schemas.test.ts
+++ b/packages/streamwall-shared/src/schemas.test.ts
@@ -296,6 +296,67 @@ describe('controlCommandMessageSchema', () => {
     ).toBe(false)
   })
 
+  test('accepts a save-layout-preset command with a non-empty name', () => {
+    expect(
+      controlCommandMessageSchema.safeParse({
+        id: 1,
+        type: 'save-layout-preset',
+        name: 'My Layout',
+      }).success,
+    ).toBe(true)
+  })
+
+  test('rejects save-layout-preset with an empty or overlong name', () => {
+    expect(
+      controlCommandMessageSchema.safeParse({
+        id: 1,
+        type: 'save-layout-preset',
+        name: '',
+      }).success,
+    ).toBe(false)
+    expect(
+      controlCommandMessageSchema.safeParse({
+        id: 1,
+        type: 'save-layout-preset',
+        name: 'x'.repeat(101),
+      }).success,
+    ).toBe(false)
+  })
+
+  test('accepts load-layout-preset and delete-layout-preset with a non-empty presetId', () => {
+    expect(
+      controlCommandMessageSchema.safeParse({
+        id: 1,
+        type: 'load-layout-preset',
+        presetId: 'preset-1',
+      }).success,
+    ).toBe(true)
+    expect(
+      controlCommandMessageSchema.safeParse({
+        id: 1,
+        type: 'delete-layout-preset',
+        presetId: 'preset-1',
+      }).success,
+    ).toBe(true)
+  })
+
+  test('rejects load-layout-preset and delete-layout-preset with an empty presetId', () => {
+    expect(
+      controlCommandMessageSchema.safeParse({
+        id: 1,
+        type: 'load-layout-preset',
+        presetId: '',
+      }).success,
+    ).toBe(false)
+    expect(
+      controlCommandMessageSchema.safeParse({
+        id: 1,
+        type: 'delete-layout-preset',
+        presetId: '',
+      }).success,
+    ).toBe(false)
+  })
+
   test('parsed commands remain assignable to the ControlCommand type', () => {
     const result = controlCommandMessageSchema.safeParse({
       id: 7,

--- a/packages/streamwall-shared/src/schemas.ts
+++ b/packages/streamwall-shared/src/schemas.ts
@@ -44,6 +44,14 @@ const rotationSchema = z.number().min(0).max(MAX_ROTATION)
 const viewIdxSchema = z.number().int().min(0).max(MAX_VIEW_IDX)
 const gridDimensionSchema = z.number().int().min(GRID_MIN).max(GRID_MAX)
 
+/** Longest allowed name for a saved layout preset. */
+export const MAX_LAYOUT_PRESET_NAME_LENGTH = 100
+const layoutPresetNameSchema = z
+  .string()
+  .min(1)
+  .max(MAX_LAYOUT_PRESET_NAME_LENGTH)
+const layoutPresetIdSchema = z.string().min(1).max(100)
+
 /** Optional descriptive fields shared by every stream-data shape. */
 const streamMetaFields = {
   label: z.string().optional(),
@@ -179,6 +187,18 @@ export const controlCommandSchema = z.discriminatedUnion('type', [
     type: z.literal('set-grid-size'),
     cols: gridDimensionSchema,
     rows: gridDimensionSchema,
+  }),
+  z.object({
+    type: z.literal('save-layout-preset'),
+    name: layoutPresetNameSchema,
+  }),
+  z.object({
+    type: z.literal('load-layout-preset'),
+    presetId: layoutPresetIdSchema,
+  }),
+  z.object({
+    type: z.literal('delete-layout-preset'),
+    presetId: layoutPresetIdSchema,
   }),
 ])
 

--- a/packages/streamwall-shared/src/types.ts
+++ b/packages/streamwall-shared/src/types.ts
@@ -98,6 +98,16 @@ export interface AuthTokenInfo {
   name: string
 }
 
+/** A named, saved grid layout: its dimensions and per-cell stream assignments. */
+export interface LayoutPreset {
+  id: string
+  name: string
+  cols: number
+  rows: number
+  /** Sparse: only cells with an assigned stream are present. */
+  views: { [viewIdx: string]: { streamId: string } }
+}
+
 export interface StreamwallState {
   identity: {
     role: StreamwallRole
@@ -111,6 +121,7 @@ export interface StreamwallState {
   customStreams: StreamList
   views: ViewState[]
   streamdelay: StreamDelayStatus | null
+  layoutPresets: LayoutPreset[]
 }
 
 type MessageMeta = {
@@ -137,6 +148,9 @@ export type ControlCommand =
   | { type: 'create-invite'; role: string; name: string }
   | { type: 'delete-token'; tokenId: string }
   | { type: 'set-grid-size'; cols: number; rows: number }
+  | { type: 'save-layout-preset'; name: string }
+  | { type: 'load-layout-preset'; presetId: string }
+  | { type: 'delete-layout-preset'; presetId: string }
 
 export type ControlUpdate = {
   type: 'state'

--- a/packages/streamwall-shared/src/uplink.test.ts
+++ b/packages/streamwall-shared/src/uplink.test.ts
@@ -17,6 +17,12 @@ describe('isCommandAllowedFromUplink', () => {
     expect(isCommandAllowedFromUplink('set-grid-size')).toBe(true)
   })
 
+  test('allows layout preset commands', () => {
+    expect(isCommandAllowedFromUplink('save-layout-preset')).toBe(true)
+    expect(isCommandAllowedFromUplink('load-layout-preset')).toBe(true)
+    expect(isCommandAllowedFromUplink('delete-layout-preset')).toBe(true)
+  })
+
   test('rejects code-execution commands from the uplink', () => {
     expect(isCommandAllowedFromUplink('browse')).toBe(false)
     expect(isCommandAllowedFromUplink('dev-tools')).toBe(false)

--- a/packages/streamwall-shared/src/uplink.ts
+++ b/packages/streamwall-shared/src/uplink.ts
@@ -27,6 +27,9 @@ const UPLINK_ALLOWED_COMMANDS: ReadonlySet<ControlCommand['type']> = new Set<
   'set-stream-censored',
   'set-stream-running',
   'set-grid-size',
+  'save-layout-preset',
+  'load-layout-preset',
+  'delete-layout-preset',
 ])
 
 /**

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -3,6 +3,7 @@ import { BrowserWindow, app } from 'electron'
 import started from 'electron-squirrel-startup'
 import fs from 'fs'
 import { throttle } from 'lodash-es'
+import { randomUUID } from 'node:crypto'
 import EventEmitter from 'node:events'
 import { join } from 'node:path'
 import ReconnectingWebSocket from 'reconnecting-websocket'
@@ -35,6 +36,11 @@ import {
   watchDataFile,
 } from './data'
 import { applyGridResize } from './gridResize'
+import {
+  addLayoutPreset,
+  applyLayoutPreset,
+  buildLayoutPreset,
+} from './layoutPresets'
 import { denyWindowOpen } from './navigationSecurity'
 import { BROWSE_PARTITION, hardenSession } from './partitions'
 import { PlaylistScheduler } from './playlist'
@@ -414,6 +420,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     customStreams: [],
     views: [],
     streamdelay: null,
+    layoutPresets: db.data.layoutPresets,
   }
 
   function updateViewsFromStateDoc() {
@@ -594,6 +601,49 @@ async function main(argv: ReturnType<typeof parseArgs>) {
       // the new dimensions (issue #15) — so no explicit updateViewsFromStateDoc()
       // call is needed here.
       updateState({})
+    } else if (msg.type === 'save-layout-preset') {
+      console.debug('Saving layout preset:', msg.name)
+      const preset = buildLayoutPreset(
+        {
+          viewsState,
+          cols: streamWindowConfig.cols,
+          rows: streamWindowConfig.rows,
+        },
+        randomUUID(),
+        msg.name,
+      )
+      const layoutPresets = addLayoutPreset(clientState.layoutPresets, preset)
+      db.update((data) => {
+        data.layoutPresets = layoutPresets
+      })
+      updateState({ layoutPresets })
+    } else if (msg.type === 'load-layout-preset') {
+      const preset = clientState.layoutPresets.find(
+        (p) => p.id === msg.presetId,
+      )
+      if (preset) {
+        console.debug('Loading layout preset:', preset.name)
+        applyLayoutPreset(
+          {
+            viewsState,
+            transact: (fn) => stateDoc.transact(fn),
+            setGridSize: (cols, rows) => streamWindow.setGridSize(cols, rows),
+          },
+          preset,
+        )
+        // See the set-grid-size branch above: broadcast the shared config
+        // object via updateState({}) rather than detaching a copy.
+        updateState({})
+      }
+    } else if (msg.type === 'delete-layout-preset') {
+      console.debug('Deleting layout preset:', msg.presetId)
+      const layoutPresets = clientState.layoutPresets.filter(
+        (p) => p.id !== msg.presetId,
+      )
+      db.update((data) => {
+        data.layoutPresets = layoutPresets
+      })
+      updateState({ layoutPresets })
     }
   }
 

--- a/packages/streamwall/src/main/layoutPresets.test.ts
+++ b/packages/streamwall/src/main/layoutPresets.test.ts
@@ -1,0 +1,163 @@
+import type { LayoutPreset } from 'streamwall-shared'
+import { describe, expect, it } from 'vitest'
+import * as Y from 'yjs'
+import {
+  addLayoutPreset,
+  applyLayoutPreset,
+  buildLayoutPreset,
+  MAX_LAYOUT_PRESETS,
+} from './layoutPresets'
+
+function makeViewsState(assignments: Record<number, string | undefined>) {
+  const doc = new Y.Doc()
+  const viewsState = doc.getMap<Y.Map<string | undefined>>('views')
+  doc.transact(() => {
+    for (const [key, streamId] of Object.entries(assignments)) {
+      const data = new Y.Map<string | undefined>()
+      data.set('streamId', streamId)
+      viewsState.set(key, data)
+    }
+  })
+  return { doc, viewsState }
+}
+
+describe('buildLayoutPreset', () => {
+  it('captures the current grid dimensions and non-empty cell assignments', () => {
+    const { viewsState } = makeViewsState({
+      0: 'stream-a',
+      1: undefined,
+      2: 'stream-b',
+    })
+
+    const preset = buildLayoutPreset(
+      { viewsState, cols: 2, rows: 2 },
+      'preset-1',
+      'My Layout',
+    )
+
+    expect(preset).toEqual<LayoutPreset>({
+      id: 'preset-1',
+      name: 'My Layout',
+      cols: 2,
+      rows: 2,
+      views: {
+        '0': { streamId: 'stream-a' },
+        '2': { streamId: 'stream-b' },
+      },
+    })
+  })
+
+  it('produces an empty views object for an entirely empty grid', () => {
+    const { viewsState } = makeViewsState({ 0: undefined, 1: undefined })
+
+    const preset = buildLayoutPreset(
+      { viewsState, cols: 2, rows: 1 },
+      'preset-2',
+      'Empty',
+    )
+
+    expect(preset.views).toEqual({})
+  })
+})
+
+describe('addLayoutPreset', () => {
+  const preset = (id: string): LayoutPreset => ({
+    id,
+    name: id,
+    cols: 2,
+    rows: 2,
+    views: {},
+  })
+
+  it('appends a preset to the list', () => {
+    const result = addLayoutPreset([preset('a')], preset('b'))
+    expect(result.map((p) => p.id)).toEqual(['a', 'b'])
+  })
+
+  it('bounds the list to MAX_LAYOUT_PRESETS by dropping the oldest entries', () => {
+    const full = Array.from({ length: MAX_LAYOUT_PRESETS }, (_, i) =>
+      preset(`p${i}`),
+    )
+
+    const result = addLayoutPreset(full, preset('newest'))
+
+    expect(result).toHaveLength(MAX_LAYOUT_PRESETS)
+    expect(result[result.length - 1].id).toBe('newest')
+    expect(result[0].id).toBe('p1')
+    expect(result.some((p) => p.id === 'p0')).toBe(false)
+  })
+})
+
+describe('applyLayoutPreset', () => {
+  it('resizes the grid and rewrites viewsState to match the preset', () => {
+    const { doc, viewsState } = makeViewsState({
+      0: 'old-a',
+      1: 'old-b',
+      2: undefined,
+      3: undefined,
+    })
+
+    let cols = 2
+    let rows = 2
+    const ctx = {
+      viewsState,
+      transact: (fn: () => void) => doc.transact(fn),
+      setGridSize: (c: number, r: number) => {
+        cols = c
+        rows = r
+      },
+    }
+
+    const preset: LayoutPreset = {
+      id: 'preset-1',
+      name: 'Saved',
+      cols: 3,
+      rows: 2,
+      views: {
+        '0': { streamId: 'new-a' },
+        '4': { streamId: 'new-b' },
+      },
+    }
+
+    applyLayoutPreset(ctx, preset)
+
+    expect(cols).toBe(3)
+    expect(rows).toBe(2)
+    expect(
+      [...viewsState.keys()].sort((a, b) => Number(a) - Number(b)),
+    ).toEqual(['0', '1', '2', '3', '4', '5'])
+    expect(viewsState.get('0')?.get('streamId')).toBe('new-a')
+    expect(viewsState.get('4')?.get('streamId')).toBe('new-b')
+    expect(viewsState.get('1')?.get('streamId')).toBeUndefined()
+  })
+
+  it('applies the new grid size before the transact observer runs', () => {
+    const { doc, viewsState } = makeViewsState({ 0: 'a' })
+    let cols = 1
+    let rows = 1
+    const observedDims: Array<[number, number]> = []
+    viewsState.observeDeep(() => observedDims.push([cols, rows]))
+
+    const ctx = {
+      viewsState,
+      transact: (fn: () => void) => doc.transact(fn),
+      setGridSize: (c: number, r: number) => {
+        cols = c
+        rows = r
+      },
+    }
+
+    applyLayoutPreset(ctx, {
+      id: 'preset-1',
+      name: 'Saved',
+      cols: 2,
+      rows: 2,
+      views: {},
+    })
+
+    expect(observedDims.length).toBeGreaterThan(0)
+    for (const dims of observedDims) {
+      expect(dims).toEqual([2, 2])
+    }
+  })
+})

--- a/packages/streamwall/src/main/layoutPresets.ts
+++ b/packages/streamwall/src/main/layoutPresets.ts
@@ -1,0 +1,81 @@
+import type { LayoutPreset } from 'streamwall-shared'
+import * as Y from 'yjs'
+
+/** Maximum number of saved layout presets, bounding unbounded storage growth. */
+export const MAX_LAYOUT_PRESETS = 50
+
+export interface LayoutPresetSaveContext {
+  /** Yjs map of grid cell index (as string) -> a `{ streamId }` map. */
+  viewsState: Y.Map<Y.Map<string | undefined>>
+  cols: number
+  rows: number
+}
+
+/** Captures the current grid dimensions and per-cell stream assignments as a named preset. */
+export function buildLayoutPreset(
+  ctx: LayoutPresetSaveContext,
+  id: string,
+  name: string,
+): LayoutPreset {
+  const views: LayoutPreset['views'] = {}
+  for (const [key, viewData] of ctx.viewsState) {
+    const streamId = viewData.get('streamId')
+    if (streamId) {
+      views[key] = { streamId }
+    }
+  }
+  return { id, name, cols: ctx.cols, rows: ctx.rows, views }
+}
+
+/**
+ * Appends `preset` to `presets`, bounding the list to `MAX_LAYOUT_PRESETS` by
+ * dropping the oldest entries when full — saving a new preset always succeeds.
+ */
+export function addLayoutPreset(
+  presets: LayoutPreset[],
+  preset: LayoutPreset,
+): LayoutPreset[] {
+  const next = [...presets, preset]
+  return next.length > MAX_LAYOUT_PRESETS
+    ? next.slice(next.length - MAX_LAYOUT_PRESETS)
+    : next
+}
+
+/**
+ * Collaborators the layout-preset load orchestration needs from the main
+ * process, mirroring `GridResizeContext` in `gridResize.ts`.
+ */
+export interface LayoutPresetLoadContext {
+  viewsState: Y.Map<Y.Map<string | undefined>>
+  /** Runs `fn` inside the shared `stateDoc.transact`, batching the mutations. */
+  transact: (fn: () => void) => void
+  /** Applies the preset's grid dimensions to the wall (mutates the shared config). */
+  setGridSize: (cols: number, rows: number) => void
+}
+
+/**
+ * Resizes the wall grid and rewrites `viewsState` to exactly match a saved
+ * layout preset.
+ *
+ * Ordering mirrors `applyGridResize`: the grid size is applied BEFORE the
+ * transact so the stateDoc's synchronous `observeDeep` observer re-lays the
+ * wall out against the new dimensions (see gridResize.ts for the full
+ * rationale, issue #15).
+ */
+export function applyLayoutPreset(
+  ctx: LayoutPresetLoadContext,
+  preset: LayoutPreset,
+): void {
+  ctx.setGridSize(preset.cols, preset.rows)
+
+  ctx.transact(() => {
+    for (const key of [...ctx.viewsState.keys()]) {
+      ctx.viewsState.delete(key)
+    }
+    for (let i = 0; i < preset.cols * preset.rows; i++) {
+      const data = new Y.Map<string | undefined>()
+      data.set('streamId', preset.views[String(i)]?.streamId)
+      ctx.viewsState.set(String(i), data)
+    }
+  })
+}

--- a/packages/streamwall/src/main/storage.test.ts
+++ b/packages/streamwall/src/main/storage.test.ts
@@ -1,11 +1,20 @@
+import { mkdtempSync, rmSync } from 'fs'
 import { Low, Memory } from 'lowdb'
-import { describe, expect, it, vi } from 'vitest'
-import { flushStorage, StorageDB, StreamwallStoredData } from './storage'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { describe, expect, it, test, vi } from 'vitest'
+import {
+  flushStorage,
+  loadStorage,
+  StorageDB,
+  StreamwallStoredData,
+} from './storage'
 
 function makeDB(initial: Partial<StreamwallStoredData> = {}): StorageDB {
   return new Low<StreamwallStoredData>(new Memory(), {
     stateDoc: '',
     localStreamData: [],
+    layoutPresets: [],
     ...initial,
   })
 }
@@ -49,5 +58,39 @@ describe('flushStorage', () => {
     expect(persisted?.localStreamData).toEqual([
       { _id: 'a', kind: 'video', link: 'https://example.test' },
     ])
+  })
+})
+
+describe('loadStorage', () => {
+  test('defaults layoutPresets to an empty array for a fresh db', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'streamwall-storage-test-'))
+    try {
+      const dbPath = join(dir, 'storage.json')
+      const db = await loadStorage(dbPath)
+
+      expect(db.data.layoutPresets).toEqual([])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('db.update persists a saved layout preset onto db.data', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'streamwall-storage-test-'))
+    try {
+      const dbPath = join(dir, 'storage.json')
+      const db = await loadStorage(dbPath)
+
+      await db.update((data) => {
+        data.layoutPresets = [
+          { id: 'p1', name: 'My Layout', cols: 2, rows: 2, views: {} },
+        ]
+      })
+
+      expect(db.data.layoutPresets).toEqual([
+        { id: 'p1', name: 'My Layout', cols: 2, rows: 2, views: {} },
+      ])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/streamwall/src/main/storage.ts
+++ b/packages/streamwall/src/main/storage.ts
@@ -1,15 +1,17 @@
 import { Low, Memory } from 'lowdb'
 import { JSONFilePreset } from 'lowdb/node'
-import { StreamDataContent } from 'streamwall-shared'
+import { LayoutPreset, StreamDataContent } from 'streamwall-shared'
 
 export interface StreamwallStoredData {
   stateDoc: string
   localStreamData: StreamDataContent[]
+  layoutPresets: LayoutPreset[]
 }
 
 const defaultData: StreamwallStoredData = {
   stateDoc: '',
   localStreamData: [],
+  layoutPresets: [],
 }
 
 export type StorageDB = Low<StreamwallStoredData>


### PR DESCRIPTION
## Summary

Closes #78.

Adds named layout presets: save the current grid (dimensions + per-cell stream assignments) under a name, and recall it in one click — rendered next to the `GRID_PRESETS` size buttons in the control UI header, per the issue's requested placement.

## Technical solution

- **streamwall-shared**: new `LayoutPreset` type and `StreamwallState.layoutPresets`; three new `ControlCommand` variants (`save-layout-preset`, `load-layout-preset`, `delete-layout-preset`) with bounded Zod schemas; added to the `operator` permission tier (same as `set-grid-size`) and to the uplink allowlist.
- **streamwall (main process)**: `layoutPresets.ts` provides pure, unit-testable helpers — `buildLayoutPreset` captures the current grid from `viewsState`, `applyLayoutPreset` rewrites `viewsState` to match a saved preset (mirroring `applyGridResize`'s critical ordering: grid size is set *before* the `stateDoc.transact` so the synchronous `observeDeep` layout observer sees the new dimensions — see the ordering note in `gridResize.ts`, issue #15), and `addLayoutPreset` bounds the saved list to `MAX_LAYOUT_PRESETS` (50) to prevent unbounded storage growth. Presets persist via the existing lowdb `storage.ts`.
- **streamwall-control-server**: `StateWrapper.view()` now passes `layoutPresets` through to every role's state view (read-only visibility; the save/load/delete actions themselves stay `roleCan`-gated).
- **streamwall-control-ui**: new `LayoutPresetControls` component — a name input + save button, and a load/delete button pair per saved preset — gated by `roleCan(role, 'save-layout-preset')`.

### Architecture decisions

- Presets are a plain JSON-serializable shape (`{ id, name, cols, rows, views }`), not a raw Yjs snapshot, so they travel over the existing Zod-validated `ControlCommand` JSON channel and compose with the same `viewsState` mutation helpers already used for grid resize.
- The command's own id field is named `presetId` (not `id`) to avoid colliding with the message envelope's numeric `id` under `controlCommandMessageSchema`'s `z.intersection`.
- No control-server changes were needed for command relaying — `save-layout-preset`/`load-layout-preset`/`delete-layout-preset` fall through the existing generic forward branch exactly like `set-grid-size` does today.

## Testing performed

- TDD throughout: `layoutPresets.test.ts`, `storage.test.ts`, `LayoutPresetControls.test.tsx`, plus schema/uplink/roles coverage in `streamwall-shared`, and `StateWrapper.view` coverage in `streamwall-control-server`.
- Full quality gate green: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` (all workspaces), and `npm -w streamwall-control-client run build`.
- Manually verified in the browser via the control-client dev harness (`dev.html`): the save form renders next to the grid-size buttons, accepts a name, and dispatches the correct `save-layout-preset` command.

## Risks / breaking changes

None. `StreamwallState.layoutPresets` is a new required field on an internal type; all in-repo construction sites (main process, control-server, dev fixtures) were updated. No persisted-storage migration is needed — `layoutPresets` defaults to `[]` for existing `streamwall-storage.json` files.