### PR TITLE
fix(streamwall): tear down setViews boxes skipped for missing content/stream

### DIFF
--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -1,4 +1,4 @@
-import type { StreamWindowConfig } from 'streamwall-shared'
+import type { StreamWindowConfig, ViewContentMap } from 'streamwall-shared'
 import { describe, expect, it, vi } from 'vitest'
 
 // StreamWindow pulls in Electron (directly and via ./loadHTML and
@@ -159,3 +159,58 @@ function makeFakeViewActorWithSnapshot(snapshot: {
     send: vi.fn(),
   } as unknown as ReturnType<typeof StreamWindow.prototype.createView>
 }
+
+/**
+ * A stand-in for a ViewActor with enough of the `setViews()` teardown surface
+ * (`stop()`, `context.view`/`context.offscreenWin`) to verify a skipped view
+ * is torn down rather than leaked.
+ */
+function makeTeardownTrackingViewActor(id: number) {
+  const contentView = { webContents: { close: vi.fn() } }
+  const offscreenWin = {
+    contentView: { removeChildView: vi.fn() },
+    destroy: vi.fn(),
+  }
+  const stop = vi.fn()
+  return {
+    stop,
+    contentView,
+    offscreenWin,
+    actor: {
+      getSnapshot: () => ({
+        context: { id, view: contentView, offscreenWin, pos: null },
+        matches: () => false,
+      }),
+      matches: () => false,
+      send: vi.fn(),
+      stop,
+    } as unknown as ReturnType<typeof StreamWindow.prototype.createView>,
+  }
+}
+
+describe('StreamWindow.setViews', () => {
+  it('tears down a newly created view whose box content has no matching stream, instead of leaking it', () => {
+    const sw = makeStreamWindow(makeConfig({ cols: 1, rows: 1 }))
+    sw.win = {
+      contentView: { removeChildView: vi.fn() },
+    } as unknown as InstanceType<typeof StreamWindow>['win']
+    sw.views = new Map()
+
+    const tracked = makeTeardownTrackingViewActor(99)
+    sw.createView = vi.fn(() => tracked.actor)
+
+    // A box exists for space 0, but the URL it references is not present in
+    // `streams.byURL`, exercising the `!stream` skip branch in setViews.
+    const viewContentMap: ViewContentMap = new Map([
+      ['0', { url: 'https://example.com/missing', kind: 'video' }],
+    ])
+    const streams = { byURL: new Map() }
+
+    sw.setViews(viewContentMap, streams)
+
+    expect(tracked.stop).toHaveBeenCalled()
+    expect(tracked.contentView.webContents.close).toHaveBeenCalled()
+    expect(tracked.offscreenWin.destroy).toHaveBeenCalled()
+    expect(sw.views.size).toBe(0)
+  })
+})

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -375,11 +375,17 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
     for (const { box, view } of viewsToDisplay) {
       const { content, x, y, w, h, spaces } = box
       if (!content) {
+        // Route through the teardown path below instead of dropping the
+        // reference outright, or the actor/WebContentsView/offscreen
+        // BrowserWindow behind it leaks permanently.
+        unusedViews.add(view)
         continue
       }
 
       const stream = streams.byURL?.get(content.url)
       if (!stream) {
+        // Same leak risk as above, for a box whose URL isn't in `streams.byURL`.
+        unusedViews.add(view)
         continue
       }
 


### PR DESCRIPTION
## Problem

`StreamWindow.setViews()` builds `viewsToDisplay` by either reusing an existing view (removed from `unusedViews`) or creating a new one (`this.createView()`) for every box computed from the current `viewContentMap`. When building the new `this.views` map from `viewsToDisplay`, two branches `continue` past a box:

- the box has no `content`
- the box's `content.url` has no entry in `streams.byURL`

In both cases the view behind that box (an XState actor driving a `WebContentsView` plus a hidden offscreen `BrowserWindow`) was neither added to the new `newViews` map nor added back to `unusedViews`, so it fell out of `setViews()`'s bookkeeping entirely without ever being stopped or destroyed — a permanent resource leak per skipped box.

`content` is always truthy for boxes produced by the current `boxesFromViewContentMap` (streamwall-shared/src/geometry.ts), so that branch is latent today. `streams.byURL` is consistent with the current server, so the `!stream` branch is also latent today, but both become live leaks for any future caller passing an inconsistent `StreamList`/`ViewContentMap` pair.

## Fix

Route both skip branches through the existing `unusedViews` teardown path (`view.stop()` + view/offscreen-window cleanup at the end of `setViews()`) instead of dropping the reference. This covers both a reused-but-now-unusable view (already removed from `unusedViews` by the matcher) and a freshly created one (never in `unusedViews`).

## Testing

- Added a regression test (`StreamWindow.test.ts`) that drives `setViews()` with a box whose URL is absent from `streams.byURL` and asserts the resulting view actor is stopped and its `WebContentsView`/offscreen `BrowserWindow` are torn down, and that it does not survive into `this.views`. Confirmed the test fails against the pre-fix code (leaked view: `stop()` never called) and passes after the fix.
- Full quality gate green locally: `format:check`, `lint`, `typecheck` (all workspaces), `npm test` (all workspaces, 615 tests), and the CI build step (`streamwall-control-client` build).

## Risk / breaking changes

None — this only changes cleanup behavior for two branches that are unreachable through the current server/config, so there is no behavioral change to any currently-exercised path.

Closes #22