### PR TITLE
refactor(control-server): extract shared WebSocket test helpers

### DIFF
--- a/packages/streamwall-control-server/src/multiplexing.test.ts
+++ b/packages/streamwall-control-server/src/multiplexing.test.ts
@@ -1,107 +1,21 @@
 import assert from 'node:assert/strict'
 import { once } from 'node:events'
-import type { AddressInfo } from 'node:net'
 import { after, test } from 'node:test'
 import { setTimeout as delay } from 'node:timers/promises'
 import WebSocket from 'ws'
 
-import { buildTestApp } from './testHelpers.ts'
+import type { StreamwallRole } from 'streamwall-shared'
+import {
+  buildTestApp,
+  connectStreamwallUplink,
+  listenTestApp,
+  messageCollector,
+  mintUplinkToken,
+  redeemInviteAndConnectClient,
+  VALID_STATE,
+} from './testHelpers.ts'
 
 const BASE_URL = 'http://localhost:3000'
-
-const VALID_STATE = {
-  identity: { role: 'admin' },
-  config: {
-    cols: 3,
-    rows: 3,
-    width: 1920,
-    height: 1080,
-    frameless: false,
-    activeColor: '#fff',
-    backgroundColor: '#000',
-  },
-  auth: { invites: [], sessions: [] },
-  streams: [],
-  customStreams: [],
-  views: [],
-  streamdelay: null,
-}
-
-/**
- * Buffers every JSON (text) frame from a socket and lets a test await one
- * matching a predicate. Already-received frames satisfy `waitFor`, so there is
- * no race between attaching a listener and a frame arriving. Binary Yjs frames
- * are ignored.
- */
-function recordJsonMessages(ws: WebSocket) {
-  const messages: any[] = []
-  const waiters: {
-    predicate: (m: any) => boolean
-    resolve: (m: any) => void
-  }[] = []
-
-  ws.on('message', (data, isBinary) => {
-    if (isBinary) {
-      return
-    }
-    let msg: any
-    try {
-      msg = JSON.parse(data.toString())
-    } catch {
-      return
-    }
-    messages.push(msg)
-    for (let i = waiters.length - 1; i >= 0; i--) {
-      if (waiters[i].predicate(msg)) {
-        waiters[i].resolve(msg)
-        waiters.splice(i, 1)
-      }
-    }
-  })
-
-  return {
-    messages,
-    waitFor(predicate: (m: any) => boolean, timeoutMs = 2000): Promise<any> {
-      const existing = messages.find(predicate)
-      if (existing) {
-        return Promise.resolve(existing)
-      }
-      return new Promise((resolve, reject) => {
-        const timer = setTimeout(
-          () => reject(new Error('timed out waiting for matching ws message')),
-          timeoutMs,
-        )
-        waiters.push({
-          predicate,
-          resolve: (m) => {
-            clearTimeout(timer)
-            resolve(m)
-          },
-        })
-      })
-    },
-  }
-}
-
-/**
- * Captures the first app-level message from the moment the socket is created,
- * so an error the server sends immediately on connect is never missed to a
- * listener-attachment race. `next(timeoutMs)` resolves with that message or
- * null if none arrives within the window.
- */
-function messageCollector(ws: WebSocket) {
-  let first: unknown | undefined
-  const received = new Promise<void>((resolve) => {
-    ws.once('message', (data) => {
-      first = JSON.parse(data.toString())
-      resolve()
-    })
-  })
-  return async (timeoutMs: number): Promise<unknown | null> => {
-    await Promise.race([received, delay(timeoutMs)])
-    return first === undefined ? null : first
-  }
-}
 
 /** Temporarily replaces `console.warn`, capturing every call made while active. */
 function spyOnConsoleWarn() {
@@ -130,48 +44,23 @@ async function bootServerWithUplink() {
 
   const { app, auth } = await buildTestApp({ baseURL: BASE_URL })
   after(() => app.close())
-  await app.listen({ port: 0, host: '127.0.0.1' })
-  const { port } = app.server.address() as AddressInfo
+  const port = await listenTestApp(app)
 
-  const swToken = await auth.createToken({
-    kind: 'streamwall',
-    role: 'admin',
-    name: 'uplink',
-  })
-  const streamwallWs = new WebSocket(
-    `ws://127.0.0.1:${port}/streamwall/${swToken.tokenId}/ws`,
-    { headers: { authorization: `Bearer ${swToken.secret}` } },
+  const { ws: streamwallWs, streamwall } = await connectStreamwallUplink<any>(
+    auth,
+    port,
   )
-  const streamwall = recordJsonMessages(streamwallWs)
-  after(() => streamwallWs.terminate())
-  await once(streamwallWs, 'open')
-
   streamwallWs.send(JSON.stringify({ type: 'state', state: VALID_STATE }))
   await delay(150)
 
-  async function connectClient(role: 'admin' | 'operator' | 'monitor') {
-    const invite = await auth.createToken({
-      kind: 'invite',
+  async function connectClient(role: StreamwallRole) {
+    const { ws: clientWs, client } = await redeemInviteAndConnectClient<any>(
+      app,
+      auth,
+      port,
+      BASE_URL,
       role,
-      name: `${role} client`,
-    })
-    const redeem = await app.inject({
-      method: 'POST',
-      url: `/invite/${invite.tokenId}`,
-      headers: { 'content-type': 'application/json' },
-      payload: { token: invite.secret },
-    })
-    const rawCookie = redeem.headers['set-cookie']
-    const cookie = (
-      Array.isArray(rawCookie) ? rawCookie[0] : String(rawCookie)
-    ).split(';')[0]
-
-    const clientWs = new WebSocket(`ws://127.0.0.1:${port}/client/ws`, {
-      headers: { Cookie: cookie, Origin: BASE_URL },
-    })
-    const client = recordJsonMessages(clientWs)
-    after(() => clientWs.terminate())
-    await once(clientWs, 'open')
+    )
     return { clientWs, client }
   }
 
@@ -358,15 +247,8 @@ async function startUplinkServer() {
   process.env.STREAMWALL_RATE_LIMIT_MAX = '10000'
   const { app, auth } = await buildTestApp({ baseURL: BASE_URL })
   after(() => app.close())
-  await app.listen({ port: 0, host: '127.0.0.1' })
-  const { port } = app.server.address() as AddressInfo
-
-  const { tokenId, secret } = await auth.createToken({
-    kind: 'streamwall',
-    role: 'admin',
-    name: 'uplink',
-  })
-  const base = `ws://127.0.0.1:${port}/streamwall/${tokenId}/ws`
+  const port = await listenTestApp(app)
+  const { base, secret } = await mintUplinkToken(auth, port)
   return { app, auth, port, base, secret }
 }
 
@@ -426,28 +308,12 @@ test('a state message sent immediately on connect is not dropped while auth vali
   await once(streamwallWs, 'open')
   streamwallWs.send(JSON.stringify({ type: 'state', state: VALID_STATE }))
 
-  const invite = await auth.createToken({
-    kind: 'invite',
-    role: 'admin',
-    name: 'client',
-  })
-  const redeem = await app.inject({
-    method: 'POST',
-    url: `/invite/${invite.tokenId}`,
-    headers: { 'content-type': 'application/json' },
-    payload: { token: invite.secret },
-  })
-  const rawCookie = redeem.headers['set-cookie']
-  const cookie = (
-    Array.isArray(rawCookie) ? rawCookie[0] : String(rawCookie)
-  ).split(';')[0]
-
-  const clientWs = new WebSocket(`ws://127.0.0.1:${port}/client/ws`, {
-    headers: { Cookie: cookie, Origin: BASE_URL },
-  })
-  after(() => clientWs.terminate())
-  const client = recordJsonMessages(clientWs)
-  await once(clientWs, 'open')
+  const { client } = await redeemInviteAndConnectClient<any>(
+    app,
+    auth,
+    port,
+    BASE_URL,
+  )
 
   const stateMsg = await client.waitFor((m) => m.type === 'state')
   assert.deepEqual(

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -1,7 +1,13 @@
 import { Low, Memory } from 'lowdb'
+import { once } from 'node:events'
 import { mkdtempSync, writeFileSync } from 'node:fs'
+import type { AddressInfo } from 'node:net'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
+import { after } from 'node:test'
+import { setTimeout as delay } from 'node:timers/promises'
+import type { StreamwallRole } from 'streamwall-shared'
+import WebSocket from 'ws'
 import { type AppOptions, initApp } from './index.ts'
 import type { StoredData } from './storage.ts'
 
@@ -37,4 +43,184 @@ export function buildTestApp(overrides: Partial<AppOptions> = {}) {
     db: inMemoryDb(),
     ...overrides,
   })
+}
+
+type TestApp = Awaited<ReturnType<typeof buildTestApp>>
+
+/** A minimal valid state doc, accepted as-is by every role's view(). */
+export const VALID_STATE = {
+  identity: { role: 'admin' },
+  config: {
+    cols: 3,
+    rows: 3,
+    width: 1920,
+    height: 1080,
+    frameless: false,
+    activeColor: '#fff',
+    backgroundColor: '#000',
+  },
+  auth: { invites: [], sessions: [] },
+  streams: [],
+  customStreams: [],
+  views: [],
+  streamdelay: null,
+}
+
+/**
+ * Starts `app` listening on a random localhost port and returns that port.
+ * Does not register any cleanup — callers decide whether/when to close `app`.
+ */
+export async function listenTestApp(app: TestApp['app']): Promise<number> {
+  await app.listen({ port: 0, host: '127.0.0.1' })
+  return (app.server.address() as AddressInfo).port
+}
+
+/**
+ * Buffers every JSON (text) frame from a socket and lets a test await one
+ * matching a predicate. Already-received frames satisfy `waitFor`, so there is
+ * no race between attaching a listener and a frame arriving. Binary Yjs frames
+ * are ignored.
+ */
+export function recordJsonMessages<T = unknown>(ws: WebSocket) {
+  const messages: T[] = []
+  const waiters: {
+    predicate: (m: T) => boolean
+    resolve: (m: T) => void
+  }[] = []
+
+  ws.on('message', (data, isBinary) => {
+    if (isBinary) {
+      return
+    }
+    let msg: T
+    try {
+      msg = JSON.parse(data.toString())
+    } catch {
+      return
+    }
+    messages.push(msg)
+    for (let i = waiters.length - 1; i >= 0; i--) {
+      if (waiters[i].predicate(msg)) {
+        waiters[i].resolve(msg)
+        waiters.splice(i, 1)
+      }
+    }
+  })
+
+  return {
+    messages,
+    waitFor(predicate: (m: T) => boolean, timeoutMs = 2000): Promise<T> {
+      const existing = messages.find(predicate)
+      if (existing !== undefined) {
+        return Promise.resolve(existing)
+      }
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error('timed out waiting for matching ws message')),
+          timeoutMs,
+        )
+        waiters.push({
+          predicate,
+          resolve: (m) => {
+            clearTimeout(timer)
+            resolve(m)
+          },
+        })
+      })
+    },
+  }
+}
+
+/**
+ * Captures the first app-level message from the moment the socket is created,
+ * so an error the server sends immediately on connect is never missed to a
+ * listener-attachment race. `next(timeoutMs)` resolves with that message or
+ * null if none arrives within the window.
+ */
+export function messageCollector(ws: WebSocket) {
+  let first: unknown | undefined
+  const received = new Promise<void>((resolve) => {
+    ws.once('message', (data) => {
+      first = JSON.parse(data.toString())
+      resolve()
+    })
+  })
+  return async (timeoutMs: number): Promise<unknown | null> => {
+    await Promise.race([received, delay(timeoutMs)])
+    return first === undefined ? null : first
+  }
+}
+
+/**
+ * Mints a Streamwall uplink token against `auth` and returns the WebSocket
+ * URL and bearer secret needed to connect it, without connecting yet.
+ */
+export async function mintUplinkToken(auth: TestApp['auth'], port: number) {
+  const { tokenId, secret } = await auth.createToken({
+    kind: 'streamwall',
+    role: 'admin',
+    name: 'uplink',
+  })
+  const base = `ws://127.0.0.1:${port}/streamwall/${tokenId}/ws`
+  return { tokenId, secret, base }
+}
+
+/**
+ * Connects an authenticated Streamwall uplink WebSocket, records its JSON
+ * frames from the moment it opens, and terminates it after the test.
+ *
+ * `T` describes the shape of the JSON frames the caller expects to record;
+ * callers that inspect arbitrary/dynamic fields can instantiate it as `any`.
+ */
+export async function connectStreamwallUplink<T = unknown>(
+  auth: TestApp['auth'],
+  port: number,
+) {
+  const { base, secret } = await mintUplinkToken(auth, port)
+  const ws = new WebSocket(base, {
+    headers: { authorization: `Bearer ${secret}` },
+  })
+  const streamwall = recordJsonMessages<T>(ws)
+  after(() => ws.terminate())
+  await once(ws, 'open')
+  return { ws, streamwall }
+}
+
+/**
+ * Redeems a freshly-minted invite for `role` and opens an authenticated
+ * `/client/ws` socket, recording its JSON frames from the moment it opens.
+ *
+ * `T` describes the shape of the JSON frames the caller expects to record;
+ * callers that inspect arbitrary/dynamic fields can instantiate it as `any`.
+ */
+export async function redeemInviteAndConnectClient<T = unknown>(
+  app: TestApp['app'],
+  auth: TestApp['auth'],
+  port: number,
+  baseURL: string,
+  role: StreamwallRole = 'admin',
+) {
+  const invite = await auth.createToken({
+    kind: 'invite',
+    role,
+    name: 'client',
+  })
+  const redeem = await app.inject({
+    method: 'POST',
+    url: `/invite/${invite.tokenId}`,
+    headers: { 'content-type': 'application/json' },
+    payload: { token: invite.secret },
+  })
+  const rawCookie = redeem.headers['set-cookie']
+  const cookie = (
+    Array.isArray(rawCookie) ? rawCookie[0] : String(rawCookie)
+  ).split(';')[0]
+
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/client/ws`, {
+    headers: { Cookie: cookie, Origin: baseURL },
+  })
+  const client = recordJsonMessages<T>(ws)
+  after(() => ws.terminate())
+  await once(ws, 'open')
+  return { ws, client }
 }

--- a/packages/streamwall-control-server/src/uplinkAuth.test.ts
+++ b/packages/streamwall-control-server/src/uplinkAuth.test.ts
@@ -1,11 +1,14 @@
 import assert from 'node:assert/strict'
 import { once } from 'node:events'
-import type { AddressInfo } from 'node:net'
 import { after, test } from 'node:test'
-import { setTimeout as delay } from 'node:timers/promises'
 import WebSocket from 'ws'
 
-import { buildTestApp } from './testHelpers.ts'
+import {
+  buildTestApp,
+  listenTestApp,
+  messageCollector,
+  mintUplinkToken,
+} from './testHelpers.ts'
 
 /**
  * Boots a listening control app and mints a streamwall uplink token, returning
@@ -14,39 +17,10 @@ import { buildTestApp } from './testHelpers.ts'
 async function startUplinkServer() {
   process.env.STREAMWALL_RATE_LIMIT_MAX = '1000'
   const { app, auth } = await buildTestApp()
-  await app.listen({ port: 0, host: '127.0.0.1' })
+  const port = await listenTestApp(app)
   after(() => app.close())
-  const { port } = app.server.address() as AddressInfo
-
-  const { tokenId, secret } = await auth.createToken({
-    kind: 'streamwall',
-    role: 'admin',
-    name: 'test',
-  })
-
-  const path = `/streamwall/${tokenId}/ws`
-  const base = `ws://127.0.0.1:${port}${path}`
+  const { tokenId, secret, base } = await mintUplinkToken(auth, port)
   return { app, port, tokenId, secret, base }
-}
-
-/**
- * Captures the first app-level message from the moment the socket is created,
- * so an error the server sends immediately on connect is never missed to a
- * listener-attachment race. `next(timeoutMs)` resolves with that message or
- * null if none arrives within the window.
- */
-function messageCollector(ws: WebSocket) {
-  let first: unknown | undefined
-  const received = new Promise<void>((resolve) => {
-    ws.once('message', (data) => {
-      first = JSON.parse(data.toString())
-      resolve()
-    })
-  })
-  return async (timeoutMs: number): Promise<unknown | null> => {
-    await Promise.race([received, delay(timeoutMs)])
-    return first === undefined ? null : first
-  }
 }
 
 // Rejections run an async scrypt verification before the error is sent, so

