### PR TITLE
fix(electron): quit when either top-level window closes

### DIFF
--- a/packages/streamwall/src/main/ControlWindow.test.ts
+++ b/packages/streamwall/src/main/ControlWindow.test.ts
@@ -1,0 +1,33 @@
+import EventEmitter from 'events'
+import { describe, expect, it, vi } from 'vitest'
+
+// ControlWindow pulls in Electron directly and via ./loadHTML. Model
+// BrowserWindow as a small EventEmitter so `win.on('close', ...)` wiring can
+// be exercised the same way the real window would drive it, without an
+// Electron runtime.
+class FakeBrowserWindow extends EventEmitter {
+  webContents = { send: vi.fn() }
+  removeMenu = vi.fn()
+}
+
+vi.mock('electron', () => ({
+  BrowserWindow: FakeBrowserWindow,
+  ipcMain: { handle: vi.fn() },
+}))
+
+vi.mock('./loadHTML', () => ({ loadHTML: vi.fn() }))
+
+const { default: ControlWindow } = await import('./ControlWindow')
+
+describe('ControlWindow close', () => {
+  it('forwards the underlying Electron close event so callers can preventDefault', () => {
+    const controlWindow = new ControlWindow()
+    const closeListener = vi.fn()
+    controlWindow.on('close', closeListener)
+
+    const fakeEvent = { preventDefault: vi.fn() }
+    controlWindow.win.emit('close', fakeEvent)
+
+    expect(closeListener).toHaveBeenCalledWith(fakeEvent)
+  })
+})

--- a/packages/streamwall/src/main/ControlWindow.ts
+++ b/packages/streamwall/src/main/ControlWindow.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, ipcMain } from 'electron'
+import { BrowserWindow, Event as ElectronEvent, ipcMain } from 'electron'
 import EventEmitter from 'events'
 import path from 'path'
 import { ControlCommand, StreamwallState } from 'streamwall-shared'
@@ -6,7 +6,7 @@ import { loadHTML } from './loadHTML'
 
 export interface ControlWindowEventMap {
   load: []
-  close: []
+  close: [ElectronEvent]
   command: [ControlCommand]
   ydoc: [Uint8Array]
 }
@@ -28,7 +28,7 @@ export default class ControlWindow extends EventEmitter<ControlWindowEventMap> {
     })
     this.win.removeMenu()
 
-    this.win.on('close', () => this.emit('close'))
+    this.win.on('close', (event) => this.emit('close', event))
 
     loadHTML(this.win.webContents, 'control')
 

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/electron/main'
-import { BrowserWindow, app } from 'electron'
+import { BrowserWindow, Event as ElectronEvent, app } from 'electron'
 import started from 'electron-squirrel-startup'
 import fs from 'fs'
 import { throttle } from 'lodash-es'
@@ -41,7 +41,10 @@ import { flushStorage, loadStorage } from './storage'
 import StreamdelayClient from './StreamdelayClient'
 import StreamWindow from './StreamWindow'
 import TwitchBot from './TwitchBot'
-import { shouldHideInsteadOfQuit } from './windowCloseBehavior'
+import {
+  shouldHideInsteadOfQuit,
+  shouldQuitOnAllWindowsClosed,
+} from './windowCloseBehavior'
 
 const SENTRY_DSN =
   'https://e630a21dcf854d1a9eb2a7a8584cbd0b@o459879.ingest.sentry.io/5459505'
@@ -613,7 +616,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   controlWindow.on('ydoc', (update) => Y.applyUpdate(stateDoc, update))
   controlWindow.on('command', (command) => onCommand(command, 'local'))
 
-  // Closing the stream window quits the app, except on macOS where the
+  // Closing either top-level window quits the app, except on macOS where the
   // convention is to hide the window and keep the app (and its dock icon)
   // running until the user explicitly quits.
   let isQuitting = false
@@ -623,14 +626,33 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   })
   app.on('activate', () => {
     streamWindow.win.show()
+    controlWindow.win.show()
   })
