### PR TITLE
feat(control-ui): warn when the layout preset cap silently evicts the oldest preset

### DIFF
--- a/packages/streamwall-control-ui/src/LayoutPresetControls.test.tsx
+++ b/packages/streamwall-control-ui/src/LayoutPresetControls.test.tsx
@@ -1,6 +1,6 @@
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
-import type { LayoutPreset } from 'streamwall-shared'
+import { MAX_LAYOUT_PRESETS, type LayoutPreset } from 'streamwall-shared'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { LayoutPresetControls } from './LayoutPresetControls.tsx'
 
@@ -132,5 +132,56 @@ describe('LayoutPresetControls', () => {
 
     expect(input.disabled).toBe(false)
     expect(presetButton.disabled).toBe(false)
+  })
+
+  test('shows how many of the preset cap are used', () => {
+    const el = renderControls()
+    expect(el.querySelector('.preset-count')?.textContent).toBe(
+      `2 / ${MAX_LAYOUT_PRESETS}`,
+    )
+  })
+
+  test('does not warn about eviction below the preset cap', () => {
+    const el = renderControls()
+    expect(el.querySelector('.preset-cap-warning')).toBeNull()
+  })
+
+  test('warns which preset a save would evict once the cap is reached', () => {
+    const fullPresets: LayoutPreset[] = Array.from(
+      { length: MAX_LAYOUT_PRESETS },
+      (_, i) => ({
+        id: `p${i}`,
+        name: `Layout ${i}`,
+        cols: 1,
+        rows: 1,
+        views: {},
+      }),
+    )
+
+    const el = renderControls({ presets: fullPresets })
+
+    expect(el.querySelector('.preset-count')?.textContent).toBe(
+      `${MAX_LAYOUT_PRESETS} / ${MAX_LAYOUT_PRESETS}`,
+    )
+    expect(el.querySelector('.preset-cap-warning')?.textContent).toContain(
+      'Layout 0',
+    )
+  })
+
+  test('does not show the eviction warning for a role without save-layout-preset permission', () => {
+    const fullPresets: LayoutPreset[] = Array.from(
+      { length: MAX_LAYOUT_PRESETS },
+      (_, i) => ({
+        id: `p${i}`,
+        name: `Layout ${i}`,
+        cols: 1,
+        rows: 1,
+        views: {},
+      }),
+    )
+
+    const el = renderControls({ presets: fullPresets, role: 'monitor' })
+
+    expect(el.querySelector('.preset-cap-warning')).toBeNull()
   })
 })

--- a/packages/streamwall-control-ui/src/LayoutPresetControls.tsx
+++ b/packages/streamwall-control-ui/src/LayoutPresetControls.tsx
@@ -1,6 +1,8 @@
 import { type JSX } from 'preact'
 import { useCallback, useState } from 'preact/hooks'
