### PR TITLE
feat(streamwall): improve the first-run experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Configuration precedence is:
 
 See `example.config.toml` for an example.
 
+On first launch, if no user data `config.toml` exists yet, the control
+window shows a dismissible hint with the exact path above. Use **File →
+Open Config Folder** in the app menu at any time to open that directory.
+
 ### Telemetry
 
 Streamwall reports uncaught errors to a Sentry project run by the maintainers

--- a/packages/streamwall/src/main/ControlWindow.test.ts
+++ b/packages/streamwall/src/main/ControlWindow.test.ts
@@ -16,18 +16,32 @@ class FakeBrowserWindow extends EventEmitter {
   }
 }
 
+type IpcHandler = (event: { sender: unknown }, ...args: unknown[]) => unknown
+
+const ipcHandlers = new Map<string, IpcHandler>()
+const handle = vi.fn((channel: string, handler: IpcHandler) => {
+  ipcHandlers.set(channel, handler)
+})
+const openPath = vi.fn()
+
 vi.mock('electron', () => ({
   BrowserWindow: FakeBrowserWindow,
-  ipcMain: { handle: vi.fn() },
+  ipcMain: { handle },
+  shell: { openPath },
 }))
 
 vi.mock('./loadHTML', () => ({ loadHTML: vi.fn() }))
 
 const { default: ControlWindow } = await import('./ControlWindow')
 
