### PR TITLE
fix(control-server): sane storage default and a deployment story

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ invites), **operator** (control the grid and streams), and **monitor**
 See
 [`packages/streamwall-control-server/README.md`](packages/streamwall-control-server/README.md)
 for environment variable configuration (hostname/port, storage location, rate
-limits).
+limits) and a production deployment walkthrough.
 
 ## Data sources
 

--- a/packages/streamwall-control-server/README.md
+++ b/packages/streamwall-control-server/README.md
@@ -30,13 +30,13 @@ All configuration is provided via environment variables.
 
 ### Server
 
-| Variable                      | Default                 | Description                                               |
-| ----------------------------- | ----------------------- | --------------------------------------------------------- |
-| `STREAMWALL_CONTROL_URL`      | `http://localhost:3000` | Public base URL; its scheme selects http/https behaviour. |
-| `STREAMWALL_CONTROL_HOSTNAME` | host from base URL      | Interface to bind.                                        |
-| `STREAMWALL_CONTROL_PORT`     | port from base URL      | Port to bind.                                             |
-| `STREAMWALL_CONTROL_STATIC`   | bundled client `dist`   | Directory of static client assets to serve.               |
-| `DB_PATH`                     | `storage.json`          | lowdb storage file.                                       |
+| Variable                      | Default                                     | Description                                                                                                                                                                                                        |
+| ----------------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `STREAMWALL_CONTROL_URL`      | `http://localhost:3000`                     | Public base URL; its scheme selects http/https behaviour.                                                                                                                                                          |
+| `STREAMWALL_CONTROL_HOSTNAME` | host from base URL                          | Interface to bind.                                                                                                                                                                                                 |
+| `STREAMWALL_CONTROL_PORT`     | port from base URL                          | Port to bind.                                                                                                                                                                                                      |
+| `STREAMWALL_CONTROL_STATIC`   | bundled client `dist`                       | Directory of static client assets to serve.                                                                                                                                                                        |
+| `DB_PATH`                     | `~/.streamwall-control-server/storage.json` | lowdb storage file (auth tokens). Anchored to the home directory, not the working directory, so it stays put regardless of where the server is started from; missing parent directories are created automatically. |
 
 ### Security / abuse protection
 
@@ -59,3 +59,43 @@ A WebSocket connection that exceeds its message budget is closed with code
 The Content-Security-Policy is kept compatible with the served control client.
 `upgrade-insecure-requests` is only emitted when `STREAMWALL_CONTROL_URL` uses
 `https`, so the plain-`http` local setup keeps working over `ws://`.
+
+## Deployment
+
+There is no separate compile step: the source targets Node 22's native
+TypeScript support (type-only syntax plus explicit `.ts` import specifiers),
+so it runs directly from `src/`. To run in production:
+
+```
+npm ci
+npm -w streamwall-control-client run build
+node packages/streamwall-control-server/src/index.ts
+```
+
+The first two commands install the workspace and build the static web control
+client that this server serves at `/`; the third starts the server itself
+(equivalent to `npm run start:server` at the repo root, which chains all
+three).
+
+Set at least `STREAMWALL_CONTROL_URL` to the server's public address (its
+scheme controls secure-cookie and CSP behaviour — see above) and `DB_PATH` to
+a path on persistent storage, e.g. under a mounted volume or a directory
+included in your backup strategy. A minimal `systemd` unit:
+
+```ini
+[Service]
+ExecStart=/usr/bin/node /opt/streamwall/packages/streamwall-control-server/src/index.ts
+Environment=STREAMWALL_CONTROL_URL=https://control.example.com
+Environment=DB_PATH=/var/lib/streamwall-control-server/storage.json
+Restart=on-failure
+```
+
+`WorkingDirectory` is deliberately left unset above: the default `DB_PATH`
+no longer depends on it (see the configuration table), but an explicit
+`DB_PATH` is still recommended in production so the storage location is
+obvious and easy to back up.
+
+> [!WARNING]
+> Never run the server with `NODE_ENV=test` set. lowdb's Node preset treats
+> that value as a signal to use an in-memory adapter instead of the file on
+> disk, so auth tokens would silently stop persisting across restarts.

