### PR TITLE
fix(control-ui): reset body margin and min-width to stop horizontal overflow

### DIFF
--- a/packages/streamwall-control-ui/src/globalStyle.test.tsx
+++ b/packages/streamwall-control-ui/src/globalStyle.test.tsx
@@ -1,0 +1,46 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { afterEach, describe, expect, test } from 'vitest'
+import { GlobalStyle } from './index.tsx'
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+  document
+    .querySelectorAll('style[data-styled]')
+    .forEach((style) => style.remove())
+})
+
+// The browser default 8px body margin is never reset, so the flex shell (sized
+// to the viewport) ends up wider than the viewport once that margin is added -
+// producing a horizontal scrollbar on every page (see #225). GlobalStyle must
+// reset it explicitly.
+//
+// Resetting the margin alone isn't enough: `body` is a flex item of `html`
+// with no explicit `min-width`, so its automatic minimum size falls back to
+// its content's min-content width, which can exceed the viewport and inflate
+// `body` past it anyway (verified in a real browser: 1306px body in a 1280px
+// viewport even with margin: 0). `min-width: 0` removes that content-based
+// floor so `body` actually shrinks to fit the viewport.
+describe('GlobalStyle', () => {
+  test('resets the default body margin and min-width so the shell cannot exceed the viewport width', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+
+    act(() => {
+      render(<GlobalStyle />, container!)
+    })
+
+    const css = Array.from(document.querySelectorAll('style'))
+      .map((style) => style.textContent)
+      .join('\n')
+
+    expect(css).toMatch(/html,\s*body\s*{[^}]*margin:\s*0/)
+    expect(css).toMatch(/html,\s*body\s*{[^}]*min-width:\s*0/)
+  })
+})

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -200,6 +200,12 @@ export const GlobalStyle = createGlobalStyle`
   html, body {
     display: flex;
     flex: 1;
+    margin: 0;
+    /* body is a flex item of html with no explicit min-width, so its
+       automatic minimum size falls back to its content's min-content width -
+       which can exceed the viewport and inflate body past it even with the
+       margin reset above (see #225). */
+    min-width: 0;
     background: var(--bg);
     color: var(--text);
     font-family: var(--font-ui);


### PR DESCRIPTION
## Problem

The web control client overflows horizontally on desktop viewports. At a 1280px viewport, `document.documentElement.scrollWidth` measured 1306px (body itself 1306px wide), producing a horizontal scrollbar.

This is pre-existing and independent of the responsive layout work in #226 — reverting that work reproduces the identical overflow.

## Root cause

Two compounding issues in `GlobalStyle`'s `html, body` rule:

1. The browser's default 8px `<body>` margin was never reset, adding 16px of width beyond the viewport.
2. `body` is a flex item of `html` (`html, body { display: flex; flex: 1 }`) with no explicit `min-width`. Its automatic minimum size therefore falls back to its content's min-content width, which can exceed the viewport and inflate `body` past it — even once the margin above is fixed. This accounted for the remaining ~26px measured in a real browser at 1280px.

## Fix

Added `margin: 0` and `min-width: 0` to the `html, body` rule in `GlobalStyle`.

## Testing

- New unit test (`globalStyle.test.tsx`) renders `GlobalStyle` and asserts the injected CSS resets both `margin` and `min-width` on `html, body` — regresses if either rule is removed.
- Manually verified in a real browser (control-client `dev.html` via Vite) at 1280px, 375px, and 1920px viewports: `document.documentElement.scrollWidth` no longer exceeds `window.innerWidth` at any of them (previously overflowed at 1280px).
- Full quality gate green: `prettier --check .`, `eslint .`, `typecheck` (all workspaces), `test` (all workspaces — control-server 90/90, control-ui 68/68 incl. the new test), and `streamwall-control-client` build.

## Risks / breaking changes

None expected — this only tightens layout box-model rules that were previously relying on browser defaults; no visual regression observed across the tested viewport widths.

Closes #225