### PR TITLE
fix(deps): declare cross-workspace streamwall-shared and lodash-es deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14877,6 +14877,7 @@
         "react-icons": "^5.7.0",
         "reconnecting-websocket": "^4.4.0",
         "source-map-support": "^0.5.21",
+        "streamwall-shared": "*",
         "styled-components": "^6.4.3",
         "update-electron-app": "^3.3.0",
         "utf-8-validate": "^6.0.6",
@@ -14917,6 +14918,7 @@
       "dependencies": {
         "jsondiffpatch": "^0.7.6",
         "reconnecting-websocket": "^4.4.0",
+        "streamwall-shared": "*",
         "yjs": "^13.6.31"
       },
       "devDependencies": {
@@ -15031,6 +15033,7 @@
         "fastify": "^5.10.0",
         "jsondiffpatch": "^0.7.6",
         "lowdb": "^7.0.1",
+        "streamwall-shared": "*",
         "tsx": "^4.23.0",
         "ws": "^8.21.0",
         "yjs": "^13.6.31"
@@ -15079,6 +15082,7 @@
         "react-hotkeys-hook": "^5.3.3",
         "react-icons": "^5.7.0",
         "reconnecting-websocket": "^4.4.0",
+        "streamwall-shared": "*",
         "styled-components": "^6.4.3",
         "xstate": "^5.32.4",
         "yjs": "^13.6.31"
@@ -15143,6 +15147,7 @@
       "dependencies": {
         "color": "^5.0.3",
         "jsondiffpatch": "^0.7.6",
+        "lodash-es": "^4.18.1",
         "yjs": "^13.6.31",
         "zod": "^4.4.3"
       },

--- a/packages/streamwall-control-client/package.json
+++ b/packages/streamwall-control-client/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "jsondiffpatch": "^0.7.6",
     "reconnecting-websocket": "^4.4.0",
+    "streamwall-shared": "*",
     "yjs": "^13.6.31"
   },
   "devDependencies": {

--- a/packages/streamwall-control-server/package.json
+++ b/packages/streamwall-control-server/package.json
@@ -22,6 +22,7 @@
     "fastify": "^5.10.0",
     "jsondiffpatch": "^0.7.6",
     "lowdb": "^7.0.1",
+    "streamwall-shared": "*",
     "tsx": "^4.23.0",
     "ws": "^8.21.0",
     "yjs": "^13.6.31"

--- a/packages/streamwall-control-ui/package.json
+++ b/packages/streamwall-control-ui/package.json
@@ -18,6 +18,7 @@
     "react-hotkeys-hook": "^5.3.3",
     "react-icons": "^5.7.0",
     "reconnecting-websocket": "^4.4.0",
+    "streamwall-shared": "*",
     "styled-components": "^6.4.3",
     "xstate": "^5.32.4",
     "yjs": "^13.6.31"

--- a/packages/streamwall-shared/package.json
+++ b/packages/streamwall-shared/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "color": "^5.0.3",
     "jsondiffpatch": "^0.7.6",
+    "lodash-es": "^4.18.1",
     "yjs": "^13.6.31",
     "zod": "^4.4.3"
   },

--- a/packages/streamwall/package.json
+++ b/packages/streamwall/package.json
@@ -62,6 +62,7 @@
     "react-icons": "^5.7.0",
     "reconnecting-websocket": "^4.4.0",
     "source-map-support": "^0.5.21",
+    "streamwall-shared": "*",
     "styled-components": "^6.4.3",
     "update-electron-app": "^3.3.0",
     "utf-8-validate": "^6.0.6",


### PR DESCRIPTION
## Problem

None of `streamwall`, `streamwall-control-client`, `streamwall-control-ui`, or `streamwall-control-server` list `streamwall-shared` in their `package.json` `dependencies`, even though all of them `import ... from 'streamwall-shared'`. This only worked because a full-repo `npm install`/`npm ci` unconditionally symlinks every workspace package into the root `node_modules`, regardless of which workspace actually declares a dependency on it.

The same gap existed one level down: `streamwall-shared/src/geometry.ts` imports `lodash-es`, which `streamwall-shared/package.json` did not list as a dependency either — it only resolved because another workspace (`streamwall-control-ui`) happened to declare `lodash-es` and got hoisted to the shared root `node_modules`.

A scoped, workspace-filtered install (e.g. `npm install --workspace=streamwall-control-server --workspace=streamwall-shared`, the kind of install a minimal production/Docker build for a single package would want to avoid pulling in unrelated workspaces like the Electron app) failed at runtime with `ERR_MODULE_NOT_FOUND: lodash-es`, because that scoped install correctly does not hoist packages nobody declared a dependency on.

## Solution

- Added `"streamwall-shared": "*"` as an explicit dependency in every package that imports it: `streamwall`, `streamwall-control-client`, `streamwall-control-ui`, `streamwall-control-server`.
- Added `"lodash-es": "^4.18.1"` as an explicit dependency of `streamwall-shared` itself.
- Regenerated `package-lock.json` via `npm install`.

No production code changed — this is purely a `package.json`/lockfile correction that makes the already-existing implicit dependency graph explicit.

## Testing performed

- `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` (all packages), and `npm -w streamwall-control-client run build` — all green.
- Verified the fix directly per the issue's suggested reproduction: for each of the four consumer packages, ran a scoped install (`npm install --workspace=packages/<pkg> --workspace=packages/streamwall-shared`) in an isolated git worktree and confirmed both `streamwall-shared` and `lodash-es` resolve at runtime (`node --input-type=module -e "import(...)"`). Before this fix, the `streamwall-control-client` scoped install reproduced the reported `ERR_MODULE_NOT_FOUND: lodash-es` failure; after, all four resolve cleanly.
- No unit tests added: this change has no testable runtime behavior (it only makes declared dependencies match actual imports); correctness is verified by the scoped-install reproduction above and the full quality gate.

## Risks / breaking changes

None expected. This only adds already-present-at-runtime dependencies as explicit `package.json` entries; it does not change any resolved versions or runtime behavior for the existing full-repo install path used by CI and local development.

Closes #215