--- a/packages/streamwall-control-server/src/storage.test.ts
+++ b/packages/streamwall-control-server/src/storage.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { homedir, tmpdir } from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { after, afterEach, describe, test } from 'node:test'
+
+import { loadStorage, resolveDbPath } from './storage.ts'
+
+describe('resolveDbPath', () => {
+  const originalDbPath = process.env.DB_PATH
+  const originalCwd = process.cwd()
+
+  afterEach(() => {
+    if (originalDbPath === undefined) {
+      delete process.env.DB_PATH
+    } else {
+      process.env.DB_PATH = originalDbPath
+    }
+    process.chdir(originalCwd)
+  })
+
+  test('defaults to a path under the home directory, not the working directory', () => {
+    delete process.env.DB_PATH
+
+    const resolved = resolveDbPath()
+
+    assert.ok(
+      resolved.startsWith(homedir()),
+      `expected ${resolved} to live under the home directory`,
+    )
+    assert.notEqual(
+      resolved,
+      path.join(process.cwd(), 'storage.json'),
+      'the default must not be the cwd-relative legacy path',
+    )
+  })
+
+  test('the default path is stable regardless of the process working directory', () => {
+    delete process.env.DB_PATH
+    const fromOriginalCwd = resolveDbPath()
+
+    const scratchCwd = mkdtempSync(path.join(tmpdir(), 'sw-cwd-'))
+    process.chdir(scratchCwd)
+    const fromScratchCwd = resolveDbPath()
+
+    assert.equal(
+      fromScratchCwd,
+      fromOriginalCwd,
+      'launching from a different directory must resolve to the same storage file',
+    )
+  })
+
+  test('an explicit DB_PATH override always wins', () => {
+    process.env.DB_PATH = '/custom/path/storage.json'
+
+    assert.equal(resolveDbPath(), '/custom/path/storage.json')
+  })
+})
+
+describe('loadStorage', () => {
+  const originalDbPath = process.env.DB_PATH
+  let scratchDir: string
+
+  afterEach(() => {
+    if (originalDbPath === undefined) {
+      delete process.env.DB_PATH
+    } else {
+      process.env.DB_PATH = originalDbPath
+    }
+  })
+
+  after(() => {
+    if (scratchDir) {
+      rmSync(scratchDir, { recursive: true, force: true })
+    }
+  })
+
+  test('creates missing parent directories so a first write succeeds', async () => {
+    scratchDir = mkdtempSync(path.join(tmpdir(), 'sw-storage-'))
+    const dbPath = path.join(scratchDir, 'nested', 'deeper', 'storage.json')
+    process.env.DB_PATH = dbPath
+
+    const db = await loadStorage()
+    assert.deepEqual(db.data.auth, { salt: null, tokens: [] })
+
+    // Without creating the parent directories up front, this write would
+    // fail with ENOENT (lowdb's file adapter never creates directories).
+    await db.write()
+
+    assert.equal(existsSync(dbPath), true)
+  })
+
+  test('persists writes to the resolved path', async () => {
+    scratchDir = mkdtempSync(path.join(tmpdir(), 'sw-storage-'))
+    const dbPath = path.join(scratchDir, 'storage.json')
+    process.env.DB_PATH = dbPath
+
+    const db = await loadStorage()
+    db.data.auth.salt = 'test-salt'
+    await db.write()
+
+    const onDisk = JSON.parse(await readFile(dbPath, 'utf-8'))
+    assert.equal(onDisk.auth.salt, 'test-salt')
+  })
+})

--- a/packages/streamwall-control-server/src/storage.ts
+++ b/packages/streamwall-control-server/src/storage.ts
@@ -1,5 +1,8 @@
 import type { Low } from 'lowdb'
 import { JSONFilePreset } from 'lowdb/node'
+import { mkdir } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import path from 'node:path'
 import process from 'node:process'
 import type { AuthToken } from './auth.ts'
 
