### PR TITLE
feat: add user-accessible logging and data-source health diagnostics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10058,6 +10058,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10079,6 +10080,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10100,6 +10102,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10121,6 +10124,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10142,6 +10146,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10163,6 +10168,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10184,6 +10190,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10205,6 +10212,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10226,6 +10234,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10247,6 +10256,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10268,6 +10278,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7545,6 +7545,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/electron-log": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.4.4.tgz",
+      "integrity": "sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/electron-squirrel-startup": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/electron-squirrel-startup/-/electron-squirrel-startup-1.0.1.tgz",
@@ -14863,6 +14872,7 @@
         "color": "^5.0.3",
         "dank-twitch-irc": "^4.3.0",
         "ejs": "^6.0.1",
+        "electron-log": "^5.4.4",
         "electron-squirrel-startup": "^1.0.1",
         "esbuild-register": "^3.6.0",
         "hls.js": "^1.6.16",

--- a/packages/streamwall-control-client/src/dev.tsx
+++ b/packages/streamwall-control-client/src/dev.tsx
@@ -165,6 +165,7 @@ const demoState: StreamwallState = {
   views: demoViews as unknown as StreamwallState['views'],
   streamdelay: null,
   layoutPresets: [],
+  dataSourceHealth: [],
 }
 
 function useMockConnection(): StreamwallConnection {

--- a/packages/streamwall-control-server/src/auth.test.ts
+++ b/packages/streamwall-control-server/src/auth.test.ts
@@ -315,6 +315,7 @@ function makeState(): StreamwallState {
     layoutPresets: [
       { id: 'p1', name: 'My Layout', cols: 2, rows: 2, views: {} },
     ],
+    dataSourceHealth: [],
   }
 }
 

--- a/packages/streamwall-control-server/src/auth.ts
+++ b/packages/streamwall-control-server/src/auth.ts
@@ -95,6 +95,7 @@ export class StateWrapper extends EventEmitter {
       views,
       streamdelay,
       layoutPresets,
+      dataSourceHealth,
     } = this._value
 
     const state: StreamwallState = {
@@ -107,6 +108,7 @@ export class StateWrapper extends EventEmitter {
       views,
       streamdelay,
       layoutPresets,
+      dataSourceHealth,
     }
     if (role === 'admin') {
       state.auth = auth

--- a/packages/streamwall-control-ui/src/DataSourceHealthBanner.test.tsx
+++ b/packages/streamwall-control-ui/src/DataSourceHealthBanner.test.tsx
@@ -1,0 +1,109 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { type DataSourceHealth } from 'streamwall-shared'
+import { afterEach, describe, expect, test } from 'vitest'
+import { DataSourceHealthBanner } from './DataSourceHealthBanner.tsx'
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+function renderBanner(dataSourceHealth: DataSourceHealth[]): HTMLDivElement {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    render(
+      <DataSourceHealthBanner dataSourceHealth={dataSourceHealth} />,
+      container!,
+    )
+  })
+  return container
+}
+
+describe('DataSourceHealthBanner', () => {
+  test('renders nothing when there is no data source health yet', () => {
+    const el = renderBanner([])
+    expect(el.querySelector('.data-source-health-warning')).toBeNull()
+  })
+
+  test('renders nothing when every data source is healthy', () => {
+    const el = renderBanner([
+      {
+        id: 'https://a.example/streams.json',
+        type: 'json-url',
+        status: 'ok',
+        message: null,
+        updatedAt: 1000,
+      },
+    ])
+    expect(el.querySelector('.data-source-health-warning')).toBeNull()
+  })
+
+  test('warns about a failing json-url source, naming the URL', () => {
+    const el = renderBanner([
+      {
+        id: 'https://dead.example/streams.json',
+        type: 'json-url',
+        status: 'error',
+        message: 'fetch failed',
+        updatedAt: 1000,
+      },
+    ])
+    const warning = el.querySelector('.data-source-health-warning')
+    expect(warning?.textContent).toContain('https://dead.example/streams.json')
+    expect(warning?.getAttribute('title')).toBe('fetch failed')
+  })
+
+  test('warns about a failing toml-file source, naming the path', () => {
+    const el = renderBanner([
+      {
+        id: '/etc/streamwall/streams.toml',
+        type: 'toml-file',
+        status: 'error',
+        message: 'ENOENT',
+        updatedAt: 1000,
+      },
+    ])
+    expect(
+      el.querySelector('.data-source-health-warning')?.textContent,
+    ).toContain('/etc/streamwall/streams.toml')
+  })
+
+  test('lists a warning per failing source and ignores healthy ones', () => {
+    const el = renderBanner([
+      {
+        id: 'https://a.example/streams.json',
+        type: 'json-url',
+        status: 'ok',
+        message: null,
+        updatedAt: 1000,
+      },
+      {
+        id: 'https://b.example/streams.json',
+        type: 'json-url',
+        status: 'error',
+        message: 'timeout',
+        updatedAt: 1000,
+      },
+      {
+        id: '/tmp/streams.toml',
+        type: 'toml-file',
+        status: 'error',
+        message: 'ENOENT',
+        updatedAt: 1000,
+      },
+    ])
+    const warnings = [
+      ...el.querySelectorAll('.data-source-health-warning'),
+    ].map((w) => w.textContent)
+    expect(warnings).toHaveLength(2)
+    expect(warnings.join(' ')).toContain('https://b.example/streams.json')
+    expect(warnings.join(' ')).toContain('/tmp/streams.toml')
+  })
+})

