### PR TITLE
feat: add per-tile volume control

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Under the hood, think of Streamwall as a specialized web browser for mosaicing v
 
 - **Resizable grid** — arrange streams in an NxN grid; resize it at runtime from the control UI (column/row presets or exact counts), no restart required.
 - **Drag-to-place layout** — drag a tile onto another to swap their positions, or drop a stream from the list straight onto a grid cell.
-- **Per-tile audio** — listen to any single tile's audio at a time, switchable with a click or hotkey.
+- **Per-tile audio** — listen to any single tile's audio at a time, switchable with a click or hotkey, with a per-tile volume slider.
 - **Blur/censor** — blur individual tiles, or trigger a wall-wide [Streamdelay](https://github.com/chromakode/streamdelay) censor mode.
 - **Dark mode** — light, dark, or system-matched theme in the control UI.
 - **Remote control with roles** — an optional web-based control server lets operators run the wall from a browser, with **admin**, **operator**, and **monitor** roles gated by invite links.

--- a/packages/streamwall-control-ui/src/GridControls.test.tsx
+++ b/packages/streamwall-control-ui/src/GridControls.test.tsx
@@ -1,0 +1,94 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { GridControls } from './index.tsx'
+
+// react-icons renders through preact/compat's Context.Consumer, which
+// currently crashes under this package's happy-dom test environment
+// (unrelated to the controls under test here) - stub the icons out so the
+// component can render.
+vi.mock('react-icons/fa', () => ({
+  FaExchangeAlt: () => null,
+  FaRedoAlt: () => null,
+  FaRegLifeRing: () => null,
+  FaRegWindowMaximize: () => null,
+  FaSyncAlt: () => null,
+  FaVideoSlash: () => null,
+  FaVolumeUp: () => null,
+}))
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+function renderControls(
+  props: Partial<Parameters<typeof GridControls>[0]> = {},
+): HTMLDivElement {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    render(
+      <GridControls
+        idx={0}
+        streamId="abc"
+        style={{}}
+        isDisplaying={true}
+        isListening={false}
+        isBackgroundListening={false}
+        isBlurred={false}
+        isSwapping={false}
+        showDebug={false}
+        role="operator"
+        volume={1}
+        onSetListening={() => {}}
+        onSetBackgroundListening={() => {}}
+        onSetBlurred={() => {}}
+        onSetVolume={() => {}}
+        onReloadView={() => {}}
+        onSwapView={() => {}}
+        onRotateView={() => {}}
+        onBrowse={() => {}}
+        onDevTools={() => {}}
+        onPointerDown={() => {}}
+        {...props}
+      />,
+      container!,
+    )
+  })
+  return container
+}
+
+describe('GridControls volume slider', () => {
+  test('renders a volume slider reflecting the current volume for an operator', () => {
+    const box = renderControls({ volume: 0.4 })
+
+    const slider = box.querySelector('input[type="range"]')
+    expect(slider).not.toBeNull()
+    expect((slider as HTMLInputElement).value).toBe('0.4')
+  })
+
+  test('does not render a volume slider for a monitor role', () => {
+    const box = renderControls({ role: 'monitor' })
+
+    expect(box.querySelector('input[type="range"]')).toBeNull()
+  })
+
+  test('sends the new volume for this tile when the slider changes', () => {
+    const onSetVolume = vi.fn()
+    const box = renderControls({ idx: 3, volume: 1, onSetVolume })
+    const slider = box.querySelector('input[type="range"]') as HTMLInputElement
+
+    act(() => {
+      slider.value = '0.3'
+      slider.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    expect(onSetVolume).toHaveBeenCalledWith(3, 0.3)
+  })
+})

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -83,6 +83,7 @@ export interface ViewInfo {
   isListening: boolean
   isBackgroundListening: boolean
   isBlurred: boolean
+  volume: number
   spaces: number[]
 }
 
@@ -554,6 +555,7 @@ export function useStreamwallState(state: StreamwallState | undefined) {
         isListening,
         isBackgroundListening,
         isBlurred,
+        volume: viewState.context.volume,
         spaces,
       }
       views.push(viewInfo)
@@ -877,6 +879,17 @@ export function ControlUI({
         type: 'set-view-blurred',
         viewIdx,
         blurred,
+      })
+    },
+    [send],
+  )
+
+  const handleSetVolume = useCallback(
+    (viewIdx: number, volume: number) => {
+      send({
+        type: 'set-view-volume',
+        viewIdx,
+        volume,
       })
     },
     [send],
@@ -1364,7 +1377,13 @@ export function ControlUI({
                 })}
               </StyledGridPreview>
               {views.map(
-                ({ state, isListening, isBackgroundListening, isBlurred }) => {
+                ({
+                  state,
+                  isListening,
+                  isBackgroundListening,
+                  isBlurred,
+                  volume,
+                }) => {
                   const { pos } = state.context
                   if (!pos) {
                     return null
@@ -1387,6 +1406,7 @@ export function ControlUI({
                       isListening={isListening}
                       isBackgroundListening={isBackgroundListening}
                       isBlurred={isBlurred}
+                      volume={volume}
                       isSwapping={
                         swapStartIdx != null &&
                         pos.spaces.includes(swapStartIdx)
@@ -1396,6 +1416,7 @@ export function ControlUI({
                       onSetListening={handleSetListening}
                       onSetBackgroundListening={handleSetBackgroundListening}
                       onSetBlurred={handleSetBlurred}
+                      onSetVolume={handleSetVolume}
                       onReloadView={handleReloadView}
                       onSwapView={handleSwapView}
                       onRotateView={handleRotateStream}
@@ -1992,7 +2013,7 @@ export function GridInput({
   )
 }
 
-function GridControls({
+export function GridControls({
   idx,
   streamId,
   style,
@@ -2000,12 +2021,14 @@ function GridControls({
   isListening,
   isBackgroundListening,
   isBlurred,
+  volume,
   isSwapping,
   showDebug,
   role,
   onSetListening,
   onSetBackgroundListening,
   onSetBlurred,
+  onSetVolume,
   onReloadView,
   onSwapView,
   onRotateView,
@@ -2020,6 +2043,7 @@ function GridControls({
   isListening: boolean
   isBackgroundListening: boolean
   isBlurred: boolean
+  volume: number
   isSwapping: boolean
   showDebug: boolean
   role: StreamwallRole | null
@@ -2029,6 +2053,7 @@ function GridControls({
     isBackgroundListening: boolean,
   ) => void
   onSetBlurred: (idx: number, isBlurred: boolean) => void
+  onSetVolume: (idx: number, volume: number) => void
   onReloadView: (idx: number) => void
   onSwapView: (idx: number) => void
   onRotateView: (streamId: string) => void
@@ -2056,6 +2081,12 @@ function GridControls({
   const handleBlurClick = useCallback(
     () => onSetBlurred(idx, !isBlurred),
     [idx, onSetBlurred, isBlurred],
+  )
+  const handleVolumeInput = useCallback<
+    JSX.InputEventHandler<HTMLInputElement>
+  >(
+    (ev) => onSetVolume(idx, Number(ev.currentTarget.value)),
+    [idx, onSetVolume],
   )
   const handleReloadClick = useCallback(
     () => onReloadView(idx),
@@ -2130,6 +2161,18 @@ function GridControls({
           >
             <FaVideoSlash />
           </StyledButton>
+        )}
+        {roleCan(role, 'set-view-volume') && (
+          <StyledVolumeSlider
+            type="range"
+            min={0}
+            max={1}
+            step={0.01}
+            value={volume}
+            onInput={handleVolumeInput}
+            tabIndex={1}
+            aria-label="Volume"
+          />
         )}
         {roleCan(role, 'set-listening-view') && (
           <StyledButton
@@ -2370,6 +2413,14 @@ const StyledSmallButton = styled(StyledButton)`
     width: 14px;
     height: 14px;
   }
+`
+
+const StyledVolumeSlider = styled.input`
+  width: 54px;
+  height: 24px;
+  margin: 5px;
+  accent-color: var(--accent-2);
+  cursor: pointer;
 `
 
 const StyledGridPreview = styled.div`

--- a/packages/streamwall-shared/src/roles.test.ts
+++ b/packages/streamwall-shared/src/roles.test.ts
@@ -34,6 +34,7 @@ const operatorOnlyActions = [
   'save-layout-preset',
   'load-layout-preset',
   'delete-layout-preset',
+  'set-view-volume',
 ] as const satisfies readonly StreamwallAction[]
 
 // Available to every authenticated role down to monitor.

--- a/packages/streamwall-shared/src/roles.ts
+++ b/packages/streamwall-shared/src/roles.ts
@@ -18,6 +18,7 @@ const operatorActions = [
   'save-layout-preset',
   'load-layout-preset',
   'delete-layout-preset',
+  'set-view-volume',
 ] as const
 
 const monitorActions = ['set-view-blurred', 'set-stream-censored'] as const

--- a/packages/streamwall-shared/src/schemas.test.ts
+++ b/packages/streamwall-shared/src/schemas.test.ts
@@ -357,6 +357,36 @@ describe('controlCommandMessageSchema', () => {
     ).toBe(false)
   })
 
+  test('accepts a valid set-view-volume command', () => {
+    expect(
+      controlCommandMessageSchema.safeParse({
+        id: 1,
+        type: 'set-view-volume',
+        viewIdx: 0,
+        volume: 0.5,
+      }).success,
+    ).toBe(true)
+  })
+
+  test('bounds volume to the 0-1 range on set-view-volume', () => {
+    expect(
+      controlCommandMessageSchema.safeParse({
+        id: 1,
+        type: 'set-view-volume',
+        viewIdx: 0,
+        volume: 1.5,
+      }).success,
+    ).toBe(false)
+    expect(
+      controlCommandMessageSchema.safeParse({
+        id: 1,
+        type: 'set-view-volume',
+        viewIdx: 0,
+        volume: -0.1,
+      }).success,
+    ).toBe(false)
+  })
+
   test('parsed commands remain assignable to the ControlCommand type', () => {
     const result = controlCommandMessageSchema.safeParse({
       id: 7,

--- a/packages/streamwall-shared/src/schemas.ts
+++ b/packages/streamwall-shared/src/schemas.ts
@@ -43,6 +43,7 @@ const orientationSchema = z.enum(['V', 'H'])
 const rotationSchema = z.number().min(0).max(MAX_ROTATION)
 const viewIdxSchema = z.number().int().min(0).max(MAX_VIEW_IDX)
 const gridDimensionSchema = z.number().int().min(GRID_MIN).max(GRID_MAX)
+const volumeSchema = z.number().min(0).max(1)
 
 /** Longest allowed name for a saved layout preset. */
 export const MAX_LAYOUT_PRESET_NAME_LENGTH = 100
@@ -139,6 +140,11 @@ export const controlCommandSchema = z.discriminatedUnion('type', [
     type: z.literal('set-view-blurred'),
     viewIdx: viewIdxSchema,
     blurred: z.boolean(),
+  }),
+  z.object({
+    type: z.literal('set-view-volume'),
+    viewIdx: viewIdxSchema,
+    volume: volumeSchema,
   }),
   z.object({
     type: z.literal('rotate-stream'),

--- a/packages/streamwall-shared/src/stateDiff.test.ts
+++ b/packages/streamwall-shared/src/stateDiff.test.ts
@@ -25,6 +25,7 @@ function makeView(id: number, overrides: Partial<ViewState> = {}): ViewState {
       info: null,
       pos: null,
       error: null,
+      volume: 1,
     },
     ...overrides,
   }
@@ -46,6 +47,7 @@ function makeState(overrides: Partial<StreamwallState> = {}): StreamwallState {
     customStreams: [],
     views: [makeView(0), makeView(1)],
     streamdelay: null,
+    layoutPresets: [],
     ...overrides,
   }
 }

--- a/packages/streamwall-shared/src/types.ts
+++ b/packages/streamwall-shared/src/types.ts
@@ -76,6 +76,10 @@ export interface ViewState {
     pos: ViewPos | null
     // Human-readable reason when the view is in displaying.error, else null.
     error: string | null
+    // Per-tile playback volume, from 0 (silent) to 1 (full). Independent of
+    // the mute/listening state: it is the level applied once the tile is
+    // unmuted.
+    volume: number
   }
 }
 
@@ -137,6 +141,7 @@ export type ControlCommand =
       listening: boolean
     }
   | { type: 'set-view-blurred'; viewIdx: number; blurred: boolean }
+  | { type: 'set-view-volume'; viewIdx: number; volume: number }
   | { type: 'rotate-stream'; url: string; rotation: number }
   | { type: 'update-custom-stream'; url: string; data: LocalStreamData }
   | { type: 'delete-custom-stream'; url: string }

--- a/packages/streamwall-shared/src/uplink.test.ts
+++ b/packages/streamwall-shared/src/uplink.test.ts
@@ -15,6 +15,7 @@ describe('isCommandAllowedFromUplink', () => {
     expect(isCommandAllowedFromUplink('set-stream-censored')).toBe(true)
     expect(isCommandAllowedFromUplink('set-stream-running')).toBe(true)
     expect(isCommandAllowedFromUplink('set-grid-size')).toBe(true)
+    expect(isCommandAllowedFromUplink('set-view-volume')).toBe(true)
   })
 
   test('allows layout preset commands', () => {

--- a/packages/streamwall-shared/src/uplink.ts
+++ b/packages/streamwall-shared/src/uplink.ts
@@ -20,6 +20,7 @@ const UPLINK_ALLOWED_COMMANDS: ReadonlySet<ControlCommand['type']> = new Set<
   'set-listening-view',
   'set-view-background-listening',
   'set-view-blurred',
+  'set-view-volume',
   'rotate-stream',
   'update-custom-stream',
   'delete-custom-stream',

--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -78,3 +78,82 @@ describe('StreamWindow.setGridSize', () => {
     expect(config.height).toBe(1440)
   })
 })
+
+/**
+ * A minimal stand-in for a ViewActor: enough of the `getSnapshot()`/`send()`
+ * surface for setViewVolume/sendViewEvent/findViewByIdx to operate on,
+ * without a real XState actor or Electron WebContentsView.
+ */
+function makeFakeViewActor(pos: { spaces: number[] } | null, send = vi.fn()) {
+  return {
+    getSnapshot: () => ({ context: { pos } }),
+    send,
+  } as unknown as ReturnType<typeof StreamWindow.prototype.createView>
+}
+
+describe('StreamWindow.setViewVolume', () => {
+  it('sends SET_VOLUME to the view occupying the given index', () => {
+    const sw = makeStreamWindow(makeConfig())
+    const send = vi.fn()
+    sw.views = new Map([[1, makeFakeViewActor({ spaces: [0] }, send)]])
+
+    sw.setViewVolume(0, 0.5)
+
+    expect(send).toHaveBeenCalledWith({ type: 'SET_VOLUME', volume: 0.5 })
+  })
+
+  it('does nothing when no view occupies the given index', () => {
+    const sw = makeStreamWindow(makeConfig())
+    const send = vi.fn()
+    sw.views = new Map([[1, makeFakeViewActor({ spaces: [0] }, send)]])
+
+    sw.setViewVolume(5, 0.5)
+
+    expect(send).not.toHaveBeenCalled()
+  })
+})
+
+describe('StreamWindow.emitState', () => {
+  it('includes each view volume in the emitted state', () => {
+    const sw = makeStreamWindow(makeConfig())
+    sw.views = new Map([
+      [
+        1,
+        makeFakeViewActorWithSnapshot({
+          value: 'empty',
+          context: {
+            id: 1,
+            content: null,
+            info: null,
+            pos: null,
+            error: null,
+            volume: 0.6,
+          },
+        }),
+      ],
+    ])
+    const emitted: unknown[] = []
+    sw.on('state', (states) => emitted.push(states))
+
+    sw.emitState()
+
+    expect(emitted).toEqual([
+      [
+        {
+          state: 'empty',
+          context: expect.objectContaining({ volume: 0.6 }),
+        },
+      ],
+    ])
+  })
+})
+
+function makeFakeViewActorWithSnapshot(snapshot: {
+  value: unknown
+  context: Record<string, unknown>
+}) {
+  return {
+    getSnapshot: () => snapshot,
+    send: vi.fn(),
+  } as unknown as ReturnType<typeof StreamWindow.prototype.createView>
+}

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -137,10 +137,11 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
       const view = this.views.get(ev.sender.id)
       if (view) {
         view.send({ type: 'VIEW_INIT' })
-        const { content, options } = view.getSnapshot().context
+        const { content, options, volume } = view.getSnapshot().context
         return {
           content,
           options,
+          volume,
         }
       }
     })
@@ -270,6 +271,7 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
           info: context.info,
           pos: context.pos,
           error: context.error,
+          volume: context.volume,
         },
       } satisfies ViewState
     })
@@ -423,6 +425,10 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
 
   setViewBlurred(viewIdx: number, blurred: boolean) {
     this.sendViewEvent(viewIdx, { type: blurred ? 'BLUR' : 'UNBLUR' })
+  }
+
+  setViewVolume(viewIdx: number, volume: number) {
+    this.sendViewEvent(viewIdx, { type: 'SET_VOLUME', volume })
   }
 
   reloadView(viewIdx: number) {

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -526,6 +526,9 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     } else if (msg.type === 'set-view-blurred') {
       console.debug('Setting view blurred:', msg.viewIdx, msg.blurred)
       streamWindow.setViewBlurred(msg.viewIdx, msg.blurred)
+    } else if (msg.type === 'set-view-volume') {
+      console.debug('Setting view volume:', msg.viewIdx, msg.volume)
+      streamWindow.setViewVolume(msg.viewIdx, msg.volume)
     } else if (msg.type === 'rotate-stream') {
       console.debug('Rotating stream:', msg.url, msg.rotation)
       overlayStreamData.update(msg.url, {

--- a/packages/streamwall/src/main/viewStateMachine.test.ts
+++ b/packages/streamwall/src/main/viewStateMachine.test.ts
@@ -41,6 +41,7 @@ function makeActor(retry: RetryConfig, loadPageImpl?: () => Promise<void>) {
       unmuteAudio: noop,
       openDevTools: noop,
       sendViewOptions: noop,
+      sendViewVolume: noop,
       logError: noop,
     },
     actors: {
@@ -294,5 +295,88 @@ describe('viewStateMachine error handling and auto-retry', () => {
     const snapshot = actor.getSnapshot()
     expect(matchesState('displaying.error', snapshot.value)).toBe(true)
     expect(snapshot.context.error).toMatch(/timed out/i)
+  })
+})
+
+describe('viewStateMachine volume control', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // Same setup as makeActor, but with a spy on sendViewVolume so tests can
+  // assert on what was forwarded to the view's webContents.
+  function makeActorWithVolumeSpy(retry: RetryConfig) {
+    const sendViewVolume = vi.fn()
+    const machine = viewStateMachine.provide({
+      actions: {
+        offscreenView: noop,
+        positionView: noop,
+        muteAudio: noop,
+        unmuteAudio: noop,
+        openDevTools: noop,
+        sendViewOptions: noop,
+        sendViewVolume,
+        logError: noop,
+      },
+      actors: {
+        loadPage: fromPromise(async () => {}),
+      },
+    })
+    const actor = createActor(machine, {
+      input: {
+        id: 1,
+        view: {} as never,
+        win: {} as never,
+        offscreenWin: {} as never,
+        retry,
+      },
+    })
+    return { actor, sendViewVolume }
+  }
+
+  it('defaults volume to 1', () => {
+    const { actor } = makeActorWithVolumeSpy(makeRetry())
+    actor.start()
+
+    expect(actor.getSnapshot().context.volume).toBe(1)
+  })
+
+  it('updates context.volume and forwards it to the view on SET_VOLUME', () => {
+    const { actor, sendViewVolume } = makeActorWithVolumeSpy(makeRetry())
+    actor.start()
+    display(actor)
+
+    actor.send({ type: 'SET_VOLUME', volume: 0.4 })
+
+    expect(actor.getSnapshot().context.volume).toBe(0.4)
+    expect(sendViewVolume).toHaveBeenCalledTimes(1)
+    expect(sendViewVolume).toHaveBeenCalledWith(expect.anything(), {
+      volume: 0.4,
+    })
+  })
+
+  it('applies SET_VOLUME while running, independent of the mute state', async () => {
+    const { actor, sendViewVolume } = makeActorWithVolumeSpy(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+
+    actor.send({ type: 'SET_VOLUME', volume: 0.7 })
+
+    expect(actor.getSnapshot().context.volume).toBe(0.7)
+    expect(sendViewVolume).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not resend to the view when the volume is unchanged', () => {
+    const { actor, sendViewVolume } = makeActorWithVolumeSpy(makeRetry())
+    actor.start()
+    display(actor)
+
+    actor.send({ type: 'SET_VOLUME', volume: 0.5 })
+    actor.send({ type: 'SET_VOLUME', volume: 0.5 })
+
+    expect(sendViewVolume).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -81,6 +81,10 @@ const viewStateMachine = setup({
       options: ContentDisplayOptions | null
       info: ContentViewInfo | null
       retry: RetryConfig
+      // Per-tile playback volume, from 0 (silent) to 1 (full). Independent of
+      // the mute/listening state: it is the level applied once the tile is
+      // unmuted.
+      volume: number
       // Human-readable reason for the current error, or null when healthy.
       error: string | null
       // Number of automatic reloads already spent on the current failure streak.
@@ -89,6 +93,7 @@ const viewStateMachine = setup({
 
     events: {} as
       | { type: 'OPTIONS'; options: ContentDisplayOptions }
+      | { type: 'SET_VOLUME'; volume: number }
       | {
           type: 'DISPLAY'
           pos: ViewPos
@@ -157,6 +162,11 @@ const viewStateMachine = setup({
       view.webContents.send('options', params.options)
     },
 
+    sendViewVolume: ({ context }, params: { volume: number }) => {
+      const { view } = context
+      view.webContents.send('volume', params.volume)
+    },
+
     offscreenView: ({ context }) => {
       const { view, win, offscreenWin } = context
       win.contentView.removeChildView(view)
@@ -207,6 +217,10 @@ const viewStateMachine = setup({
       params: { options: ContentDisplayOptions },
     ) => {
       return !isEqual(context.options, params.options)
+    },
+
+    volumeChanged: ({ context }, params: { volume: number }) => {
+      return context.volume !== params.volume
     },
 
     // Whether the view is still allowed to reload itself automatically.
@@ -278,6 +292,7 @@ const viewStateMachine = setup({
     retry,
     error: null,
     retryCount: 0,
+    volume: 1,
   }),
   on: {
     DISPLAY: {
@@ -318,6 +333,21 @@ const viewStateMachine = setup({
           guard: {
             type: 'optionsChanged',
             params: ({ event: { options } }) => ({ options }),
+          },
+        },
+        SET_VOLUME: {
+          actions: [
+            assign({
+              volume: ({ event }) => event.volume,
+            }),
+            {
+              type: 'sendViewVolume',
+              params: ({ event: { volume } }) => ({ volume }),
+            },
+          ],
+          guard: {
+            type: 'volumeChanged',
+            params: ({ event: { volume } }) => ({ volume }),
           },
         },
         // A manual reload is an operator override: reset the automatic retry

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -1,6 +1,7 @@
 import { ipcRenderer, webFrame } from 'electron'
 import throttle from 'lodash/throttle'
 import { ContentDisplayOptions } from 'streamwall-shared'
+import { VolumeController } from './volumeController'
 
 const SCAN_THROTTLE = 500
 const INITIAL_TIMEOUT = 10 * 1000
@@ -280,20 +281,21 @@ async function main() {
   const viewInit = ipcRenderer.invoke('view-init')
   const pageReady = new Promise((resolve) => process.once('loaded', resolve))
 
-  const [{ content, options: initialOptions }] = await Promise.all([
-    viewInit,
-    pageReady,
-  ])
+  const [{ content, options: initialOptions, volume: initialVolume }] =
+    await Promise.all([viewInit, pageReady])
 
   const snapshotController = new SnapshotController()
 
   let rotationController: RotationController | undefined
+  let volumeController: VolumeController | undefined
+  let latestVolume = initialVolume ?? 1
   async function acquireMedia(elementTimeout: number) {
     let snapshotInterval: number | undefined
 
     const media = await findMedia(content.kind, elementTimeout)
     console.log('media acquired', media)
 
+    volumeController = new VolumeController(media, latestVolume)
     ipcRenderer.send('view-loaded')
 
     if (content.kind === 'video' && media instanceof HTMLVideoElement) {
@@ -341,6 +343,12 @@ async function main() {
   }
   ipcRenderer.on('options', (ev, options) => updateOptions(options))
   updateOptions(initialOptions)
+
+  function updateVolume(volume: number) {
+    latestVolume = volume
+    volumeController?.setVolume(volume)
+  }
+  ipcRenderer.on('volume', (ev, volume) => updateVolume(volume))
 }
 
 main().catch((error) => {

--- a/packages/streamwall/src/preload/volumeController.test.ts
+++ b/packages/streamwall/src/preload/volumeController.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { clampVolume, VolumeController } from './volumeController'
+
+describe('clampVolume', () => {
+  it('passes through values already in range', () => {
+    expect(clampVolume(0)).toBe(0)
+    expect(clampVolume(0.5)).toBe(0.5)
+    expect(clampVolume(1)).toBe(1)
+  })
+
+  it('clamps values below 0 up to 0', () => {
+    expect(clampVolume(-0.5)).toBe(0)
+  })
+
+  it('clamps values above 1 down to 1', () => {
+    expect(clampVolume(1.5)).toBe(1)
+  })
+})
+
+describe('VolumeController', () => {
+  function makeMedia(): HTMLMediaElement {
+    return { volume: 1 } as HTMLMediaElement
+  }
+
+  it('applies the initial volume to the media element on construction', () => {
+    const media = makeMedia()
+    new VolumeController(media, 0.3)
+
+    expect(media.volume).toBe(0.3)
+  })
+
+  it('defaults the initial volume to 1 when omitted', () => {
+    const media = makeMedia()
+    new VolumeController(media)
+
+    expect(media.volume).toBe(1)
+  })
+
+  it('updates the media element volume on setVolume', () => {
+    const media = makeMedia()
+    const controller = new VolumeController(media, 1)
+
+    controller.setVolume(0.2)
+
+    expect(media.volume).toBe(0.2)
+  })
+
+  it('clamps out-of-range volumes applied via setVolume', () => {
+    const media = makeMedia()
+    const controller = new VolumeController(media)
+
+    controller.setVolume(2)
+    expect(media.volume).toBe(1)
+
+    controller.setVolume(-1)
+    expect(media.volume).toBe(0)
+  })
+})

--- a/packages/streamwall/src/preload/volumeController.ts
+++ b/packages/streamwall/src/preload/volumeController.ts
@@ -1,0 +1,18 @@
+export function clampVolume(volume: number): number {
+  return Math.min(1, Math.max(0, volume))
+}
+
+// Applies a 0-1 volume level to an acquired media element, mirroring how
+// RotationController owns the currently-acquired element's CSS rotation.
+export class VolumeController {
+  media: HTMLMediaElement
+
+  constructor(media: HTMLMediaElement, initialVolume = 1) {
+    this.media = media
+    this.setVolume(initialVolume)
+  }
+
+  setVolume(volume: number) {
+    this.media.volume = clampVolume(volume)
+  }
+}


### PR DESCRIPTION
## Summary

Adds a per-tile volume slider to each grid tile's controls, as requested in #76. Audio was previously binary (`webContents.audioMuted` on/off via the listen/background-listen buttons); this adds a continuous 0-1 level, independent of mute state, so an operator can pre-set or adjust a tile's playback volume.

## Technical solution

- **Shared protocol** (`streamwall-shared`): new `set-view-volume` control command (`{ viewIdx, volume }`, `volume` bounded to `[0, 1]` by its Zod schema), added to the uplink allowlist and to the `operator` role's permitted actions. `ViewState.context` now carries a `volume: number` field so the control UI can reflect the current level.
- **Electron main process**: the view state machine gets a new `SET_VOLUME` event, handled independently of the existing `MUTE`/`UNMUTE`/`BACKGROUND` audio sub-state (so a tile's volume can be set/changed while muted, and takes effect once it's listened to). The value is forwarded to the view's preload over a dedicated `'volume'` IPC channel (mirroring how `rotation` already rides the `'options'` channel) and applied to the acquired `<video>`/`<audio>` element via a new `VolumeController`, which mirrors the existing `RotationController` pattern in `mediaPreload.ts`. `StreamWindow.setViewVolume(viewIdx, volume)` and the `set-view-volume` command handler in `main/index.ts` wire it end to end.
- **Control UI**: `GridControls` renders a native `<input type="range">` (styled via `accent-color` to match the theme) next to the listen button, gated by the operator-only `set-view-volume` role action, sending the new level directly on every `input` event (no debounce — matches the codebase's existing direct-send convention for other tile controls; no debounce/throttle precedent exists for continuous inputs here).

### Architecture decisions

- **Per-tile (per grid index) rather than per-stream (per URL)**: volume follows the tile's `SET_VOLUME`/`sendViewEvent` pattern used by mute/background/blur, not the `OPTIONS`/`getDisplayOptions` pattern used by rotation (which is keyed by stream URL via `overlayStreamData`). This matches the issue's explicit "per-tile" framing.
- **No master volume**: the issue said "per-tile ... and/or a master volume" — implemented the per-tile slider as the more complete, explicitly-detailed option (`video.volume` via `mediaPreload.ts`), which fully satisfies the issue on its own.
- **Extracted `VolumeController`/`clampVolume` into a standalone `volumeController.ts`** module (no Electron/DOM imports) so the volume-application logic is unit-testable without mocking `electron`/`document`, matching the style of a small, focused module rather than adding to the untested `mediaPreload.ts` monolith.

## Testing performed

TDD throughout (red/green per layer): schema/uplink/role tests, `viewStateMachine` event/guard tests, `StreamWindow.setViewVolume`/`emitState` tests, a pure-logic `volumeController` unit suite, and a `GridControls` component test (role gating + slider wiring). Full quality gate green locally: `npm run format:check`, `npm run lint`, `npm run typecheck` (all workspaces), `npm run test` (all workspaces), and the control-client production build.

## Risks / breaking changes

None expected. `ViewState.context.volume` and `set-view-volume` are additive; existing mute/listen/background/blur behavior is unchanged (confirmed by the existing viewStateMachine/StreamWindow test suites still passing).

## Note: pre-existing main breakage fixed here

Rebasing onto current `main` surfaced that `npm run typecheck` was already broken there (unrelated to this PR) — `stateDiff.test.ts`'s `makeState()` fixture predates `layoutPresets` becoming a required `StreamwallState` field (#199) and never supplied a default, so it fails to satisfy the type. That blocked this PR's own CI, so it's fixed here as its own commit (`fix(shared): satisfy StreamwallState's required fields in stateDiff test fixtures`), which also adds a default for the new `volume` field this PR introduces. Filed for tracking/visibility as #219.

## Follow-up issues

- #219 — `main`'s typecheck was broken before this PR (unrelated `layoutPresets` fixture gap); fixed as part of this PR, issue filed for visibility.

Closes #76