@@ -27,8 +30,23 @@ const defaultData: StoredData = {
 
 export type StorageDB = Low<StoredData>
 
+// Anchored to the user's home directory rather than the process's working
+// directory, so the server always finds the same storage file regardless of
+// where (or by what process manager) it was started -- mirroring how the
+// desktop app resolves its storage path via `app.getPath('userData')`.
+const DEFAULT_DB_PATH = path.join(
+  homedir(),
+  '.streamwall-control-server',
+  'storage.json',
+)
+
+export function resolveDbPath(): string {
+  return process.env.DB_PATH || DEFAULT_DB_PATH
+}
+
 export async function loadStorage() {
-  const dbPath = process.env.DB_PATH || 'storage.json'
+  const dbPath = resolveDbPath()
+  await mkdir(path.dirname(dbPath), { recursive: true })
   const db = await JSONFilePreset<StoredData>(dbPath, defaultData)
   return db
 }


### PR DESCRIPTION
## Problem

`streamwall-control-server` had no documented deploy story beyond local dev
(`npm run start:server`), and its `DB_PATH` default (`storage.json`) was
resolved relative to the process's working directory. Starting the server
from anywhere other than the package directory — a different cwd, a process
manager with its own `WorkingDirectory`, a container with a different
`WORKDIR` — silently created a fresh, empty auth database instead of finding
the existing one, invalidating every session and the desktop uplink pairing.

## Solution

- **Storage path**: `DB_PATH` now defaults to
  `~/.streamwall-control-server/storage.json`, resolved via `os.homedir()`
  instead of `process.cwd()`. This mirrors how the desktop app already
  resolves its own storage path via `app.getPath('userData')` instead of a
  cwd-relative path. Missing parent directories are now created
  automatically for both the default path and an explicit `DB_PATH`
  override (previously, pointing `DB_PATH` at a not-yet-existing directory
  would crash on first write).
- **Deployment story**: added a "Deployment" section to
  `packages/streamwall-control-server/README.md` covering:
  - a no-build production run — the server already runs directly from
    TypeScript source via Node 22's native type-stripping support (verified
    empirically; no `tsx` or compile step needed at runtime)
  - a minimal `systemd` unit demonstrating the fixed storage-path behavior
  - a warning about `NODE_ENV=test`, which causes lowdb's Node preset to
    silently swap in a non-persistent in-memory adapter (discovered while
    testing this change; documented since it's directly adjacent to storage
    configuration and an easy footgun in a deploy config)
  - the root `README.md` now points at this section

I chose a documented, no-build deployment path over a Dockerfile: this is an
npm-workspaces monorepo where `streamwall-control-server` has an undeclared
transitive dependency on `streamwall-shared` (and `streamwall-shared` on
`lodash-es`), currently masked by full-monorepo installs always hoisting
every workspace. A scoped Docker build surfaces that gap immediately (see
follow-up issue below); fixing it repo-wide is out of scope here, so a
Dockerfile built on top of it today would be fragile. Filed as a follow-up: #215.

## Testing

- Added `src/storage.test.ts` (TDD): default path is home-anchored and
  cwd-independent, an explicit `DB_PATH` override wins, and `loadStorage()`
  creates missing parent directories so the first write succeeds instead of
  throwing `ENOENT`.
- Full quality gate green locally: `format:check`, `lint`, `typecheck`
  (all workspaces), `test` (all workspaces, 78 + 52 passing), and the
  control-client production `build`.
- Manually ran the built server end-to-end (`node
  packages/streamwall-control-server/src/index.ts`): served the built
  control client over HTTP, created `~/.streamwall-control-server/storage.json`
  by default, and confirmed the directory stays empty when started from an
  unrelated working directory.

## Risks / breaking changes

Deployments that rely on the old cwd-relative default (rather than setting
`DB_PATH` explicitly) will start with a fresh, empty auth database after
this upgrade — existing sessions and the desktop uplink pairing will need to
be re-established once via the newly-printed admin invite link. This is a
one-time, low-stakes reset (no user data beyond auth tokens is stored here)
and is called out in the new deployment doc. No other behavior changes.

Closes #65
