### PR TITLE
feat(control-ui): show the assigned audio hotkey on tile hover

### DIFF
--- a/packages/streamwall-control-ui/src/GridPreviewBox.test.tsx
+++ b/packages/streamwall-control-ui/src/GridPreviewBox.test.tsx
@@ -98,4 +98,32 @@ describe('GridPreviewBox', () => {
       }
     }
   })
+
+  test('shows the assigned audio hotkey as a tooltip for a cell within the hotkey range (#84)', () => {
+    const box = renderBox({
+      pos: { x: 0, y: 0, width: 100, height: 100, spaces: [0] },
+    })
+
+    expect(box.firstElementChild?.getAttribute('title')).toBe(
+      'Alt+1 toggles audio',
+    )
+  })
+
+  test('surfaces the correct key for a later cell within the hotkey range (#84)', () => {
+    const box = renderBox({
+      pos: { x: 0, y: 0, width: 100, height: 100, spaces: [10] },
+    })
+
+    expect(box.firstElementChild?.getAttribute('title')).toBe(
+      'Alt+Q toggles audio',
+    )
+  })
+
+  test('omits the hotkey tooltip for a cell beyond the fixed 20-slot hotkey range (#84)', () => {
+    const box = renderBox({
+      pos: { x: 0, y: 0, width: 100, height: 100, spaces: [20] },
+    })
+
+    expect(box.firstElementChild?.hasAttribute('title')).toBe(false)
+  })
 })

--- a/packages/streamwall-control-ui/src/hotkeyLabel.test.ts
+++ b/packages/streamwall-control-ui/src/hotkeyLabel.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'vitest'
+import { getHotkeyLabel } from './index.tsx'
+
+describe('getHotkeyLabel', () => {
+  test('labels the first hotkey slot', () => {
+    expect(getHotkeyLabel(0)).toBe('Alt+1')
+  })
+
+  test('labels the last digit slot', () => {
+    expect(getHotkeyLabel(9)).toBe('Alt+0')
+  })
+
+  test('labels the first letter slot', () => {
+    expect(getHotkeyLabel(10)).toBe('Alt+Q')
+  })
+
+  test('labels the last of the fixed 20 slots', () => {
+    expect(getHotkeyLabel(19)).toBe('Alt+P')
+  })
+
+  test('returns undefined beyond the fixed 20-slot range', () => {
+    expect(getHotkeyLabel(20)).toBeUndefined()
+  })
+
+  test('returns undefined for a negative index', () => {
+    expect(getHotkeyLabel(-1)).toBeUndefined()
+  })
+})

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -118,6 +118,17 @@ const hotkeyTriggers = [
 ]
 
 /**
+ * Label for the `alt+<key>` hotkey that toggles audio on grid cell `idx`, or
+ * `undefined` if `idx` falls outside hotkeyTriggers' fixed 20-slot range
+ * (grids can have up to GRID_MAX * GRID_MAX = 64 cells, so not every cell has
+ * an assigned hotkey).
+ */
+export function getHotkeyLabel(idx: number): string | undefined {
+  const key = hotkeyTriggers[idx]
+  return key === undefined ? undefined : `Alt+${key.toUpperCase()}`
+}
+
+/**
  * Theme tokens. Light is the base; dark is applied either by the OS setting
  * (prefers-color-scheme) when no explicit choice is made, or by an explicit
  * `data-theme` attribute on <html> (set by the theme switcher).
@@ -1756,6 +1767,7 @@ export function GridPreviewBox({
   state: string | undefined
   style?: JSX.HTMLAttributes['style']
 }) {
+  const hotkeyLabel = getHotkeyLabel(pos.spaces[0])
   return (
     <StyledGridPreviewBox
       $color={color}
@@ -1765,6 +1777,7 @@ export function GridPreviewBox({
       $windowHeight={windowHeight}
       $isListening={isListening}
       $isError={isError}
+      title={hotkeyLabel ? `${hotkeyLabel} toggles audio` : undefined}
     >
       <StyledGridInfo className={isSmall ? 'small' : undefined}>
         <StyledGridLabel>


### PR DESCRIPTION
## Problem

The grid can hold up to `GRID_MAX * GRID_MAX` = 64 cells (`geometry.ts`), but the `alt+<key>` audio-listen hotkey only covers the first 20 cells (`hotkeyTriggers` in `streamwall-control-ui/src/index.tsx`). Nothing in the UI showed which key toggled audio on which cell, so the mapping was effectively undiscoverable.

## Solution

- Added `getHotkeyLabel(idx)`, a small pure helper that returns the `Alt+<KEY>` label assigned to a grid index, or `undefined` once `idx` falls outside the fixed 20-slot `hotkeyTriggers` range.
- Wired it into `GridPreviewBox` (the per-cell tile in the control UI grid preview) as a native `title` attribute, so hovering a tile now shows a tooltip like `Alt+1 toggles audio` for the first 20 cells. Cells beyond the 20-slot range get no tooltip, since none is currently assigned.

This directly implements the issue's "Desired" behavior: *"show the hotkey on tile hover."*

### Scope note

The issue also floated *"consider two-key chords for large grids"* as an optional stretch to extend hotkey coverage past 20 cells. That's a genuine UX/keybinding design decision (which modifier/chord scheme, how discoverable it stays, cross-platform conflicts) that the issue itself only hedges as "consider," not a firm requirement. I kept this PR scoped to the concrete, unambiguous ask (surfacing the existing mapping) and filed a follow-up issue for the extension so it gets proper design input rather than a guessed implementation.

## Testing

- New unit tests for `getHotkeyLabel` covering the first slot, last digit slot, first/last letter slots, and out-of-range indices (negative and beyond 20).
- New `GridPreviewBox` tests asserting the tooltip text for an early and a later in-range cell, and its absence for a cell beyond the 20-slot range.
- Full quality gate green locally: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` (all workspaces), `npm -w streamwall-control-client run build`.

## Risks / breaking changes

None. Purely additive UI affordance (a hover tooltip); no behavior change to the hotkeys themselves.

Closes #84