### PR TITLE
feat(streamwall): extend Sentry crash reporting to trusted renderer processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,14 @@ Open Config Folder** in the app menu at any time to open that directory.
 ### Telemetry
 
 Streamwall reports uncaught errors to a Sentry project run by the maintainers
-(`telemetry.sentry`, default `true`). To opt out, set `sentry = false` under
-`[telemetry]` in your config file (see `example.config.toml`) or pass
-`--telemetry.sentry=false` on the command line.
+(`telemetry.sentry`, default `true`). This covers the main process and every
+renderer the app fully authors (the control window, and the background and
+overlay layers); it deliberately does **not** cover the per-stream views or
+the "browse" window, since those load arbitrary third-party URLs and
+attaching error reporting there would leak that content's context to Sentry.
+To opt out, set `sentry = false` under `[telemetry]` in your config file (see
+`example.config.toml`) or pass `--telemetry.sentry=false` on the command
+line.
 
 ## Remote control server
 

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -19,6 +19,11 @@ import { updateElectronApp } from 'update-electron-app'
 import WebSocket from 'ws'
 import yargs from 'yargs'
 import * as Y from 'yjs'
+import {
+  SENTRY_DSN,
+  SENTRY_ENABLED_SWITCH,
+  sentryEnabledSwitchValue,
+} from '../sentryConfig'
 import { createSessionHostResolver, ensureValidURL } from '../util'
 import {
   ConfigError,
@@ -53,9 +58,6 @@ import {
   shouldHideInsteadOfQuit,
   shouldQuitOnAllWindowsClosed,
 } from './windowCloseBehavior'
-
-const SENTRY_DSN =
-  'https://e630a21dcf854d1a9eb2a7a8584cbd0b@o459879.ingest.sentry.io/5459505'
 
 /**
  * Builds a WebSocket subclass for the control uplink.
@@ -907,6 +909,13 @@ function init() {
   if (argv.telemetry.sentry) {
     Sentry.init({ dsn: SENTRY_DSN })
   }
+  // Sandboxed preload scripts (control, background, overlay) have no other
+  // channel to this config, so pass it down as a command-line switch every
+  // Chromium subprocess receives -- see sentryConfig.ts and sentryPreload.ts.
+  app.commandLine.appendSwitch(
+    SENTRY_ENABLED_SWITCH,
+    sentryEnabledSwitchValue(argv.telemetry.sentry),
+  )
 
   updateElectronApp()
 

--- a/packages/streamwall/src/preload/controlPreload.ts
+++ b/packages/streamwall/src/preload/controlPreload.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron'
 import { StreamwallState } from 'streamwall-shared'
+import './sentryPreload'
 
 export interface FirstRunInfo {
   configPath: string

--- a/packages/streamwall/src/preload/layerPreload.ts
+++ b/packages/streamwall/src/preload/layerPreload.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron'
 import { StreamwallState } from 'streamwall-shared'
+import './sentryPreload'
 
 const api = {
   openDevTools: () => ipcRenderer.send('devtools-overlay'),

--- a/packages/streamwall/src/preload/sentryPreload.ts
+++ b/packages/streamwall/src/preload/sentryPreload.ts
@@ -1,0 +1,13 @@
+import '@sentry/electron/preload'
+import { contextBridge } from 'electron'
+import { isSentryEnabledArg } from '../sentryConfig'
+
+// Import for the side effect only: it wires up the sandboxed IPC transport
+// `@sentry/electron/renderer`'s init() needs to forward events to the main
+// process. Only pull this into preloads for renderers the app fully authors
+// (control, background, overlay) -- never into a preload facing arbitrary
+// third-party content.
+contextBridge.exposeInMainWorld(
+  'sentryEnabled',
+  isSentryEnabledArg(process.argv),
+)

--- a/packages/streamwall/src/renderer/background.tsx
+++ b/packages/streamwall/src/renderer/background.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'preact/hooks'
 import { styled } from 'styled-components'
 import { StreamData, StreamList } from '../../../streamwall-shared/src/types'
 import { StreamwallLayerGlobal } from '../preload/layerPreload'
+import { initRendererSentry } from './initSentry'
 import { LAYER_FRAME_SANDBOX } from './layerFrameSandbox'
 
 declare global {
@@ -13,6 +14,8 @@ declare global {
     streamwall: StreamwallLayerGlobal
   }
 }
+
+initRendererSentry()
 
 function Background({ streams }: { streams: StreamList }) {
   const backgrounds = streams.filter((s) => s.kind === 'background')

--- a/packages/streamwall/src/renderer/control.tsx
+++ b/packages/streamwall/src/renderer/control.tsx
@@ -16,6 +16,7 @@ import {
   StreamwallControlGlobal,
 } from '../preload/controlPreload'
 import { FirstRunHint } from './FirstRunHint'
+import { initRendererSentry } from './initSentry'
 
 const DISMISSED_STORAGE_KEY = 'streamwall:first-run-hint-dismissed'
 
@@ -24,6 +25,8 @@ declare global {
     streamwallControl: StreamwallControlGlobal
   }
 }
+
+initRendererSentry()
 
 function useStreamwallIPCConnection(): StreamwallConnection {
   const {

--- a/packages/streamwall/src/renderer/initSentry.test.ts
+++ b/packages/streamwall/src/renderer/initSentry.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const init = vi.fn()
+vi.mock('@sentry/electron/renderer', () => ({ init }))
+
+const { initRendererSentry } = await import('./initSentry')
+
+describe('initRendererSentry', () => {
+  beforeEach(() => {
+    init.mockClear()
+    // @ts-expect-error test-only global exposed by the preload script
+    delete window.sentryEnabled
+  })
+
+  it('initializes Sentry when the preload-exposed flag is enabled', () => {
+    window.sentryEnabled = true
+
+    initRendererSentry()
+
+    expect(init).toHaveBeenCalledTimes(1)
+    expect(init).toHaveBeenCalledWith(
+      expect.objectContaining({ dsn: expect.any(String) }),
+    )
+  })
+
+  it('does not initialize Sentry when the flag is disabled', () => {
+    window.sentryEnabled = false
+
+    initRendererSentry()
+
+    expect(init).not.toHaveBeenCalled()
+  })
+
+  it('does not initialize Sentry when the flag is missing entirely', () => {
+    initRendererSentry()
+
+    expect(init).not.toHaveBeenCalled()
+  })
+})

--- a/packages/streamwall/src/renderer/initSentry.ts
+++ b/packages/streamwall/src/renderer/initSentry.ts
@@ -1,0 +1,21 @@
+import * as Sentry from '@sentry/electron/renderer'
+import { SENTRY_DSN } from '../sentryConfig'
+
+declare global {
+  interface Window {
+    /** Set by the window's preload script (see sentryPreload.ts). */
+    sentryEnabled: boolean
+  }
+}
+
+/**
+ * Initializes Sentry in a trusted renderer (control, background, overlay).
+ * Only call this from renderers the app fully authors -- never from a
+ * renderer that can navigate to arbitrary third-party content (e.g. the
+ * per-stream views), since that would leak that page's context to Sentry.
+ */
+export function initRendererSentry(): void {
+  if (window.sentryEnabled) {
+    Sentry.init({ dsn: SENTRY_DSN })
+  }
+}