+import { FaExclamationTriangle } from 'react-icons/fa'
 import {
+  MAX_LAYOUT_PRESETS,
   roleCan,
   type LayoutPreset,
   type StreamwallRole,
@@ -45,6 +47,17 @@ const StyledLayoutPresetControls = styled.div`
     padding: 2px 6px;
     color: var(--text-dim, #888);
   }
+  .preset-count {
+    font-size: 12px;
+    color: var(--text-dim, #888);
+  }
+  .preset-cap-warning {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: #e0a800;
+  }
 `
 
 /**
@@ -68,6 +81,12 @@ export function LayoutPresetControls({
   const disabled = !roleCan(role, 'save-layout-preset')
 
   const [nameDraft, setNameDraft] = useState('')
+
+  // `addLayoutPreset` (main/layoutPresets.ts) silently drops the oldest
+  // preset once the list is at MAX_LAYOUT_PRESETS, so warn before that
+  // happens rather than let a preset vanish with no explanation (issue #218).
+  const atCapacity = presets.length >= MAX_LAYOUT_PRESETS
+  const oldestPreset = presets[0]
 
   const handleChangeName = useCallback<JSX.InputEventHandler<HTMLInputElement>>(
     (ev) => {
@@ -102,6 +121,18 @@ export function LayoutPresetControls({
           save layout
         </button>
       </form>
+      <span className="preset-count">
+        {presets.length} / {MAX_LAYOUT_PRESETS}
+      </span>
+      {atCapacity && !disabled && oldestPreset && (
+        <span
+          className="preset-cap-warning"
+          title={`The preset list is full. Saving a new one will remove the oldest: "${oldestPreset.name}".`}
+        >
+          <FaExclamationTriangle />
+          Saving will replace &ldquo;{oldestPreset.name}&rdquo;
+        </span>
+      )}
       {presets.map((preset) => (
         <span className="preset-chip" key={preset.id}>
           <button

--- a/packages/streamwall-shared/src/types.ts
+++ b/packages/streamwall-shared/src/types.ts
@@ -102,6 +102,9 @@ export interface AuthTokenInfo {
   name: string
 }
 
+/** Maximum number of saved layout presets, bounding unbounded storage growth. */
+export const MAX_LAYOUT_PRESETS = 50
+
 /** A named, saved grid layout: its dimensions and per-cell stream assignments. */
 export interface LayoutPreset {
   id: string

--- a/packages/streamwall/src/main/layoutPresets.test.ts
+++ b/packages/streamwall/src/main/layoutPresets.test.ts
@@ -1,11 +1,10 @@
-import type { LayoutPreset } from 'streamwall-shared'
+import { MAX_LAYOUT_PRESETS, type LayoutPreset } from 'streamwall-shared'
 import { describe, expect, it } from 'vitest'
 import * as Y from 'yjs'
 import {
   addLayoutPreset,
   applyLayoutPreset,
   buildLayoutPreset,
-  MAX_LAYOUT_PRESETS,
 } from './layoutPresets'
 
 function makeViewsState(assignments: Record<number, string | undefined>) {

--- a/packages/streamwall/src/main/layoutPresets.ts
+++ b/packages/streamwall/src/main/layoutPresets.ts
@@ -1,8 +1,5 @@
-import type { LayoutPreset } from 'streamwall-shared'
+import { MAX_LAYOUT_PRESETS, type LayoutPreset } from 'streamwall-shared'
 import * as Y from 'yjs'
-
-/** Maximum number of saved layout presets, bounding unbounded storage growth. */
-export const MAX_LAYOUT_PRESETS = 50
 
 export interface LayoutPresetSaveContext {
   /** Yjs map of grid cell index (as string) -> a `{ streamId }` map. */


### PR DESCRIPTION
## Problem

`addLayoutPreset` (`packages/streamwall/src/main/layoutPresets.ts`) bounds the saved preset list to `MAX_LAYOUT_PRESETS` (50) by silently dropping the oldest entry once the cap is reached. Saving a new preset always succeeds, but an old one can disappear from `LayoutPresetControls.tsx`'s list with no indication why.

## Solution

This takes the "expose the cap in the UI" option from the issue, since a genuine per-request eviction notice would require new round-trip plumbing across the control-server/desktop uplink boundary (the `save-layout-preset` command is forwarded fire-and-forget to the desktop process today, which has no "reply to sender" concept — see the investigation notes below).

- `MAX_LAYOUT_PRESETS` moves from `streamwall`'s main-process-only `layoutPresets.ts` into `streamwall-shared`, so both the desktop process and the control-ui read the same constant.
- `LayoutPresetControls.tsx` now shows a persistent `N / 50` counter next to the saved presets.
- Once the list is at capacity, it also names the preset that the next save will evict (e.g. "Saving will replace “Layout 0”"), with a tooltip explaining why. The warning only shows for roles that can actually save (`save-layout-preset` permission).

### Why not the respond()-style round trip?

Traced the full path: `create-invite`'s response works because it's handled *entirely inside* the control-server (`respond()` is a closure scoped to one synchronous request). `save-layout-preset` is forwarded verbatim to the desktop over the uplink connection and only ever gets a reply via the next full `state` broadcast — the desktop's `onCommand` never reads the forwarded `id`/`clientId`, and the control-server's uplink handler only accepts `state` messages by schema. Wiring a real per-command reply would mean a new message schema, new routing in the uplink handler keyed by `clientId`, and a new "reply to sender" concept in the desktop process — a lot of new surface area for a low-priority DX warning. The client-side capacity indicator achieves the same operator-facing goal using data already broadcast today.

## Testing

- Added Vitest cases to `LayoutPresetControls.test.tsx` for the counter, the absence of a warning below capacity, the eviction warning naming the oldest preset at capacity, and that the warning is hidden for a role without permission to save.
- Updated `layoutPresets.test.ts`'s import of `MAX_LAYOUT_PRESETS` to the new shared location (no behavior change).
- Full quality gate green: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` (all workspaces), `npm -w streamwall-control-client run build`.

## Risks / breaking changes

None. Purely additive UI, no protocol or schema changes.

Closes #218