### PR TITLE
fix(renderer): inline the loading spinner instead of svg-loaders-react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12991,11 +12991,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/svg-loaders-react": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/svg-loaders-react/-/svg-loaders-react-3.1.1.tgz",
-      "integrity": "sha512-zREh+e1S7blwCAW14i8j0eorC6Jmm0jC0BqmdxFfQxoV/hkrpxsogXons+FK6IUdOGtdN1IM3IBtT1mOvcPnSg=="
-    },
     "node_modules/tapable": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
@@ -14883,7 +14878,6 @@
         "reconnecting-websocket": "^4.4.0",
         "source-map-support": "^0.5.21",
         "styled-components": "^6.4.3",
-        "svg-loaders-react": "^3.1.1",
         "update-electron-app": "^3.3.0",
         "utf-8-validate": "^6.0.6",
         "ws": "^8.21.0",

--- a/packages/streamwall/package.json
+++ b/packages/streamwall/package.json
@@ -63,7 +63,6 @@
     "reconnecting-websocket": "^4.4.0",
     "source-map-support": "^0.5.21",
     "styled-components": "^6.4.3",
-    "svg-loaders-react": "^3.1.1",
     "update-electron-app": "^3.3.0",
     "utf-8-validate": "^6.0.6",
     "ws": "^8.21.0",

--- a/packages/streamwall/src/renderer/OverlayViewTile.test.tsx
+++ b/packages/streamwall/src/renderer/OverlayViewTile.test.tsx
@@ -2,18 +2,8 @@
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
 import type { StreamData } from 'streamwall-shared'
-import { afterEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, describe, expect, test } from 'vitest'
 import { OverlayViewTile } from './OverlayViewTile'
-
-// Unlike react-icons and styled-components (see vitest.config.ts),
-// svg-loaders-react ships CJS only, so it has no ESM build for Vite's
-// resolver to route through the `react` -> `preact/compat` alias - it always
-// resolves the real `react` package, which crashes when preact/compat's
-// forwardRef-wrapped `styled(TailSpin)` renders it. Stub it out so the
-// tile's own rendering logic can be exercised in isolation.
-vi.mock('svg-loaders-react', () => ({
-  TailSpin: () => null,
-}))
 
 let container: HTMLDivElement | undefined
 