+const configInfo = {
+  configPath: '/home/test/.config/Streamwall/config.toml',
+  hasUserConfig: false,
+}
+
 describe('ControlWindow close', () => {
   it('forwards the underlying Electron close event so callers can preventDefault', () => {
-    const controlWindow = new ControlWindow()
+    const controlWindow = new ControlWindow(configInfo)
     const closeListener = vi.fn()
     controlWindow.on('close', closeListener)
 
@@ -38,10 +52,65 @@ describe('ControlWindow close', () => {
   })
 
   it('keeps the native close control enabled so the quit/hide behavior wired through the close event is reachable from the window chrome', () => {
-    const controlWindow = new ControlWindow()
+    const controlWindow = new ControlWindow(configInfo)
 
     expect(
       (controlWindow.win as unknown as FakeBrowserWindow).options.closable,
     ).not.toBe(false)
+  })
+
+  it('does not strip the window menu, so the app-level "Open Config Folder" menu item stays reachable on Windows/Linux', () => {
+    const controlWindow = new ControlWindow(configInfo)
+
+    expect(
+      (controlWindow.win as unknown as FakeBrowserWindow).removeMenu,
+    ).not.toHaveBeenCalled()
+  })
+})
+
+describe('ControlWindow first-run info', () => {
+  it('returns the config path/existence to the renderer that owns the window', () => {
+    const controlWindow = new ControlWindow(configInfo)
+    const sender = (controlWindow.win as unknown as FakeBrowserWindow)
+      .webContents
+
+    const result = ipcHandlers.get('control:first-run-info')!({ sender })
+
+    expect(result).toEqual(configInfo)
+  })
+
+  it('ignores requests from a sender other than its own window', () => {
+    const controlWindow = new ControlWindow(configInfo)
+    void controlWindow
+
+    const result = ipcHandlers.get('control:first-run-info')!({
+      sender: { send: vi.fn() },
+    })
+
+    expect(result).toBeUndefined()
+  })
+})
+
+describe('ControlWindow open-config-folder', () => {
+  it('opens the directory containing the config file', () => {
+    const controlWindow = new ControlWindow(configInfo)
+    const sender = (controlWindow.win as unknown as FakeBrowserWindow)
+      .webContents
+
+    ipcHandlers.get('control:open-config-folder')!({ sender })
+
+    expect(openPath).toHaveBeenCalledWith('/home/test/.config/Streamwall')
+  })
+
+  it('ignores requests from a sender other than its own window', () => {
+    const controlWindow = new ControlWindow(configInfo)
+    void controlWindow
+    openPath.mockClear()
+
+    ipcHandlers.get('control:open-config-folder')!({
+      sender: { send: vi.fn() },
+    })
+
+    expect(openPath).not.toHaveBeenCalled()
   })
 })

--- a/packages/streamwall/src/main/ControlWindow.ts
+++ b/packages/streamwall/src/main/ControlWindow.ts
@@ -1,5 +1,6 @@
-import { BrowserWindow, Event as ElectronEvent, ipcMain } from 'electron'
+import { BrowserWindow, Event as ElectronEvent, ipcMain, shell } from 'electron'
 import EventEmitter from 'events'
+import { dirname } from 'node:path'
 import path from 'path'
 import { ControlCommand, StreamwallState } from 'streamwall-shared'
 import { loadHTML } from './loadHTML'
@@ -11,10 +12,16 @@ export interface ControlWindowEventMap {
   ydoc: [Uint8Array]
 }
 
+/** Where the user data `config.toml` would live, and whether it exists yet. */
+export interface ConfigInfo {
+  configPath: string
+  hasUserConfig: boolean
+}
+
 export default class ControlWindow extends EventEmitter<ControlWindowEventMap> {
   win: BrowserWindow
 
-  constructor() {
+  constructor(configInfo: ConfigInfo) {
     super()
 
     this.win = new BrowserWindow({
@@ -25,7 +32,9 @@ export default class ControlWindow extends EventEmitter<ControlWindowEventMap> {
         preload: path.join(__dirname, 'controlPreload.js'),
       },
     })
-    this.win.removeMenu()
+    // Deliberately keeps the window menu (unlike StreamWindow, which stays
+    // menu-free for clean capture): on Windows/Linux this is what surfaces
+    // the app-level "Open Config Folder" item (#86).
 
     this.win.on('close', (event) => this.emit('close', event))
 
@@ -54,6 +63,20 @@ export default class ControlWindow extends EventEmitter<ControlWindowEventMap> {
         return
       }
       this.emit('ydoc', update)
+    })
+
+    ipcMain.handle('control:first-run-info', (ev) => {
+      if (ev.sender !== this.win.webContents) {
+        return
+      }
+      return configInfo
+    })
+
+    ipcMain.handle('control:open-config-folder', (ev) => {
+      if (ev.sender !== this.win.webContents) {
+        return
+      }
+      shell.openPath(dirname(configInfo.configPath))
     })
   }
 

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -41,6 +41,7 @@ import {
   applyLayoutPreset,
   buildLayoutPreset,
 } from './layoutPresets'
+import { installApplicationMenu } from './menu'
 import { denyWindowOpen } from './navigationSecurity'
 import { BROWSE_PARTITION, hardenSession } from './partitions'
 import { PlaylistScheduler } from './playlist'
@@ -375,6 +376,14 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     join(app.getPath('userData'), 'streamwall-storage.json'),
   )
 
+  // Recomputes the same path parseArgs() already read from - fs.existsSync
+  // here (rather than threading a flag through the yargs config) keeps this
+  // check local to where it's needed, for the "Open Config Folder" menu item
+  // and the control UI's first-run hint (#86).
+  const userConfigPath = join(app.getPath('userData'), 'config.toml')
+  const hasUserConfig = fs.existsSync(userConfigPath)
+  installApplicationMenu(userConfigPath)
+
   console.debug('Creating StreamWindow...')
   const idGen = new StreamIDGenerator()
 
@@ -408,7 +417,10 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     stalledTimeout: argv.retry['stalled-timeout'] * 1000,
   }
   const streamWindow = new StreamWindow(streamWindowConfig, retryConfig)
-  const controlWindow = new ControlWindow()
+  const controlWindow = new ControlWindow({
+    configPath: userConfigPath,
+    hasUserConfig,
+  })
 
   let browseWindow: BrowserWindow | null = null
   let streamdelayClient: StreamdelayClient | null = null

