### PR TITLE
fix(streamwall): spoof document visibility from mediaPreload, not post-navigation

### DIFF
--- a/packages/streamwall/src/main/viewStateMachine.test.ts
+++ b/packages/streamwall/src/main/viewStateMachine.test.ts
@@ -490,3 +490,65 @@ describe('viewStateMachine content swap while running', () => {
     expect(actor.getSnapshot().context.retryCount).toBe(0)
   })
 })
+
+describe('viewStateMachine loadPage navigation', () => {
+  // Unlike the other describe blocks, this exercises the real `loadPage`
+  // actor instead of overriding it, so it can assert on what the navigate
+  // step actually does to the webContents.
+  function makeActorWithRealLoadPage(retry: RetryConfig) {
+    const executeJavaScript = vi.fn()
+    const loadURL = vi.fn().mockResolvedValue(undefined)
+    const resolveHost = vi
+      .fn()
+      .mockResolvedValue({ endpoints: [{ address: '93.184.216.34' }] })
+
+    const view = {
+      webContents: {
+        session: { resolveHost },
+        executeJavaScript,
+        loadURL,
+        audioMuted: false,
+      },
+    }
+
+    const machine = viewStateMachine.provide({
+      actions: {
+        offscreenView: noop,
+        positionView: noop,
+        muteAudio: noop,
+        unmuteAudio: noop,
+        openDevTools: noop,
+        sendViewOptions: noop,
+        sendViewVolume: noop,
+        logError: noop,
+      },
+    })
+    const actor = createActor(machine, {
+      input: {
+        id: 1,
+        view: view as never,
+        win: {} as never,
+        offscreenWin: {} as never,
+        retry,
+      },
+    })
+    return { actor, view, executeJavaScript, loadURL }
+  }
+
+  it('navigates via loadURL without running any script against the pre-navigation document', async () => {
+    const { actor, view, executeJavaScript, loadURL } =
+      makeActorWithRealLoadPage(makeRetry())
+    actor.start()
+    display(actor)
+
+    await vi.waitFor(() => expect(loadURL).toHaveBeenCalled())
+
+    expect(loadURL).toHaveBeenCalledWith(CONTENT.url)
+    expect(view.webContents.audioMuted).toBe(true)
+    // The visibility spoof used to run here via executeJavaScript against
+    // the pre-navigation document, which loadURL immediately discards
+    // (see #25). It now lives in mediaPreload.ts instead, so navigate
+    // should not touch executeJavaScript at all.
+    expect(executeJavaScript).not.toHaveBeenCalled()
+  })
+})

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -252,17 +252,6 @@ const viewStateMachine = setup({
         const wc = view.webContents
         await ensureValidURL(content.url, createSessionHostResolver(wc.session))
         wc.audioMuted = true
-        wc.executeJavaScript(`
-          Object.defineProperty(document, 'visibilityState', {
-            value: 'visible',
-            writable: true
-          });
-          Object.defineProperty(document, 'hidden', {
-            value: false,
-            writable: true
-          });
-          document.dispatchEvent(new Event('visibilitychange'));
-        `)
 
         if (/\.m3u8?$/.test(content.url)) {
           loadHTML(wc, 'playHLS', { query: { src: content.url } })

--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const executeJavaScript = vi.fn()
+// Never resolves, so the assertions below can prove the visibility spoof
+// does not wait on the view-init round trip before running.
+const invoke = vi.fn(() => new Promise(() => {}))
+
+vi.mock('electron', () => ({
+  ipcRenderer: { invoke, send: vi.fn(), on: vi.fn() },
+  webFrame: { executeJavaScript, insertCSS: vi.fn() },
+}))
+
+describe('mediaPreload visibility spoofing', () => {
+  afterEach(() => {
+    vi.resetModules()
+    executeJavaScript.mockClear()
+    invoke.mockClear()
+  })
+
+  it('overrides document.visibilityState/hidden in the page world as soon as the preload script runs', async () => {
+    await import('./mediaPreload')
+
+    expect(executeJavaScript).toHaveBeenCalledTimes(1)
+    const [code] = executeJavaScript.mock.calls[0]
+    expect(code).toContain(`'visibilityState'`)
+    expect(code).toContain(`value: 'visible'`)
+    expect(code).toContain(`'hidden'`)
+    expect(code).toContain('value: false')
+
+    // main() is still awaiting the never-resolving view-init invoke, proving
+    // the spoof isn't gated on it -- it must apply before the page's own
+    // scripts run, not after this preload script finishes its own setup.
+    expect(invoke).toHaveBeenCalledWith('view-init')
+  })
+})

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -70,6 +70,30 @@ const NO_SCROLL_STYLE = `
 const sleep = (ms: number) =>
   new Promise<void>((resolve) => setTimeout(() => resolve(), ms))
 
+// Spoof `document.visibilityState`/`document.hidden` as visible so that
+// sites which pause playback when backgrounded (checking these properties)
+// keep playing inside the offscreen/background WebContentsView. This must
+// run via `webFrame.executeJavaScript`, not as a plain assignment against
+// this preload script's own `document` reference: with contextIsolation,
+// property overrides made in the preload's isolated world are invisible to
+// the page's own main-world scripts (see `lockdownMediaTags` below for the
+// same reasoning applied to muting). Preload scripts run before the page's
+// own scripts on every navigation, so this fires here -- unawaited, since it
+// only needs to land before the page's own scripts run and there is nothing
+// meaningful to do if it doesn't. Previously this ran from the main process
+// against the pre-navigation document, which `loadURL` immediately discards
+// (see #25).
+webFrame.executeJavaScript(`
+  Object.defineProperty(document, 'visibilityState', {
+    value: 'visible',
+    writable: true
+  });
+  Object.defineProperty(document, 'hidden', {
+    value: false,
+    writable: true
+  });
+`)
+
 const pageReady = new Promise((resolve) =>
   document.addEventListener('DOMContentLoaded', resolve, { once: true }),
 )


### PR DESCRIPTION
## Problem

`loadPage` in `viewStateMachine.ts` ran a `document.visibilityState`/`hidden` spoof via `wc.executeJavaScript(...)` right before calling `wc.loadURL(...)`. `loadURL` discards the current document and navigates to a new one, so the script executed against the soon-to-be-replaced document and had no effect on the actual stream page. Sites that pause video/audio playback based on page visibility were unaffected by this code path, defeating its purpose in an offscreen/background `WebContentsView`. The call was also fired without awaiting or catching, so it could reject with an unhandled rejection if the webContents was destroyed mid-navigation.

## Solution

Moved the visibility spoof into `mediaPreload.ts`, which Electron injects fresh into every new document before the page's own scripts run (per `webPreferences.preload` on the stream views in `StreamWindow.ts`). Because the view runs with `contextIsolation: true`, a plain property assignment from the preload script's own isolated-world `document` reference would not be visible to the page's own main-world scripts — the same reasoning `lockdownMediaTags` already relies on in this file for muting. The override therefore uses `webFrame.executeJavaScript(...)` to run in the page's main world, consistent with that existing pattern, and fires unawaited at module scope so it lands before the page's own scripts, without waiting on the `view-init` IPC round trip.

Removed the now-dead `executeJavaScript` call (and its `visibilitychange` dispatch, which had nothing listening at that point) from `loadPage`.

## Testing

- Added a test in `viewStateMachine.test.ts` that exercises the real `loadPage` actor (previously always mocked out in this suite) and asserts `executeJavaScript` is never called during navigation while `loadURL` still receives the correct URL.
- Added `mediaPreload.test.ts` asserting the visibility override is sent via `webFrame.executeJavaScript` with the correct property values, and that it fires before the `view-init` IPC call resolves (proving it isn't gated on that round trip).
- Full package test suite (240 tests), typecheck, lint, and Prettier all pass locally.

No breaking changes; behavior-only fix confined to `packages/streamwall`.

Closes #25