### PR TITLE
fix(streamwall): stop stale Streamdelay status from overriding isConnected

### DIFF
--- a/packages/streamwall/src/main/StreamdelayClient.test.ts
+++ b/packages/streamwall/src/main/StreamdelayClient.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest'
+import WebSocket from 'ws'
+import StreamdelayClient from './StreamdelayClient'
+
+describe('StreamdelayClient emitState', () => {
+  it('reports disconnected even when the cached status still says connected', () => {
+    const client = new StreamdelayClient({ endpoint: 'http://x', key: 'k' })
+    // Simulate a status message received while connected, which itself
+    // carries a stale `isConnected: true` (the server echoes it back).
+    client.status = {
+      isConnected: true,
+      delaySeconds: 0,
+      restartSeconds: 0,
+      isCensored: false,
+      isStreamRunning: false,
+      startTime: 0,
+      state: 'running',
+    }
+    // The socket has since closed.
+    client.ws = { readyState: WebSocket.CLOSED } as unknown as typeof client.ws
+
+    const listener = vi.fn()
+    client.on('state', listener)
+    client.emitState()
+
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({ isConnected: false }),
+    )
+  })
+
+  it('reports connected when the socket is open', () => {
+    const client = new StreamdelayClient({ endpoint: 'http://x', key: 'k' })
+    client.status = {
+      isConnected: false,
+      delaySeconds: 0,
+      restartSeconds: 0,
+      isCensored: false,
+      isStreamRunning: false,
+      startTime: 0,
+      state: 'running',
+    }
+    client.ws = { readyState: WebSocket.OPEN } as unknown as typeof client.ws
+
+    const listener = vi.fn()
+    client.on('state', listener)
+    client.emitState()
+
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({ isConnected: true }),
+    )
+  })
+})

--- a/packages/streamwall/src/main/StreamdelayClient.ts
+++ b/packages/streamwall/src/main/StreamdelayClient.ts
@@ -57,8 +57,8 @@ export default class StreamdelayClient extends EventEmitter {
       return
     }
     this.emit('state', {
-      isConnected,
       ...this.status,
+      isConnected,
     })
   }
 


### PR DESCRIPTION
## Problem

`StreamdelayClient.emitState()` computed `isConnected` from the WebSocket's live `readyState`, but then spread `this.status` *after* it:

```ts
this.emit('state', {
  isConnected,
  ...this.status,
})
```

`StreamDelayStatus` (the shape of `this.status`) itself contains an `isConnected` field, echoed back by the Streamdelay server in each status broadcast. Because the spread came last, a cached `isConnected: true` from the most recent status message silently overrode the freshly computed value whenever the socket closed — so the UI kept showing Streamdelay as connected while the connection was actually down.

## Fix

Spread `this.status` first, then apply the computed flag, so the live socket state always wins:

```ts
this.emit('state', {
  ...this.status,
  isConnected,
})
```

## Testing

- New unit test (`StreamdelayClient.test.ts`) exercises `emitState()` directly: one case reproduces the bug (cached `isConnected: true` status + a closed socket must still report `isConnected: false`), the other covers the happy path (open socket reports `isConnected: true`). Both fail against the pre-fix code and pass after.
- Full quality gate green: `prettier --check .`, `eslint .`, `typecheck` (all workspaces), `test` (all workspaces — streamwall 240/240 incl. the 2 new tests, control-server 90/90, control-ui 77/77), and the `streamwall-control-client` build.

## Risks / breaking changes

None expected — this only changes the precedence of two object spreads in an internal event payload; no public API or message schema changes.

Closes #27
