### PR TITLE
fix(streamwall): catch async rejections in TwitchBot timers and handlers

### DIFF
--- a/packages/streamwall/src/main/TwitchBot.test.ts
+++ b/packages/streamwall/src/main/TwitchBot.test.ts
@@ -1,0 +1,144 @@
+import { EventEmitter } from 'events'
+import type { StreamData } from 'streamwall-shared'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type TwitchBotType from './TwitchBot'
+
+class FakeChatClient extends EventEmitter {
+  ready = false
+  setColor = vi.fn().mockResolvedValue(undefined)
+  join = vi.fn().mockResolvedValue(undefined)
+  say = vi.fn().mockResolvedValue(undefined)
+  connect = vi.fn()
+  close = vi.fn()
+  use = vi.fn()
+}
+
+let fakeClient: FakeChatClient
+
+vi.mock('dank-twitch-irc', () => ({
+  ChatClient: vi.fn().mockImplementation(function ChatClient() {
+    return fakeClient
+  }),
+  LoginError: class LoginError extends Error {},
+  SlowModeRateLimiter: vi.fn(),
+}))
+
+const CONFIG = {
+  channel: 'testchannel',
+  username: 'testuser',
+  token: 'testtoken',
+  color: '#ff0000',
+  announce: { template: 'now playing', interval: 60, delay: 30 },
+  vote: { template: 'winner', interval: 5 },
+}
+
+const STREAM: StreamData = {
+  kind: 'video',
+  link: 'https://example.com/stream',
+  _id: 'id1',
+  _dataSource: 'test',
+}
+
+describe('TwitchBot', () => {
+  let TwitchBot: typeof TwitchBotType
+  let unhandledRejections: unknown[]
+  let onUnhandledRejection: (err: unknown) => void
+  let consoleError: ReturnType<typeof vi.spyOn>
+
+  beforeEach(async () => {
+    vi.resetModules()
+    fakeClient = new FakeChatClient()
+    ;({ default: TwitchBot } = await import('./TwitchBot'))
+    vi.useFakeTimers()
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    unhandledRejections = []
+    onUnhandledRejection = (err) => unhandledRejections.push(err)
+    process.on('unhandledRejection', onUnhandledRejection)
+  })
+
+  afterEach(() => {
+    process.off('unhandledRejection', onUnhandledRejection)
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('connects and emits "connected" once the client is ready', async () => {
+    const bot = new TwitchBot(CONFIG)
+    const connected = vi.fn()
+    bot.on('connected', connected)
+
+    fakeClient.emit('ready')
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(fakeClient.join).toHaveBeenCalledWith(CONFIG.channel)
+    expect(connected).toHaveBeenCalled()
+    expect(unhandledRejections).toEqual([])
+  })
+
+  it('does not crash the process when onReady rejects', async () => {
+    fakeClient.setColor.mockRejectedValue(new Error('setColor failed'))
+    new TwitchBot(CONFIG)
+
+    fakeClient.emit('ready')
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(unhandledRejections).toEqual([])
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('onReady'),
+      expect.any(Error),
+    )
+  })
+
+  it('does not crash the process when the vote tally interval rejects', async () => {
+    fakeClient.say.mockRejectedValue(new Error('say failed'))
+    const bot = new TwitchBot(CONFIG)
+    bot.votes.set(1, 3)
+
+    await vi.advanceTimersByTimeAsync(CONFIG.vote.interval * 1000)
+
+    expect(fakeClient.say).toHaveBeenCalled()
+    expect(unhandledRejections).toEqual([])
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('tallyVotes'),
+      expect.any(Error),
+    )
+  })
+
+  it('does not crash the process when the dwell-timeout announce rejects', async () => {
+    fakeClient.ready = true
+    fakeClient.say.mockRejectedValue(new Error('say failed'))
+    const bot = new TwitchBot(CONFIG)
+    bot.streams = [STREAM]
+    bot.listeningURL = STREAM.link
+
+    bot.onListeningURLChange(STREAM.link)
+    await vi.advanceTimersByTimeAsync(CONFIG.announce.delay * 1000)
+
+    expect(fakeClient.say).toHaveBeenCalled()
+    expect(unhandledRejections).toEqual([])
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('announce'),
+      expect.any(Error),
+    )
+  })
+
+  it('does not crash the process when the repeat-announce timeout rejects', async () => {
+    fakeClient.ready = true
+    const bot = new TwitchBot(CONFIG)
+    bot.streams = [STREAM]
+    bot.listeningURL = STREAM.link
+
+    await bot.announce()
+    expect(fakeClient.say).toHaveBeenCalledTimes(1)
+
+    fakeClient.say.mockRejectedValue(new Error('say failed'))
+    await vi.advanceTimersByTimeAsync(CONFIG.announce.interval * 1000)
+
+    expect(fakeClient.say).toHaveBeenCalledTimes(2)
+    expect(unhandledRejections).toEqual([])
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('announce'),
+      expect.any(Error),
+    )
+  })
+})

