### PR TITLE
fix(streamwall): prune stale viewsState keys so ghost streams don't reappear on grid grow

### DIFF
--- a/packages/streamwall-shared/src/geometry.test.ts
+++ b/packages/streamwall-shared/src/geometry.test.ts
@@ -75,6 +75,33 @@ describe('remapGridAssignments', () => {
     expect(result.get(0)).toBeUndefined()
     expect(result.get(1)).toBe('a')
   })
+
+  it('ignores a stale entry beyond the true old grid when oldRows is given (issue #17)', () => {
+    // The true old grid was only 3x1 (3 cells). Index 17 is a leftover key from
+    // some previous, larger grid config that was never pruned. Naively reading
+    // it via oldCols=3 alone gives (x=17%3=2, y=floor(17/3)=5), which lands
+    // inside a large-enough new grid and would revive as a ghost stream.
+    const old = new Map<number, string | undefined>([
+      [0, 'a'],
+      [17, 'ghost'],
+    ])
+    const result = remapGridAssignments(3, 6, 6, old, 1)
+    expect([...result.values()]).not.toContain('ghost')
+    expect(result.get(0)).toBe('a')
+  })
+
+  it('keeps an entry within the true old grid when oldRows is given', () => {
+    // 3x2 grid: idx3 = (x=0, y=1).
+    const old = new Map<number, string | undefined>([[3, 'b']])
+    const result = remapGridAssignments(3, 4, 4, old, 2)
+    expect(result.get(4)).toBe('b') // (0,1) -> 4*1 + 0 = 4
+  })
+
+  it('applies no extra filtering when oldRows is omitted (back-compat)', () => {
+    const old = new Map<number, string | undefined>([[17, 'ghost']])
+    const result = remapGridAssignments(3, 6, 6, old)
+    expect(result.get(32)).toBe('ghost') // (x=2, y=5) -> 6*5 + 2 = 32
+  })
 })
 
 describe('parseGridDimensionInput', () => {

--- a/packages/streamwall-shared/src/geometry.ts
+++ b/packages/streamwall-shared/src/geometry.ts
@@ -213,19 +213,30 @@ export function hasGridAssignments(
  * @param newCols Column count of the target grid.
  * @param newRows Row count of the target grid.
  * @param oldAssignments Map of old cell index -> streamId (undefined/'' = empty).
+ * @param oldRows Row count of the true old grid. When given, entries whose
+ *   index falls outside `oldCols * oldRows` are dropped as stale before
+ *   remapping, rather than being read against `oldCols` alone — a stale key
+ *   left over from a previously larger grid config can otherwise land inside
+ *   the new grid by coincidence and resurface as a ghost stream (issue #17).
+ *   Omit when `oldAssignments` is already known to cover exactly the old grid.
  */
 export function remapGridAssignments(
   oldCols: number,
   newCols: number,
   newRows: number,
   oldAssignments: Map<number, string | undefined>,
+  oldRows?: number,
 ): Map<number, string | undefined> {
   const result = new Map<number, string | undefined>()
   for (let idx = 0; idx < newCols * newRows; idx++) {
     result.set(idx, undefined)
   }
+  const oldCellCount = oldRows === undefined ? undefined : oldCols * oldRows
   for (const [oldIdx, streamId] of oldAssignments) {
     if (streamId === undefined || streamId === '') {
+      continue
+    }
+    if (oldCellCount !== undefined && oldIdx >= oldCellCount) {
       continue
     }
     const x = oldIdx % oldCols

--- a/packages/streamwall/src/main/gridResize.test.ts
+++ b/packages/streamwall/src/main/gridResize.test.ts
@@ -86,6 +86,7 @@ function setupWall(cols: number, rows: number) {
     viewsState,
     transact: (fn) => doc.transact(fn),
     getCols: () => wall.cols,
+    getRows: () => wall.rows,
     setGridSize: (c, r) => wall.setGridSize(c, r),
   }
 
@@ -154,6 +155,7 @@ describe('applyGridResize', () => {
       viewsState,
       transact: (fn) => doc.transact(fn),
       getCols: () => cols,
+      getRows: () => rows,
       setGridSize: (c, r) => {
         cols = c
         rows = r
@@ -221,5 +223,28 @@ describe('applyGridResize', () => {
 
     expect(applied).toEqual({ cols: 1, rows: GRID_MAX })
     expect(viewsState.size).toBe(1 * GRID_MAX)
+  })
+
+  it('does not resurrect a stale viewsState key left over from a larger grid (issue #17)', () => {
+    // The true current grid is 3x1. A key like "17" can only be a leftover
+    // from some previous, larger grid config that was never pruned (e.g. an
+    // 8x8 wall) - it has no meaning under the current 3x1 dimensions.
+    const { viewsState, wall, ctx } = setupWall(3, 1)
+    seedAssignments(viewsState, 3, 1, { 0: 'stream-a' })
+    viewsState.doc!.transact(() => {
+      const ghost = new Y.Map<string | undefined>()
+      ghost.set('streamId', 'ghost')
+      viewsState.set('17', ghost)
+    })
+
+    // Grow to 6x6: naively reading idx=17 via oldCols=3 gives (x=2, y=5),
+    // which fits inside 6x6 and would revive the ghost at cell 32.
+    applyGridResize(ctx, 6, 6)
+
+    expect(wall.live.has('ghost')).toBe(false)
+    for (const [, viewData] of viewsState) {
+      expect(viewData.get('streamId')).not.toBe('ghost')
+    }
+    expect(viewsState.get('0')?.get('streamId')).toBe('stream-a')
   })
 })

--- a/packages/streamwall/src/main/gridResize.ts
+++ b/packages/streamwall/src/main/gridResize.ts
@@ -13,6 +13,13 @@ export interface GridResizeContext {
   transact: (fn: () => void) => void
   /** Current column count of the wall (used to read each cell's (x, y)). */
   getCols: () => number
+  /**
+   * Current row count of the wall. Bounds `oldCols * oldRows` so a stale
+   * `viewsState` key left over from a previously larger grid (see
+   * `getCols`) is dropped as out-of-range rather than remapped by
+   * coincidence (issue #17).
+   */
+  getRows: () => number
   /** Applies the new grid dimensions to the wall (mutates the shared config). */
   setGridSize: (cols: number, rows: number) => void
 }
@@ -41,6 +48,7 @@ export function applyGridResize(
   const cols = clampGridDimension(requestedCols)
   const rows = clampGridDimension(requestedRows)
   const oldCols = ctx.getCols()
+  const oldRows = ctx.getRows()
 
   // Read current assignments keyed by old cell index.
   const oldAssignments = new Map<number, string | undefined>()
@@ -54,6 +62,7 @@ export function applyGridResize(
     cols,
     rows,
     oldAssignments,
+    oldRows,
   )
 
   // Update the grid dimensions BEFORE the transact so the synchronous observer

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -49,6 +49,7 @@ import { flushStorage, loadStorage } from './storage'
 import StreamdelayClient from './StreamdelayClient'
 import StreamWindow from './StreamWindow'
 import TwitchBot from './TwitchBot'
+import { initializeViewsState } from './viewsStateInit'
 import {
   shouldHideInsteadOfQuit,
   shouldQuitOnAllWindowsClosed,
@@ -494,16 +495,11 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   }, 1000)
   stateDoc.on('update', persistStateDoc)
 
-  stateDoc.transact(() => {
-    for (let i = 0; i < argv.grid.cols * argv.grid.rows; i++) {
-      if (viewsState.has(String(i))) {
-        continue
-      }
-      const data = new Y.Map<string | undefined>()
-      data.set('streamId', undefined)
-      viewsState.set(String(i), data)
-    }
-  })
+  initializeViewsState(
+    { viewsState, transact: (fn) => stateDoc.transact(fn) },
+    argv.grid.cols,
+    argv.grid.rows,
+  )
 
   updateViewsFromStateDoc()
   viewsState.observeDeep(updateViewsFromStateDoc)
@@ -620,6 +616,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
           viewsState,
           transact: (fn) => stateDoc.transact(fn),
           getCols: () => streamWindowConfig.cols,
+          getRows: () => streamWindowConfig.rows,
           setGridSize: (cols, rows) => streamWindow.setGridSize(cols, rows),
         },
         msg.cols,

--- a/packages/streamwall/src/main/viewsStateInit.test.ts
+++ b/packages/streamwall/src/main/viewsStateInit.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import * as Y from 'yjs'
+import {
+  initializeViewsState,
+  type ViewsStateInitContext,
+} from './viewsStateInit'
+
+function setup() {
+  const doc = new Y.Doc()
+  const viewsState = doc.getMap<Y.Map<string | undefined>>('views')
+  const ctx: ViewsStateInitContext = {
+    viewsState,
+    transact: (fn) => doc.transact(fn),
+  }
+  return { doc, viewsState, ctx }
+}
+
+describe('initializeViewsState', () => {
+  it('fills every cell of the configured grid', () => {
+    const { viewsState, ctx } = setup()
+
+    initializeViewsState(ctx, 2, 2)
+
+    expect([...viewsState.keys()].sort()).toEqual(['0', '1', '2', '3'])
+  })
+
+  it('leaves an existing in-range assignment untouched', () => {
+    const { viewsState, ctx } = setup()
+    viewsState.doc!.transact(() => {
+      const data = new Y.Map<string | undefined>()
+      data.set('streamId', 'stream-a')
+      viewsState.set('1', data)
+    })
+
+    initializeViewsState(ctx, 2, 2)
+
+    expect(viewsState.get('1')?.get('streamId')).toBe('stream-a')
+  })
+
+  it('prunes a stale key left over from a previously larger grid (issue #17)', () => {
+    const { viewsState, ctx } = setup()
+    viewsState.doc!.transact(() => {
+      // Leftover from a previous 8x8 config; never cleaned up because the old
+      // fill logic only ever added missing keys.
+      const ghost = new Y.Map<string | undefined>()
+      ghost.set('streamId', 'ghost')
+      viewsState.set('60', ghost)
+    })
+
+    initializeViewsState(ctx, 3, 3)
+
+    expect(viewsState.has('60')).toBe(false)
+    expect(
+      [...viewsState.keys()].sort((a, b) => Number(a) - Number(b)),
+    ).toEqual(['0', '1', '2', '3', '4', '5', '6', '7', '8'])
+  })
+
+  it('is a no-op when the grid is already exactly filled', () => {
+    const { viewsState, ctx } = setup()
+    initializeViewsState(ctx, 2, 2)
+    const before = [...viewsState.keys()].sort()
+
+    initializeViewsState(ctx, 2, 2)
+
+    expect([...viewsState.keys()].sort()).toEqual(before)
+  })
+})

--- a/packages/streamwall/src/main/viewsStateInit.ts
+++ b/packages/streamwall/src/main/viewsStateInit.ts
@@ -1,0 +1,45 @@
+import * as Y from 'yjs'
+
+/**
+ * Collaborators the startup view-state seeding needs from the main process.
+ */
+export interface ViewsStateInitContext {
+  /** Yjs map of grid cell index (as string) -> a `{ streamId }` map. */
+  viewsState: Y.Map<Y.Map<string | undefined>>
+  /** Runs `fn` inside the shared `stateDoc.transact`, batching the mutations. */
+  transact: (fn: () => void) => void
+}
+
+/**
+ * Seeds `viewsState` with an empty cell for every index of the configured
+ * grid, and prunes any leftover keys outside that range.
+ *
+ * The persisted Yjs doc keeps every cell key ever created across restarts,
+ * and the fill used to only ever add missing keys. A key from a previous,
+ * larger grid config (e.g. index 60 from an old 8x8 wall) would then survive
+ * invisibly once the app restarted with a smaller grid, and could resurface
+ * as a ghost stream in an arbitrary cell the next time the grid was grown
+ * (issue #17).
+ */
+export function initializeViewsState(
+  ctx: ViewsStateInitContext,
+  cols: number,
+  rows: number,
+): void {
+  const totalCells = cols * rows
+  ctx.transact(() => {
+    for (const key of [...ctx.viewsState.keys()]) {
+      if (Number(key) >= totalCells) {
+        ctx.viewsState.delete(key)
+      }
+    }
+    for (let i = 0; i < totalCells; i++) {
+      if (ctx.viewsState.has(String(i))) {
+        continue
+      }
+      const data = new Y.Map<string | undefined>()
+      data.set('streamId', undefined)
+      ctx.viewsState.set(String(i), data)
+    }
+  })
+}


### PR DESCRIPTION
## Problem

The persisted Yjs `stateDoc` keeps every grid-cell key ever created. The startup fill only ever *added* missing keys for the currently configured grid — it never removed keys left over from a previous, larger configuration. `remapGridAssignments` also had no way to reject an old index that fell outside the *true* old grid, since it only knew the current `oldCols`.

**Failure scenario:** run with an 8x8 grid and a stream assigned to cell 60. Edit the config down to 3x3 and restart — key `"60"` survives in the persisted doc, invisible under the smaller grid. Send `set-grid-size` 6x6: the stale index can satisfy `x < newCols && y < newRows` when read against the *current* (3) column count, so a ghost stream the operator never assigned materializes in an arbitrary cell of the new grid.

## Solution

Two independent, defense-in-depth fixes, both suggested in the issue:

1. **Prune at startup.** Extracted the inline view-state fill in `index.ts` into `initializeViewsState()` (`packages/streamwall/src/main/viewsStateInit.ts`), which now deletes any `viewsState` key `>= cols * rows` in the same transact that fills missing cells. This removes stale keys at the source, on every launch.
2. **Guard the remap.** `remapGridAssignments()` (`packages/streamwall-shared/src/geometry.ts`) gains an optional `oldRows` parameter; when given, entries whose old index falls outside `oldCols * oldRows` are skipped before remapping, rather than being read against `oldCols` alone. `applyGridResize()` now reads the current row count via a new `GridResizeContext.getRows()` and passes it through, so a stale key can't be remapped by coincidence even if one somehow survives.

`oldRows` is optional (not a breaking change) — the one other caller (`streamwall-control-ui`'s `yUndo.test.ts`, simulating the server-side remap) is unaffected.

## Testing

All new behavior is covered by unit tests, following TDD (failing test confirmed before each fix landed):

- `packages/streamwall-shared/src/geometry.test.ts`: `remapGridAssignments` drops a stale entry outside the true old grid when `oldRows` is given, keeps an in-range entry, and preserves prior behavior when `oldRows` is omitted.
- `packages/streamwall/src/main/gridResize.test.ts`: regression test injecting a stale out-of-bounds `viewsState` key and asserting `applyGridResize` does not resurrect it as a ghost stream.
- `packages/streamwall/src/main/viewsStateInit.test.ts` (new): fills every cell of the configured grid, leaves in-range assignments untouched, prunes a stale key left over from a larger grid, and is a no-op when already exactly filled.

Full quality gate run locally: `format:check`, `lint` (touched files), `typecheck` (all workspaces), and `test --workspaces` (all workspaces) — all green, no new failures.

## Risks / breaking changes

None expected. The startup prune only removes cells outside the currently configured grid dimensions, which were already inaccessible/invisible to the operator. `remapGridAssignments`'s new parameter is optional and backward-compatible.

Closes #17