--- a/packages/streamwall/src/main/menu.test.ts
+++ b/packages/streamwall/src/main/menu.test.ts
@@ -1,0 +1,98 @@
+import type { MenuItemConstructorOptions } from 'electron'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const setApplicationMenu = vi.fn()
+const buildFromTemplate = vi.fn((template: MenuItemConstructorOptions[]) => ({
+  __template: template,
+}))
+const openPath = vi.fn()
+
+vi.mock('electron', () => ({
+  Menu: { setApplicationMenu, buildFromTemplate },
+  shell: { openPath },
+  app: { name: 'Streamwall' },
+}))
+
+const { buildApplicationMenuTemplate, installApplicationMenu } =
+  await import('./menu')
+
+function searchForOpenConfigFolderItem(
+  template: MenuItemConstructorOptions[],
+): MenuItemConstructorOptions | undefined {
+  for (const item of template) {
+    if (item.label === 'Open Config Folder') {
+      return item
+    }
+    if (Array.isArray(item.submenu)) {
+      const found = searchForOpenConfigFolderItem(
+        item.submenu as MenuItemConstructorOptions[],
+      )
+      if (found) {
+        return found
+      }
+    }
+  }
+  return undefined
+}
+
+function findOpenConfigFolderItem(
+  template: MenuItemConstructorOptions[],
+): MenuItemConstructorOptions {
+  const found = searchForOpenConfigFolderItem(template)
+  if (!found) {
+    throw new Error('"Open Config Folder" menu item not found in template')
+  }
+  return found
+}
+
+describe('buildApplicationMenuTemplate', () => {
+  afterEach(() => {
+    openPath.mockClear()
+  })
+
+  it('includes an "Open Config Folder" item that opens the directory containing the config path', () => {
+    const template = buildApplicationMenuTemplate(
+      '/Users/test/Library/Application Support/Streamwall/config.toml',
+    )
+
+    const item = findOpenConfigFolderItem(template)
+    expect(typeof item.click).toBe('function')
+
+    ;(item.click as () => void)()
+
+    expect(openPath).toHaveBeenCalledWith(
+      '/Users/test/Library/Application Support/Streamwall',
+    )
+  })
+
+  it('works when the config file does not exist yet (first run)', () => {
+    const template = buildApplicationMenuTemplate(
+      '/home/test/.config/Streamwall/config.toml',
+    )
+
+    const item = findOpenConfigFolderItem(template)
+    ;(item.click as () => void)()
+
+    // openPath targets the userData directory itself, which Electron always
+    // creates - unlike shell.showItemInFolder, it doesn't require config.toml
+    // to already exist.
+    expect(openPath).toHaveBeenCalledWith('/home/test/.config/Streamwall')
+  })
+})
+
+describe('installApplicationMenu', () => {
+  afterEach(() => {
+    setApplicationMenu.mockClear()
+    buildFromTemplate.mockClear()
+  })
+
+  it('builds a menu from the template and installs it as the application menu', () => {
+    installApplicationMenu('/home/test/.config/Streamwall/config.toml')
+
+    expect(buildFromTemplate).toHaveBeenCalledTimes(1)
+    expect(setApplicationMenu).toHaveBeenCalledTimes(1)
+    expect(setApplicationMenu).toHaveBeenCalledWith(
+      buildFromTemplate.mock.results[0]?.value,
+    )
+  })
+})