--- a/packages/streamwall/src/main/TwitchBot.ts
+++ b/packages/streamwall/src/main/TwitchBot.ts
@@ -52,11 +52,15 @@ export default class TwitchBot extends EventEmitter {
     if (vote.interval) {
       this.voteTemplate = ejs.compile(config.vote.template)
       this.votes = new Map()
-      setInterval(this.tallyVotes.bind(this), vote.interval * 1000)
+      setInterval(() => {
+        this.tallyVotes().catch((err) =>
+          this.handleAsyncError('tallyVotes', err),
+        )
+      }, vote.interval * 1000)
     }
 
     client.on('ready', () => {
-      this.onReady()
+      this.onReady().catch((err) => this.handleAsyncError('onReady', err))
     })
     client.on('error', (err) => {
       console.error('Twitch connection error:', err)
@@ -78,6 +82,10 @@ export default class TwitchBot extends EventEmitter {
   connect() {
     const { client } = this
     client.connect()
+  }
+
+  private handleAsyncError(context: string, err: unknown) {
+    console.error(`Twitch bot error (${context}):`, err)
   }
 
   async onReady() {
@@ -120,7 +128,7 @@ export default class TwitchBot extends EventEmitter {
     clearTimeout(this.dwellTimeout)
     this.dwellTimeout = setTimeout(() => {
       if (!this.announceTimeouts.has(listeningURL)) {
-        this.announce()
+        this.announce().catch((err) => this.handleAsyncError('announce', err))
       }
     }, announce.delay * 1000)
   }
@@ -144,7 +152,7 @@ export default class TwitchBot extends EventEmitter {
     const timeout = setTimeout(() => {
       this.announceTimeouts.delete(listeningURL)
       if (this.listeningURL === listeningURL) {
-        this.announce()
+        this.announce().catch((err) => this.handleAsyncError('announce', err))
       }
     }, announce.interval * 1000)
     this.announceTimeouts.set(listeningURL, timeout)


### PR DESCRIPTION
## Problem

`TwitchBot` invokes several `async` methods from event handlers and timers without awaiting or catching them:

- `client.on('ready', () => { this.onReady() })` — `onReady` calls `client.setColor` and `client.join`.
- `setInterval(this.tallyVotes.bind(this), ...)` — `tallyVotes` calls `client.say`.
- The dwell-timeout callback in `onListeningURLChange` calls `this.announce()`.
- The repeat-announce `setTimeout` inside `announce()` calls `this.announce()` again.

If any of the underlying `dank-twitch-irc` client calls reject (banned/suspended channel, rate limiting, a dropped connection), the rejection is never handled, producing an unhandled promise rejection instead of a log line — at startup for `onReady`, and recurring for the timer-driven `tallyVotes`/`announce` calls.

## Solution

Added a small `handleAsyncError(context, err)` helper that logs the failing context and error, and wired a `.catch(...)` onto each of the four fire-and-forget call sites listed above. Behavior on success is unchanged; on failure the error is now logged instead of escaping as an unhandled rejection.

## Testing

Added `packages/streamwall/src/main/TwitchBot.test.ts`, mocking `dank-twitch-irc`'s `ChatClient` and using Vitest fake timers:

- happy path: the `ready` event still connects and emits `connected`.
- `onReady` rejecting (`setColor` failure) is caught and logged, no unhandled rejection.
- the vote-tally interval rejecting (`say` failure) is caught and logged.
- the dwell-timeout announce rejecting is caught and logged.
- the repeat-announce timeout rejecting is caught and logged.

Each test asserts against a temporary `process.on('unhandledRejection', ...)` listener to prove the rejection was actually handled, not just that `console.error` was called.

Full quality gate run locally: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` (all workspaces, 243/243 passing in `streamwall`), and `npm -w streamwall-control-client run build`.

## Risks / breaking changes

None. This only adds error handling around existing fire-and-forget calls; no behavioral change on the success path.

Closes #19