### PR TITLE
test(shared): cover hashText and idColor color hashing

### DIFF
--- a/packages/streamwall-shared/src/colors.test.ts
+++ b/packages/streamwall-shared/src/colors.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { hashText, idColor } from './colors.ts'
+
+describe('hashText', () => {
+  it('returns a fixed hash for a fixed input', () => {
+    expect(hashText('streamwall', 360)).toBe(292)
+    expect(hashText('streamwall', 40)).toBe(28)
+  })
+
+  it('is deterministic across repeated calls', () => {
+    expect(hashText('example-id', 360)).toBe(hashText('example-id', 360))
+    expect(hashText('example-id', 40)).toBe(hashText('example-id', 40))
+  })
+
+  it('returns 0 for an empty string', () => {
+    expect(hashText('', 360)).toBe(0)
+  })
+
+  it('stays within [0, range) for short ids', () => {
+    for (const range of [360, 40]) {
+      for (const id of ['a', 'ab', 'abc']) {
+        const hash = hashText(id, range)
+        expect(hash).toBeGreaterThanOrEqual(0)
+        expect(hash).toBeLessThan(range)
+      }
+    }
+  })
+
+  // Longer or higher-charCode inputs previously overflowed the 32-bit
+  // accumulator (`val << 5`), producing hashes outside [0, range) — e.g.
+  // hashText('streamwall', 40) used to return -12.
+  it('stays within [0, range) for ids that previously overflowed', () => {
+    const ids = [
+      'stream1',
+      'streamwall',
+      'dQw4w9WgXcQ',
+      'UCabcdefghij1234567890',
+      'https://twitch.tv/somechannel',
+      'x'.repeat(100),
+    ]
+    for (const range of [360, 40]) {
+      for (const id of ids) {
+        const hash = hashText(id, range)
+        expect(hash).toBeGreaterThanOrEqual(0)
+        expect(hash).toBeLessThan(range)
+      }
+    }
+  })
+})
+
+describe('idColor', () => {
+  it('returns white for an empty id', () => {
+    const color = idColor('')
+    expect(color.hex()).toBe('#FFFFFF')
+    expect(color.hsl().object()).toEqual({ h: 0, s: 0, l: 100 })
+  })
+
+  it('returns a fixed color for a fixed id', () => {
+    const color = idColor('streamwall')
+    expect(color.hex()).toBe('#AC42BD')
+    expect(color.hsl().object()).toEqual({ h: 292, s: 48, l: 50 })
+  })
+
+  it('is deterministic for the same id', () => {
+    expect(idColor('stream-1').hex()).toBe(idColor('stream-1').hex())
+  })
+
+  it('produces different colors for different ids', () => {
+    expect(idColor('a').hex()).not.toBe(idColor('b').hex())
+  })
+
+  it('keeps hue and saturation within their expected bounds for ids that previously overflowed', () => {
+    const ids = ['dQw4w9WgXcQ', 'https://twitch.tv/somechannel', 'streamwall']
+    for (const id of ids) {
+      const { h, s, l } = idColor(id).hsl().object()
+      expect(h).toBeGreaterThanOrEqual(0)
+      expect(h).toBeLessThan(360)
+      expect(s).toBeGreaterThanOrEqual(20)
+      expect(s).toBeLessThan(60)
+      expect(l).toBe(50)
+    }
+  })
+})

--- a/packages/streamwall-shared/src/colors.ts
+++ b/packages/streamwall-shared/src/colors.ts
@@ -19,7 +19,9 @@ export function hashText(text: string, range: number) {
     val += charVal
   }
 
-  return (val + range) % range
+  // val can wrap into large negative values due to the 32-bit `<<` above, so
+  // reduce it into (-range, range) before shifting into [0, range).
+  return ((val % range) + range) % range
 }
 
 export function idColor(id: string) {


### PR DESCRIPTION
## Problem

`hashText`/`idColor` in `packages/streamwall-shared/src/colors.ts` had no test coverage: fixed-input determinism, the `[0, range)` bound, and empty-id handling were all unverified.

## Technical solution

- Added `colors.test.ts` covering:
  - deterministic hashing for a fixed input (regression-pinned values)
  - `hashText` staying within `[0, range)`
  - empty string/id handling (`hashText('') === 0`, `idColor('')` is white)
  - distinct ids producing distinct colors
- While pinning the `[0, range)` bound, the test caught a real bug: `hashText` builds up `val` with plain (non-truncating) addition across the loop, but `val << 5` forces it through a 32-bit signed integer. For realistic inputs (~41% of fuzzed strings in local testing, e.g. `hashText('streamwall', 40)`), this wrapped `val` to a large negative number, and the final `(val + range) % range` only corrects values in `(-range, 0)` — so the function returned hashes outside its documented `[0, range)` contract. `idColor` forwarded this straight into `Color({h, s, l})` as a negative/invalid hue or saturation, which the `color` library silently clamps (e.g. negative saturation collapses to gray), degrading the color-based visual distinction between streams for many real IDs (YouTube ids, full URLs, etc.).
- Fixed with a minimal change to the final reduction: `((val % range) + range) % range`, which reduces `val` into `(-range, range)` before shifting into `[0, range)`. Verified via fuzzing that this only changes previously out-of-range outputs — every already-valid hash is unchanged.

## Testing performed

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test` (all workspaces)
- `npm -w streamwall-control-client run build`
- New tests fail against the pre-fix code for the documented reason (32-bit overflow), and pass after the fix.

## Risks / breaking changes

None expected. The fix only changes hash outputs that were previously out of range (i.e. already violating the function's contract); all previously in-range/valid hash values are unchanged, verified by fuzz-testing before and after.

Closes #56