--- a/packages/streamwall/src/main/menu.ts
+++ b/packages/streamwall/src/main/menu.ts
@@ -1,0 +1,49 @@
+import { Menu, MenuItemConstructorOptions, app, shell } from 'electron'
+import { dirname } from 'node:path'
+
+/**
+ * Builds the application menu template. Its main purpose is the "Open Config
+ * Folder" item: the userData config path is otherwise only ever printed via
+ * `console.debug`, which is invisible to anyone running the packaged app
+ * outside a terminal (#86).
+ */
+export function buildApplicationMenuTemplate(
+  configPath: string,
+): MenuItemConstructorOptions[] {
+  const openConfigFolder = () => {
+    // Targets the userData directory itself (not the config file), since
+    // Electron always creates that directory - unlike
+    // shell.showItemInFolder, this works even before config.toml exists.
+    shell.openPath(dirname(configPath))
+  }
+
+  const template: MenuItemConstructorOptions[] = []
+
+  if (process.platform === 'darwin') {
+    template.push({
+      label: app.name,
+      submenu: [{ role: 'about' }, { type: 'separator' }, { role: 'quit' }],
+    })
+  }
+
+  template.push({
+    label: 'File',
+    submenu: [
+      { label: 'Open Config Folder', click: openConfigFolder },
+      ...(process.platform === 'darwin'
+        ? []
+        : ([
+            { type: 'separator' },
+            { role: 'quit' },
+          ] as MenuItemConstructorOptions[])),
+    ],
+  })
+
+  return template
+}
+
+export function installApplicationMenu(configPath: string): void {
+  Menu.setApplicationMenu(
+    Menu.buildFromTemplate(buildApplicationMenuTemplate(configPath)),
+  )
+}

--- a/packages/streamwall/src/preload/controlPreload.ts
+++ b/packages/streamwall/src/preload/controlPreload.ts
@@ -1,12 +1,20 @@
 import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron'
 import { StreamwallState } from 'streamwall-shared'
 
