### PR TITLE
fix(control-ui): share a single Color module instance with streamwall-shared

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15074,7 +15074,6 @@
         "@fontsource/noto-sans": "^5.2.10",
         "@fontsource/oswald": "^5.2.8",
         "@fontsource/saira-stencil-one": "^5.2.8",
-        "color": "^5.0.3",
         "jsondiffpatch": "^0.7.6",
         "lodash-es": "^4.18.1",
         "luxon": "^3.7.2",
@@ -15094,52 +15093,6 @@
         "happy-dom": "^20.10.6",
         "typescript": "^6.0.3",
         "vitest": "^4.1.10"
-      }
-    },
-    "packages/streamwall-control-ui/node_modules/color": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
-      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^3.1.3",
-        "color-string": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/streamwall-control-ui/node_modules/color-convert": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
-      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.6"
-      }
-    },
-    "packages/streamwall-control-ui/node_modules/color-name": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
-      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      }
-    },
-    "packages/streamwall-control-ui/node_modules/color-string": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
-      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "packages/streamwall-shared": {

--- a/packages/streamwall-control-ui/package.json
+++ b/packages/streamwall-control-ui/package.json
@@ -10,7 +10,6 @@
     "@fontsource/noto-sans": "^5.2.10",
     "@fontsource/oswald": "^5.2.8",
     "@fontsource/saira-stencil-one": "^5.2.8",
-    "color": "^5.0.3",
     "jsondiffpatch": "^0.7.6",
     "lodash-es": "^4.18.1",
     "luxon": "^3.7.2",

--- a/packages/streamwall-control-ui/src/GridInput.test.tsx
+++ b/packages/streamwall-control-ui/src/GridInput.test.tsx
@@ -1,21 +1,6 @@
-import Color from 'color'
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
 import { afterEach, describe, expect, test, vi } from 'vitest'
-
-// `idColor` (from streamwall-shared) returns a `Color` instance built from
-// *that* package's own `color` module copy — the monorepo doesn't dedupe it
-// against this package's copy (see packages/streamwall-shared/node_modules/color
-// vs packages/streamwall-control-ui/node_modules/color in package-lock.json).
-// `GridInput`'s styled component then re-wraps it via `Color($color)...` using
-// *this* package's copy, which can't parse an instance from the other copy.
-// That's an unrelated, pre-existing cross-package bug (tracked separately);
-// stub `idColor` here with a same-copy `Color` instance so this test isolates
-// the pointer-event wiring this file is actually about.
-vi.mock('streamwall-shared', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('streamwall-shared')>()
-  return { ...actual, idColor: () => Color('white') }
-})
 
 import { GridInput } from './index.tsx'
 

--- a/packages/streamwall-control-ui/src/GridPreviewBox.test.tsx
+++ b/packages/streamwall-control-ui/src/GridPreviewBox.test.tsx
@@ -1,6 +1,6 @@
-import Color from 'color'
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
+import { Color } from 'streamwall-shared'
 import { afterEach, describe, expect, test } from 'vitest'
 import { GridPreviewBox } from './index.tsx'
 

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -7,7 +7,6 @@ import '@fontsource/jetbrains-mono/500.css'
 import '@fontsource/jetbrains-mono/700.css'
 import '@fontsource/oswald/600.css'
 import '@fontsource/saira-stencil-one'
-import Color from 'color'
 import { orderBy, range, truncate } from 'lodash-es'
 import { DateTime } from 'luxon'
 import { type JSX } from 'preact'
