### PR TITLE
test(control-server): de-flake the second-uplink-rejection test

### DIFF
--- a/packages/streamwall-control-server/src/multiplexing.test.ts
+++ b/packages/streamwall-control-server/src/multiplexing.test.ts
@@ -371,19 +371,35 @@ async function startUplinkServer() {
 }
 
 test('rejects a second Streamwall connection while the first stays connected', async () => {
-  const { base, secret } = await startUplinkServer()
+  const {
+    auth,
+    port,
+    streamwallWs: first,
+    connectClient,
+  } = await bootServerWithUplink()
   const warn = spyOnConsoleWarn()
 
   try {
-    const first = new WebSocket(base, {
-      headers: { authorization: `Bearer ${secret}` },
-    })
-    after(() => first.terminate())
-    await once(first, 'open')
+    // Registering the first uplink connection requires the server to await a
+    // real `validateToken` scrypt derivation, so the client's 'open' event
+    // (and even the fixed delay in `bootServerWithUplink`) is not proof that
+    // registration has actually completed — most visible on a loaded/slower
+    // CI runner. Round-trip a client through the state broadcast the uplink
+    // just sent: that broadcast can only happen after registration finished,
+    // so it deterministically proves the race window has closed rather than
+    // assuming a fixed ordering.
+    const { client } = await connectClient('admin')
+    await client.waitFor((m) => m.type === 'state')
 
-    const second = new WebSocket(base, {
-      headers: { authorization: `Bearer ${secret}` },
+    const secondToken = await auth.createToken({
+      kind: 'streamwall',
+      role: 'admin',
+      name: 'second uplink',
     })
+    const second = new WebSocket(
+      `ws://127.0.0.1:${port}/streamwall/${secondToken.tokenId}/ws`,
+      { headers: { authorization: `Bearer ${secondToken.secret}` } },
+    )
     after(() => second.terminate())
     const nextMessage = messageCollector(second)
 


### PR DESCRIPTION
## Problem

`multiplexing.test.ts`'s "rejects a second Streamwall connection while the first stays connected" test is intermittently flaky, unrelated to whatever change happens to be in the PR that triggers it.

Reproduced locally at ~33% failure rate over 15 runs, matching the exact failure reported in the issue:

```
error: the second connection must be rejected
+ actual - expected
+ null
- {
-   error: 'streamwall already connected'
- }
```

## Root cause

The `/streamwall/:id/ws` route handler `await`s a real, async `scrypt`-based `validateToken` call before registering the connection as the active uplink (`currentStreamwallWs = ws`). The client-side `'open'` event fires as soon as the WebSocket handshake completes, which happens **before** that async validation (and registration) finishes server-side.

The test opened a second connection as soon as the first's client-side `'open'` fired, with no guarantee the server had actually finished registering the first connection yet. On a loaded/slower runner (macOS CI in particular), the second connection's own `validateToken` could resolve *before* the first's registration completed, so the server never saw `currentStreamwallWs != null` and let the second connection through unrejected.

## Fix

Instead of trusting a fixed delay or the client `'open'` event, the test now round-trips a client through the `state` broadcast the first uplink already sent (via the existing `bootServerWithUplink`/`connectClient` helpers). That broadcast can only happen after the server has fully processed and registered the first connection, so by the time the test opens the second connection, the race window is provably closed — not just less likely to be hit.

## Testing performed

- Reproduced the original flake: 5/15 local runs of `multiplexing.test.ts` failed before the fix.
- After the fix: 25/25, then another 15/15 runs passed (40 consecutive clean runs total).
- Full quality gate: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm run test` (all workspaces) — all green.
- No production code changed; this is a test-only fix, so no new behavior needed unit coverage beyond de-flaking the existing test itself.

## Risks / breaking changes

None — test-only change, no production code touched.

Closes #221