### PR TITLE
fix(streamwall): sign and notarize macOS/Windows release builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,3 +196,41 @@ that's the Electron control UI or the standalone web control client:
 The overlay window has its own hotkey:
 
 - **ctrl+shift+i**: Open devtools for the overlay
+
+## Building & releasing the desktop app
+
+`npm run package` / `npm run make` / `npm run publish` (in
+`packages/streamwall`) build the Electron app with
+[Electron Forge](https://www.electronforge.io/). By default these produce
+**unsigned** binaries — fine for local development, but macOS and Windows
+both warn or outright block unsigned apps for end users, and Electron's
+auto-updater requires a signed app on macOS.
+
+To produce signed, notarized builds, set these environment variables before
+running `make`/`publish` (see `packages/streamwall/forge.signing.ts`):
+
+| Variable                       | Purpose                                                           |
+| ------------------------------ | ----------------------------------------------------------------- |
+| `APPLE_TEAM_ID`                | Apple Developer Team ID                                           |
+| `APPLE_API_KEY`                | Path to an App Store Connect API key (`.p8`) used by `notarytool` |
+| `APPLE_API_KEY_ID`             | App Store Connect API Key ID                                      |
+| `APPLE_API_ISSUER`             | App Store Connect API Issuer ID                                   |
+| `WINDOWS_CERTIFICATE_FILE`     | Path to a Windows code-signing certificate (`.pfx`)               |
+| `WINDOWS_CERTIFICATE_PASSWORD` | Password for the certificate above                                |
+
+macOS signing additionally requires a Developer ID Application certificate to
+already be present in the signing machine's keychain (e.g. imported via
+[`apple-actions/import-codesign-certs`](https://github.com/Apple-Actions/import-codesign-certs-action)
+in CI). The macOS and Windows variables are independent — set either, both,
+or neither. Builds with none of these set are unsigned, exactly as before.
+
+**Until a release is signed:** macOS quarantines downloaded, unsigned apps
+and may refuse to open them ("Streamwall is damaged and can't be opened").
+Users can work around this by removing the quarantine attribute after
+downloading:
+
+```sh
+xattr -cr /Applications/Streamwall.app
+```
+
+or by right-clicking the app and choosing "Open" instead of double-clicking.

--- a/packages/streamwall/forge.config.ts
+++ b/packages/streamwall/forge.config.ts
@@ -7,14 +7,25 @@ import { VitePlugin } from '@electron-forge/plugin-vite'
 import type { ForgeConfig } from '@electron-forge/shared-types'
 import { FuseV1Options, FuseVersion } from '@electron/fuses'
 
+import {
+  getMacSigningConfig,
+  getWindowsSigningConfig,
+  isSigningConfigured,
+} from './forge.signing'
+
+const macSigning = getMacSigningConfig(process.env)
+const windowsSigning = getWindowsSigningConfig(process.env)
+const signingConfigured = isSigningConfigured(process.env)
+
 const config: ForgeConfig = {
   packagerConfig: {
     executableName: 'streamwall',
     asar: true,
+    ...macSigning,
   },
   rebuildConfig: {},
   makers: [
-    new MakerSquirrel({}),
+    new MakerSquirrel({ ...windowsSigning }),
     new MakerZIP({}, ['darwin']),
     new MakerRpm({}),
     new MakerDeb({}),
@@ -68,8 +79,11 @@ const config: ForgeConfig = {
       [FuseV1Options.EnableCookieEncryption]: true,
       [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
       [FuseV1Options.EnableNodeCliInspectArguments]: false,
-      [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: false,
-      [FuseV1Options.OnlyLoadAppFromAsar]: false,
+      // ASAR integrity validation only holds up once the app itself is
+      // signed (otherwise the embedded hash can be stripped along with the
+      // signature), so only turn these on for signed builds.
+      [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: signingConfigured,
+      [FuseV1Options.OnlyLoadAppFromAsar]: signingConfigured,
     }),
   ],
 }

--- a/packages/streamwall/forge.signing.test.ts
+++ b/packages/streamwall/forge.signing.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'vitest'
+import {
+  getMacSigningConfig,
+  getWindowsSigningConfig,
+  isSigningConfigured,
+} from './forge.signing'
+
+describe('getMacSigningConfig', () => {
+  test('returns undefined when no Apple credentials are set', () => {
+    expect(getMacSigningConfig({})).toBeUndefined()
+  })
+
+  test('returns undefined when only some Apple credentials are set', () => {
+    expect(
+      getMacSigningConfig({
+        APPLE_TEAM_ID: 'TEAM123',
+        APPLE_API_KEY: '/path/to/key.p8',
+      }),
+    ).toBeUndefined()
+  })
+
+  test('returns osxSign/osxNotarize config when all Apple credentials are set', () => {
+    const config = getMacSigningConfig({
+      APPLE_TEAM_ID: 'TEAM123',
+      APPLE_API_KEY: '/path/to/key.p8',
+      APPLE_API_KEY_ID: 'KEYID123',
+      APPLE_API_ISSUER: 'issuer-uuid',
+    })
+
+    expect(config).toEqual({
+      osxSign: {},
+      osxNotarize: {
+        appleApiKey: '/path/to/key.p8',
+        appleApiKeyId: 'KEYID123',
+        appleApiIssuer: 'issuer-uuid',
+      },
+    })
+  })
+})
+
+describe('getWindowsSigningConfig', () => {
+  test('returns undefined when no certificate is configured', () => {
+    expect(getWindowsSigningConfig({})).toBeUndefined()
+  })
+
+  test('returns undefined when only the certificate file is set', () => {
+    expect(
+      getWindowsSigningConfig({ WINDOWS_CERTIFICATE_FILE: './cert.pfx' }),
+    ).toBeUndefined()
+  })
+
+  test('returns certificateFile/certificatePassword when both are set', () => {
+    expect(
+      getWindowsSigningConfig({
+        WINDOWS_CERTIFICATE_FILE: './cert.pfx',
+        WINDOWS_CERTIFICATE_PASSWORD: 'hunter2',
+      }),
+    ).toEqual({
+      certificateFile: './cert.pfx',
+      certificatePassword: 'hunter2',
+    })
+  })
+})
+
+describe('isSigningConfigured', () => {
+  test('is false when neither macOS nor Windows signing is configured', () => {
+    expect(isSigningConfigured({})).toBe(false)
+  })
+
+  test('is true when macOS signing is configured', () => {
+    expect(
+      isSigningConfigured({
+        APPLE_TEAM_ID: 'TEAM123',
+        APPLE_API_KEY: '/path/to/key.p8',
+        APPLE_API_KEY_ID: 'KEYID123',
+        APPLE_API_ISSUER: 'issuer-uuid',
+      }),
+    ).toBe(true)
+  })
+
+  test('is true when Windows signing is configured', () => {
+    expect(
+      isSigningConfigured({
+        WINDOWS_CERTIFICATE_FILE: './cert.pfx',
+        WINDOWS_CERTIFICATE_PASSWORD: 'hunter2',
+      }),
+    ).toBe(true)
+  })
+})

--- a/packages/streamwall/forge.signing.ts
+++ b/packages/streamwall/forge.signing.ts
@@ -1,0 +1,82 @@
+export type SigningEnv = Partial<
+  Record<
+    | 'APPLE_TEAM_ID'
+    | 'APPLE_API_KEY'
+    | 'APPLE_API_KEY_ID'
+    | 'APPLE_API_ISSUER'
+    | 'WINDOWS_CERTIFICATE_FILE'
+    | 'WINDOWS_CERTIFICATE_PASSWORD',
+    string | undefined
+  >
+>
+
+export interface MacSigningConfig {
+  /** Empty object enables signing with the identity already in the keychain (see docs). */
+  osxSign: Record<string, never>
+  osxNotarize: {
+    appleApiKey: string
+    appleApiKeyId: string
+    appleApiIssuer: string
+  }
+}
+
+/**
+ * Builds the macOS signing/notarization config from App Store Connect API key
+ * credentials (`xcrun notarytool`'s recommended, non-interactive auth method).
+ * Returns undefined when the credentials aren't fully configured, so builds
+ * without secrets (e.g. local contributor machines) stay unsigned as today.
+ */
+export function getMacSigningConfig(
+  env: SigningEnv,
+): MacSigningConfig | undefined {
+  const { APPLE_TEAM_ID, APPLE_API_KEY, APPLE_API_KEY_ID, APPLE_API_ISSUER } =
+    env
+  if (
+    !APPLE_TEAM_ID ||
+    !APPLE_API_KEY ||
+    !APPLE_API_KEY_ID ||
+    !APPLE_API_ISSUER
+  ) {
+    return undefined
+  }
+
+  return {
+    osxSign: {},
+    osxNotarize: {
+      appleApiKey: APPLE_API_KEY,
+      appleApiKeyId: APPLE_API_KEY_ID,
+      appleApiIssuer: APPLE_API_ISSUER,
+    },
+  }
+}
+
+export interface WindowsSigningConfig {
+  certificateFile: string
+  certificatePassword: string
+}
+
+/**
+ * Builds the Windows Squirrel installer signing config from a PFX
+ * certificate. Returns undefined when unconfigured, leaving Windows builds
+ * unsigned as today.
+ */
+export function getWindowsSigningConfig(
+  env: SigningEnv,
+): WindowsSigningConfig | undefined {
+  const { WINDOWS_CERTIFICATE_FILE, WINDOWS_CERTIFICATE_PASSWORD } = env
+  if (!WINDOWS_CERTIFICATE_FILE || !WINDOWS_CERTIFICATE_PASSWORD) {
+    return undefined
+  }
+
+  return {
+    certificateFile: WINDOWS_CERTIFICATE_FILE,
+    certificatePassword: WINDOWS_CERTIFICATE_PASSWORD,
+  }
+}
+
+export function isSigningConfigured(env: SigningEnv): boolean {
+  return (
+    getMacSigningConfig(env) !== undefined ||
+    getWindowsSigningConfig(env) !== undefined
+  )
+}


### PR DESCRIPTION
## Problem

`packages/streamwall/forge.config.ts` shipped every packaged build completely
unsigned:

- `packagerConfig` had no `osxSign`/`osxNotarize` options.
- `MakerSquirrel({})` (Windows installer) had no signing certificate.
- The macOS build only produces a `MakerZIP`, and the app depends on
  `update-electron-app` at runtime, which requires a signed app to
  auto-update on macOS.

Unsigned builds also trigger OS-level warnings ("app is damaged"/"unknown
publisher") for end users on both macOS and Windows.

## Solution

Added `packages/streamwall/forge.signing.ts`, which derives the signing
config from environment variables:

- **macOS**: `osxSign`/`osxNotarize`, using an App Store Connect API key for
  `notarytool` (`APPLE_TEAM_ID`, `APPLE_API_KEY`, `APPLE_API_KEY_ID`,
  `APPLE_API_ISSUER`) — the modern, non-interactive notarization method
  (Apple's legacy Apple-ID/app-specific-password flow is deprecated).
- **Windows**: `MakerSquirrel` `certificateFile`/`certificatePassword` from a
  PFX certificate (`WINDOWS_CERTIFICATE_FILE`, `WINDOWS_CERTIFICATE_PASSWORD`).

Both are opt-in and independent: if the relevant variables aren't set, that
platform's build stays unsigned exactly as before — no change for local
contributor builds or until secrets are actually provisioned.

`forge.config.ts` also now flips `OnlyLoadAppFromAsar` and
`EnableEmbeddedAsarIntegrityValidation` on once *any* signing is configured
(mirrors the issue's suggestion): asar integrity validation only means
anything once the binary itself is signed, so it stays off for unsigned
builds.

Documented the required secrets and the interim macOS un-quarantine
workaround (`xattr -cr`) in the README under a new "Building & releasing the
desktop app" section.

### Scope note

The issue mentioned "wire secrets into release.yml", but this repo has no
release CI workflow today — releases are run manually via
`npm run publish`. Building a full signed-release GitHub Actions pipeline is
a materially larger, separate piece of work (matrix builds, cert import
steps, cannot be verified end-to-end without real Apple/Windows
credentials), so I scoped this PR to the config wiring + docs and filed a
follow-up issue for the CI pipeline itself (linked below).

## Testing

- Added `forge.signing.test.ts` (9 cases): both signing configs return
  `undefined` when unset or only partially set, and the correct config
  object when fully set; `isSigningConfigured` covers all three states.
- `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm run test`
  all green across the monorepo.
- `npm run package` (in `packages/streamwall`) still builds successfully
  unsigned with no env vars set, confirming no regression to the default
  path.

## Risks / breaking changes

None for existing usage — signing is strictly opt-in via new environment
variables. Actually producing signed builds requires the repo owner to
provision real Apple/Windows credentials, which is outside what this PR can
supply or verify.

Closes #61