### PR TITLE
feat: make the control client mobile-friendly (viewport + responsive layout)

### DIFF
--- a/packages/streamwall-control-client/dev.html
+++ b/packages/streamwall-control-client/dev.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Streamwall Control — Dev</title>
     <!-- Fonts are bundled locally via @fontsource (imported in control-ui),
          so no CDN is needed — dev matches the production CSP. -->

--- a/packages/streamwall-control-client/index.html
+++ b/packages/streamwall-control-client/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Streamwall Control</title>
     <meta
       http-equiv="Content-Security-Policy"

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -1162,17 +1162,8 @@ export function ControlUI({
   }
 
   return (
-    <Stack
-      $flex="1"
-      $direction="row"
-      $gap={16}
-      style={{ height: '100vh', minHeight: 0, padding: 16, overflow: 'hidden' }}
-    >
-      <Stack
-        className="grid-container"
-        $flex="1"
-        style={{ minWidth: 0, minHeight: 0 }}
-      >
+    <AppShell className="app-shell">
+      <Stack className="grid-container">
         <StyledHeader>
           <div className="wm">
             STREAM<span>·</span>WALL
@@ -1426,12 +1417,7 @@ export function ControlUI({
           </span>
         </StyledStatusBar>
       </Stack>
-      <Stack
-        className="stream-list"
-        $scroll={true}
-        $minHeight={200}
-        style={{ flex: '0 0 340px' }}
-      >
+      <Stack className="stream-list" $scroll={true} $minHeight={200}>
         <StyledDataContainer $isConnected={isConnected}>
           {isConnected ? (
             <div>
@@ -1526,7 +1512,7 @@ export function ControlUI({
             )}
         </StyledDataContainer>
       </Stack>
-    </Stack>
+    </AppShell>
   )
 }
 
@@ -1543,6 +1529,57 @@ const Stack = styled.div<{
   ${({ $gap }) => $gap && `gap: ${$gap}px`};
   ${({ $scroll }) => $scroll && `overflow-y: auto`};
   ${({ $minHeight }) => $minHeight && `min-height: ${$minHeight}px`};
+`
+
+// Below this viewport width the side-by-side wall/stream-list layout stops
+// fitting, so the shell stacks the two regions vertically instead (see #81).
+// Shared with the header so both switch to their narrow layout together.
+const NARROW_BREAKPOINT = 820
+
+// Root layout. Desktop: the wall preview and the stream list sit side by side,
+// pinned to the viewport height with only the stream list scrolling. Narrow
+// screens (phones, small windows): the two regions stack and the whole page
+// scrolls. Layout that the media query needs to override lives here rather than
+// as inline styles on the children so the cascade can win cleanly.
+const AppShell = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: row;
+  gap: 16px;
+  height: 100vh;
+  min-height: 0;
+  padding: 16px;
+  overflow: hidden;
+
+  > .grid-container {
+    flex: 1;
+    min-width: 0;
+    min-height: 0;
+  }
+
+  > .stream-list {
+    flex: 0 0 340px;
+  }
+
+  @media (max-width: ${NARROW_BREAKPOINT}px) {
+    flex-direction: column;
+    height: auto;
+    min-height: 100vh;
+    overflow: visible;
+
+    /* Stack both regions at their natural height and let the whole page
+       scroll, rather than pinning them to the viewport and competing for its
+       height (which collapses the wall region to nothing). */
+    > .grid-container {
+      flex: 0 0 auto;
+    }
+
+    > .stream-list {
+      flex: 0 0 auto;
+      min-width: 0;
+      overflow-y: visible;
+    }
+  }
 `
 
 function StreamDurationClock({ startTime }: { startTime: number }) {
@@ -2308,6 +2345,13 @@ const StyledHeader = styled.header`
   }
   .status .dot.off {
     background: var(--text-faint);
+  }
+
+  /* On narrow screens the header controls no longer fit on one line - let them
+     wrap instead of overflowing the viewport (see #81). */
+  @media (max-width: ${NARROW_BREAKPOINT}px) {
+    flex-wrap: wrap;
+    gap: 10px 14px;
   }
 `
 

--- a/packages/streamwall-control-ui/src/responsiveLayout.test.tsx
+++ b/packages/streamwall-control-ui/src/responsiveLayout.test.tsx
@@ -1,0 +1,99 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import type { StreamDelayStatus } from 'streamwall-shared'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import * as Y from 'yjs'
+import { ControlUI, type StreamwallConnection } from './index.tsx'
+
+// react-icons renders through preact/compat's Context.Consumer, which currently
+// crashes under this package's happy-dom test environment (unrelated to the
+// layout under test here) - stub the icons out so ControlUI's own rendering can
+// be exercised in isolation.
+vi.mock('react-icons/fa', () => ({
+  FaExchangeAlt: () => null,
+  FaExclamationTriangle: () => null,
+  FaRedoAlt: () => null,
+  FaRegLifeRing: () => null,
+  FaRegWindowMaximize: () => null,
+  FaSyncAlt: () => null,
+  FaVideoSlash: () => null,
+  FaVolumeUp: () => null,
+}))
+vi.mock('react-icons/md', () => ({
+  MdOutlineStayCurrentLandscape: () => null,
+  MdOutlineStayCurrentPortrait: () => null,
+}))
+// react-hotkeys-hook resolves its own copy of `react` (bypassing this package's
+// `react` -> `preact/compat` test alias), which crashes under happy-dom - stub
+// it out so the component's own rendering logic can be exercised in isolation.
+vi.mock('react-hotkeys-hook', () => ({
+  useHotkeys: () => {},
+}))
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+function renderControlUI(): HTMLDivElement {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+
+  const delayState: StreamDelayStatus = {
+    isConnected: true,
+    delaySeconds: 0,
+    restartSeconds: 0,
+    isCensored: false,
+    isStreamRunning: true,
+    startTime: 0,
+    state: 'idle',
+  }
+
+  const connection: StreamwallConnection = {
+    isConnected: true,
+    role: 'operator',
+    send: () => {},
+    sharedState: { views: {} },
+    stateDoc: new Y.Doc(),
+    config: undefined,
+    streams: [],
+    customStreams: [],
+    views: [],
+    stateIdxMap: new Map(),
+    delayState,
+    authState: undefined,
+    layoutPresets: [],
+  }
+
+  act(() => {
+    render(<ControlUI connection={connection} />, container!)
+  })
+  return container
+}
+
+// The responsive layout stacks the wall preview and the stream list below each
+// other on narrow screens via a CSS media query (see #81). That media query
+// targets the shell and its two regions by class name, so the DOM contract they
+// rely on is what this test guards - if the shell or a region is renamed or
+// removed, the responsive stacking silently breaks.
+describe('responsive app shell', () => {
+  test('renders a shell containing the wall and stream-list regions', () => {
+    const root = renderControlUI()
+
+    const shell = root.querySelector('.app-shell')
+    expect(shell, 'app shell container is missing').not.toBeNull()
+    expect(
+      shell!.querySelector('.grid-container'),
+      'wall region is missing from the shell',
+    ).not.toBeNull()
+    expect(
+      shell!.querySelector('.stream-list'),
+      'stream-list region is missing from the shell',
+    ).not.toBeNull()
+  })
+})

--- a/packages/streamwall-shared/src/stateDiff.test.ts
+++ b/packages/streamwall-shared/src/stateDiff.test.ts
@@ -46,6 +46,7 @@ function makeState(overrides: Partial<StreamwallState> = {}): StreamwallState {
     customStreams: [],
     views: [makeView(0), makeView(1)],
     streamdelay: null,
+    layoutPresets: [],
     ...overrides,
   }
 }


### PR DESCRIPTION
## Problem

The web control client (`streamwall-control-client`) was unusable on phones:

- `index.html` had no `<meta name="viewport">`, so phones rendered a zoomed-out 980px desktop layout.
- The control UI had no width media queries (only `prefers-color-scheme`). The wall preview and the stream list were pinned side by side with a fixed 340px sidebar, and the whole thing was locked to the viewport height.

Closes #81.

## Solution

- **Viewport meta** — added `<meta name="viewport" content="width=device-width, initial-scale=1">` to `index.html` and the `dev.html` harness so phones render at device width.
- **Responsive shell** — introduced an `AppShell` styled container that owns the root layout. The layout that the media query must override used to live in *inline styles* (which the cascade can't beat), so moving it into `AppShell` lets a single `@media (max-width: 820px)` block flip cleanly:
  - **Desktop (≥ 820px):** unchanged — wall preview fills, stream list is a fixed 340px sidebar scrolling internally, page pinned to `100vh`.
  - **Narrow (< 820px):** the two regions stack at their natural height and the whole page scrolls; the header controls wrap instead of overflowing.

## Architecture notes

- The 820px breakpoint is a shared `NARROW_BREAKPOINT` constant used by both the shell and the header so they switch together.
- The critical bug found during verification: naively stacking with `flex: 1` on both regions collapsed the wall region to height 0 (it lost the height race against the content-sized stream list). Fixed by giving both regions `flex: 0 0 auto` in the narrow layout so they size to content and the page scrolls as one.

## Testing

- **New test** `responsiveLayout.test.tsx` renders `ControlUI` and asserts the responsive shell renders both named regions (`.grid-container`, `.stream-list`) that the media query targets — a regression guard for the DOM contract the CSS relies on. (CSS media-query *layout* itself isn't observable under happy-dom, which has no layout engine, so the behavioural check is the manual browser verification below.)
- **Manual browser verification** via the `dev.html` mock harness:
  - 375px: wall + stream list stack, wall renders at correct aspect ratio, no horizontal overflow, page scrolls.
  - 1280px: two-column layout unchanged.
- Full quality gate green locally: Prettier, ESLint, `tsc` (all workspaces), tests, and the web-client build.

## Incidental fix (required for green CI)

`main` was already red on the `tsc` "Static checks" job: the named-layout-presets feature (#199) made `layoutPresets` a required field on `StreamwallState` but never updated the `makeState` helper in `streamwall-shared/src/stateDiff.test.ts`. This PR adds `layoutPresets: []` to that helper as a separate commit so CI can go green; without it no PR can pass the required check.

## Follow-ups

- #225 — pre-existing horizontal overflow on desktop (default `<body>` margin; verified present on the original `ControlUI`, out of scope here).
- #221 — pre-existing flaky control-server test `rejects a second Streamwall connection` (unrelated package; flaked once during a full test run, passes on retry).

## Risks / breaking changes

None. Desktop layout is byte-for-byte behaviourally unchanged (verified). The change is presentational plus a static meta tag; no state, protocol, or API surface is touched.