### PR TITLE
fix(renderer): generate a per-instance gradient id in TailSpin

### DIFF
--- a/packages/streamwall/src/renderer/TailSpin.test.tsx
+++ b/packages/streamwall/src/renderer/TailSpin.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment happy-dom
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { afterEach, describe, expect, test } from 'vitest'
+import { TailSpin } from './TailSpin'
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+describe('TailSpin', () => {
+  test('uses a per-instance gradient id so multiple simultaneous spinners stay valid SVG', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      render(
+        <div>
+          <TailSpin />
+          <TailSpin />
+        </div>,
+        container!,
+      )
+    })
+
+    const svgs = container.querySelectorAll('svg')
+    expect(svgs).toHaveLength(2)
+
+    const gradientIds = Array.from(svgs).map(
+      (svg) => svg.querySelector('linearGradient')!.id,
+    )
+
+    // Per the SVG/HTML spec, `id` must be document-unique; duplicate ids
+    // mean `url(#...)` references can resolve to the wrong element (#212).
+    expect(new Set(gradientIds).size).toBe(gradientIds.length)
+    for (const id of gradientIds) {
+      expect(id).not.toBe('')
+    }
+
+    // Each path's stroke must reference its own tile's gradient, not just
+    // any gradient with a matching (possibly duplicated) id.
+    svgs.forEach((svg) => {
+      const gradientId = svg.querySelector('linearGradient')!.id
+      const path = svg.querySelector('path')!
+      expect(path.getAttribute('stroke')).toBe(`url(#${gradientId})`)
+    })
+  })
+})

--- a/packages/streamwall/src/renderer/TailSpin.tsx
+++ b/packages/streamwall/src/renderer/TailSpin.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'preact/hooks'
 import type { SVGProps } from 'react'
 
 // Inlined from svg-loaders-react's TailSpin (MIT, Copyright (c) 2014 Sam
@@ -8,6 +9,10 @@ import type { SVGProps } from 'react'
 // keeps the visuals identical while making it a plain function component
 // that resolves correctly in both the app and its tests.
 export function TailSpin(props: SVGProps<SVGSVGElement>) {
+  // Multiple tiles can be loading at once (see overlay.tsx), so the gradient
+  // id must be unique per instance rather than a hardcoded string (#212).
+  const gradientId = `tailSpinGradient-${useId()}`
+
   return (
     <svg width={38} height={38} viewBox="0 0 38 38" {...props}>
       <defs>
@@ -16,7 +21,7 @@ export function TailSpin(props: SVGProps<SVGSVGElement>) {
           y1="0%"
           x2="65.682%"
           y2="23.865%"
-          id="tailSpinGradient"
+          id={gradientId}
         >
           <stop stopColor="#fff" stopOpacity={0} offset="0%" />
           <stop stopColor="#fff" stopOpacity={0.631} offset="63.146%" />
@@ -26,7 +31,7 @@ export function TailSpin(props: SVGProps<SVGSVGElement>) {
       <g transform="translate(1 1)" fill="none" fillRule="evenodd">
         <path
           d="M36 18c0-9.94-8.06-18-18-18"
-          stroke="url(#tailSpinGradient)"
+          stroke={`url(#${gradientId})`}
           strokeWidth={2}
         >
           <animateTransform


### PR DESCRIPTION
## Problem

`TailSpin` (the per-tile loading spinner used by `OverlayViewTile`) renders a `<linearGradient id="tailSpinGradient">` with a static, hardcoded id. `overlay.tsx` renders one `OverlayViewTile` per active grid view, and it's routine for several tiles to be loading at once (e.g. on startup, or when cycling many streams). Each loading tile independently mounted its own `<svg><defs><linearGradient id="tailSpinGradient">`, producing duplicate `id` attributes in the same document — invalid per the SVG/HTML spec, since `id` must be document-unique.

In practice the gradients are visually identical, so this was usually unnoticeable, but `url(#tailSpinGradient)` references could resolve to the wrong (or a mid-removal) element depending on browser/Chromium behavior when one tile's spinner unmounts while others are still loading.

This bug pre-dates #182 — the original `svg-loaders-react` `TailSpin` source has the same hardcoded id — but became first-party code (and therefore ours to fix) once #182 inlined it.

## Solution

Use Preact's `useId()` hook to scope the gradient id (and its `stroke="url(#...)"` reference) to each rendered `TailSpin` instance, so simultaneous spinners no longer collide.

## Testing

- Added `TailSpin.test.tsx`, which renders two `TailSpin` instances simultaneously and asserts their gradient ids are unique and that each path's `stroke` references its own instance's gradient.
- Ran the full `streamwall` package suite (`vitest run`): 203/203 tests passing.
- `tsc --noEmit` and `eslint` clean on the changed files.

## Risks / breaking changes

None. Purely a rendering-correctness fix with no API or behavioral change — the spinner's visuals are identical.

Closes #212