--- a/packages/streamwall/src/renderer/overlay.tsx
+++ b/packages/streamwall/src/renderer/overlay.tsx
@@ -6,6 +6,7 @@ import { styled } from 'styled-components'
 import { matchesState } from 'xstate'
 import packageInfo from '../../package.json'
 import { StreamwallLayerGlobal } from '../preload/layerPreload'
+import { initRendererSentry } from './initSentry'
 import { LAYER_FRAME_SANDBOX } from './layerFrameSandbox'
 import { OverlayViewTile } from './OverlayViewTile'
 
@@ -17,6 +18,8 @@ declare global {
     streamwallLayer: StreamwallLayerGlobal
   }
 }
+
+initRendererSentry()
 
 function Overlay({
   config,

--- a/packages/streamwall/src/sentryConfig.test.ts
+++ b/packages/streamwall/src/sentryConfig.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isSentryEnabledArg,
+  SENTRY_ENABLED_SWITCH,
+  sentryEnabledSwitchValue,
+} from './sentryConfig'
+
+describe('sentryEnabledSwitchValue', () => {
+  it('renders true as the literal string "true"', () => {
+    expect(sentryEnabledSwitchValue(true)).toBe('true')
+  })
+
+  it('renders false as the literal string "false"', () => {
+    expect(sentryEnabledSwitchValue(false)).toBe('false')
+  })
+})
+
+describe('isSentryEnabledArg', () => {
+  it('is true when the switch is present and set to true', () => {
+    expect(isSentryEnabledArg([`--${SENTRY_ENABLED_SWITCH}=true`])).toBe(true)
+  })
+
+  it('is false when the switch is present and set to false', () => {
+    expect(isSentryEnabledArg([`--${SENTRY_ENABLED_SWITCH}=false`])).toBe(false)
+  })
+
+  it('is false when the switch is absent', () => {
+    expect(isSentryEnabledArg(['--some-other-flag=true'])).toBe(false)
+  })
+
+  it('is false for an empty argv', () => {
+    expect(isSentryEnabledArg([])).toBe(false)
+  })
+})

--- a/packages/streamwall/src/sentryConfig.ts
+++ b/packages/streamwall/src/sentryConfig.ts
@@ -1,0 +1,19 @@
+export const SENTRY_DSN =
+  'https://e630a21dcf854d1a9eb2a7a8584cbd0b@o459879.ingest.sentry.io/5459505'
+
+/**
+ * Command-line switch name main/index.ts sets via `app.commandLine.appendSwitch`
+ * once `telemetry.sentry` is known. Sandboxed preload scripts run in their own
+ * process with no other channel to main-process config, so this is how they
+ * learn whether the trusted renderers they front (control, background,
+ * overlay) should initialize Sentry.
+ */
+export const SENTRY_ENABLED_SWITCH = 'sentry-enabled'
+
+export function sentryEnabledSwitchValue(enabled: boolean): string {
+  return String(enabled)
+}
+
+export function isSentryEnabledArg(argv: readonly string[]): boolean {
+  return argv.includes(`--${SENTRY_ENABLED_SWITCH}=true`)
+}


### PR DESCRIPTION
## Problem

Sentry (`@sentry/electron/main`, gated by `telemetry.sentry`) was only initialized in the main process. Crashes and uncaught errors in the control window, and the background/overlay layers, went unreported — the exact renderer surfaces an operator actually watches during a live wall.

## Solution

- `telemetry.sentry` now also governs three renderer processes: **control**, **background**, and **overlay**. These are the renderers the app fully authors.
- Deliberately **excluded**: the per-stream (`playHLS`) views and the "browse" window, since both load arbitrary third-party URLs — attaching a renderer SDK there would leak that content's context to Sentry and adds attack surface for no benefit. `streamwall-control-client` (a standalone web app, not an Electron renderer) and `streamwall-control-server` (a plain Node process) are also out of scope for this Electron-focused issue.
- Sandboxed preload scripts have no other channel to main-process config, so main passes the flag down via `app.commandLine.appendSwitch` (a pattern already used in this file for other flags), which every Chromium subprocess receives. Each trusted preload imports `@sentry/electron/preload` (wires up the sandboxed IPC transport) and exposes the flag via `contextBridge`; the renderer entry point conditionally calls `@sentry/electron/renderer`'s `init()`.

### New files
- `src/sentryConfig.ts` — shared DSN constant + the pure switch-name/argv-parsing helpers (unit tested).
- `src/renderer/initSentry.ts` — `initRendererSentry()`, called once from each trusted renderer entry point (unit tested with a mocked SDK).
- `src/preload/sentryPreload.ts` — preload-side glue (thin wiring, consistent with the other untested preload files).

## Testing

- `sentryConfig.test.ts`: switch-value formatting and argv detection, including absent/false/empty-argv cases.
- `initSentry.test.ts` (happy-dom): initializes only when the preload-exposed flag is `true`; does not initialize when `false` or missing.
- Full quality gate green locally: `format:check`, `lint`, `typecheck`, and `test` across every workspace (npm test: 213 + 90 + 67 passing).
- Not further unit-tested: the one-line wiring in `main/index.ts`, the two preload files, and the three renderer entry points — these are thin call sites into the tested modules above, matching how the existing (untested) preload/renderer entry files in this codebase are structured.

## Risk / breaking changes

None for operators who already have `telemetry.sentry = false` — no new events are sent. For the default (`true`), this is strictly additive reporting coverage; no new config surface, no renderer content is read by Sentry (only its own SDK's error/breadcrumb data).

Closes #87