-  streamWindow.on('close', (event) => {
+
+  function handleWindowClose(win: BrowserWindow, event: ElectronEvent) {
     if (shouldHideInsteadOfQuit(process.platform, isQuitting)) {
       event.preventDefault()
-      streamWindow.win.hide()
+      win.hide()
       return
     }
     app.quit()
+  }
+  streamWindow.on('close', (event) =>
+    handleWindowClose(streamWindow.win, event),
+  )
+  controlWindow.on('close', (event) =>
+    handleWindowClose(controlWindow.win, event),
+  )
+
+  // Standard Electron convention as a safety net: if every window somehow
+  // ends up closed without the app already quitting (e.g. a future window
+  // added without wiring into the close handling above), quit rather than
+  // linger as a windowless background process. macOS is excluded, matching
+  // the hide-instead-of-quit convention above.
+  app.on('window-all-closed', () => {
+    if (shouldQuitOnAllWindowsClosed(process.platform)) {
+      app.quit()
+    }
   })
 
   // The throttled stateDoc persist above may still have a pending write when

--- a/packages/streamwall/src/main/windowCloseBehavior.test.ts
+++ b/packages/streamwall/src/main/windowCloseBehavior.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { shouldHideInsteadOfQuit } from './windowCloseBehavior'
+import {
+  shouldHideInsteadOfQuit,
+  shouldQuitOnAllWindowsClosed,
+} from './windowCloseBehavior'
 
 describe('shouldHideInsteadOfQuit', () => {
   it('hides the window on macOS when the app is not quitting', () => {
@@ -18,5 +21,19 @@ describe('shouldHideInsteadOfQuit', () => {
   it('lets the window close on Linux regardless of quitting state', () => {
     expect(shouldHideInsteadOfQuit('linux', false)).toBe(false)
     expect(shouldHideInsteadOfQuit('linux', true)).toBe(false)
+  })
+})
+
+describe('shouldQuitOnAllWindowsClosed', () => {
+  it('does not quit on macOS once every window has closed', () => {
+    expect(shouldQuitOnAllWindowsClosed('darwin')).toBe(false)
+  })
+
+  it('quits on Windows once every window has closed', () => {
+    expect(shouldQuitOnAllWindowsClosed('win32')).toBe(true)
+  })
+
+  it('quits on Linux once every window has closed', () => {
+    expect(shouldQuitOnAllWindowsClosed('linux')).toBe(true)
   })
 })

--- a/packages/streamwall/src/main/windowCloseBehavior.ts
+++ b/packages/streamwall/src/main/windowCloseBehavior.ts
@@ -10,3 +10,14 @@ export function shouldHideInsteadOfQuit(
 ): boolean {
   return platform === 'darwin' && !isQuitting
 }
+
+/**
+ * Standard Electron convention: once every window has closed, quit the app.
+ * macOS is the exception -- the app (and its dock icon) stays running with no
+ * windows open until the user explicitly quits.
+ */
+export function shouldQuitOnAllWindowsClosed(
+  platform: NodeJS.Platform,
+): boolean {
+  return platform !== 'darwin'
+}


### PR DESCRIPTION
## Problem

`ControlWindow` emits a `close` event (`ControlWindow.ts:31`), but `main/index.ts` never listened for it. Closing just the control window did nothing beyond destroying that window — the app kept running with no obvious way to quit other than closing the (possibly hidden, on macOS) stream window.

There was also no `app.on('window-all-closed', ...)` handler, so the standard Electron convention of quitting once every window is closed (non-macOS) wasn't implemented at the app level.

## Solution

- `ControlWindow` now forwards the underlying Electron `close` event (previously it emitted a bare `close` with no event object), matching the pattern `StreamWindow` already used. This lets listeners call `event.preventDefault()`.
- `main/index.ts` extracts the existing quit-or-hide logic (used for the stream window) into a shared `handleWindowClose(win, event)` helper and wires the control window's `close` event through it too. Closing either window now quits the app (non-macOS) or hides it (macOS, mirroring the stream window's convention), and `app.on('activate', ...)` re-shows both windows.
- Added `app.on('window-all-closed', ...)` as a standard-Electron-convention safety net: quits on non-macOS if every window is ever closed without already being wired into `handleWindowClose` (e.g. a future window).
- New pure `shouldQuitOnAllWindowsClosed(platform)` predicate in `windowCloseBehavior.ts`, alongside the existing `shouldHideInsteadOfQuit`, unit-tested the same way.

## Architecture decisions

- Reused the existing `shouldHideInsteadOfQuit` convention (hide on macOS, quit elsewhere) for the control window rather than inventing new behavior, so both top-level windows behave consistently.
- Followed the repo's existing testing pattern for Electron main-process code: extract pure, platform-driven predicates into `windowCloseBehavior.ts` and unit test those directly; the actual Electron wiring in `index.ts` mirrors the untested pattern already used for the stream window's close handling (also true of the merged #191), since it requires a live Electron runtime to exercise meaningfully.
- Added a `ControlWindow.test.ts` (none existed before) that models `BrowserWindow` as an `EventEmitter`, to directly cover the new close-event forwarding — this is real, previously-untested behavior, not just wiring.

## Testing performed

- `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm run test` (all workspaces) — all green.
- New/updated tests: `windowCloseBehavior.test.ts` (`shouldQuitOnAllWindowsClosed`), `ControlWindow.test.ts` (close-event forwarding).

## Risks / breaking changes

None expected. Closing the control window now quits the app on Windows/Linux instead of silently doing nothing; this is the intended fix and matches how closing the stream window already behaves.

Closes #193