### PR TITLE
refactor(control-server): type WebSocket test message fixtures with real schemas

### DIFF
--- a/packages/streamwall-control-server/src/multiplexing.test.ts
+++ b/packages/streamwall-control-server/src/multiplexing.test.ts
@@ -4,7 +4,13 @@ import { after, test } from 'node:test'
 import { setTimeout as delay } from 'node:timers/promises'
 import WebSocket from 'ws'
 
-import type { StreamwallRole } from 'streamwall-shared'
+import type {
+  ClientCommandResponse,
+  ClientStateMessage,
+  ControlCommandMessage,
+  ServerToClientMessage,
+  StreamwallRole,
+} from 'streamwall-shared'
 import {
   buildTestApp,
   connectStreamwallUplink,
@@ -16,6 +22,22 @@ import {
 } from './testHelpers.ts'
 
 const BASE_URL = 'http://localhost:3000'
+
+/** Narrows to the server's reply to the client command with the given `id`. */
+function isResponseTo(id: number) {
+  return (m: ServerToClientMessage): m is ClientCommandResponse =>
+    'response' in m && m.response === true && m.id === id
+}
+
+/** Narrows to a forwarded control command of the given `type`. */
+function isCommandType<Type extends ControlCommandMessage['type']>(type: Type) {
+  return (
+    m: ControlCommandMessage,
+  ): m is Extract<ControlCommandMessage, { type: Type }> => m.type === type
+}
+
+const isStateMessage = (m: ServerToClientMessage): m is ClientStateMessage =>
+  'type' in m && m.type === 'state'
 
 /** Temporarily replaces `console.warn`, capturing every call made while active. */
 function spyOnConsoleWarn() {
@@ -46,7 +68,7 @@ async function bootServerWithUplink() {
   after(() => app.close())
   const port = await listenTestApp(app)
 
-  const { ws: streamwallWs, streamwall } = await connectStreamwallUplink<any>(
+  const { ws: streamwallWs, streamwall } = await connectStreamwallUplink(
     auth,
     port,
   )
@@ -54,7 +76,7 @@ async function bootServerWithUplink() {
   await delay(150)
 
   async function connectClient(role: StreamwallRole) {
-    const { ws: clientWs, client } = await redeemInviteAndConnectClient<any>(
+    const { ws: clientWs, client } = await redeemInviteAndConnectClient(
       app,
       auth,
       port,
@@ -83,9 +105,7 @@ test('an operator cannot create-invite: it is dropped, logged, and never forward
     )
     clientWs.send(JSON.stringify({ id: 2, type: 'reload-view', viewIdx: 0 }))
 
-    const response = await client.waitFor(
-      (m) => m.response === true && m.id === 1,
-    )
+    const response = await client.waitFor(isResponseTo(1))
     assert.equal(response.error, 'unauthorized')
 
     await streamwall.waitFor((m) => m.type === 'reload-view')
@@ -115,9 +135,7 @@ test('an operator cannot browse: it is dropped, logged, and never forwarded', as
     )
     clientWs.send(JSON.stringify({ id: 4, type: 'reload-view', viewIdx: 0 }))
 
-    const response = await client.waitFor(
-      (m) => m.response === true && m.id === 3,
-    )
+    const response = await client.waitFor(isResponseTo(3))
     assert.equal(response.error, 'unauthorized')
 
     await streamwall.waitFor((m) => m.type === 'reload-view')
@@ -154,9 +172,7 @@ test('a monitor cannot create-invite: it is dropped, logged, and never forwarded
       JSON.stringify({ id: 6, type: 'set-stream-censored', isCensored: true }),
     )
 
-    const response = await client.waitFor(
-      (m) => m.response === true && m.id === 5,
-    )
+    const response = await client.waitFor(isResponseTo(5))
     assert.equal(response.error, 'unauthorized')
 
     await streamwall.waitFor((m) => m.type === 'set-stream-censored')
@@ -188,9 +204,7 @@ test('a monitor cannot browse: it is dropped, logged, and never forwarded', asyn
       JSON.stringify({ id: 8, type: 'set-stream-censored', isCensored: true }),
     )
 
-    const response = await client.waitFor(
-      (m) => m.response === true && m.id === 7,
-    )
+    const response = await client.waitFor(isResponseTo(7))
     assert.equal(response.error, 'unauthorized')
 
     await streamwall.waitFor((m) => m.type === 'set-stream-censored')
@@ -218,7 +232,7 @@ test('an operator can set-listening-view: it is forwarded to the Streamwall upli
   )
 
   const forwarded = await streamwall.waitFor(
-    (m) => m.type === 'set-listening-view',
+    isCommandType('set-listening-view'),
   )
   assert.equal(forwarded.viewIdx, 0)
 })
@@ -228,8 +242,8 @@ test("an admin's state broadcast includes auth while an operator's does not", as
   const { client: adminClient } = await connectClient('admin')
   const { client: operatorClient } = await connectClient('operator')
 
-  const adminState = await adminClient.waitFor((m) => m.type === 'state')
-  const operatorState = await operatorClient.waitFor((m) => m.type === 'state')
+  const adminState = await adminClient.waitFor(isStateMessage)
+  const operatorState = await operatorClient.waitFor(isStateMessage)
 
   assert.ok(
     adminState.state.auth && Array.isArray(adminState.state.auth.sessions),
@@ -271,7 +285,7 @@ test('rejects a second Streamwall connection while the first stays connected', a
     // so it deterministically proves the race window has closed rather than
     // assuming a fixed ordering.
     const { client } = await connectClient('admin')
-    await client.waitFor((m) => m.type === 'state')
+    await client.waitFor(isStateMessage)
 
     const secondToken = await auth.createToken({
       kind: 'streamwall',
@@ -324,14 +338,14 @@ test('a state message sent immediately on connect is not dropped while auth vali
   await once(streamwallWs, 'open')
   streamwallWs.send(JSON.stringify({ type: 'state', state: VALID_STATE }))
 
-  const { client } = await redeemInviteAndConnectClient<any>(
+  const { client } = await redeemInviteAndConnectClient(
     app,
     auth,
     port,
     BASE_URL,
   )
 
-  const stateMsg = await client.waitFor((m) => m.type === 'state')
+  const stateMsg = await client.waitFor(isStateMessage)
   assert.deepEqual(
     stateMsg.state.config,
     VALID_STATE.config,

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -6,7 +6,11 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { after } from 'node:test'
 import { setTimeout as delay } from 'node:timers/promises'
-import type { StreamwallRole } from 'streamwall-shared'
+import type {
+  ControlCommandMessage,
+  ServerToClientMessage,
+  StreamwallRole,
+} from 'streamwall-shared'
 import WebSocket from 'ws'
 import { type AppOptions, initApp } from './index.ts'
 import type { StoredData } from './storage.ts'
@@ -107,28 +111,36 @@ export function recordJsonMessages<T = unknown>(ws: WebSocket) {
     }
   })
 
-  return {
-    messages,
-    waitFor(predicate: (m: T) => boolean, timeoutMs = 2000): Promise<T> {
-      const existing = messages.find(predicate)
-      if (existing !== undefined) {
-        return Promise.resolve(existing)
-      }
-      return new Promise((resolve, reject) => {
-        const timer = setTimeout(
-          () => reject(new Error('timed out waiting for matching ws message')),
-          timeoutMs,
-        )
-        waiters.push({
-          predicate,
-          resolve: (m) => {
-            clearTimeout(timer)
-            resolve(m)
-          },
-        })
+  /**
+   * Overloaded so callers that pass a type-predicate (`(m): m is Foo => ...`)
+   * get back a `Promise<Foo>` instead of the wider `Promise<T>`.
+   */
+  function waitFor<S extends T>(
+    predicate: (m: T) => m is S,
+    timeoutMs?: number,
+  ): Promise<S>
+  function waitFor(predicate: (m: T) => boolean, timeoutMs?: number): Promise<T>
+  function waitFor(predicate: (m: T) => boolean, timeoutMs = 2000): Promise<T> {
+    const existing = messages.find(predicate)
+    if (existing !== undefined) {
+      return Promise.resolve(existing)
+    }
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error('timed out waiting for matching ws message')),
+        timeoutMs,
+      )
+      waiters.push({
+        predicate,
+        resolve: (m) => {
+          clearTimeout(timer)
+          resolve(m)
+        },
       })
-    },
+    })
   }
+
+  return { messages, waitFor }
 }
 
 /**
@@ -169,10 +181,10 @@ export async function mintUplinkToken(auth: TestApp['auth'], port: number) {
  * Connects an authenticated Streamwall uplink WebSocket, records its JSON
  * frames from the moment it opens, and terminates it after the test.
  *
- * `T` describes the shape of the JSON frames the caller expects to record;
- * callers that inspect arbitrary/dynamic fields can instantiate it as `any`.
+ * `T` describes the shape of the JSON frames the caller expects to record,
+ * defaulting to the real shape the server forwards over this connection.
  */
-export async function connectStreamwallUplink<T = unknown>(
+export async function connectStreamwallUplink<T = ControlCommandMessage>(
   auth: TestApp['auth'],
   port: number,
 ) {
@@ -190,10 +202,10 @@ export async function connectStreamwallUplink<T = unknown>(
  * Redeems a freshly-minted invite for `role` and opens an authenticated
  * `/client/ws` socket, recording its JSON frames from the moment it opens.
  *
- * `T` describes the shape of the JSON frames the caller expects to record;
- * callers that inspect arbitrary/dynamic fields can instantiate it as `any`.
+ * `T` describes the shape of the JSON frames the caller expects to record,
+ * defaulting to the real shape the server sends over this connection.
  */
-export async function redeemInviteAndConnectClient<T = unknown>(
+export async function redeemInviteAndConnectClient<T = ServerToClientMessage>(
   app: TestApp['app'],
   auth: TestApp['auth'],
   port: number,

--- a/packages/streamwall-control-server/src/wsValidation.test.ts
+++ b/packages/streamwall-control-server/src/wsValidation.test.ts
@@ -2,7 +2,13 @@ import assert from 'node:assert/strict'
 import { once } from 'node:events'
 import { after, test } from 'node:test'
 import { setTimeout as delay } from 'node:timers/promises'
-import type { StreamwallRole } from 'streamwall-shared'
+import type {
+  ClientCommandResponse,
+  ClientErrorMessage,
+  ControlCommandMessage,
+  ServerToClientMessage,
+  StreamwallRole,
+} from 'streamwall-shared'
 import * as Y from 'yjs'
 import {
   buildTestApp,
@@ -13,6 +19,23 @@ import {
 } from './testHelpers.ts'
 
 const BASE_URL = 'http://localhost:3000'
+
+/** Narrows to the server's reply to the client command with the given `id`. */
+function isResponseTo(id: number) {
+  return (m: ServerToClientMessage): m is ClientCommandResponse =>
+    'response' in m && m.response === true && m.id === id
+}
+
+/** Narrows to a forwarded control command of the given `type`. */
+function isCommandType<Type extends ControlCommandMessage['type']>(type: Type) {
+  return (
+    m: ControlCommandMessage,
+  ): m is Extract<ControlCommandMessage, { type: Type }> => m.type === type
+}
+
+/** Narrows to a bare connection-level rejection (never has `response`). */
+const isBareError = (m: ServerToClientMessage): m is ClientErrorMessage =>
+  !('response' in m) && 'error' in m
 
 // A per-test override of the update cap must not leak into other test files.
 after(() => {
@@ -48,14 +71,14 @@ async function connectStreamwallAndClient({
   after(() => app.close())
   const port = await listenTestApp(app)
 
-  const { ws: streamwallWs, streamwall } = await connectStreamwallUplink<any>(
+  const { ws: streamwallWs, streamwall } = await connectStreamwallUplink(
     auth,
     port,
   )
   streamwallWs.send(JSON.stringify(stateMessage))
   await delay(150)
 
-  const { ws: clientWs, client } = await redeemInviteAndConnectClient<any>(
+  const { ws: clientWs, client } = await redeemInviteAndConnectClient(
     app,
     auth,
     port,
@@ -76,7 +99,7 @@ test('does not forward an out-of-bounds command to the Streamwall uplink', async
 
   await streamwall.waitFor((m) => m.type === 'reload-view' && m.viewIdx === 2)
 
-  const reloads = streamwall.messages.filter((m) => m.type === 'reload-view')
+  const reloads = streamwall.messages.filter(isCommandType('reload-view'))
   assert.equal(reloads.length, 1, 'only the valid command should be forwarded')
   assert.equal(reloads[0].viewIdx, 2)
 })
@@ -92,7 +115,8 @@ test('does not forward an unknown command type to the Streamwall uplink', async 
   await streamwall.waitFor((m) => m.type === 'reload-view' && m.viewIdx === 1)
 
   assert.ok(
-    !streamwall.messages.some((m) => m.type === 'evil-command'),
+    // Not a real ControlCommand type: cast, since it can never actually match.
+    !streamwall.messages.some((m) => (m.type as string) === 'evil-command'),
     'the unknown command must never be forwarded',
   )
 })
@@ -102,9 +126,7 @@ test('answers an invalid command with an error response', async () => {
 
   clientWs.send(JSON.stringify({ id: 42, type: 'reload-view', viewIdx: -5 }))
 
-  const response = await client.waitFor(
-    (m) => m.response === true && m.id === 42,
-  )
+  const response = await client.waitFor(isResponseTo(42))
   assert.equal(response.error, 'invalid message')
 })
 
@@ -116,7 +138,7 @@ test('rejects a state message with no payload instead of wiring a broken connect
     stateMessage: { type: 'state' },
   })
 
-  const response = await client.waitFor((m) => typeof m.error === 'string')
+  const response = await client.waitFor(isBareError)
   assert.equal(response.error, 'streamwall disconnected')
 })
 

--- a/packages/streamwall-shared/src/types.ts
+++ b/packages/streamwall-shared/src/types.ts
@@ -1,3 +1,4 @@
+import type { Delta } from 'jsondiffpatch'
 import type { ViewContent, ViewPos } from './geometry.ts'
 import type { StreamwallRole } from './roles.ts'
 
@@ -168,3 +169,42 @@ export type ControlUpdate = {
 export type ControlCommandMessage = MessageMeta & ControlCommand
 
 export type ControlUpdateMessage = MessageMeta & ControlUpdate
+
+/** Sent to a `/client/ws` socket once, immediately after it connects. */
+export type ClientStateMessage = {
+  type: 'state'
+  state: StreamwallState
+}
+
+/** An incremental jsondiffpatch delta applied to a client's last-known state. */
+export type ClientStateDeltaMessage = {
+  type: 'state-delta'
+  delta: Delta
+}
+
+/** A connection-level rejection, sent before a client session is ever established. */
+export type ClientErrorMessage = {
+  error: string
+}
+
+/**
+ * The server's reply to a specific client-issued command, correlated by the
+ * client-supplied `id`. `error` is present only when the command was
+ * rejected; a successful `create-invite` additionally returns the minted
+ * token's `name`/`secret`/`tokenId`.
+ */
+export type ClientCommandResponse = {
+  response: true
+  id?: number
+  error?: string
+  name?: string
+  secret?: string
+  tokenId?: string
+}
+
+/** Every message shape the control server sends over a `/client/ws` socket. */
+export type ServerToClientMessage =
+  | ClientStateMessage
+  | ClientStateDeltaMessage
+  | ClientErrorMessage
+  | ClientCommandResponse


### PR DESCRIPTION
## Problem

`packages/streamwall-control-server/src/testHelpers.ts` exports generic helpers for recording/collecting JSON WebSocket frames in tests — `recordJsonMessages<T>`, `connectStreamwallUplink<T>`, and `redeemInviteAndConnectClient<T>`. Every call site instantiated `T` as `any` (e.g. `redeemInviteAndConnectClient<any>(...)`), since `testHelpers.ts` isn't covered by the repo's `no-explicit-any` test-file exemption in `eslint.config.mjs`.

This meant tests inspecting deep fields on these messages (e.g. `adminState.state.auth.sessions`, `stateMsg.state.config`) got no compile-time protection against typos or shape drift.

## Solution

- **`streamwall-shared/src/types.ts`**: adds `ClientStateMessage`, `ClientStateDeltaMessage`, `ClientErrorMessage`, `ClientCommandResponse`, and the `ServerToClientMessage` discriminated union — covering every message shape the control server actually sends over a `/client/ws` socket (`{ type: 'state', state }`, `{ type: 'state-delta', delta }`, bare `{ error }` rejections, and `{ response: true, id, error? }` command replies). The existing `ControlCommandMessage` type already covers what's forwarded to the Streamwall uplink.
- **`testHelpers.ts`**: defaults `connectStreamwallUplink<T>` to `ControlCommandMessage` and `redeemInviteAndConnectClient<T>` to `ServerToClientMessage` instead of `unknown`, so every call site can drop `<any>`. `waitFor()` gains a type-predicate overload (`(m): m is Foo => ...`) so callers that narrow the message type get back the narrowed type instead of the full union.
- **Test files**: `multiplexing.test.ts` and `wsValidation.test.ts` drop `<any>` at every call site and add small local type-predicate helpers (`isResponseTo`, `isCommandType`, `isStateMessage`, `isBareError`) wherever a test accesses a field that isn't common to every member of the union (e.g. `.error` on a command response vs. a bare rejection).

## Architecture decisions

- Kept the union types in `streamwall-shared/src/types.ts` as plain TS types (not zod schemas), matching the existing `ControlCommandMessage`/`ControlUpdateMessage` pattern — these messages are server-authored and never parsed off the wire, so runtime validation isn't the goal here, only compile-time shape safety in tests.
- `waitFor`'s type-predicate overload is a minimal generic addition rather than rewriting the recorder API, so the change stays scoped to typing and doesn't touch runtime behavior.

## Testing performed

- `npm run typecheck` (all workspaces) — clean
- `npm run lint` — clean
- `npm run format:check` — clean
- `npm test` (all workspaces) — 90/90 control-server tests, 208/208 shared, 204/204 streamwall, 67/67 control-ui, all passing
- `npm -w streamwall-control-client run build` — succeeds

No new tests were added: this is a compile-time-only tightening of existing test helper generics with no behavior change. The existing WebSocket test suite continues to pass unchanged and now gets real type-checking on message field access instead of `any`.

## Risks / breaking changes

None — internal test-only typing change, no production code paths touched.

Closes #233