+export interface FirstRunInfo {
+  configPath: string
+  hasUserConfig: boolean
+}
+
 const api = {
   load: () => ipcRenderer.invoke('control:load'),
   openDevTools: () => ipcRenderer.invoke('control:devtools'),
   invokeCommand: (msg: object) => ipcRenderer.invoke('control:command', msg),
   updateYDoc: (update: Uint8Array) =>
     ipcRenderer.invoke('control:ydoc', update),
+  getFirstRunInfo: (): Promise<FirstRunInfo> =>
+    ipcRenderer.invoke('control:first-run-info'),
+  openConfigFolder: () => ipcRenderer.invoke('control:open-config-folder'),
   onState: (handleState: (state: StreamwallState) => void) => {
     const internalHandler = (_ev: IpcRendererEvent, state: StreamwallState) =>
       handleState(state)

--- a/packages/streamwall/src/renderer/FirstRunHint.test.tsx
+++ b/packages/streamwall/src/renderer/FirstRunHint.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment happy-dom
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { FirstRunHint } from './FirstRunHint'
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+function renderHint(props: Partial<Parameters<typeof FirstRunHint>[0]> = {}) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  const onOpenConfigFolder = vi.fn()
+  const onDismiss = vi.fn()
+  act(() => {
+    render(
+      <FirstRunHint
+        configPath="/home/test/.config/Streamwall/config.toml"
+        onOpenConfigFolder={onOpenConfigFolder}
+        onDismiss={onDismiss}
+        {...props}
+      />,
+      container!,
+    )
+  })
+  return { onOpenConfigFolder, onDismiss }
+}
+
+describe('FirstRunHint', () => {
+  test('shows the userData config path so a first-time user knows where to add streams', () => {
+    renderHint({
+      configPath: '/home/test/.config/Streamwall/config.toml',
+    })
+
+    expect(container!.textContent).toContain(
+      '/home/test/.config/Streamwall/config.toml',
+    )
+  })
+
+  test('opens the config folder when its action button is clicked', () => {
+    const { onOpenConfigFolder } = renderHint()
+
+    const button = container!.querySelector(
+      'button[data-testid="open-config-folder"]',
+    ) as HTMLButtonElement
+    act(() => button.click())
+
+    expect(onOpenConfigFolder).toHaveBeenCalledTimes(1)
+  })
+
+  test('dismisses the hint when its close button is clicked', () => {
+    const { onDismiss } = renderHint()
+
+    const button = container!.querySelector(
+      'button[data-testid="dismiss-first-run-hint"]',
+    ) as HTMLButtonElement
+    act(() => button.click())
+
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/streamwall/src/renderer/FirstRunHint.tsx
+++ b/packages/streamwall/src/renderer/FirstRunHint.tsx
@@ -1,0 +1,91 @@
+import { styled } from 'styled-components'
+
+const Banner = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 13px;
+`
+
+const Message = styled.div`
+  flex: 1;
+  min-width: 0;
+`
+
+const ConfigPath = styled.code`
+  font-family: var(--font-mono);
+  background: var(--surface-3);
+  border-radius: var(--r-sm);
+  padding: 1px 5px;
+  word-break: break-all;
+`
+
+const ActionButton = styled.button`
+  flex-shrink: 0;
+  background: var(--accent-2);
+  color: var(--surface);
+  border: none;
+  border-radius: var(--r-sm);
+  padding: 6px 10px;
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+`
+
+const DismissButton = styled.button`
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px;
+`
+
+export interface FirstRunHintProps {
+  configPath: string
+  onOpenConfigFolder: () => void
+  onDismiss: () => void
+}
+
+/**
+ * Shown when the app started with no userData config.toml (#86): the wall
+ * and control window are otherwise silently empty, with the config path
+ * previously surfaced only via `console.debug`.
+ */
+export function FirstRunHint({
+  configPath,
+  onOpenConfigFolder,
+  onDismiss,
+}: FirstRunHintProps) {
+  return (
+    <Banner>
+      <Message>
+        No <ConfigPath>config.toml</ConfigPath> found yet, so the wall has no
+        streams configured. Add one at <ConfigPath>{configPath}</ConfigPath>, or
+        pass <ConfigPath>--config</ConfigPath> / data source flags on the
+        command line.
+      </Message>
+      <ActionButton
+        data-testid="open-config-folder"
+        onClick={onOpenConfigFolder}
+      >
+        Open Config Folder
+      </ActionButton>
+      <DismissButton
+        data-testid="dismiss-first-run-hint"
+        aria-label="Dismiss"
+        onClick={onDismiss}
+      >
+        ×
+      </DismissButton>
+    </Banner>
+  )
+}

--- a/packages/streamwall/src/renderer/control.tsx
+++ b/packages/streamwall/src/renderer/control.tsx
@@ -11,7 +11,13 @@ import {
 } from 'streamwall-control-ui'
 import { ControlCommand, StreamwallState } from 'streamwall-shared'
 import * as Y from 'yjs'
-import { StreamwallControlGlobal } from '../preload/controlPreload'
+import {
+  FirstRunInfo,
+  StreamwallControlGlobal,
+} from '../preload/controlPreload'
+import { FirstRunHint } from './FirstRunHint'
+
+const DISMISSED_STORAGE_KEY = 'streamwall:first-run-hint-dismissed'
 
 declare global {
   interface Window {
@@ -79,8 +85,39 @@ function useStreamwallIPCConnection(): StreamwallConnection {
   }
 }
 
+/**
+ * Surfaces the first-run hint until the user either has a userData
+ * config.toml or explicitly dismisses it (persisted across restarts, since
+ * a config-less setup - e.g. one driven entirely by CLI flags - is valid and
+ * shouldn't nag every launch).
+ */
+function useFirstRunHint() {
+  const [firstRunInfo, setFirstRunInfo] = useState<FirstRunInfo>()
+  const [dismissed, setDismissed] = useState(
+    () => localStorage.getItem(DISMISSED_STORAGE_KEY) === 'true',
+  )
+
+  useEffect(() => {
+    window.streamwallControl.getFirstRunInfo().then(setFirstRunInfo)
+  }, [])
+
+  const dismiss = useCallback(() => {
+    localStorage.setItem(DISMISSED_STORAGE_KEY, 'true')
+    setDismissed(true)
+  }, [])
+
+  return {
+    isVisible: Boolean(
+      firstRunInfo && !firstRunInfo.hasUserConfig && !dismissed,
+    ),
+    configPath: firstRunInfo?.configPath,
+    dismiss,
+  }
+}
+
 function App() {
   const connection = useStreamwallIPCConnection()
+  const firstRunHint = useFirstRunHint()
 
   useHotkeys('ctrl+shift+i', () => {
     window.streamwallControl.openDevTools()
@@ -89,6 +126,13 @@ function App() {
   return (
     <>
       <GlobalStyle />
+      {firstRunHint.isVisible && (
+        <FirstRunHint
+          configPath={firstRunHint.configPath!}
+          onOpenConfigFolder={() => window.streamwallControl.openConfigFolder()}
+          onDismiss={firstRunHint.dismiss}
+        />
+      )}
       <ControlUI connection={connection} />
     </>
   )


### PR DESCRIPTION
## Problem

On first launch, both the wall and the control window are empty with no
explanation. The userData `config.toml` path is only ever printed via
`console.debug`, which is invisible when the packaged app is launched
outside a terminal (e.g. double-clicked from Finder/Explorer). There was
also no way to jump to that folder short of typing the OS-specific path
by hand.

## Solution

- **Application menu** (`src/main/menu.ts`): adds a minimal `Menu` with a
  `File > Open Config Folder` item that opens the userData directory via
  `shell.openPath` (works even before `config.toml` exists, unlike
  `shell.showItemInFolder`).
- **ControlWindow** now receives the resolved config path and whether
  `config.toml` exists yet, and exposes both over IPC
  (`control:first-run-info`, `control:open-config-folder`). It also no
  longer calls `win.removeMenu()`, so the new menu item is reachable on
  Windows/Linux, not just macOS's global menu bar. `StreamWindow` is
  untouched and stays menu-free for clean capture.
- **Control UI**: a new `FirstRunHint` banner renders above `ControlUI`
  when no user config exists, naming the exact path and offering an
  "Open Config Folder" button. Dismissal is persisted in `localStorage`,
  since a config-less setup driven entirely by CLI flags/`--config` is a
  valid, permanent choice and shouldn't nag every launch.
- **README**: a short note under Configuration pointing at the new hint
  and menu item.

## Architecture decisions

- The first-run hint and "Open Config Folder" only make sense for the
  local desktop app (filesystem access to userData), not the remote
  web-based control client. Everything here is scoped to the `streamwall`
  package's local IPC bridge (`control.tsx` / `controlPreload.ts`) rather
  than the shared `StreamwallState` network protocol used by
  `streamwall-control-ui` / `streamwall-control-server` - no changes to
  the remote control surface.
- The per-OS config path table in the README already existed (#70), so
  this is scoped to the runtime hint + menu item that #86 was actually
  missing.

## Testing

- TDD throughout: `menu.test.ts`, `ControlWindow.test.ts` (extended),
  `FirstRunHint.test.tsx` all written before their implementations.
- `controlPreload.ts`'s two new methods are untested by design, matching
  the existing untested methods there (thin IPC passthroughs).
- Full quality gate green: `format:check`, `lint`, `typecheck` (all
  workspaces), `test` (all workspaces, 380 tests), and `electron-forge
  package` (production Vite build of main/preload/renderer) succeed.
- Not verified: a live GUI run of the packaged app. This environment has
  no display; build success + full unit coverage of the IPC handlers,
  menu template, and hint component's rendering/interactions is the
  available signal.

## Risks / breaking changes

None expected. `ControlWindow`'s constructor now requires a
`configInfo` argument, but it has a single call site (`main()` in
`index.ts`), updated in the same change.

Closes #86

## Follow-up issues

- #246 — DX: offer a "Create Example Config" action on first run (split out of #86's problem statement; not part of its "Desired" scope)
