### PR TITLE
test(control-ui): extract grid drag-move/resize math into gridInteractions.ts

### DIFF
--- a/packages/streamwall-control-ui/src/gridInteractions.test.ts
+++ b/packages/streamwall-control-ui/src/gridInteractions.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  computeResizeAssignments,
+  computeSwap,
+  type SwapBox,
+} from './gridInteractions'
+
+describe('computeSwap', () => {
+  it('swaps two equal-sized (single-space) boxes', () => {
+    const boxes = new Map<number, SwapBox>([
+      [0, { spaces: [0], streamId: 'stream-a' }],
+      [1, { spaces: [1], streamId: 'stream-b' }],
+    ])
+
+    expect(computeSwap(boxes, 0, 1)).toEqual(
+      new Map([
+        [0, 'stream-b'],
+        [1, 'stream-a'],
+      ]),
+    )
+  })
+
+  it('swaps boxes of unequal size, reassigning every space of both boxes', () => {
+    // A 1x1 box at idx 0 and a 2x1 box spanning idx 1 and idx 2 (e.g. after a resize).
+    const boxes = new Map<number, SwapBox>([
+      [0, { spaces: [0], streamId: 'stream-a' }],
+      [1, { spaces: [1, 2], streamId: 'stream-b' }],
+    ])
+
+    expect(computeSwap(boxes, 0, 1)).toEqual(
+      new Map([
+        [0, 'stream-b'],
+        [1, 'stream-a'],
+        [2, 'stream-a'],
+      ]),
+    )
+  })
+
+  it('is a no-op when dropped on its own box', () => {
+    const boxes = new Map<number, SwapBox>([
+      [0, { spaces: [0], streamId: 'stream-a' }],
+    ])
+
+    expect(computeSwap(boxes, 0, 0)).toEqual(new Map())
+  })
+
+  it('treats a box missing from the map as a single space at its own index', () => {
+    const boxes = new Map<number, SwapBox>([
+      [1, { spaces: [1], streamId: 'stream-b' }],
+    ])
+
+    expect(computeSwap(boxes, 0, 1)).toEqual(
+      new Map([
+        [0, 'stream-b'],
+        [1, undefined],
+      ]),
+    )
+  })
+
+  it('swaps an empty box with an occupied one, clearing the target spaces', () => {
+    const boxes = new Map<number, SwapBox>([
+      [0, { spaces: [0], streamId: undefined }],
+      [1, { spaces: [1], streamId: 'stream-b' }],
+    ])
+
+    expect(computeSwap(boxes, 0, 1)).toEqual(
+      new Map([
+        [0, 'stream-b'],
+        [1, undefined],
+      ]),
+    )
+  })
+})
+
+describe('computeResizeAssignments', () => {
+  it('assigns a single cell when the anchor and hover are the same', () => {
+    expect(computeResizeAssignments(3, 4, 4, 'stream-a')).toEqual(
+      new Map([[4, 'stream-a']]),
+    )
+  })
+
+  it('assigns every cell in the box spanned by the anchor and hover, overwriting other streams', () => {
+    // 3-col grid; anchor at idx 0 (x0,y0), hover at idx 4 (x1,y1) spans the
+    // 2x2 box { 0, 1, 3, 4 }. Cells 1 and 3 belong to other, unrelated boxes
+    // before the resize — they must be overwritten by the anchor's stream.
+    expect(computeResizeAssignments(3, 0, 4, 'stream-a')).toEqual(
+      new Map([
+        [0, 'stream-a'],
+        [1, 'stream-a'],
+        [3, 'stream-a'],
+        [4, 'stream-a'],
+      ]),
+    )
+  })
+
+  it('spans the box the same way regardless of drag direction', () => {
+    // Same 2x2 box as above, but dragged from the bottom-right corner back
+    // up to the top-left anchor.
+    expect(computeResizeAssignments(3, 4, 0, 'stream-a')).toEqual(
+      new Map([
+        [0, 'stream-a'],
+        [1, 'stream-a'],
+        [3, 'stream-a'],
+        [4, 'stream-a'],
+      ]),
+    )
+  })
+
+  it('does not include cells outside the spanned box', () => {
+    const assignments = computeResizeAssignments(3, 0, 4, 'stream-a')
+    expect(assignments.has(2)).toBe(false)
+    expect(assignments.has(5)).toBe(false)
+  })
+})