--- a/packages/streamwall-control-server/src/wsRateLimit.test.ts
+++ b/packages/streamwall-control-server/src/wsRateLimit.test.ts
@@ -1,26 +1,19 @@
 import assert from 'node:assert/strict'
 import { once } from 'node:events'
-import type { AddressInfo } from 'node:net'
 import { test } from 'node:test'
 import { setTimeout as delay } from 'node:timers/promises'
 import WebSocket from 'ws'
-import { buildTestApp } from './testHelpers.ts'
+import { buildTestApp, listenTestApp, mintUplinkToken } from './testHelpers.ts'
 
 async function startStreamwallSocket(env: Record<string, string>) {
   process.env.STREAMWALL_RATE_LIMIT_MAX = '1000'
   Object.assign(process.env, env)
 
   const { app, auth } = await buildTestApp()
-  await app.listen({ port: 0, host: '127.0.0.1' })
-  const { port } = app.server.address() as AddressInfo
+  const port = await listenTestApp(app)
+  const { base, secret } = await mintUplinkToken(auth, port)
 
-  const { tokenId, secret } = await auth.createToken({
-    kind: 'streamwall',
-    role: 'admin',
-    name: 'test',
-  })
-
-  const ws = new WebSocket(`ws://127.0.0.1:${port}/streamwall/${tokenId}/ws`, {
+  const ws = new WebSocket(base, {
     headers: { authorization: `Bearer ${secret}` },
   })
   await once(ws, 'open')

--- a/packages/streamwall-control-server/src/wsValidation.test.ts
+++ b/packages/streamwall-control-server/src/wsValidation.test.ts
@@ -1,11 +1,16 @@
 import assert from 'node:assert/strict'
 import { once } from 'node:events'
-import type { AddressInfo } from 'node:net'
 import { after, test } from 'node:test'
 import { setTimeout as delay } from 'node:timers/promises'
-import WebSocket from 'ws'
+import type { StreamwallRole } from 'streamwall-shared'
 import * as Y from 'yjs'
-import { buildTestApp } from './testHelpers.ts'
+import {
+  buildTestApp,
+  connectStreamwallUplink,
+  listenTestApp,
+  redeemInviteAndConnectClient,
+  VALID_STATE,
+} from './testHelpers.ts'
 
 const BASE_URL = 'http://localhost:3000'
 
@@ -13,80 +18,6 @@ const BASE_URL = 'http://localhost:3000'
 after(() => {
   delete process.env.STREAMWALL_WS_UPDATE_MAX_BYTES
 })
-
-const VALID_STATE = {
-  identity: { role: 'admin' },
-  config: {
-    cols: 3,
-    rows: 3,
-    width: 1920,
-    height: 1080,
-    frameless: false,
-    activeColor: '#fff',
-    backgroundColor: '#000',
-  },
-  auth: { invites: [], sessions: [] },
-  streams: [],
-  customStreams: [],
-  views: [],
-  streamdelay: null,
-}
-
-/**
- * Buffers every JSON (text) frame from a socket and lets a test await one
- * matching a predicate. Already-received frames satisfy `waitFor`, so there is
- * no race between attaching a listener and a frame arriving. Binary Yjs frames
- * are ignored.
- */
-function recordJsonMessages(ws: WebSocket) {
-  const messages: any[] = []
-  const waiters: {
-    predicate: (m: any) => boolean
-    resolve: (m: any) => void
-  }[] = []
-
-  ws.on('message', (data, isBinary) => {
-    if (isBinary) {
-      return
-    }
-    let msg: any
-    try {
-      msg = JSON.parse(data.toString())
-    } catch {
-      return
-    }
-    messages.push(msg)
-    for (let i = waiters.length - 1; i >= 0; i--) {
-      if (waiters[i].predicate(msg)) {
-        waiters[i].resolve(msg)
-        waiters.splice(i, 1)
-      }
-    }
-  })
-
-  return {
-    messages,
-    waitFor(predicate: (m: any) => boolean, timeoutMs = 2000): Promise<any> {
-      const existing = messages.find(predicate)
-      if (existing) {
-        return Promise.resolve(existing)
-      }
-      return new Promise((resolve, reject) => {
-        const timer = setTimeout(
-          () => reject(new Error('timed out waiting for matching ws message')),
-          timeoutMs,
-        )
-        waiters.push({
-          predicate,
-          resolve: (m) => {
-            clearTimeout(timer)
-            resolve(m)
-          },
-        })
-      })
-    },
-  }
-}
 
 /**
  * Boots a live server, connects a Streamwall uplink and seeds a state message,
@@ -98,11 +29,11 @@ async function connectStreamwallAndClient({
     string,
     unknown
   >,
-  role = 'admin' as const,
+  role = 'admin' as StreamwallRole,
   wsUpdateMaxBytes,
 }: {
   stateMessage?: Record<string, unknown>
-  role?: 'admin' | 'operator' | 'monitor'
+  role?: StreamwallRole
   wsUpdateMaxBytes?: number
 } = {}) {
   process.env.STREAMWALL_RATE_LIMIT_MAX = '10000'
@@ -115,47 +46,22 @@ async function connectStreamwallAndClient({
 
   const { app, auth } = await buildTestApp({ baseURL: BASE_URL })
   after(() => app.close())
-  await app.listen({ port: 0, host: '127.0.0.1' })
-  const { port } = app.server.address() as AddressInfo
+  const port = await listenTestApp(app)
 
-  const swToken = await auth.createToken({
-    kind: 'streamwall',
-    role: 'admin',
-    name: 'uplink',
-  })
-  const streamwallWs = new WebSocket(
-    `ws://127.0.0.1:${port}/streamwall/${swToken.tokenId}/ws`,
-    { headers: { authorization: `Bearer ${swToken.secret}` } },
+  const { ws: streamwallWs, streamwall } = await connectStreamwallUplink<any>(
+    auth,
+    port,
   )
-  const streamwall = recordJsonMessages(streamwallWs)
-  after(() => streamwallWs.terminate())
-  await once(streamwallWs, 'open')
-
   streamwallWs.send(JSON.stringify(stateMessage))
   await delay(150)
 
-  const invite = await auth.createToken({
-    kind: 'invite',
+  const { ws: clientWs, client } = await redeemInviteAndConnectClient<any>(
+    app,
+    auth,
+    port,
+    BASE_URL,
     role,
-    name: 'client',
-  })
-  const redeem = await app.inject({
-    method: 'POST',
-    url: `/invite/${invite.tokenId}`,
-    headers: { 'content-type': 'application/json' },
-    payload: { token: invite.secret },
-  })
-  const rawCookie = redeem.headers['set-cookie']
-  const cookie = (
-    Array.isArray(rawCookie) ? rawCookie[0] : String(rawCookie)
-  ).split(';')[0]
-
-  const clientWs = new WebSocket(`ws://127.0.0.1:${port}/client/ws`, {
-    headers: { Cookie: cookie, Origin: BASE_URL },
-  })
-  const client = recordJsonMessages(clientWs)
-  after(() => clientWs.terminate())
-  await once(clientWs, 'open')
+  )
 
   return { app, auth, streamwallWs, clientWs, streamwall, client }
 }


### PR DESCRIPTION
## Problem

`packages/streamwall-control-server/src/*.test.ts` had accumulated several near-identical helper functions, copy-pasted independently into each file:

- `recordJsonMessages(ws)` — duplicated verbatim in `wsValidation.test.ts` and `multiplexing.test.ts`.
- `messageCollector(ws)` — duplicated verbatim in `uplinkAuth.test.ts` and `multiplexing.test.ts`.
- Boot helpers that spin up a live app via `buildTestApp`, mint a Streamwall uplink token, connect a real `ws` socket, and optionally redeem an invite to connect a role-cookied client — reimplemented with small variations in `wsValidation.test.ts`, `uplinkAuth.test.ts`, `wsRateLimit.test.ts`, and `multiplexing.test.ts`.

Every future WebSocket-integration test either duplicated these helpers again or reached into an unrelated test file to copy them, and a bug fix to one copy would need to be found and re-applied to every other copy by hand.

## Solution

Extracted the shared pieces into `testHelpers.ts` (which already held `buildTestApp`/`inMemoryDb`/`makeStaticDir`):

- `VALID_STATE` — the minimal valid state doc, previously duplicated in two files.
- `recordJsonMessages<T>(ws)` — buffers JSON frames with a `waitFor(predicate)`.
- `messageCollector<T>(ws)` — captures the first message with a timeout.
- `listenTestApp(app)` — starts `app` listening and returns the port (no implicit cleanup, since one caller closes the app manually mid-test instead of via `after()`).
- `mintUplinkToken(auth, port)` — mints a Streamwall uplink token and returns the WS URL/secret.
- `connectStreamwallUplink<T>(auth, port)` — mints a token, connects the uplink socket, and records its frames.
- `redeemInviteAndConnectClient<T>(app, auth, port, baseURL, role)` — redeems an invite for `role` and connects an authenticated `/client/ws` socket.

All four test files (`wsValidation.test.ts`, `multiplexing.test.ts`, `uplinkAuth.test.ts`, `wsRateLimit.test.ts`) now import these instead of keeping their own copies.

### Architecture decision: generics instead of `any`

`recordJsonMessages`/`connectStreamwallUplink`/`redeemInviteAndConnectClient` are generic (`<T = unknown>`) rather than typed as `any` internally. `testHelpers.ts` isn't a `*.test.ts` file, so it isn't covered by the repo's `no-explicit-any` test-file exemption in `eslint.config.mjs`. Call sites that need to inspect dynamic/arbitrary JSON fields (e.g. `adminState.state.auth.sessions`) instantiate the generic as `<any>` at the call site inside the `.test.ts` files, where that exemption already applies — so no lint-config change was needed.

## Testing

No behavior change, so no new tests were added (pure test-code refactor). The existing test suites are the verification:

- `packages/streamwall-control-server`: all 90 assertions still pass.
- Full repo: `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm run test` (559 tests across all workspaces) all pass clean.

## Risks / breaking changes

None — this only touches test-support code in one package; no production code changed.

Closes #216