### PR TITLE
fix(electron): avoid a full offscreen reload on content swap while running

### DIFF
--- a/packages/streamwall/src/main/viewStateMachine.test.ts
+++ b/packages/streamwall/src/main/viewStateMachine.test.ts
@@ -380,3 +380,113 @@ describe('viewStateMachine volume control', () => {
     expect(sendViewVolume).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('viewStateMachine content swap while running', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const OTHER_CONTENT = {
+    url: 'https://example.com/other-stream',
+    kind: 'video' as const,
+  }
+  const OTHER_POS = { x: 10, y: 10, width: 50, height: 50, spaces: [1] }
+
+  // Same setup as makeActor, but with spies on offscreenView/positionView so
+  // tests can assert whether the view was shuffled offscreen and repositioned.
+  function makeActorWithPlacementSpies(retry: RetryConfig) {
+    const offscreenView = vi.fn()
+    const positionView = vi.fn()
+    const machine = viewStateMachine.provide({
+      actions: {
+        offscreenView,
+        positionView,
+        muteAudio: noop,
+        unmuteAudio: noop,
+        openDevTools: noop,
+        sendViewOptions: noop,
+        sendViewVolume: noop,
+        logError: noop,
+      },
+      actors: {
+        loadPage: fromPromise(async () => {}),
+      },
+    })
+    const actor = createActor(machine, {
+      input: {
+        id: 1,
+        view: {} as never,
+        win: {} as never,
+        offscreenWin: {} as never,
+        retry,
+      },
+    })
+    return { actor, offscreenView, positionView }
+  }
+
+  it('reloads directly into loading without re-shuffling the view offscreen', async () => {
+    const { actor, offscreenView } = makeActorWithPlacementSpies(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    expect(offscreenView).toHaveBeenCalledTimes(1)
+
+    actor.send({
+      type: 'DISPLAY',
+      pos: OTHER_POS,
+      content: OTHER_CONTENT,
+    })
+
+    const snapshot = actor.getSnapshot()
+    expect(matchesState('displaying.loading', snapshot.value)).toBe(true)
+    expect(snapshot.context.content).toEqual(OTHER_CONTENT)
+    expect(snapshot.context.pos).toEqual(OTHER_POS)
+    // The view is already live in the main window; swapping content must not
+    // repeat the "move offscreen while it (re)loads" shuffle that a fresh
+    // display does.
+    expect(offscreenView).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns to running with the new content and repositions the view', async () => {
+    const { actor, offscreenView, positionView } =
+      makeActorWithPlacementSpies(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    positionView.mockClear()
+
+    actor.send({
+      type: 'DISPLAY',
+      pos: OTHER_POS,
+      content: OTHER_CONTENT,
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'VIEW_INIT' })
+    actor.send({ type: 'VIEW_LOADED' })
+
+    const snapshot = actor.getSnapshot()
+    expect(matchesState('displaying.running', snapshot.value)).toBe(true)
+    expect(snapshot.context.content).toEqual(OTHER_CONTENT)
+    expect(snapshot.context.pos).toEqual(OTHER_POS)
+    expect(offscreenView).toHaveBeenCalledTimes(1)
+    expect(positionView).toHaveBeenCalledTimes(1)
+  })
+
+  it('still performs a fresh load for the new content (retry budget included)', async () => {
+    const { actor } = makeActorWithPlacementSpies(makeRetry({ maxRetries: 1 }))
+    actor.start()
+    await reachRunning(actor)
+
+    actor.send({
+      type: 'DISPLAY',
+      pos: OTHER_POS,
+      content: OTHER_CONTENT,
+    })
+    actor.send({ type: 'VIEW_ERROR', error: new Error('boom') })
+
+    // A fresh content swap should get its own retry budget rather than
+    // inheriting exhaustion from whatever the previous content did.
+    expect(actor.getSnapshot().context.retryCount).toBe(0)
+  })
+})

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -462,6 +462,24 @@ const viewStateMachine = setup({
                   params: ({ event: { content } }) => ({ content }),
                 },
               },
+              // Content actually changed (e.g. a playlist advance or manual
+              // reassignment) while this cell was already running: reload
+              // straight into `loading` as a sibling transition instead of
+              // going through the root DISPLAY handler, which would re-enter
+              // `displaying` and repeat its entry actions -- most visibly
+              // `offscreenView`, which briefly pulls the view out of the wall
+              // even though it's already live and positioned there. This
+              // still fully reloads the WebContentsView (see `loadPage`);
+              // there is no crossfade or seamless handoff. Removing that
+              // reload cost would require preloading the next view in
+              // parallel before swapping it in.
+              {
+                target: '#view.displaying.loading',
+                actions: assign({
+                  pos: ({ event }) => event.pos,
+                  content: ({ event }) => event.content,
+                }),
+              },
             ],
           },
           states: {


### PR DESCRIPTION
## Problem

`PlaylistScheduler` (#77) and manual drag-to-place reassignment both advance a grid cell's content by sending a `DISPLAY` event into `viewStateMachine`. While the cell is already `displaying.running`, a genuine content change (not just a position change) wasn't handled by any guarded transition inside `running`, so it fell through to the root-level, unconditional `DISPLAY` handler.

That handler retargets to `.displaying`, which re-enters the `displaying` compound state and re-runs its entry actions -- most visibly `offscreenView`, which pulls the `WebContentsView` out of the wall into the offscreen window and back once loading finishes. The cell was already live and positioned, so this extra shuffle just adds a more visible blank period on every playlist advance / reassignment than the reload itself requires.

## Solution

Added a third, unguarded branch to the existing `running.on.DISPLAY` array (after the no-op and position-only branches) that targets `#view.displaying.loading` directly -- a sibling transition within `displaying`, matching the same pattern already used for stalled-view and error retries. Because `displaying` stays active across the transition, its entry actions don't re-run, so the offscreen shuffle and the redundant retry-state reset are skipped.

This does **not** eliminate the reload itself: `loadPage` still calls `wc.loadURL` for the new content, so there's no crossfade or seamless handoff between old and new source. Removing that cost would require preloading a second `WebContentsView` in parallel before swapping it in -- a larger change I'm filing as a follow-up rather than bundling here, per the issue's own scoping.

## Testing

TDD: added three tests to `viewStateMachine.test.ts` first (confirmed red), then implemented the fix (confirmed green):
- content swap while running reloads directly into `loading` without a second `offscreenView` call
- the view returns to `running` with the new content/position and is repositioned exactly once
- a fresh content swap gets its own retry budget

Full quality gate run locally:
- `npm run format:check` ✅
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` (all workspaces) ✅ -- 207 + 208 + 90 + 67 tests passing
- `npm -w streamwall-control-client run build` ✅ (matches the CI `build` job)

## Risks / breaking changes

None expected. The change only affects the transition path taken when a running cell's content changes; behavior for fresh displays, position-only moves, errors, and stalled-view retries is untouched (all covered by existing tests, still green).

Closes #198