### PR TITLE
feat(ci): add a signed, tag-triggered release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+# Least privilege by default; the publish job elevates to contents: write to
+# create the GitHub release.
+permissions:
+  contents: read
+
+# Never cancel a release mid-publish (unlike CI's PR runs).
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  quality-gate:
+    name: Quality gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - name: Lint
+        run: npm run lint
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Test
+        run: npm test
+
+  publish:
+    name: Publish (${{ matrix.platform.name }})
+    needs: quality-gate
+    runs-on: ${{ matrix.platform.os }}
+    timeout-minutes: 30
+    permissions:
+      contents: write # electron-forge's GitHub publisher creates/updates the release
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - { name: linux, os: ubuntu-latest }
+          - { name: windows, os: windows-latest }
+          - { name: macos, os: macos-latest }
+    # Signing is opt-in (see packages/streamwall/forge.signing.ts): builds
+    # stay unsigned, exactly as before, until these secrets are provisioned.
+    # `secrets` isn't available in step `if:` conditions, so the presence
+    # checks are hoisted into job-level env vars here.
+    env:
+      APPLE_SIGNING_CONFIGURED: ${{ secrets.APPLE_CERTIFICATE_P12 != '' }}
+      APPLE_NOTARIZATION_CONFIGURED: ${{ secrets.APPLE_API_KEY_BASE64 != '' }}
+      WINDOWS_SIGNING_CONFIGURED: ${{ secrets.WINDOWS_CERTIFICATE_BASE64 != '' }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+
+      - name: Import macOS signing certificate
+        if: matrix.platform.name == 'macos' && env.APPLE_SIGNING_CONFIGURED == 'true'
+        uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7.0.0
+        with:
+          p12-file-base64: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+
+      - name: Write macOS notarization API key
+        if: matrix.platform.name == 'macos' && env.APPLE_NOTARIZATION_CONFIGURED == 'true'
+        shell: bash
+        env:
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+        run: |
+          key_path="$RUNNER_TEMP/apple-api-key.p8"
+          base64 --decode <<< "$APPLE_API_KEY_BASE64" > "$key_path"
+          echo "APPLE_API_KEY=$key_path" >> "$GITHUB_ENV"
+
+      - name: Write Windows signing certificate
+        if: matrix.platform.name == 'windows' && env.WINDOWS_SIGNING_CONFIGURED == 'true'
+        shell: bash
+        env:
+          WINDOWS_CERTIFICATE_BASE64: ${{ secrets.WINDOWS_CERTIFICATE_BASE64 }}
+        run: |
+          cert_path="$RUNNER_TEMP/windows-cert.pfx"
+          base64 --decode <<< "$WINDOWS_CERTIFICATE_BASE64" > "$cert_path"
+          echo "WINDOWS_CERTIFICATE_FILE=$cert_path" >> "$GITHUB_ENV"
+
+      - name: Publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+        run: npm -w streamwall run publish

--- a/README.md
+++ b/README.md
@@ -234,3 +234,30 @@ xattr -cr /Applications/Streamwall.app
 ```
 
 or by right-clicking the app and choosing "Open" instead of double-clicking.
+
+### CI releases
+
+Pushing a `v*` tag (or running the workflow manually) triggers
+`.github/workflows/release.yml`, which runs the quality gate (lint, typecheck,
+test) and then builds and publishes a GitHub release for Linux, Windows, and
+macOS via `electron-forge publish`. Signing in CI is opt-in, matching the
+local `make`/`publish` behavior above: builds stay unsigned until these
+repository secrets are set.
+
+| Secret                         | Purpose                                                       |
+| ------------------------------ | ------------------------------------------------------------- |
+| `APPLE_CERTIFICATE_P12`        | Developer ID Application certificate (`.p12`), base64-encoded |
+| `APPLE_CERTIFICATE_PASSWORD`   | Password for the certificate above                            |
+| `APPLE_TEAM_ID`                | Apple Developer Team ID                                       |
+| `APPLE_API_KEY_BASE64`         | App Store Connect API key (`.p8`), base64-encoded             |
+| `APPLE_API_KEY_ID`             | App Store Connect API Key ID                                  |
+| `APPLE_API_ISSUER`             | App Store Connect API Issuer ID                               |
+| `WINDOWS_CERTIFICATE_BASE64`   | Windows code-signing certificate (`.pfx`), base64-encoded     |
+| `WINDOWS_CERTIFICATE_PASSWORD` | Password for the certificate above                            |
+
+The workflow imports the macOS certificate into the runner's keychain via
+`apple-actions/import-codesign-certs`, decodes the base64 secrets into
+temporary files for the Windows certificate and the Apple API key, and sets
+the corresponding `APPLE_*`/`WINDOWS_*` environment variables (see
+`packages/streamwall/forge.signing.ts`) before publishing. macOS and Windows
+signing are independent — provision either, both, or neither.

--- a/packages/streamwall/forge.config.ts
+++ b/packages/streamwall/forge.config.ts
@@ -7,15 +7,18 @@ import { VitePlugin } from '@electron-forge/plugin-vite'
 import type { ForgeConfig } from '@electron-forge/shared-types'
 import { FuseV1Options, FuseVersion } from '@electron/fuses'
 
+import { parseGithubRepository } from './forge.publisher'
 import {
   getMacSigningConfig,
   getWindowsSigningConfig,
   isSigningConfigured,
 } from './forge.signing'
+import packageJson from './package.json'
 
 const macSigning = getMacSigningConfig(process.env)
 const windowsSigning = getWindowsSigningConfig(process.env)
 const signingConfigured = isSigningConfigured(process.env)
+const publishRepository = parseGithubRepository(packageJson.repository)
 
 const config: ForgeConfig = {
   packagerConfig: {
@@ -34,10 +37,7 @@ const config: ForgeConfig = {
     {
       name: '@electron-forge/publisher-github',
       config: {
-        repository: {
-          owner: 'streamwall',
-          name: 'streamwall',
-        },
+        repository: publishRepository,
         prerelease: true,
       },
     },

--- a/packages/streamwall/forge.publisher.test.ts
+++ b/packages/streamwall/forge.publisher.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'vitest'
+import { parseGithubRepository } from './forge.publisher'
+
+describe('parseGithubRepository', () => {
+  test('parses the "github:owner/name" shorthand', () => {
+    expect(parseGithubRepository('github:NilsR0711/streamwall')).toEqual({
+      owner: 'NilsR0711',
+      name: 'streamwall',
+    })
+  })
+
+  test('parses names containing dots and dashes', () => {
+    expect(parseGithubRepository('github:some-org/my.repo-name')).toEqual({
+      owner: 'some-org',
+      name: 'my.repo-name',
+    })
+  })
+
+  test('throws when the value is not in "github:owner/name" form', () => {
+    expect(() => parseGithubRepository('NilsR0711/streamwall')).toThrow(
+      /github:owner\/name/,
+    )
+  })
+
+  test('throws for a full URL instead of the shorthand', () => {
+    expect(() =>
+      parseGithubRepository('https://github.com/NilsR0711/streamwall'),
+    ).toThrow(/github:owner\/name/)
+  })
+})

--- a/packages/streamwall/forge.publisher.ts
+++ b/packages/streamwall/forge.publisher.ts
@@ -1,0 +1,21 @@
+export interface RepositoryOwnerName {
+  owner: string
+  name: string
+}
+
+/**
+ * Parses npm's `github:owner/name` repository shorthand into the
+ * owner/name pair `@electron-forge/publisher-github` expects, so the
+ * publish target is derived from package.json instead of a hardcoded
+ * value that can drift out of sync with it (see issue #209).
+ */
+export function parseGithubRepository(repository: string): RepositoryOwnerName {
+  const match = /^github:([^/]+)\/(.+)$/.exec(repository)
+  if (!match) {
+    throw new Error(
+      `Expected package.json "repository" to be in "github:owner/name" form, got: ${repository}`,
+    )
+  }
+  const [, owner, name] = match
+  return { owner, name }
+}


### PR DESCRIPTION
## Problem

There is no CI workflow that builds or publishes a Streamwall release — `.github/workflows/release.yml` was intentionally removed in #120 as an unused electron-forge publish flow. Releases today are run manually (`npm run publish` from a maintainer's machine), which means:

- The macOS/Windows code signing and notarization support added in #61 (`packages/streamwall/forge.signing.ts`) never actually gets exercised end-to-end unless a maintainer has the right certs/keys installed locally.
- `forge.config.ts`'s GitHub publisher config still targeted the original upstream repository owner (`streamwall/streamwall`) instead of this fork (#209), which would make `electron-forge publish` fail or publish to the wrong place.

## Solution

**`forge.config.ts` publisher owner (#209, prerequisite called out in #211's body):**

Added `packages/streamwall/forge.publisher.ts` with `parseGithubRepository`, which parses `package.json`'s `"repository": "github:owner/name"` field into the `{ owner, name }` pair the GitHub publisher needs. `forge.config.ts` now derives its publisher repository from this instead of a hardcoded value, so it can't drift out of sync with `package.json` again.

**`.github/workflows/release.yml`:**

- Triggers on `v*` tags and `workflow_dispatch`.
- `quality-gate` job runs lint/typecheck/test before anything is packaged.
- `publish` job runs on a Linux/Windows/macOS matrix, reusing the same `./.github/actions/setup` composite action (Node 22, npm cache) as `ci.yml`.
- Imports the macOS Developer ID Application certificate into the runner's keychain via `apple-actions/import-codesign-certs`, and decodes the Windows PFX certificate and the Apple API key from base64 repository secrets into files, before setting the `APPLE_*`/`WINDOWS_*` environment variables `forge.signing.ts` already reads.
- Signing stays strictly opt-in, mirroring the existing local `make`/`publish` behavior: any platform's certificate secrets can be left unset (checked via job-level `env` booleans, since the `secrets` context isn't available in step `if:` conditions) and that platform's build just stays unsigned.
- Publishes via `electron-forge publish` (`npm -w streamwall run publish`).

Documented the required repository secrets in the README under a new "CI releases" subsection.

## Architecture decisions

- **Derive the publisher repo instead of hardcoding the fork's owner** — avoids the exact kind of drift that caused #209 if the repo is ever forked/renamed again.
- **Job-level `env` booleans for the signing-secret presence checks** — `actionlint` rejects the `secrets` context inside a step's `if:` (`context "secrets" is not allowed here`); hoisting the check into the job's `env:` block (which does allow `secrets`) keeps the per-platform signing steps skippable without secrets provisioned.
- **Base64-encoded secrets, decoded to files at runtime** — `forge.signing.ts` expects filesystem paths for `APPLE_API_KEY`/`WINDOWS_CERTIFICATE_FILE`, but GitHub secrets are strings; decoding into `$RUNNER_TEMP` files in CI is the standard pattern for this.
- **Quality gate as a separate job the matrix `needs:`** — matches "runs the existing quality gate... before packaging" from the issue, and avoids the quality gate running redundantly on all three platforms.

## Testing

- `packages/streamwall/forge.publisher.test.ts` (4 cases): parses the `github:owner/name` shorthand, handles names with dots/dashes, and throws on malformed input (bare `owner/name`, a full URL).
- Sanity-checked `forge.config.ts` actually resolves to `{ owner: 'NilsR0711', name: 'streamwall' }` by loading it with `esbuild-register`.
- `actionlint` passes clean on `release.yml` (and all other workflows).
- `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` (208+208+90+67 tests) all green across the monorepo; `npm -w streamwall-control-client run build` succeeds.
- The `release.yml` publish job itself can't be exercised in this session — it needs a `v*` tag push (or manual dispatch) against the real repository, and real Apple/Windows credentials to verify signing end-to-end.

## Risks / breaking changes

None for existing usage. The workflow only runs on tag pushes / manual dispatch, not on `pull_request`, so no secrets are exposed to untrusted PR code. Signing remains opt-in — an unsigned release still publishes successfully if no certificate secrets are configured, identical to today's manual `npm run publish` behavior.

Closes #211
Closes #209