@@ -35,6 +34,7 @@ import {
 } from 'react-icons/md'
 import {
   clampGridDimension,
+  Color,
   type ContentKind,
   type ControlCommand,
   GRID_MAX,
@@ -75,8 +75,9 @@ import { LazyChangeInput } from './LazyChangeInput.tsx'
 import { resolveTargetViewIdx, resolveWriteStreamId } from './viewPlacement.ts'
 import { createSharedUndoManager } from './yUndo.ts'
 
-// `import Color from 'color'` binds only the value; alias the instance type
-// (as returned by the Color factory) for use in styled-component prop types.
+// `import { Color } from 'streamwall-shared'` binds only the value; alias
+// the instance type (as returned by the Color factory) for use in
+// styled-component prop types.
 type ColorInstance = ReturnType<typeof Color>
 
 export interface ViewInfo {

--- a/packages/streamwall-shared/src/colors.test.ts
+++ b/packages/streamwall-shared/src/colors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { hashText, idColor } from './colors.ts'
+import { Color, hashText, idColor } from './colors.ts'
 
 describe('hashText', () => {
   it('returns a fixed hash for a fixed input', () => {
@@ -79,5 +79,16 @@ describe('idColor', () => {
       expect(s).toBeLessThan(60)
       expect(l).toBe(50)
     }
+  })
+
+  // Consumers in other workspaces (e.g. streamwall-control-ui) re-wrap this
+  // value with `Color(...)` themselves. That only works if they construct
+  // their own `Color` from this same re-exported constructor rather than
+  // importing the `color` package directly — otherwise the two modules are
+  // physically different copies (see the monorepo's per-workspace
+  // node_modules layout in package-lock.json), and `Color`'s `instanceof`
+  // fast path fails, throwing "Unable to parse color from object".
+  it('returns an instance recognized by the re-exported Color constructor', () => {
+    expect(idColor('streamwall')).toBeInstanceOf(Color)
   })
 })

--- a/packages/streamwall-shared/src/colors.ts
+++ b/packages/streamwall-shared/src/colors.ts
@@ -1,5 +1,12 @@
 import Color from 'color'
 
+// Re-exported so consumers construct/re-wrap colors via this exact module
+// instance instead of installing their own copy of 'color' — the monorepo's
+// per-workspace node_modules layout means a separately imported copy is a
+// physically different class, breaking Color's `instanceof` fast path for
+// values returned by idColor() below.
+export { Color }
+
 export function hashText(text: string, range: number) {
   // DJBX33A-ish
   // based on https://github.com/euphoria-io/heim/blob/978c921063e6b06012fc8d16d9fbf1b3a0be1191/client/lib/hueHash.js#L16-L45


### PR DESCRIPTION
## Problem

`idColor()` in `streamwall-shared` builds `Color` instances from that package's own installed copy of the `color` npm package. `streamwall-control-ui` imported `color` separately (its own installed copy) and re-wrapped values returned by `idColor()` — e.g. `GridInput`'s and `StreamLine`'s styled components, and `GridPreviewBox` — via `Color($color).lightness(...)`.

Because the two `Color` classes are physically different module instances in the monorepo's per-workspace `node_modules` layout, `color`'s internal `instanceof` fast path fails and it falls through to generic object parsing, which throws:

```
Unable to parse color from object: {"model":"rgb","color":[255,255,255],"valpha":1}
```

This is a real, reproducible crash — not just a test isolation artifact. It fires on every render of `GridInput`, `StreamLine` (`StyledId`), and `GridPreviewBox`, i.e. almost every grid tile and stream list row.

## Root cause

npm workspaces normally hoist a single shared copy of a dependency when every requester wants the same version. Here that didn't happen: the repo root already carries an older `color-convert@2.0.1` (pulled in by dev tooling), which conflicts with the `color-convert@^3.1.3` that `color@5.0.3` requires. npm's installer resolved that by nesting the entire `color` package (not just the conflicting `color-convert` sub-dependency) separately under each of the three workspaces that declared it directly (`streamwall`, `streamwall-shared`, `streamwall-control-ui`), rather than hoisting `color` itself to the root.

## Fix

Rather than relying on npm's install-time dedup behavior (which is what caused this in the first place, and isn't something this fix should depend on going forward), `streamwall-shared` now re-exports its `Color` constructor, and `streamwall-control-ui` imports `Color` from `streamwall-shared` instead of depending on `color` directly. Every `Color` instance that crosses the package boundary is now built and consumed by the exact same class, regardless of how npm lays out `node_modules` across workspaces.

`streamwall` (the Electron main process) keeps its own direct `color` dependency — it only uses `Color` to parse a user-supplied Twitch chat color string in `TwitchBot.ts`, entirely independent of `idColor()`, so it was never affected by this bug and doesn't need to change.

Removing `control-ui`'s now-unused `color` dependency let `npm install` dedupe its nested copy away; verified with the real built `streamwall-control-client` Vite bundle, which now contains exactly one copy of the `color` package (previously the source of this exact crash).

## Testing performed

- `packages/streamwall-shared/src/colors.test.ts`: new assertion that `idColor()`'s return value is an `instanceof` the package's re-exported `Color` constructor.
- `packages/streamwall-control-ui/src/GridInput.test.tsx`: removed the `vi.mock('streamwall-shared', ...)` workaround that stubbed `idColor` specifically to sidestep this bug (added in #194) — the test now exercises the real `idColor()` → `Color()` path end-to-end. Confirmed it reproduces the exact crash before the fix (red), passes after (green).
- `packages/streamwall-control-ui/src/GridPreviewBox.test.tsx`: updated its own direct `color` import (now unresolvable after removing the workspace dependency) to use the shared re-export instead.
- Full quality gate: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` (all workspaces) — all green.
- `npm -w streamwall-control-client run build` — succeeds; confirmed the built bundle contains exactly one copy of the `color` package (`grep -c "Unable to parse color from object" dist/assets/index-*.js` → `1`).

## Risks / breaking changes

None. This only changes which module instance `streamwall-control-ui` imports `Color` from (same underlying `color` package/version); no behavior or public API changes.

Closes #196