### PR TITLE
fix(streamwall): catch unhandled rejections on storage db.update calls

### DIFF
--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -45,7 +45,7 @@ import { installApplicationMenu } from './menu'
 import { denyWindowOpen } from './navigationSecurity'
 import { BROWSE_PARTITION, hardenSession } from './partitions'
 import { PlaylistScheduler } from './playlist'
-import { flushStorage, loadStorage } from './storage'
+import { flushStorage, loadStorage, safeUpdate } from './storage'
 import StreamdelayClient from './StreamdelayClient'
 import StreamWindow from './StreamWindow'
 import TwitchBot from './TwitchBot'
@@ -403,7 +403,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
 
   const localStreamData = new LocalStreamData(db.data.localStreamData)
   localStreamData.on('update', (entries) => {
-    db.update((data) => {
+    safeUpdate(db, (data) => {
       data.localStreamData = entries
     })
   })
@@ -487,7 +487,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   }
 
   const persistStateDoc = throttle(() => {
-    db.update((data) => {
+    safeUpdate(db, (data) => {
       const fullDoc = Y.encodeStateAsUpdate(stateDoc)
       data.stateDoc = Buffer.from(fullDoc).toString('base64')
     })
@@ -647,7 +647,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
         msg.name,
       )
       const layoutPresets = addLayoutPreset(clientState.layoutPresets, preset)
-      db.update((data) => {
+      safeUpdate(db, (data) => {
         data.layoutPresets = layoutPresets
       })
       updateState({ layoutPresets })
@@ -674,7 +674,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
       const layoutPresets = clientState.layoutPresets.filter(
         (p) => p.id !== msg.presetId,
       )
-      db.update((data) => {
+      safeUpdate(db, (data) => {
         data.layoutPresets = layoutPresets
       })
       updateState({ layoutPresets })

--- a/packages/streamwall/src/main/storage.test.ts
+++ b/packages/streamwall/src/main/storage.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, test, vi } from 'vitest'
 import {
   flushStorage,
   loadStorage,
+  safeUpdate,
   StorageDB,
   StreamwallStoredData,
 } from './storage'
@@ -58,6 +59,38 @@ describe('flushStorage', () => {
     expect(persisted?.localStreamData).toEqual([
       { _id: 'a', kind: 'video', link: 'https://example.test' },
     ])
+  })
+})
+
+describe('safeUpdate', () => {
+  it('applies the update to db.data', async () => {
+    const db = makeDB()
+
+    await safeUpdate(db, (data) => {
+      data.stateDoc = 'updated'
+    })
+
+    expect(db.data.stateDoc).toBe('updated')
+  })
+
+  it('logs and swallows a rejection instead of throwing', async () => {
+    const db = makeDB()
+    const writeError = new Error('disk full')
+    vi.spyOn(db, 'write').mockRejectedValueOnce(writeError)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect(
+      safeUpdate(db, (data) => {
+        data.stateDoc = 'updated'
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to persist storage update'),
+      writeError,
+    )
+
+    consoleError.mockRestore()
   })
 })
 

--- a/packages/streamwall/src/main/storage.ts
+++ b/packages/streamwall/src/main/storage.ts
@@ -34,6 +34,22 @@ export async function loadStorage(dbPath: string) {
 }
 
 /**
+ * Applies an update and persists it, logging (rather than throwing on) a
+ * rejected write -- e.g. a full disk or a permissions error -- so a single
+ * failed persist doesn't surface as an unhandled promise rejection.
+ */
+export async function safeUpdate(
+  db: StorageDB,
+  fn: (data: StreamwallStoredData) => void,
+): Promise<void> {
+  try {
+    await db.update(fn)
+  } catch (err) {
+    console.error('Failed to persist storage update', err)
+  }
+}
+
+/**
  * Guarantees the latest state is on disk before the app quits.
  *
  * Writes that go through a throttled updater (e.g. the Yjs stateDoc persist)


### PR DESCRIPTION
## Problem

`db.update()` (lowdb) returns a promise that rejects if the underlying write fails -- e.g. the disk is full or a permissions error -- but none of the four call sites in `packages/streamwall/src/main/index.ts` awaited or caught that promise:

- persisting `localStreamData` updates
- the throttled `stateDoc` persist
- saving a layout preset
- deleting a layout preset

A rejected write in any of these paths becomes an unhandled promise rejection instead of a visible, recoverable error.

Note: the closely related "closing the stream window hard-exits via `process.exit(0)` and drops the throttled pending write" part of this issue was already fixed by #191 (`before-quit` now flushes the throttled `stateDoc` persist and awaits `db.write()` before quitting). This PR addresses the remaining "add `.catch` to `db.update`" part.

## Solution

- Added `safeUpdate(db, fn)` to `storage.ts`: applies the update via `db.update(fn)` and logs (rather than throws) a rejected write, so a single failed persist can't surface as an unhandled rejection.
- Routed all four `db.update()` call sites in `index.ts` through `safeUpdate` instead of calling `db.update` directly.

## Testing performed

- `storage.test.ts`: new `safeUpdate` describe block covering (1) the update is applied to `db.data`, and (2) a rejected write is logged via `console.error` and the returned promise resolves rather than rejects.
- Full quality gate run locally across all workspaces: `format:check`, `lint`, `typecheck`, `test` (all green, no new warnings).

## Risks / breaking changes

None expected. Behavior is unchanged on the happy path; a failed write now logs an error instead of crashing/going unhandled.

Closes #21