--- a/packages/streamwall-control-ui/src/gridInteractions.ts
+++ b/packages/streamwall-control-ui/src/gridInteractions.ts
@@ -1,0 +1,70 @@
+/**
+ * Pure computation for grid drag-move (swap) and resize commits.
+ *
+ * These decide *what* a committed gesture changes — which grid cell ends up
+ * with which streamId — independent of the Yjs doc mutation and pointer-event
+ * wiring in the `ControlUI` component, so the assignment math can be
+ * unit-tested in isolation.
+ */
+import { idxToCoords } from 'streamwall-shared'
+
+export interface SwapBox {
+  /** Grid cell indexes occupied by this box. */
+  spaces: number[]
+  streamId: string | undefined
+}
+
+/**
+ * Compute the streamId reassignment for swapping the box anchored at
+ * `fromIdx` with the box anchored at `toIdx`: every space of one box takes on
+ * the other box's streamId, so boxes of unequal size swap correctly. A box
+ * missing from `boxes` is treated as a single space at its own index (mirrors
+ * dropping onto a grid cell that has no box yet). Returns an empty map — a
+ * no-op — when `fromIdx` and `toIdx` name the same box.
+ */
+export function computeSwap(
+  boxes: Map<number, SwapBox>,
+  fromIdx: number,
+  toIdx: number,
+): Map<number, string | undefined> {
+  if (fromIdx === toIdx) {
+    return new Map()
+  }
+  const fromBox = boxes.get(fromIdx)
+  const toBox = boxes.get(toIdx)
+  const assignments = new Map<number, string | undefined>()
+  for (const idx of fromBox?.spaces ?? [fromIdx]) {
+    assignments.set(idx, toBox?.streamId)
+  }
+  for (const idx of toBox?.spaces ?? [toIdx]) {
+    assignments.set(idx, fromBox?.streamId)
+  }
+  return assignments
+}
+
+/**
+ * Compute the streamId assignment for a resize gesture: every grid cell in
+ * the rectangle spanned by `anchorIdx` and `hoverIdx` (inclusive, in either
+ * drag direction) is assigned `streamId`, overwriting whatever stream(s)
+ * currently occupy that box.
+ */
+export function computeResizeAssignments(
+  cols: number,
+  anchorIdx: number,
+  hoverIdx: number,
+  streamId: string,
+): Map<number, string> {
+  const { x: anchorX, y: anchorY } = idxToCoords(cols, anchorIdx)
+  const { x: hoverX, y: hoverY } = idxToCoords(cols, hoverIdx)
+  const lowX = Math.min(anchorX, hoverX)
+  const highX = Math.max(anchorX, hoverX)
+  const lowY = Math.min(anchorY, hoverY)
+  const highY = Math.max(anchorY, hoverY)
+  const assignments = new Map<number, string>()
+  for (let y = lowY; y <= highY; y++) {
+    for (let x = lowX; x <= highX; x++) {
+      assignments.set(cols * y + x, streamId)
+    }
+  }
+  return assignments
+}

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -62,6 +62,11 @@ import {
   isPrimaryButton,
   resolveMoveTarget,
 } from './gestures'
+import {
+  computeResizeAssignments,
+  computeSwap,
+  type SwapBox,
+} from './gridInteractions'
 import './index.css'
 import { LazyChangeInput } from './LazyChangeInput.tsx'
 import { resolveTargetViewIdx, resolveWriteStreamId } from './viewPlacement.ts'
@@ -595,48 +600,37 @@ export function ControlUI({
     },
     [stateIdxMap],
   )
+  const swapBoxes = useCallback(
+    (fromIdx: number, toIdx: number) => {
+      stateDoc.transact(() => {
+        const viewsMap = stateDoc.getMap<Y.Map<string | undefined>>('views')
+        const boxes = new Map<number, SwapBox>(
+          [fromIdx, toIdx].map((idx) => [
+            idx,
+            {
+              spaces: stateIdxMap.get(idx)?.spaces ?? [idx],
+              streamId: viewsMap.get(String(idx))?.get('streamId'),
+            },
+          ]),
+        )
+        const assignments = computeSwap(boxes, fromIdx, toIdx)
+        for (const [idx, streamId] of assignments) {
+          viewsMap.get(String(idx))?.set('streamId', streamId)
+        }
+      })
+    },
+    [stateDoc, stateIdxMap],
+  )
+
   const handleSwap = useCallback(
     (toIdx: number) => {
       if (swapStartIdx === undefined) {
         return
       }
-      stateDoc.transact(() => {
-        const viewsState = stateDoc.getMap<Y.Map<string | undefined>>('views')
-        const startStreamId = viewsState
-          ?.get(String(swapStartIdx))
-          ?.get('streamId')
-        const toStreamId = viewsState.get(String(toIdx))?.get('streamId')
-        const startSpaces = stateIdxMap.get(swapStartIdx)?.spaces ?? []
-        const toSpaces = stateIdxMap.get(toIdx)?.spaces ?? []
-        for (const startSpaceIdx of startSpaces) {
-          viewsState.get(String(startSpaceIdx))?.set('streamId', toStreamId)
-        }
-        for (const toSpaceIdx of toSpaces) {
-          viewsState.get(String(toSpaceIdx))?.set('streamId', startStreamId)
-        }
-      })
+      swapBoxes(swapStartIdx, toIdx)
       setSwapStartIdx(undefined)
     },
-    [stateDoc, stateIdxMap, swapStartIdx],
-  )
-
-  const swapBoxes = useCallback(
-    (fromIdx: number, toIdx: number) => {
-      stateDoc.transact(() => {
-        const viewsMap = stateDoc.getMap<Y.Map<string | undefined>>('views')
-        const fromStreamId = viewsMap.get(String(fromIdx))?.get('streamId')
-        const toStreamId = viewsMap.get(String(toIdx))?.get('streamId')
-        const fromSpaces = stateIdxMap.get(fromIdx)?.spaces ?? [fromIdx]
-        const toSpaces = stateIdxMap.get(toIdx)?.spaces ?? [toIdx]
-        for (const idx of fromSpaces) {
-          viewsMap.get(String(idx))?.set('streamId', toStreamId)
-        }
-        for (const idx of toSpaces) {
-          viewsMap.get(String(idx))?.set('streamId', fromStreamId)
-        }
-      })
-    },
-    [stateDoc, stateIdxMap],
+    [swapBoxes, swapStartIdx],
   )
 
   const [hoveringIdx, setHoveringIdx] = useState<number>()
