### PR TITLE
fix(streamwall): handle chokidar unlink/add/error events in watchDataFile

### DIFF
--- a/packages/streamwall/src/main/data.test.ts
+++ b/packages/streamwall/src/main/data.test.ts
@@ -1,17 +1,48 @@
-import { mkdtempSync, writeFileSync } from 'node:fs'
+import { EventEmitter } from 'node:events'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { createServer, type Server } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import type { StreamDataContent } from 'streamwall-shared'
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 import { pollDataURL, watchDataFile } from './data'
+
+class FakeWatcher extends EventEmitter {
+  close = vi.fn(async () => {})
+}
+
+let fakeWatcher: FakeWatcher | undefined
+
+vi.mock('chokidar', () => ({
+  watch: vi.fn(() => {
+    fakeWatcher = new FakeWatcher()
+    return fakeWatcher
+  }),
+}))
 
 function writeTomlFile(contents: string): string {
   const dir = mkdtempSync(path.join(tmpdir(), 'sw-data-'))
   const file = path.join(dir, 'streams.toml')
   writeFileSync(file, contents)
   return file
+}
+
+// Async generator resumption (and therefore listener registration inside
+// the generator body) is not synchronous with the .next() call that
+// triggers it, so tests poll for the listener rather than emitting
+// immediately after calling next().
+async function waitForListener(
+  emitter: EventEmitter,
+  event: string,
+): Promise<void> {
+  for (let i = 0; i < 100; i++) {
+    if (emitter.listenerCount(event) > 0) {
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+  throw new Error(`listener for "${event}" was not registered in time`)
 }
 
 describe('watchDataFile', () => {
@@ -63,6 +94,126 @@ _dataSource = "attacker"
     try {
       const { value } = await gen.next()
       expect(value).toEqual([])
+    } finally {
+      await gen.return(undefined)
+    }
+  })
+
+  test('re-reads on an unlink+add cycle instead of only on change', async () => {
+    const file = writeTomlFile(`
+[[streams]]
+link = "https://a.example/s"
+`)
+    const gen = watchDataFile(file)
+    try {
+      const first = await gen.next()
+      expect(first.value?.map((s: StreamDataContent) => s.link)).toEqual([
+        'https://a.example/s',
+      ])
+
+      writeFileSync(
+        file,
+        `
+[[streams]]
+link = "https://b.example/s"
+`,
+      )
+      const watcher = fakeWatcher!
+      const next = gen.next()
+      await waitForListener(watcher, 'all')
+      // Simulate an atomic replace that chokidar reports as unlink+add
+      // rather than a single 'change' event.
+      watcher.emit('all', 'unlink', file)
+      watcher.emit('all', 'add', file)
+      const second = await next
+      expect(second.value?.map((s: StreamDataContent) => s.link)).toEqual([
+        'https://b.example/s',
+      ])
+    } finally {
+      await gen.return(undefined)
+    }
+  })
+
+  test('does not crash and keeps watching after a watcher error', async () => {
+    const file = writeTomlFile(`
+[[streams]]
+link = "https://a.example/s"
+`)
+    const gen = watchDataFile(file)
+    try {
+      await gen.next()
+      const watcher = fakeWatcher!
+
+      const next = gen.next()
+      await waitForListener(watcher, 'all')
+      watcher.emit('error', new Error('EPERM'))
+      writeFileSync(
+        file,
+        `
+[[streams]]
+link = "https://b.example/s"
+`,
+      )
+      watcher.emit('all', 'change', file)
+      const { value } = await next
+      expect(value?.map((s: StreamDataContent) => s.link)).toEqual([
+        'https://b.example/s',
+      ])
+    } finally {
+      await gen.return(undefined)
+    }
+  })
+
+  test('keeps the last known-good streams when a read fails after a successful read', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'sw-data-'))
+    const file = path.join(dir, 'streams.toml')
+    writeFileSync(
+      file,
+      `
+[[streams]]
+link = "https://a.example/s"
+`,
+    )
+    const gen = watchDataFile(file)
+    try {
+      const first = await gen.next()
+      expect(first.value?.map((s: StreamDataContent) => s.link)).toEqual([
+        'https://a.example/s',
+      ])
+
+      // Delete the file so the next read fails, then notify the watcher.
+      // A single outstanding next() call spans both the failed re-read
+      // (which must not surface an empty/wiped list) and the eventual
+      // successful re-read below.
+      rmSync(file)
+      const watcher = fakeWatcher!
+      const pendingNext = gen.next()
+      await waitForListener(watcher, 'all')
+      watcher.emit('all', 'unlink', file)
+
+      // The failed re-read must not surface a wiped-out empty list:
+      // pendingNext should still be unresolved at this point.
+      const stillPending = Symbol('pending')
+      const raceResult = await Promise.race([
+        pendingNext,
+        new Promise((resolve) => setTimeout(() => resolve(stillPending), 50)),
+      ])
+      expect(raceResult).toBe(stillPending)
+
+      writeFileSync(
+        file,
+        `
+[[streams]]
+link = "https://b.example/s"
+`,
+      )
+      await waitForListener(watcher, 'all')
+      watcher.emit('all', 'add', file)
+
+      const second = await pendingNext
+      expect(second.value?.map((s: StreamDataContent) => s.link)).toEqual([
+        'https://b.example/s',
+      ])
     } finally {
       await gen.return(undefined)
     }

--- a/packages/streamwall/src/main/data.ts
+++ b/packages/streamwall/src/main/data.ts
@@ -46,21 +46,46 @@ export async function* pollDataURL(url: string, intervalSecs: number) {
 
 export async function* watchDataFile(path: string): DataSource {
   const watcher = watch(path)
+  // chokidar emits 'error' for issues like a removed watch directory; an
+  // unhandled 'error' event on an EventEmitter throws, so a permanent
+  // listener is required to keep the watcher (and this generator) alive.
+  watcher.on('error', (err) => {
+    console.warn('error watching data file', path, err)
+  })
   try {
+    let lastStreams: StreamDataContent[] = []
     while (true) {
-      let data
+      let streams: StreamDataContent[] = []
       try {
         const text = await fsPromises.readFile(path)
-        data = TOML.parse(text.toString())
+        const data = TOML.parse(text.toString())
+        const parsed = parseStreamList(data?.streams)
+        if (parsed.errors.length) {
+          console.warn(
+            `ignoring ${parsed.errors.length} invalid stream(s) in ${path}`,
+          )
+        }
+        streams = parsed.streams as StreamDataContent[]
       } catch (err) {
         console.warn('error reading data file', err)
       }
-      const { streams, errors } = parseStreamList(data?.streams)
-      if (errors.length) {
-        console.warn(`ignoring ${errors.length} invalid stream(s) in ${path}`)
+
+      // If the read/parse fails and we already have data, keep serving it
+      // instead of wiping out every stream (mirrors pollDataURL).
+      if (!streams.length && lastStreams.length) {
+        console.warn('using cached stream data')
+      } else {
+        yield streams
+        lastStreams = streams
       }
-      yield streams as StreamDataContent[]
-      await once(watcher, 'change')
+
+      try {
+        // Wait for any filesystem event, not just 'change': an atomic
+        // replace of the watched file can surface as unlink+add instead.
+        await once(watcher, 'all')
+      } catch (err) {
+        console.warn('error watching data file', path, err)
+      }
     }
   } finally {
     await watcher.close()


### PR DESCRIPTION
## Problem

`watchDataFile` (`packages/streamwall/src/main/data.ts`) only awaited chokidar's `'change'` event and had no error handler:

1. If the watched TOML file is deleted and recreated outside chokidar's atomic-write coalescing window, chokidar reports `unlink`+`add` instead of a single `change` event. The generator was waiting exclusively on `'change'`, so it would hang forever and stop delivering updates — while the failed read in between had already yielded `[]`, wiping all streams from that source.
2. `events.once(watcher, 'change')` has Node's built-in special-case handling: it also rejects if the watcher emits `'error'` (e.g. `EPERM`, watched directory removed). With no listener otherwise attached and no try/catch, this propagated out of the generator, up through `Repeater.latest`, and crashed the whole process.
3. On any transient read/parse failure, the loop yielded an empty stream list (`parseStreamList(undefined?.streams)` returns `{ streams: [] }`), overwriting previously known-good streams instead of preserving them.

## Fix

- Wait on chokidar's `'all'` event instead of only `'change'`, so any filesystem event (add/change/unlink/etc.) triggers a re-read.
- Attach a permanent `watcher.on('error', ...)` listener (preventing the default "throw on unhandled error event" behavior) and wrap the event wait in a `try`/`catch` (Node's `events.once` rejects on `'error'` even with other listeners present).
- Keep the last known-good stream list on read/parse failure instead of yielding `[]`, mirroring the existing cache-and-skip-yield pattern already used in `pollDataURL`.

## Testing

Added `packages/streamwall/src/main/data.test.ts` coverage using a mocked `chokidar.watch()` (a plain `EventEmitter`) for deterministic control over watcher events:

- Re-reads on an `unlink`+`add` cycle instead of only on `change`.
- Does not crash and keeps watching after a watcher `'error'` event.
- Keeps the last known-good streams when a read fails after a previously successful read (does not surface a wiped-out empty list).

All three tests were confirmed failing against the pre-fix code (timeouts caused by the hang/crash bug) before implementing the fix, then passing after.

Quality gate run locally: `format:check`, `lint`, `typecheck`, and `test` all green across every workspace.

## Risks / breaking changes

None expected — this only changes internal watcher event handling and failure-mode behavior in `watchDataFile`; the public generator contract (`AsyncIterableIterator<StreamDataContent[]>`) is unchanged.

Closes #18