### PR TITLE
fix(control-ui): confirm before a layout preset overwrites the wall

### DIFF
--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -40,6 +40,7 @@ import {
   GRID_MAX,
   GRID_MIN,
   gridWouldDropAssignments,
+  hasGridAssignments,
   idColor,
   idxInBox,
   inviteLink,
@@ -1048,9 +1049,27 @@ export function ControlUI({
 
   const handleLoadLayoutPreset = useCallback(
     (presetId: string) => {
+      // Loading a preset unconditionally replaces every cell (see
+      // applyLayoutPreset), unlike a grid resize which only drops cells that
+      // fall outside the new bounds. So warn whenever the current layout has
+      // any live assignment, mirroring handleSetGridSize's confirm above.
+      if (sharedState) {
+        const assignments = new Map<number, string | undefined>()
+        for (const [idx, view] of Object.entries(sharedState.views)) {
+          assignments.set(Number(idx), view.streamId)
+        }
+        if (
+          hasGridAssignments(assignments) &&
+          !window.confirm(
+            'Loading this preset will replace the current layout. Save it as a preset first if you want to keep it. Continue?',
+          )
+        ) {
+          return
+        }
+      }
       send({ type: 'load-layout-preset', presetId })
     },
-    [send],
+    [send, sharedState],
   )
 
   const handleDeleteLayoutPreset = useCallback(

--- a/packages/streamwall-shared/src/geometry.test.ts
+++ b/packages/streamwall-shared/src/geometry.test.ts
@@ -4,6 +4,7 @@ import {
   GRID_MAX,
   GRID_MIN,
   gridWouldDropAssignments,
+  hasGridAssignments,
   idxToCoords,
   parseGridDimensionInput,
   remapGridAssignments,
@@ -124,5 +125,25 @@ describe('gridWouldDropAssignments', () => {
   it('returns false when the grid grows', () => {
     const assignments = new Map<number, string | undefined>([[3, 'a']])
     expect(gridWouldDropAssignments(2, 4, 4, assignments)).toBe(false)
+  })
+})
+
+describe('hasGridAssignments', () => {
+  it('returns false for an empty map', () => {
+    expect(hasGridAssignments(new Map())).toBe(false)
+  })
+  it('returns false when every cell is empty or empty-string', () => {
+    const assignments = new Map<number, string | undefined>([
+      [0, undefined],
+      [1, ''],
+    ])
+    expect(hasGridAssignments(assignments)).toBe(false)
+  })
+  it('returns true when at least one cell holds a streamId', () => {
+    const assignments = new Map<number, string | undefined>([
+      [0, undefined],
+      [1, 'a'],
+    ])
+    expect(hasGridAssignments(assignments)).toBe(true)
   })
 })

--- a/packages/streamwall-shared/src/geometry.ts
+++ b/packages/streamwall-shared/src/geometry.ts
@@ -184,6 +184,25 @@ export function gridWouldDropAssignments(
 }
 
 /**
+ * Reports whether any cell in `assignments` holds a stream. Used to decide
+ * whether an operation that unconditionally replaces the whole grid (e.g.
+ * loading a layout preset) needs a confirmation, since unlike a resize there
+ * is no partial overlap to preserve.
+ *
+ * @param assignments Map of cell index -> streamId (undefined/'' = empty).
+ */
+export function hasGridAssignments(
+  assignments: Map<number, string | undefined>,
+): boolean {
+  for (const streamId of assignments.values()) {
+    if (streamId !== undefined && streamId !== '') {
+      return true
+    }
+  }
+  return false
+}
+
+/**
  * Remaps grid cell assignments when the grid dimensions change. Each non-empty
  * assignment is preserved at the same (x, y) position if that position still
  * exists in the new grid; assignments that fall outside the new grid are


### PR DESCRIPTION
## Problem

Loading a saved layout preset (`load-layout-preset`, handled in `onCommand` in `packages/streamwall/src/main/index.ts`) immediately overwrites the current grid — every live cell assignment is replaced via `applyLayoutPreset` (`packages/streamwall/src/main/layoutPresets.ts`) with no confirmation.

This was inconsistent with the existing UX for a similarly destructive action: shrinking the grid via `GridSizeControls` already warns with `window.confirm` when the resize would drop stream assignments (`gridWouldDropAssignments` / `handleSetGridSize` in `packages/streamwall-control-ui/src/index.tsx`).

## Solution

- Added `hasGridAssignments` to `packages/streamwall-shared/src/geometry.ts`: a small pure helper reporting whether any cell in a grid-assignment map currently holds a stream.
  - Unlike a grid resize (`gridWouldDropAssignments`, which only drops cells that fall outside the new bounds), loading a preset unconditionally wipes and rewrites the *entire* `viewsState`. So the relevant question isn't "does this specific resize target drop anything" — it's simply "is the current layout non-empty."
- Wired it into `handleLoadLayoutPreset` in `packages/streamwall-control-ui/src/index.tsx`: before dispatching `load-layout-preset`, it now builds the current cell-assignment map (same pattern as `handleSetGridSize`) and, if non-empty, prompts via `window.confirm` before proceeding. Cancelling leaves the current layout untouched and does not send the command.

No changes were needed in the main process — the confirmation is a client-side UX gate, consistent with where the equivalent grid-resize confirmation already lives.

## Testing

- `hasGridAssignments`: unit-tested in `packages/streamwall-shared/src/geometry.test.ts` (empty map, all-empty cells, at least one live cell).
- The `handleLoadLayoutPreset` wiring itself has no direct unit test, matching the existing convention for this file: `index.tsx` is a large top-level component with no render-level test harness, and the equivalent `handleSetGridSize` confirm wiring it mirrors is likewise covered only through its extracted pure logic (`gridWouldDropAssignments`), not a component test.
- Full quality gate run locally: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` (all workspaces), `npm -w streamwall-control-client run build` — all green.

## Risks / breaking changes

None. Purely additive client-side confirmation; no protocol or state-shape changes.

Closes #217