@@ -762,10 +756,14 @@ export function ControlUI({
       }
       stateDoc.transact(() => {
         const viewsMap = stateDoc.getMap<Y.Map<string | undefined>>('views')
-        for (let idx = 0; idx < cols * rows; idx++) {
-          if (idxInBox(cols, resize.anchorIdx, hoveringIdx, idx)) {
-            viewsMap.get(String(idx))?.set('streamId', resize.streamId)
-          }
+        const assignments = computeResizeAssignments(
+          cols,
+          resize.anchorIdx,
+          hoveringIdx,
+          resize.streamId,
+        )
+        for (const [idx, streamId] of assignments) {
+          viewsMap.get(String(idx))?.set('streamId', streamId)
         }
       })
       setResize(undefined)


### PR DESCRIPTION
## Problem

The drag-move (swap) and resize commit decisions were pure logic trapped inside the 2,600+ line `ControlUI` component, alongside window-level pointer listeners:

- `handleSwap` (click-to-swap) and `swapBoxes` (drag-to-swap) independently computed the same box-swap reassignment.
- The resize commit looped every grid cell checking `idxInBox` instead of computing the spanned box directly.

None of this assignment math was unit-tested; it could only be exercised through full component interaction.

## Solution

Extracted two pure functions into a new `packages/streamwall-control-ui/src/gridInteractions.ts`:

- `computeSwap(boxes, fromIdx, toIdx)` — given a `Map<number, { spaces, streamId }>`, returns the streamId reassignment for swapping two boxes. Handles boxes of unequal size (every space of both boxes is reassigned) and returns an empty map when `fromIdx === toIdx` (no-op).
- `computeResizeAssignments(cols, anchorIdx, hoverIdx, streamId)` — returns the streamId assignment for every cell in the rectangle spanned by the anchor and hover cell, regardless of drag direction, using `idxToCoords` from `streamwall-shared` instead of a full-grid scan.

`ControlUI` now routes both the click-to-swap and drag-to-swap paths through a single `swapBoxes` callback backed by `computeSwap` (removing the duplicated inline logic), and the resize commit effect uses `computeResizeAssignments` instead of the per-cell `idxInBox` loop.

Drag-threshold math and the origin-cell (self-drop) no-op for drag-move were already extracted and unit-tested in `gestures.ts`/`gestures.test.ts` by #194, which landed on `main` after this issue was filed — those scenarios are not re-tested here.

## Testing

New `gridInteractions.test.ts` (`vitest`) covers:
- swapping two equal-sized boxes
- swapping boxes of unequal size (spaces of both boxes reassigned correctly)
- a same-box drop being a no-op
- a box missing from the map (defaults to a single space at its own index)
- swapping an empty box into an occupied one
- single-cell resize
- resize across a box that already contains other streams (overwritten correctly)
- resize direction-independence (drag either corner-to-corner direction)
- cells outside the spanned box are excluded

Full quality gate run locally: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm run test` (all workspaces), and `npm run build -w packages/streamwall-control-client` — all green.

## Architecture decisions

- Followed the existing `streamwall-shared`/`gestures.ts` pattern of extracting pure decision functions next to the component that uses them, rather than introducing a new package.
- `computeResizeAssignments` takes only `cols` (not `rows`), deriving the box bounds directly from the anchor/hover coordinates rather than scanning the whole grid — this also drops the function's need for the total cell count.
- Deduplicating `handleSwap`/`swapBoxes` into one callback was in scope: the issue's extraction target (`computeSwap`) is exactly the logic that was duplicated between them.
- Per the issue, full `ControlUI` component tests for the drag/resize interactions are deferred.

## Risks / breaking changes

None expected — this is an internal refactor of existing, already-shipped behavior; no public API or UI change.

Closes #54