### PR TITLE
fix(electron): let the control window close natively

### DIFF
--- a/packages/streamwall/src/main/ControlWindow.test.ts
+++ b/packages/streamwall/src/main/ControlWindow.test.ts
@@ -8,6 +8,12 @@ import { describe, expect, it, vi } from 'vitest'
 class FakeBrowserWindow extends EventEmitter {
   webContents = { send: vi.fn() }
   removeMenu = vi.fn()
+  options: Record<string, unknown>
+
+  constructor(options: Record<string, unknown>) {
+    super()
+    this.options = options
+  }
 }
 
 vi.mock('electron', () => ({
@@ -29,5 +35,13 @@ describe('ControlWindow close', () => {
     controlWindow.win.emit('close', fakeEvent)
 
     expect(closeListener).toHaveBeenCalledWith(fakeEvent)
+  })
+
+  it('keeps the native close control enabled so the quit/hide behavior wired through the close event is reachable from the window chrome', () => {
+    const controlWindow = new ControlWindow()
+
+    expect(
+      (controlWindow.win as unknown as FakeBrowserWindow).options.closable,
+    ).not.toBe(false)
   })
 })

--- a/packages/streamwall/src/main/ControlWindow.ts
+++ b/packages/streamwall/src/main/ControlWindow.ts
@@ -21,7 +21,6 @@ export default class ControlWindow extends EventEmitter<ControlWindowEventMap> {
       title: 'Streamwall Control',
       width: 1280,
       height: 1024,
-      closable: false,
       webPreferences: {
         preload: path.join(__dirname, 'controlPreload.js'),
       },


### PR DESCRIPTION
## Problem

`ControlWindow`'s `BrowserWindow` is constructed with `closable: false`, which disables the native close control (the traffic-light close button on macOS, the title-bar `X` on Windows/Linux).

Since #193/#205, closing either top-level window is routed through the same quit-or-hide handler (`handleWindowClose` in `main/index.ts`). `StreamWindow` already exposes that behavior via its native close control (it has no `closable` override). `ControlWindow`'s `closable: false` doesn't add any real safety — a user can already quit or hide the app by closing the stream window instead — it just makes the two windows behave inconsistently and hides a discoverable way to quit from the control window.

## Solution

Remove `closable: false` from `ControlWindow`'s `BrowserWindow` options so its native close control behaves the same as `StreamWindow`'s: closing it triggers the existing quit-or-hide handling.

## Testing

Added a test to `ControlWindow.test.ts` that captures the options passed to the (mocked) `BrowserWindow` constructor and asserts `closable` is not `false`. Confirmed it fails before the fix (Electron would report the field as disabled) and passes after.

Full package test suite (189 tests), lint, format check, and `npm run typecheck` all pass.

## Risk

None expected — this only re-enables a native OS-level close button. The quit-or-hide logic itself (`handleWindowClose`, `shouldHideInsteadOfQuit`, `shouldQuitOnAllWindowsClosed`) is unchanged and already covered by `windowCloseBehavior.test.ts`.

Closes #214