--- a/packages/streamwall-control-ui/src/DataSourceHealthBanner.tsx
+++ b/packages/streamwall-control-ui/src/DataSourceHealthBanner.tsx
@@ -1,0 +1,54 @@
+import { FaExclamationTriangle } from 'react-icons/fa'
+import { type DataSourceHealth } from 'streamwall-shared'
+import { styled } from 'styled-components'
+
+const StyledDataSourceHealthBanner = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+
+  .data-source-health-warning {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: #e0a800;
+  }
+`
+
+const LABEL_BY_TYPE: Record<DataSourceHealth['type'], string> = {
+  'json-url': 'Data source unreachable',
+  'toml-file': 'Data file unreadable',
+}
+
+/**
+ * Surfaces a dead `--data.json-url`/`--data.toml-file` in the control UI,
+ * naming the failing source, so it's diagnosable without reading the log
+ * (issue #85).
+ */
+export function DataSourceHealthBanner({
+  dataSourceHealth,
+}: {
+  dataSourceHealth: DataSourceHealth[]
+}) {
+  const failing = dataSourceHealth.filter((health) => health.status === 'error')
+  if (failing.length === 0) {
+    return null
+  }
+
+  return (
+    <StyledDataSourceHealthBanner>
+      {failing.map((health) => (
+        <span
+          className="data-source-health-warning"
+          key={health.id}
+          title={health.message ?? undefined}
+        >
+          <FaExclamationTriangle />
+          {LABEL_BY_TYPE[health.type]}: {health.id}
+        </span>
+      ))}
+    </StyledDataSourceHealthBanner>
+  )
+}

--- a/packages/streamwall-control-ui/src/hotkeysOptions.test.tsx
+++ b/packages/streamwall-control-ui/src/hotkeysOptions.test.tsx
@@ -69,6 +69,7 @@ function renderControlUI(): HTMLDivElement {
     delayState,
     authState: undefined,
     layoutPresets: [],
+    dataSourceHealth: [],
   }
 
   act(() => {

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -37,6 +37,7 @@ import {
   Color,
   type ContentKind,
   type ControlCommand,
+  type DataSourceHealth,
   GRID_MAX,
   GRID_MIN,
   gridWouldDropAssignments,
@@ -59,6 +60,7 @@ import {
 import { createGlobalStyle, styled } from 'styled-components'
 import { matchesState } from 'xstate'
 import * as Y from 'yjs'
+import { DataSourceHealthBanner } from './DataSourceHealthBanner.tsx'
 import {
   computeHoveringIdx,
   isPrimaryButton,
@@ -525,6 +527,7 @@ export interface StreamwallConnection {
   delayState: StreamDelayStatus | null | undefined
   authState?: StreamwallState['auth']
   layoutPresets: LayoutPreset[]
+  dataSourceHealth: DataSourceHealth[]
 }
 
 export function useStreamwallState(state: StreamwallState | undefined) {
@@ -540,6 +543,7 @@ export function useStreamwallState(state: StreamwallState | undefined) {
         delayState: undefined,
         authState: undefined,
         layoutPresets: [],
+        dataSourceHealth: [],
       }
     }
 
@@ -551,6 +555,7 @@ export function useStreamwallState(state: StreamwallState | undefined) {
       views: stateViews,
       streamdelay,
       layoutPresets,
+      dataSourceHealth,
     } = state
     const stateIdxMap = new Map()
     const views = []
@@ -599,6 +604,7 @@ export function useStreamwallState(state: StreamwallState | undefined) {
       customStreams,
       stateIdxMap,
       layoutPresets,
+      dataSourceHealth,
     }
   }, [state])
 }
@@ -623,6 +629,7 @@ export function ControlUI({
     authState,
     role,
     layoutPresets,
+    dataSourceHealth,
   } = connection
   const {
     cols,
@@ -1248,6 +1255,7 @@ export function ControlUI({
           )}
           <ThemeToggle />
         </StyledHeader>
+        <DataSourceHealthBanner dataSourceHealth={dataSourceHealth} />
         {delayState && (
           <StreamDelayBox
             role={role}

--- a/packages/streamwall-control-ui/src/responsiveLayout.test.tsx
+++ b/packages/streamwall-control-ui/src/responsiveLayout.test.tsx
@@ -68,6 +68,7 @@ function renderControlUI(): HTMLDivElement {
     delayState,
     authState: undefined,
     layoutPresets: [],
+    dataSourceHealth: [],
   }
 
   act(() => {

--- a/packages/streamwall-control-ui/src/transientProps.test.tsx
+++ b/packages/streamwall-control-ui/src/transientProps.test.tsx
@@ -86,6 +86,7 @@ function renderControlUI(): HTMLDivElement {
     delayState,
     authState: undefined,
     layoutPresets: [],
+    dataSourceHealth: [],
   }
 
   act(() => {

--- a/packages/streamwall-shared/src/stateDiff.test.ts
+++ b/packages/streamwall-shared/src/stateDiff.test.ts
@@ -49,6 +49,7 @@ function makeState(overrides: Partial<StreamwallState> = {}): StreamwallState {
     views: [makeView(0), makeView(1)],
     streamdelay: null,
     layoutPresets: [],
+    dataSourceHealth: [],
     ...overrides,
   }
 }

--- a/packages/streamwall-shared/src/types.ts
+++ b/packages/streamwall-shared/src/types.ts
@@ -97,6 +97,23 @@ export interface StreamDelayStatus {
   state: string
 }
 
+export type DataSourceType = 'json-url' | 'toml-file'
+
+/**
+ * Health of a single stream data source (a `--data.json-url` or
+ * `--data.toml-file`), so a dead source is diagnosable from the control UI
+ * instead of only from a log.
+ */
+export interface DataSourceHealth {
+  /** The URL or file path, which also identifies the source. */
+  id: string
+  type: DataSourceType
+  status: 'ok' | 'error'
+  /** Set when status is 'error'. */
+  message: string | null
+  updatedAt: number
+}
+
 export type AuthTokenKind = 'invite' | 'session' | 'streamwall'
 
 export interface AuthTokenInfo {
@@ -133,6 +150,7 @@ export interface StreamwallState {
   views: ViewState[]
   streamdelay: StreamDelayStatus | null
   layoutPresets: LayoutPreset[]
+  dataSourceHealth: DataSourceHealth[]
 }
 
 type MessageMeta = {

--- a/packages/streamwall/package.json
+++ b/packages/streamwall/package.json
@@ -52,6 +52,7 @@
     "color": "^5.0.3",
     "dank-twitch-irc": "^4.3.0",
     "ejs": "^6.0.1",
+    "electron-log": "^5.4.4",
     "electron-squirrel-startup": "^1.0.1",
     "esbuild-register": "^3.6.0",
     "hls.js": "^1.6.16",

--- a/packages/streamwall/src/main/StreamdelayClient.ts
+++ b/packages/streamwall/src/main/StreamdelayClient.ts
@@ -4,6 +4,7 @@ import ReconnectingWebSocket from 'reconnecting-websocket'
 import { StreamDelayStatus } from 'streamwall-shared'
 import * as url from 'url'
 import WebSocket from 'ws'
+import log from './logger'
 
 export interface StreamdelayClientOptions {
   endpoint: string
@@ -42,7 +43,7 @@ export default class StreamdelayClient extends EventEmitter {
       try {
         data = JSON.parse(ev.data)
       } catch (err) {
-        console.error('invalid JSON from streamdelay:', ev.data)
+        log.error('invalid JSON from streamdelay:', ev.data)
         return
       }
       this.status = data.status

--- a/packages/streamwall/src/main/TwitchBot.ts
+++ b/packages/streamwall/src/main/TwitchBot.ts
@@ -10,6 +10,7 @@ import EventEmitter from 'events'
 import { StreamList, StreamwallState } from 'streamwall-shared'
 import { matchesState } from 'xstate'
 import { StreamwallConfig } from '.'
+import log from './logger'
 
 const VOTE_RE = /^!(\d+)$/
 
@@ -63,15 +64,15 @@ export default class TwitchBot extends EventEmitter {
       this.onReady().catch((err) => this.handleAsyncError('onReady', err))
     })
     client.on('error', (err) => {
-      console.error('Twitch connection error:', err)
+      log.error('Twitch connection error:', err)
       if (err instanceof LoginError) {
         client.close()
       }
     })
     client.on('close', (err) => {
-      console.log('Twitch bot disconnected.')
+      log.info('Twitch bot disconnected.')
       if (err != null) {
-        console.error('Twitch bot disconnected due to error:', err)
+        log.error('Twitch bot disconnected due to error:', err)
       }
     })
     client.on('PRIVMSG', (msg) => {

--- a/packages/streamwall/src/main/data.test.ts
+++ b/packages/streamwall/src/main/data.test.ts
@@ -218,6 +218,36 @@ link = "https://b.example/s"
       await gen.return(undefined)
     }
   })
+
+  test('reports healthy status on a successful read', async () => {
+    const file = writeTomlFile(`
+[[streams]]
+link = "https://a.example/s"
+`)
+    const onHealth = vi.fn()
+    const gen = watchDataFile(file, onHealth)
+    try {
+      await gen.next()
+      expect(onHealth).toHaveBeenCalledWith(true)
+    } finally {
+      await gen.return(undefined)
+    }
+  })
+
+  test('reports unhealthy status with a message when the file cannot be read', async () => {
+    const missingFile = path.join(
+      mkdtempSync(path.join(tmpdir(), 'sw-data-')),
+      'does-not-exist.toml',
+    )
+    const onHealth = vi.fn()
+    const gen = watchDataFile(missingFile, onHealth)
+    try {
+      await gen.next()
+      expect(onHealth).toHaveBeenCalledWith(false, expect.any(String))
+    } finally {
+      await gen.return(undefined)
+    }
+  })
 })
 
 describe('pollDataURL', () => {
@@ -265,6 +295,30 @@ describe('pollDataURL', () => {
     try {
       const { value } = await gen.next()
       expect(value).toEqual([])
+    } finally {
+      await gen.return(undefined)
+    }
+  })
+
+  test('reports healthy status on a successful fetch', async () => {
+    const url = await serveJson([{ link: 'https://a.example/s' }])
+    const onHealth = vi.fn()
+    const gen = pollDataURL(url, 999, onHealth)
+    try {
+      await gen.next()
+      expect(onHealth).toHaveBeenCalledWith(true)
+    } finally {
+      await gen.return(undefined)
+    }
+  })
+
+  test('reports unhealthy status with a message when the fetch fails', async () => {
+    const onHealth = vi.fn()
+    // Nothing is listening on this port.
+    const gen = pollDataURL('http://127.0.0.1:1/', 999, onHealth)
+    try {
+      await gen.next()
+      expect(onHealth).toHaveBeenCalledWith(false, expect.any(String))
     } finally {
       await gen.return(undefined)
     }

--- a/packages/streamwall/src/main/data.ts
+++ b/packages/streamwall/src/main/data.ts
@@ -11,12 +11,22 @@ import {
   StreamDataContent,
   StreamList,
 } from '../../../streamwall-shared/src/types'
+import log from './logger'
 
 const sleep = promisify(setTimeout)
 
 type DataSource = AsyncIterableIterator<StreamDataContent[]>
 
-export async function* pollDataURL(url: string, intervalSecs: number) {
+// Reports whether the most recent read of a data source succeeded, so a
+// caller can surface a dead json-url/toml-file from the UI instead of it
+// only being diagnosable from a log.
+export type DataSourceHealthCallback = (ok: boolean, message?: string) => void
+
+export async function* pollDataURL(
+  url: string,
+  intervalSecs: number,
+  onHealth?: DataSourceHealthCallback,
+) {
   const refreshInterval = intervalSecs * 1000
   let lastData: StreamDataContent[] = []
   while (true) {
@@ -25,16 +35,18 @@ export async function* pollDataURL(url: string, intervalSecs: number) {
       const resp = await fetch(url)
       const { streams, errors } = parseStreamList(await resp.json())
       if (errors.length) {
-        console.warn(`ignoring ${errors.length} invalid stream(s) from ${url}`)
+        log.warn(`ignoring ${errors.length} invalid stream(s) from ${url}`)
       }
       data = streams as StreamDataContent[]
+      onHealth?.(true)
     } catch (err) {
-      console.warn('error loading stream data', err)
+      log.warn('error loading stream data', err)
+      onHealth?.(false, err instanceof Error ? err.message : String(err))
     }
 
     // If the endpoint errors or returns an empty dataset, keep the cached data.
     if (!data.length && lastData.length) {
-      console.warn('using cached stream data')
+      log.warn('using cached stream data')
     } else {
       yield data
       lastData = data
@@ -44,13 +56,16 @@ export async function* pollDataURL(url: string, intervalSecs: number) {
   }
 }
 
-export async function* watchDataFile(path: string): DataSource {
+export async function* watchDataFile(
+  path: string,
+  onHealth?: DataSourceHealthCallback,
+): DataSource {
   const watcher = watch(path)
   // chokidar emits 'error' for issues like a removed watch directory; an
   // unhandled 'error' event on an EventEmitter throws, so a permanent
   // listener is required to keep the watcher (and this generator) alive.
   watcher.on('error', (err) => {
-    console.warn('error watching data file', path, err)
+    log.warn('error watching data file', path, err)
   })
   try {
     let lastStreams: StreamDataContent[] = []
@@ -61,19 +76,21 @@ export async function* watchDataFile(path: string): DataSource {
         const data = TOML.parse(text.toString())
         const parsed = parseStreamList(data?.streams)
         if (parsed.errors.length) {
-          console.warn(
+          log.warn(
             `ignoring ${parsed.errors.length} invalid stream(s) in ${path}`,
           )
         }
         streams = parsed.streams as StreamDataContent[]
+        onHealth?.(true)
       } catch (err) {
-        console.warn('error reading data file', err)
+        log.warn('error reading data file', err)
+        onHealth?.(false, err instanceof Error ? err.message : String(err))
       }
 
       // If the read/parse fails and we already have data, keep serving it
       // instead of wiping out every stream (mirrors pollDataURL).
       if (!streams.length && lastStreams.length) {
-        console.warn('using cached stream data')
+        log.warn('using cached stream data')
       } else {
         yield streams
         lastStreams = streams
@@ -84,7 +101,7 @@ export async function* watchDataFile(path: string): DataSource {
         // replace of the watched file can surface as unlink+add instead.
         await once(watcher, 'all')
       } catch (err) {
-        console.warn('error watching data file', path, err)
+        log.warn('error watching data file', path, err)
       }
     }
   } finally {
@@ -190,7 +207,7 @@ export class StreamIDGenerator {
         let newId
         const idBase = source || label || link
         if (!idBase) {
-          console.warn('skipping empty stream', stream)
+          log.warn('skipping empty stream', stream)
           continue
         }
         const normalizedText = idBase

--- a/packages/streamwall/src/main/dataSourceHealth.test.ts
+++ b/packages/streamwall/src/main/dataSourceHealth.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'vitest'
+import { DataSourceHealthTracker } from './dataSourceHealth'
+
+describe('DataSourceHealthTracker', () => {
+  test('reports a healthy source', () => {
+    const tracker = new DataSourceHealthTracker(() => 1000)
+
+    const result = tracker.report(
+      'https://a.example/streams.json',
+      'json-url',
+      true,
+    )
+
+    expect(result).toEqual([
+      {
+        id: 'https://a.example/streams.json',
+        type: 'json-url',
+        status: 'ok',
+        message: null,
+        updatedAt: 1000,
+      },
+    ])
+  })
+
+  test('reports an unhealthy source with its message', () => {
+    const tracker = new DataSourceHealthTracker(() => 1000)
+
+    const result = tracker.report(
+      '/tmp/streams.toml',
+      'toml-file',
+      false,
+      'ENOENT: no such file',
+    )
+
+    expect(result).toEqual([
+      {
+        id: '/tmp/streams.toml',
+        type: 'toml-file',
+        status: 'error',
+        message: 'ENOENT: no such file',
+        updatedAt: 1000,
+      },
+    ])
+  })
+
+  test('drops the message when a source recovers', () => {
+    const tracker = new DataSourceHealthTracker(() => 1000)
+    tracker.report('url', 'json-url', false, 'boom')
+
+    const result = tracker.report('url', 'json-url', true)
+
+    expect(result).toEqual([
+      {
+        id: 'url',
+        type: 'json-url',
+        status: 'ok',
+        message: null,
+        updatedAt: 1000,
+      },
+    ])
+  })
+
+  test('tracks multiple sources independently, keyed by id', () => {
+    const tracker = new DataSourceHealthTracker(() => 1000)
+    tracker.report('url-a', 'json-url', true)
+
+    const result = tracker.report('url-b', 'toml-file', false, 'boom')
+
+    expect(result.map((h) => h.id)).toEqual(['url-a', 'url-b'])
+  })
+
+  test('updates an existing entry in place rather than duplicating it', () => {
+    const tracker = new DataSourceHealthTracker(() => 1000)
+    tracker.report('url', 'json-url', true)
+
+    const result = tracker.report('url', 'json-url', false, 'boom')
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ id: 'url', status: 'error' })
+  })
+})

--- a/packages/streamwall/src/main/dataSourceHealth.ts
+++ b/packages/streamwall/src/main/dataSourceHealth.ts
@@ -1,0 +1,28 @@
+import { DataSourceHealth, DataSourceType } from 'streamwall-shared'
+
+/**
+ * Aggregates the latest health of each configured stream data source, keyed
+ * by its id (the json-url or toml-file path), so a dead source is
+ * diagnosable from the control UI instead of only from a log.
+ */
+export class DataSourceHealthTracker {
+  private readonly byId = new Map<string, DataSourceHealth>()
+
+  constructor(private readonly now: () => number = Date.now) {}
+
+  report(
+    id: string,
+    type: DataSourceType,
+    ok: boolean,
+    message?: string,
+  ): DataSourceHealth[] {
+    this.byId.set(id, {
+      id,
+      type,
+      status: ok ? 'ok' : 'error',
+      message: ok ? null : (message ?? null),
+      updatedAt: this.now(),
+    })
+    return [...this.byId.values()]
+  }
+}

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -10,6 +10,7 @@ import ReconnectingWebSocket from 'reconnecting-websocket'
 import 'source-map-support/register'
 import {
   ControlCommand,
+  DataSourceType,
   StreamwallState,
   isCommandAllowedFromUplink,
   isSecureControlEndpoint,
@@ -40,12 +41,14 @@ import {
   pollDataURL,
   watchDataFile,
 } from './data'
+import { DataSourceHealthTracker } from './dataSourceHealth'
 import { applyGridResize } from './gridResize'
 import {
   addLayoutPreset,
   applyLayoutPreset,
   buildLayoutPreset,
 } from './layoutPresets'
+import log, { initLogger } from './logger'
 import { installApplicationMenu } from './menu'
 import { denyWindowOpen } from './navigationSecurity'
 import { BROWSE_PARTITION, hardenSession } from './partitions'
@@ -152,14 +155,14 @@ export interface StreamwallConfig {
 // defaults with no indication anything was wrong.
 function warnUnknownConfigKeys(raw: unknown, source: string) {
   for (const key of findUnknownConfigKeys(raw)) {
-    console.warn(`Unknown config key "${key}" in "${source}" is ignored.`)
+    log.warn(`Unknown config key "${key}" in "${source}" is ignored.`)
   }
 }
 
 function parseArgs(): StreamwallConfig {
   // Load config from user data dir, if it exists
   const configPath = join(app.getPath('userData'), 'config.toml')
-  console.debug('Reading config from ', configPath)
+  log.debug('Reading config from ', configPath)
 
   let configText: string | null = null
   try {
@@ -401,7 +404,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   const hasUserConfig = fs.existsSync(userConfigPath)
   installApplicationMenu(userConfigPath)
 
-  console.debug('Creating StreamWindow...')
+  log.debug('Creating StreamWindow...')
   const idGen = new StreamIDGenerator()
 
   const localStreamData = new LocalStreamData(db.data.localStreamData)
@@ -444,7 +447,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   let browseWindow: BrowserWindow | null = null
   let streamdelayClient: StreamdelayClient | null = null
 
-  console.debug('Creating initial state...')
+  log.debug('Creating initial state...')
   let clientState: StreamwallState = {
     identity: {
       role: 'local',
@@ -455,6 +458,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     views: [],
     streamdelay: null,
     layoutPresets: db.data.layoutPresets,
+    dataSourceHealth: [],
   }
 
   function updateViewsFromStateDoc() {
@@ -473,7 +477,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
       }
       streamWindow.setViews(viewContentMap, clientState.streams)
     } catch (err) {
-      console.error('Error updating views', err)
+      log.error('Error updating views', err)
     }
   }
 
@@ -481,11 +485,11 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   const viewsState = stateDoc.getMap<Y.Map<string | undefined>>('views')
 
   if (db.data.stateDoc) {
-    console.log('Loading stateDoc from storage...')
+    log.info('Loading stateDoc from storage...')
     try {
       Y.applyUpdate(stateDoc, Buffer.from(db.data.stateDoc, 'base64'))
     } catch (err) {
-      console.warn('Failed to restore stateDoc', err)
+      log.warn('Failed to restore stateDoc', err)
     }
   }
 
@@ -526,7 +530,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     msg: ControlCommand,
     source: 'local' | 'uplink' = 'local',
   ) => {
-    console.debug('Received message:', msg)
+    log.debug('Received message:', msg)
 
     // The remote control-server uplink is untrusted: re-validate every command
     // against the uplink allowlist so a compromised or man-in-the-middled
@@ -534,40 +538,40 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     if (source === 'uplink') {
       const type = (msg as { type?: unknown } | null)?.type
       if (typeof type !== 'string' || !isCommandAllowedFromUplink(type)) {
-        console.warn('Rejecting disallowed command from control uplink:', type)
+        log.warn('Rejecting disallowed command from control uplink:', type)
         return
       }
     }
 
     if (msg.type === 'set-listening-view') {
-      console.debug('Setting listening view:', msg.viewIdx)
+      log.debug('Setting listening view:', msg.viewIdx)
       streamWindow.setListeningView(msg.viewIdx)
     } else if (msg.type === 'set-view-background-listening') {
-      console.debug(
+      log.debug(
         'Setting view background listening:',
         msg.viewIdx,
         msg.listening,
       )
       streamWindow.setViewBackgroundListening(msg.viewIdx, msg.listening)
     } else if (msg.type === 'set-view-blurred') {
-      console.debug('Setting view blurred:', msg.viewIdx, msg.blurred)
+      log.debug('Setting view blurred:', msg.viewIdx, msg.blurred)
       streamWindow.setViewBlurred(msg.viewIdx, msg.blurred)
     } else if (msg.type === 'set-view-volume') {
-      console.debug('Setting view volume:', msg.viewIdx, msg.volume)
+      log.debug('Setting view volume:', msg.viewIdx, msg.volume)
       streamWindow.setViewVolume(msg.viewIdx, msg.volume)
     } else if (msg.type === 'rotate-stream') {
-      console.debug('Rotating stream:', msg.url, msg.rotation)
+      log.debug('Rotating stream:', msg.url, msg.rotation)
       overlayStreamData.update(msg.url, {
         rotation: msg.rotation,
       })
     } else if (msg.type === 'update-custom-stream') {
-      console.debug('Updating custom stream:', msg.url)
+      log.debug('Updating custom stream:', msg.url)
       localStreamData.update(msg.url, msg.data)
     } else if (msg.type === 'delete-custom-stream') {
-      console.debug('Deleting custom stream:', msg.url)
+      log.debug('Deleting custom stream:', msg.url)
       localStreamData.delete(msg.url)
     } else if (msg.type === 'reload-view') {
-      console.debug('Reloading view:', msg.viewIdx)
+      log.debug('Reloading view:', msg.viewIdx)
       streamWindow.reloadView(msg.viewIdx)
     } else if (msg.type === 'browse' || msg.type === 'dev-tools') {
       if (browseWindow && !browseWindow.isDestroyed()) {
@@ -591,7 +595,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
         denyWindowOpen(browseWindow.webContents)
       }
       if (msg.type === 'browse') {
-        console.debug('Attempting to browse URL:', msg.url)
+        log.debug('Attempting to browse URL:', msg.url)
         try {
           await ensureValidURL(
             msg.url,
@@ -599,18 +603,18 @@ async function main(argv: ReturnType<typeof parseArgs>) {
           )
           browseWindow.loadURL(msg.url)
         } catch (error) {
-          console.error('Invalid URL:', msg.url)
-          console.error('Error:', error)
+          log.error('Invalid URL:', msg.url)
+          log.error('Error:', error)
         }
       } else if (msg.type === 'dev-tools') {
-        console.debug('Opening DevTools for view:', msg.viewIdx)
+        log.debug('Opening DevTools for view:', msg.viewIdx)
         streamWindow.openDevTools(msg.viewIdx, browseWindow.webContents)
       }
     } else if (msg.type === 'set-stream-censored' && streamdelayClient) {
-      console.debug('Setting stream censored:', msg.isCensored)
+      log.debug('Setting stream censored:', msg.isCensored)
       streamdelayClient.setCensored(msg.isCensored)
     } else if (msg.type === 'set-stream-running' && streamdelayClient) {
-      console.debug('Setting stream running:', msg.isStreamRunning)
+      log.debug('Setting stream running:', msg.isStreamRunning)
       streamdelayClient.setStreamRunning(msg.isStreamRunning)
     } else if (msg.type === 'set-grid-size') {
       applyGridResize(
@@ -635,7 +639,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
       // call is needed here.
       updateState({})
     } else if (msg.type === 'save-layout-preset') {
-      console.debug('Saving layout preset:', msg.name)
+      log.debug('Saving layout preset:', msg.name)
       const preset = buildLayoutPreset(
         {
           viewsState,
@@ -655,7 +659,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
         (p) => p.id === msg.presetId,
       )
       if (preset) {
-        console.debug('Loading layout preset:', preset.name)
+        log.debug('Loading layout preset:', preset.name)
         applyLayoutPreset(
           {
             viewsState,
@@ -669,7 +673,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
         updateState({})
       }
     } else if (msg.type === 'delete-layout-preset') {
-      console.debug('Deleting layout preset:', msg.presetId)
+      log.debug('Deleting layout preset:', msg.presetId)
       const layoutPresets = clientState.layoutPresets.filter(
         (p) => p.id !== msg.presetId,
       )
@@ -772,7 +776,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     event.preventDefault()
     flushStorage(db, () => persistStateDoc.flush())
       .catch((err) => {
-        console.error('Failed to flush storage before quit', err)
+        log.error('Failed to flush storage before quit', err)
       })
       .finally(() => {
         storageFlushed = true
@@ -784,12 +788,12 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     argv.control.endpoint &&
     !isSecureControlEndpoint(argv.control.endpoint)
   ) {
-    console.error(
+    log.error(
       `Refusing to connect to insecure control endpoint "${argv.control.endpoint}". ` +
         'The control connection must use wss:// (or ws:// to a loopback host).',
     )
   } else if (argv.control.endpoint) {
-    console.debug('Connecting to control server...')
+    log.debug('Connecting to control server...')
     // Move the uplink secret out of the URL query string and into an
     // Authorization header so it never reaches server or proxy access logs.
     const { url: controlURL, authorization } = parseControlEndpoint(
@@ -803,12 +807,12 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     })
     ws.binaryType = 'arraybuffer'
     ws.addEventListener('open', () => {
-      console.debug('Control WebSocket connected.')
+      log.debug('Control WebSocket connected.')
       ws.send(JSON.stringify({ type: 'state', state: clientState }))
       ws.send(Y.encodeStateAsUpdate(stateDoc))
     })
     ws.addEventListener('close', () => {
-      console.debug('Control WebSocket disconnected.')
+      log.debug('Control WebSocket disconnected.')
     })
     ws.addEventListener('message', (ev) => {
       if (ev.data instanceof ArrayBuffer) {
@@ -820,7 +824,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
       try {
         msg = JSON.parse(ev.data)
       } catch (err) {
-        console.warn('Failed to parse control WebSocket message:', err)
+        log.warn('Failed to parse control WebSocket message:', err)
         return
       }
 
@@ -835,7 +839,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   }
 
   if (argv.streamdelay.key) {
-    console.debug('Setting up Streamdelay client...')
+    log.debug('Setting up Streamdelay client...')
     streamdelayClient = new StreamdelayClient({
       endpoint: argv.streamdelay.endpoint,
       key: argv.streamdelay.key,
@@ -852,7 +856,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     channel: twitchChannel,
   } = argv.twitch
   if (twitchUsername && twitchToken && twitchChannel) {
-    console.debug('Setting up Twitch bot...')
+    log.debug('Setting up Twitch bot...')
     const twitchBot = new TwitchBot({
       ...argv.twitch,
       username: twitchUsername,
@@ -866,14 +870,33 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     twitchBot.connect()
   }
 
+  const dataSourceHealthTracker = new DataSourceHealthTracker()
+  function trackDataSourceHealth(id: string, type: DataSourceType) {
+    return (ok: boolean, message?: string) => {
+      updateState({
+        dataSourceHealth: dataSourceHealthTracker.report(id, type, ok, message),
+      })
+    }
+  }
+
   const dataSources = [
     ...argv.data['json-url'].map((url) => {
-      console.debug('Setting data source from json-url:', url)
-      return markDataSource(pollDataURL(url, argv.data.interval), 'json-url')
+      log.debug('Setting data source from json-url:', url)
+      return markDataSource(
+        pollDataURL(
+          url,
+          argv.data.interval,
+          trackDataSourceHealth(url, 'json-url'),
+        ),
+        'json-url',
+      )
     }),
     ...argv.data['toml-file'].map((path) => {
-      console.debug('Setting data source from toml-file:', path)
-      return markDataSource(watchDataFile(path), 'toml-file')
+      log.debug('Setting data source from toml-file:', path)
+      return markDataSource(
+        watchDataFile(path, trackDataSourceHealth(path, 'toml-file')),
+        'toml-file',
+      )
     }),
     markDataSource(localStreamData.gen(), 'custom'),
     markDataSource(overlayStreamData.gen(), 'overlay'),
@@ -886,14 +909,15 @@ async function main(argv: ReturnType<typeof parseArgs>) {
 }
 
 function init() {
-  console.debug('Parsing command line arguments...')
+  initLogger()
+  log.debug('Parsing command line arguments...')
   let argv: ReturnType<typeof parseArgs>
   try {
     argv = parseArgs()
   } catch (err) {
     if (err instanceof ConfigError) {
       // Surface the offending file/key/line cleanly instead of a stack trace.
-      console.error(err.message)
+      log.error(err.message)
       process.exit(1)
     }
     throw err
@@ -902,7 +926,7 @@ function init() {
     return
   }
 
-  console.debug('Initializing Sentry...')
+  log.debug('Initializing Sentry...')
   if (argv.telemetry.sentry) {
     Sentry.init({ dsn: SENTRY_DSN })
   }
@@ -916,18 +940,18 @@ function init() {
 
   updateElectronApp()
 
-  console.debug('Setting up Electron...')
+  log.debug('Setting up Electron...')
   app.commandLine.appendSwitch('high-dpi-support', '1')
   app.commandLine.appendSwitch('force-device-scale-factor', '1')
 
-  console.debug('Enabling Electron sandbox...')
+  log.debug('Enabling Electron sandbox...')
   app.enableSandbox()
 
   app
     .whenReady()
     .then(() => main(argv))
     .catch((err) => {
-      console.error(err)
+      log.error(err)
       process.exit(1)
     })
 }
@@ -937,5 +961,5 @@ if (started) {
   app.quit()
 }
 
-console.debug('Starting Streamwall...')
+log.debug('Starting Streamwall...')
 init()

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -402,7 +402,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   // and the control UI's first-run hint (#86).
   const userConfigPath = join(app.getPath('userData'), 'config.toml')
   const hasUserConfig = fs.existsSync(userConfigPath)
-  installApplicationMenu(userConfigPath)
+  installApplicationMenu(userConfigPath, log.transports.file.getFile().path)
 
   log.debug('Creating StreamWindow...')
   const idGen = new StreamIDGenerator()

--- a/packages/streamwall/src/main/logger.ts
+++ b/packages/streamwall/src/main/logger.ts
@@ -1,0 +1,24 @@
+import log from 'electron-log/main'
+
+// The file transport is off by default. Merely importing this module (as
+// every main-process file that logs will) makes electron-log resolve an app
+// name/log path on first write, which throws outside a packaged Electron app
+// (e.g. under Vitest, or if package.json can't be found) and would otherwise
+// write real log files to the OS log directory as a side effect of running
+// the test suite. `initLogger` is the only place that turns the file
+// transport on, and it's only called from the real app entrypoint.
+log.transports.file.level = false
+log.transports.console.level = 'debug'
+
+/**
+ * Enables the userData log file. Call once from the app entrypoint after
+ * Electron is ready to report a userData path.
+ */
+export function initLogger() {
+  log.initialize()
+  log.transports.file.level = 'debug'
+  log.info('Log file:', log.transports.file.getFile().path)
+  return log
+}
+
+export default log

--- a/packages/streamwall/src/main/menu.test.ts
+++ b/packages/streamwall/src/main/menu.test.ts
@@ -16,16 +16,18 @@ vi.mock('electron', () => ({
 const { buildApplicationMenuTemplate, installApplicationMenu } =
   await import('./menu')
 
-function searchForOpenConfigFolderItem(
+function searchForMenuItem(
   template: MenuItemConstructorOptions[],
+  label: string,
 ): MenuItemConstructorOptions | undefined {
   for (const item of template) {
-    if (item.label === 'Open Config Folder') {
+    if (item.label === label) {
       return item
     }
     if (Array.isArray(item.submenu)) {
-      const found = searchForOpenConfigFolderItem(
+      const found = searchForMenuItem(
         item.submenu as MenuItemConstructorOptions[],
+        label,
       )
       if (found) {
         return found
@@ -35,15 +37,20 @@ function searchForOpenConfigFolderItem(
   return undefined
 }
 
-function findOpenConfigFolderItem(
+function findMenuItem(
   template: MenuItemConstructorOptions[],
+  label: string,
 ): MenuItemConstructorOptions {
-  const found = searchForOpenConfigFolderItem(template)
+  const found = searchForMenuItem(template, label)
   if (!found) {
-    throw new Error('"Open Config Folder" menu item not found in template')
+    throw new Error(`"${label}" menu item not found in template`)
   }
   return found
 }
+
+const CONFIG_PATH =
+  '/Users/test/Library/Application Support/Streamwall/config.toml'
+const LOG_PATH = '/Users/test/Library/Logs/Streamwall/main.log'
 
 describe('buildApplicationMenuTemplate', () => {
   afterEach(() => {
@@ -51,11 +58,9 @@ describe('buildApplicationMenuTemplate', () => {
   })
 
   it('includes an "Open Config Folder" item that opens the directory containing the config path', () => {
-    const template = buildApplicationMenuTemplate(
-      '/Users/test/Library/Application Support/Streamwall/config.toml',
-    )
+    const template = buildApplicationMenuTemplate(CONFIG_PATH, LOG_PATH)
 
-    const item = findOpenConfigFolderItem(template)
+    const item = findMenuItem(template, 'Open Config Folder')
     expect(typeof item.click).toBe('function')
 
     ;(item.click as () => void)()
@@ -68,15 +73,27 @@ describe('buildApplicationMenuTemplate', () => {
   it('works when the config file does not exist yet (first run)', () => {
     const template = buildApplicationMenuTemplate(
       '/home/test/.config/Streamwall/config.toml',
+      '/home/test/.config/Streamwall/logs/main.log',
     )
 
-    const item = findOpenConfigFolderItem(template)
+    const item = findMenuItem(template, 'Open Config Folder')
     ;(item.click as () => void)()
 
     // openPath targets the userData directory itself, which Electron always
     // creates - unlike shell.showItemInFolder, it doesn't require config.toml
     // to already exist.
     expect(openPath).toHaveBeenCalledWith('/home/test/.config/Streamwall')
+  })
+
+  it('includes an "Open Logs Folder" item that opens the directory containing the log file', () => {
+    const template = buildApplicationMenuTemplate(CONFIG_PATH, LOG_PATH)
+
+    const item = findMenuItem(template, 'Open Logs Folder')
+    expect(typeof item.click).toBe('function')
+
+    ;(item.click as () => void)()
+
+    expect(openPath).toHaveBeenCalledWith('/Users/test/Library/Logs/Streamwall')
   })
 })
 
@@ -87,7 +104,7 @@ describe('installApplicationMenu', () => {
   })
 
   it('builds a menu from the template and installs it as the application menu', () => {
-    installApplicationMenu('/home/test/.config/Streamwall/config.toml')
+    installApplicationMenu(CONFIG_PATH, LOG_PATH)
 
     expect(buildFromTemplate).toHaveBeenCalledTimes(1)
     expect(setApplicationMenu).toHaveBeenCalledTimes(1)

--- a/packages/streamwall/src/main/menu.ts
+++ b/packages/streamwall/src/main/menu.ts
@@ -5,16 +5,21 @@ import { dirname } from 'node:path'
  * Builds the application menu template. Its main purpose is the "Open Config
  * Folder" item: the userData config path is otherwise only ever printed via
  * `console.debug`, which is invisible to anyone running the packaged app
- * outside a terminal (#86).
+ * outside a terminal (#86). "Open Logs Folder" serves the same purpose for
+ * the electron-log file written to the OS-standard log directory (#85).
  */
 export function buildApplicationMenuTemplate(
   configPath: string,
+  logPath: string,
 ): MenuItemConstructorOptions[] {
   const openConfigFolder = () => {
     // Targets the userData directory itself (not the config file), since
     // Electron always creates that directory - unlike
     // shell.showItemInFolder, this works even before config.toml exists.
     shell.openPath(dirname(configPath))
+  }
+  const openLogsFolder = () => {
+    shell.openPath(dirname(logPath))
   }
 
   const template: MenuItemConstructorOptions[] = []
@@ -30,6 +35,7 @@ export function buildApplicationMenuTemplate(
     label: 'File',
     submenu: [
       { label: 'Open Config Folder', click: openConfigFolder },
+      { label: 'Open Logs Folder', click: openLogsFolder },
       ...(process.platform === 'darwin'
         ? []
         : ([
@@ -42,8 +48,11 @@ export function buildApplicationMenuTemplate(
   return template
 }
 
-export function installApplicationMenu(configPath: string): void {
+export function installApplicationMenu(
+  configPath: string,
+  logPath: string,
+): void {
   Menu.setApplicationMenu(
-    Menu.buildFromTemplate(buildApplicationMenuTemplate(configPath)),
+    Menu.buildFromTemplate(buildApplicationMenuTemplate(configPath, logPath)),
   )
 }

--- a/packages/streamwall/src/main/navigationSecurity.test.ts
+++ b/packages/streamwall/src/main/navigationSecurity.test.ts
@@ -3,6 +3,7 @@ import { test, vi } from 'vitest'
 
 import type { WebContents } from 'electron'
 
+import log from './logger'
 import { denyWindowOpen, secureStreamView } from './navigationSecurity'
 
 interface NavEvent {
@@ -91,7 +92,7 @@ test('secureStreamView blocks will-navigate to a different URL', () => {
 
 test('secureStreamView allows will-navigate to the same URL (self reload)', () => {
   // Silence the informational reload log so test output stays clean.
-  vi.spyOn(console, 'log').mockImplementation(() => undefined)
+  vi.spyOn(log, 'info').mockImplementation(() => undefined)
   const wc = new FakeWebContents('https://example.com/stream')
   secureStreamView(asWebContents(wc))
 
@@ -127,7 +128,7 @@ test('secureStreamView allows a redirect while the initial load is still resolvi
 
 test('secureStreamView allows will-redirect to the same URL', () => {
   // Silence the informational reload log so test output stays clean.
-  vi.spyOn(console, 'log').mockImplementation(() => undefined)
+  vi.spyOn(log, 'info').mockImplementation(() => undefined)
   const wc = new FakeWebContents('https://example.com/stream')
   secureStreamView(asWebContents(wc))
 

--- a/packages/streamwall/src/main/navigationSecurity.ts
+++ b/packages/streamwall/src/main/navigationSecurity.ts
@@ -1,4 +1,5 @@
 import type { WebContents } from 'electron'
+import log from './logger'
 
 // A navigation event as surfaced by Electron's `will-navigate` / `will-redirect`.
 // Declared as a structural subset of Electron's event so the guards below can be
@@ -25,7 +26,7 @@ function preventNavigationAway(
 
   // Allow the page to reload itself (navigating to the URL it is already on).
   if (event.url === currentURL) {
-    console.log('Allowing page to reload:', event.url)
+    log.info('Allowing page to reload:', event.url)
     return
   }
 

--- a/packages/streamwall/src/main/partitions.ts
+++ b/packages/streamwall/src/main/partitions.ts
@@ -17,6 +17,7 @@
 
 import type { Session } from 'electron'
 import { createSessionHostResolver, findRequestBlockReason } from '../util'
+import log from './logger'
 
 const VIEW_PARTITION_PREFIX = 'view-'
 
@@ -127,7 +128,7 @@ export function installRequestSSRFGuard(
         }
         const reason = await findBlockReason(details.url)
         if (reason !== null) {
-          console.warn(reason)
+          log.warn(reason)
           callback({ cancel: true })
           return
         }
@@ -136,7 +137,7 @@ export function installRequestSSRFGuard(
         // Fail open on an internal guard error: the up-front ensureValidURL
         // already vetted the top-level URL, and cancelling here would break
         // legitimate traffic on an unexpected fault.
-        console.warn('SSRF request guard error:', err)
+        log.warn('SSRF request guard error:', err)
         callback({ cancel: false })
       }
     })()

--- a/packages/streamwall/src/main/playlist.test.ts
+++ b/packages/streamwall/src/main/playlist.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import log from './logger'
 import { PlaylistScheduler } from './playlist'
 
 describe('PlaylistScheduler', () => {
@@ -83,7 +84,7 @@ describe('PlaylistScheduler', () => {
       [{ view: 0, interval: 10, urls: ['a', 'b', 'c'] }],
       deps,
     )
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {})
 
     scheduler.start()
     deps.setViewStream.mockClear()

--- a/packages/streamwall/src/main/playlist.ts
+++ b/packages/streamwall/src/main/playlist.ts
@@ -1,3 +1,5 @@
+import log from './logger'
+
 export interface PlaylistConfig {
   view: number
   /** Seconds between advances. */
@@ -49,7 +51,7 @@ export class PlaylistScheduler {
     const url = playlist.urls[cursor % playlist.urls.length]
     const streamId = this.deps.resolveStreamId(url)
     if (streamId === undefined) {
-      console.warn(
+      log.warn(
         `Playlist for view ${playlist.view}: no stream found for URL "${url}", skipping`,
       )
     } else {

--- a/packages/streamwall/src/main/storage.ts
+++ b/packages/streamwall/src/main/storage.ts
@@ -1,6 +1,7 @@
 import { Low, Memory } from 'lowdb'
 import { JSONFilePreset } from 'lowdb/node'
 import { LayoutPreset, StreamDataContent } from 'streamwall-shared'
+import log from './logger'
 
 export interface StreamwallStoredData {
   stateDoc: string
@@ -22,7 +23,7 @@ export async function loadStorage(dbPath: string) {
   try {
     db = await JSONFilePreset<StreamwallStoredData>(dbPath, defaultData)
   } catch (err) {
-    console.warn(
+    log.warn(
       'Failed to load storage at',
       dbPath,
       ' -- changes will not be persisted',

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -14,6 +14,7 @@ import {
 import { Actor, assign, fromPromise, setup } from 'xstate'
 import { createSessionHostResolver, ensureValidURL } from '../util'
 import { loadHTML } from './loadHTML'
+import log from './logger'
 
 // Safety net for the whole loading phase (navigate -> waitForInit -> waitForVideo).
 // Longer than the media preload's own acquisition timeouts (~20s) so that slow but
@@ -116,7 +117,7 @@ const viewStateMachine = setup({
 
   actions: {
     logError: (_, params: { error: unknown }) => {
-      console.warn(params.error)
+      log.warn(params.error)
     },
 
     // Store a serializable reason for the current failure so it can be surfaced


### PR DESCRIPTION
## Problem

All main-process logging went through `console.debug/warn/error/log`, which is invisible in a packaged, double-clicked app — there's no log file and no way to diagnose a startup or runtime failure without launching from a terminal. Data-source fetch/read failures (a dead `--data.json-url` or unreadable `--data.toml-file`) only ever logged a warning, so a stale source was undiagnosable from the control UI.

## Solution

**Logging**: every main-process log call now goes through `electron-log` (`packages/streamwall/src/main/logger.ts`), which writes a rotating file under the OS-standard log directory in addition to the console, once the app initializes (`initLogger()` runs early in `init()`). The file transport stays off until then — merely importing `electron-log/main` resolves an app name/log path on first write, which throws outside a packaged Electron context (e.g. under Vitest) and would otherwise write real log files to the OS log directory as a side effect of running the test suite.

**Data-source health**: `pollDataURL`/`watchDataFile` (`data.ts`) now report ok/error status (with a message) through an optional `onHealth` callback on every read. The main process aggregates that per-source via a new `DataSourceHealthTracker` into `StreamwallState.dataSourceHealth`, propagated through the control-server's role-scoped state view and the control UI's `useStreamwallState`. A new `DataSourceHealthBanner` component renders a warning per failing source, naming the URL or file path, so a dead source is diagnosable without reading a log.

**"Open Logs Folder" menu item**: the app already has a native application menu (added in #86 for "Open Config Folder"). Extended it with a matching "Open Logs Folder" item, so the new log file is reachable from the app itself, not just by knowing the OS-standard log path.

## Architecture decisions

- The file transport is off by default in `logger.ts` and only enabled by `initLogger()`, called once from the real app entrypoint — this keeps every other main-process module's `import log from './logger'` safe to load under Vitest without mocking Electron or writing real files as a test side effect.
- `pollDataURL`/`watchDataFile` keep their existing yield contract (a plain stream array) and gain the health signal via a separate optional callback, rather than changing what they yield — this kept the change to existing callers/tests minimal.
- Data-source health aggregation is a small standalone `DataSourceHealthTracker` class (`dataSourceHealth.ts`), mirroring how `gridResize.ts`/`layoutPresets.ts` extract testable logic out of `index.ts`, rather than leaving it as untested glue inside `main()`.
- The warning banner reuses the existing hardcoded warning-amber color from `LayoutPresetControls.tsx`'s preset-cap warning rather than introducing a new theme token, matching the codebase's existing convention for one-off warning affordances.
- Deliberately did not add a `--log-level`/`--verbose` CLI flag — the issue's "Desired" section calls out only the log file and data-source health. Filed as a follow-up (#250).

## Testing performed

- TDD throughout: failing tests written first for `pollDataURL`/`watchDataFile`'s `onHealth` callback, `DataSourceHealthTracker`, `DataSourceHealthBanner`, and the "Open Logs Folder" menu item, then implemented to green.
- Two existing tests (`playlist.test.ts`, `navigationSecurity.test.ts`) that spied on `console.warn`/`console.log` were updated to spy on the logger instead — `electron-log` captures its own reference to the real `console.*` function at import time, so a spy installed afterward on `console` no longer intercepts it.
- Full quality gate green locally: `format:check`, `lint`, `typecheck` (all 5 workspaces), `test` (streamwall: 257, streamwall-shared: 209, streamwall-control-server: 90, streamwall-control-ui: 82 — 638 total), and the control-client production build.

## Risks / breaking changes

- `StreamwallState` gained a required `dataSourceHealth` field — every fixture/mock constructing a full `StreamwallState`/`StreamwallConnection` across the control-server and control-ui packages was updated.
- `buildApplicationMenuTemplate`/`installApplicationMenu` gained a required second `logPath` parameter.
- No behavior change for existing data sources beyond the added health signal; log output volume/format changes (console lines now carry an electron-log timestamp prefix) but content is unchanged.

## Follow-ups

- #250 — Add a `--log-level`/`--verbose` CLI flag to control electron-log verbosity

Closes #85