@@ -101,7 +91,30 @@ describe('OverlayViewTile', () => {
     expect(tile.textContent).not.toContain('Stream error')
     expect(tile.textContent).not.toContain('Stream unavailable')
     expect(tile.textContent).toContain('Example Stream')
-    expect(tile.querySelector('svg')).toBeNull()
+    // The loading spinner is always present in the DOM (visibility is
+    // toggled via CSS, see the isLoading tests below); it's the only svg
+    // expected here since the URL doesn't match a known platform icon.
+    const svgs = tile.querySelectorAll('svg')
+    expect(svgs).toHaveLength(1)
+    expect(svgs[0].querySelector('circle')).not.toBeNull()
+  })
+
+  test('shows the loading spinner while isLoading is true', () => {
+    const tile = renderTile({ isLoading: true })
+
+    const spinner = tile.querySelector('svg circle')?.closest('svg')
+    expect(spinner).not.toBeNull()
+    expect(getComputedStyle(spinner!).opacity).toBe('0.5')
+    expect(getComputedStyle(spinner!).visibility).toBe('visible')
+  })
+
+  test('hides the loading spinner while isLoading is false', () => {
+    const tile = renderTile({ isLoading: false })
+
+    const spinner = tile.querySelector('svg circle')?.closest('svg')
+    expect(spinner).not.toBeNull()
+    expect(getComputedStyle(spinner!).opacity).toBe('0')
+    expect(getComputedStyle(spinner!).visibility).toBe('hidden')
   })
 
   test('does not leak custom styled-component props onto the DOM nodes (#152)', () => {

--- a/packages/streamwall/src/renderer/OverlayViewTile.tsx
+++ b/packages/streamwall/src/renderer/OverlayViewTile.tsx
@@ -12,7 +12,7 @@ import {
 import { RiKickFill, RiTwitterXFill } from 'react-icons/ri'
 import type { StreamData } from 'streamwall-shared'
 import { styled } from 'styled-components'
-import { TailSpin } from 'svg-loaders-react'
+import { TailSpin } from './TailSpin'
 
 // Extracted from overlay.tsx so it can be rendered and tested in isolation,
 // without pulling in the module-level `render(<App />, document.body)` call.

--- a/packages/streamwall/src/renderer/TailSpin.tsx
+++ b/packages/streamwall/src/renderer/TailSpin.tsx
@@ -1,0 +1,54 @@
+import type { SVGProps } from 'react'
+
+// Inlined from svg-loaders-react's TailSpin (MIT, Copyright (c) 2014 Sam
+// Herbert, Copyright (c) 2018 Adam Wanninger), which is CJS-only and so has
+// no ESM/browser build for Vite's resolver to route through the
+// `react` -> `preact/compat` alias under this repo's vitest test stack (see
+// vitest.config.ts and issue #182). Inlining it as a first-party component
+// keeps the visuals identical while making it a plain function component
+// that resolves correctly in both the app and its tests.
+export function TailSpin(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg width={38} height={38} viewBox="0 0 38 38" {...props}>
+      <defs>
+        <linearGradient
+          x1="8.042%"
+          y1="0%"
+          x2="65.682%"
+          y2="23.865%"
+          id="tailSpinGradient"
+        >
+          <stop stopColor="#fff" stopOpacity={0} offset="0%" />
+          <stop stopColor="#fff" stopOpacity={0.631} offset="63.146%" />
+          <stop stopColor="#fff" offset="100%" />
+        </linearGradient>
+      </defs>
+      <g transform="translate(1 1)" fill="none" fillRule="evenodd">
+        <path
+          d="M36 18c0-9.94-8.06-18-18-18"
+          stroke="url(#tailSpinGradient)"
+          strokeWidth={2}
+        >
+          <animateTransform
+            attributeName="transform"
+            type="rotate"
+            from="0 18 18"
+            to="360 18 18"
+            dur="0.9s"
+            repeatCount="indefinite"
+          />
+        </path>
+        <circle fill="#fff" cx={36} cy={18} r={1}>
+          <animateTransform
+            attributeName="transform"
+            type="rotate"
+            from="0 18 18"
+            to="360 18 18"
+            dur="0.9s"
+            repeatCount="indefinite"
+          />
+        </circle>
+      </g>
+    </svg>
+  )
+}

--- a/packages/streamwall/src/renderer/svg-loaders-react.d.ts
+++ b/packages/streamwall/src/renderer/svg-loaders-react.d.ts
@@ -1,5 +1,0 @@
-declare module 'svg-loaders-react' {
-  import { FC, SVGProps } from 'react'
-
-  export const TailSpin: FC<SVGProps<SVGSVGElement>>
-}

--- a/packages/streamwall/vitest.config.ts
+++ b/packages/streamwall/vitest.config.ts
@@ -15,10 +15,10 @@ import { defineConfig } from 'vitest/config'
 // react-icons (`Cannot add property __, object is not extensible`, a frozen
 // React element hitting Preact's reconciler) and makes styled-components
 // render elements with their generated class name as the tag instead of the
-// real DOM tag. `svg-loaders-react` (used via `styled(TailSpin)` in
-// OverlayViewTile) has no ESM build, so this fix doesn't reach it - see the
-// `vi.mock('svg-loaders-react', ...)` in OverlayViewTile.test.tsx for the
-// remaining workaround.
+// real DOM tag. `svg-loaders-react` used to have the same CJS-only problem
+// (see issue #182); it was replaced with a first-party inlined component
+// (see OverlayViewTile.tsx's TailSpin import) rather than extending this fix
+// to a third dependency.
 export default defineConfig({
   esbuild: {
     jsx: 'automatic',


### PR DESCRIPTION
## Problem

`svg-loaders-react` (used via `styled(TailSpin)` in `OverlayViewTile.tsx` for the stream-loading spinner) ships CJS only, with no ESM/browser build. Under this repo's `vitest` + `preact` + `happy-dom` component test stack, its internal `require('react')` bypasses `resolve.alias` and always resolves the real `react` package instead of `preact/compat`, throwing:

```
TypeError: Cannot add property __, object is not extensible
    at type ../../node_modules/preact/src/diff/children.js:219:15
```

This is the same crash #177/#181 fixed for `react-icons` and `styled-components`, but their fix (preferring ESM builds via `mainFields` + forcing both through Vite's transform pipeline via `test.server.deps.inline`) doesn't reach `svg-loaders-react` since it has no ESM build to route through the alias. `OverlayViewTile.test.tsx` worked around this with `vi.mock('svg-loaders-react', ...)`, which meant the loading spinner's own rendering was never actually exercised by a component test.

## Solution

Inlined `TailSpin` as a first-party component (`packages/streamwall/src/renderer/TailSpin.tsx`), copied from `svg-loaders-react`'s MIT-licensed source (Copyright Sam Herbert / Adam Wanninger), instead of extending the `mainFields`/`deps.inline` workaround to a third CJS-only dependency:

- Removed the `svg-loaders-react` dependency and its ambient type declaration.
- `OverlayViewTile.tsx` now imports `TailSpin` from the local file — visuals are unchanged.
- Removed the `vi.mock('svg-loaders-react', ...)` workaround from `OverlayViewTile.test.tsx` and added real coverage for the spinner's visibility toggling (`isLoading` true/false), asserting on computed `opacity`/`visibility` instead of just presence.
- Updated the `vitest.config.ts` comment that documented the workaround.

## Testing

- `npm test` (all workspaces) — 155 streamwall tests + full monorepo suite pass, including two new tests exercising the previously-mocked loading spinner.
- `npm run typecheck`, `npx eslint .`, `npm run format:check` — all clean.
- `electron-forge package` — production build succeeds with the dependency removed.

## Risks / breaking changes

None. Visual output of the spinner is unchanged (same SVG markup/animation); this only affects how the spinner is imported and tested.

Closes #182