### PR TITLE
fix(streamwall): stop spoofing visibility on the pre-navigation document

### DIFF
--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -252,17 +252,6 @@ const viewStateMachine = setup({
         const wc = view.webContents
         await ensureValidURL(content.url, createSessionHostResolver(wc.session))
         wc.audioMuted = true
-        wc.executeJavaScript(`
-          Object.defineProperty(document, 'visibilityState', {
-            value: 'visible',
-            writable: true
-          });
-          Object.defineProperty(document, 'hidden', {
-            value: false,
-            writable: true
-          });
-          document.dispatchEvent(new Event('visibilitychange'));
-        `)
 
         if (/\.m3u8?$/.test(content.url)) {
           loadHTML(wc, 'playHLS', { query: { src: content.url } })

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -1,10 +1,17 @@
 import { ipcRenderer, webFrame } from 'electron'
 import throttle from 'lodash/throttle'
 import { ContentDisplayOptions } from 'streamwall-shared'
+import { installVisibilityOverride } from './visibilityOverride'
 import { VolumeController } from './volumeController'
 
 const SCAN_THROTTLE = 500
 const INITIAL_TIMEOUT = 10 * 1000
+
+// Runs before any of the page's own scripts (preload semantics), unlike the
+// previous approach of calling executeJavaScript on the webContents just
+// before navigating, which targeted the pre-navigation document and was
+// discarded once loadURL navigated away (see #25).
+installVisibilityOverride(webFrame)
 
 const VIDEO_OVERRIDE_STYLE = `
   * {

--- a/packages/streamwall/src/preload/visibilityOverride.test.ts
+++ b/packages/streamwall/src/preload/visibilityOverride.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest'
+import {
+  installVisibilityOverride,
+  overrideVisibility,
+  VISIBILITY_OVERRIDE_SCRIPT,
+} from './visibilityOverride'
+
+describe('installVisibilityOverride', () => {
+  it('runs the visibility override script in the main world via webFrame.executeJavaScript', () => {
+    const executeJavaScript = vi.fn()
+
+    installVisibilityOverride({ executeJavaScript })
+
+    expect(executeJavaScript).toHaveBeenCalledTimes(1)
+    expect(executeJavaScript).toHaveBeenCalledWith(VISIBILITY_OVERRIDE_SCRIPT)
+  })
+})
+
+describe('overrideVisibility', () => {
+  function makeHidden() {
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'hidden',
+      writable: true,
+      configurable: true,
+    })
+    Object.defineProperty(document, 'hidden', {
+      value: true,
+      writable: true,
+      configurable: true,
+    })
+  }
+
+  it('spoofs document.visibilityState and hidden as visible', () => {
+    makeHidden()
+
+    overrideVisibility()
+
+    expect(document.visibilityState).toBe('visible')
+    expect(document.hidden).toBe(false)
+  })
+
+  it('dispatches a visibilitychange event so page listeners re-check visibility', () => {
+    makeHidden()
+    const dispatchSpy = vi.spyOn(document, 'dispatchEvent')
+
+    overrideVisibility()
+
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'visibilitychange' }),
+    )
+  })
+})
+
+describe('VISIBILITY_OVERRIDE_SCRIPT', () => {
+  it('is an immediately-invoked serialization of overrideVisibility', () => {
+    expect(VISIBILITY_OVERRIDE_SCRIPT).toBe(`(${overrideVisibility})()`)
+  })
+})

--- a/packages/streamwall/src/preload/visibilityOverride.ts
+++ b/packages/streamwall/src/preload/visibilityOverride.ts
@@ -1,0 +1,38 @@
+import type { WebFrame } from 'electron'
+
+/**
+ * Spoofs `document.visibilityState`/`hidden` as visible and fires
+ * `visibilitychange`, so that sites which pause media when they believe they
+ * are hidden or backgrounded keep playing on an offscreen/background tile.
+ */
+export function overrideVisibility(): void {
+  Object.defineProperty(document, 'visibilityState', {
+    value: 'visible',
+    writable: true,
+  })
+  Object.defineProperty(document, 'hidden', {
+    value: false,
+    writable: true,
+  })
+  document.dispatchEvent(new Event('visibilitychange'))
+}
+
+// Serialized so it can be run via `executeJavaScript` in the main world: with
+// contextIsolation enabled, calling `overrideVisibility()` directly from the
+// preload's own isolated `document` wrapper would not be visible to the
+// page's own scripts (see `lockdownMediaTags` in mediaPreload.ts for the same
+// pattern applied to media elements).
+export const VISIBILITY_OVERRIDE_SCRIPT = `(${overrideVisibility})()`
+
+/**
+ * Applies the override for the currently loaded document. Must be called
+ * from preload, which runs before the page's own scripts on every
+ * navigation. Running it beforehand against a webContents that is about to
+ * navigate (e.g. before `loadURL`) targets the pre-navigation document, which
+ * `loadURL` discards, making the call a no-op (see #25).
+ */
+export function installVisibilityOverride(
+  webFrame: Pick<WebFrame, 'executeJavaScript'>,
+): void {
+  webFrame.executeJavaScript(VISIBILITY_OVERRIDE_SCRIPT)
+}


### PR DESCRIPTION
## Problem

`viewStateMachine`'s `loadPage` actor called `wc.executeJavaScript(...)` to spoof `document.visibilityState`/`hidden` as visible (and dispatch `visibilitychange`) right before navigating with `wc.loadURL(content.url)`. `loadURL` discards the currently loaded document, so the override was applied to the document being replaced (the initial `about:blank`, or whatever page was previously loaded), never to the actual stream page. The call was a silent no-op for every stream tile — the un-awaited promise could also reject on a destroyed `webContents`.

Sites that pause/mute media when they think they're hidden or backgrounded (an offscreen/background tile genuinely can be) were unaffected by this code.

## Solution

Moved the override into `mediaPreload.ts`, which Electron guarantees runs before the page's own scripts on *every* navigation (that's what `preload` means), so it always lands on the real document instead of a discarded one.

Extracted the logic into a new, independently testable module, `packages/streamwall/src/preload/visibilityOverride.ts`:
- `overrideVisibility()` — the actual `Object.defineProperty`/`dispatchEvent` logic, serialized (via `${overrideVisibility}`) into `VISIBILITY_OVERRIDE_SCRIPT`.
- `installVisibilityOverride(webFrame)` — runs that script through `webFrame.executeJavaScript`, which is required to reach the main world despite `contextIsolation` (the same pattern `lockdownMediaTags` already uses in this file for media-element overrides).

`mediaPreload.ts` calls `installVisibilityOverride(webFrame)` unconditionally at module top level, and the dead `wc.executeJavaScript(...)` call in `viewStateMachine.ts`'s `loadPage` actor was removed.

## Architecture decisions

- Extracted a small dedicated module rather than inlining the fix directly in `mediaPreload.ts`, mirroring the existing `volumeController.ts` extraction — `mediaPreload.ts`'s `main()` has heavy Electron/DOM dependencies that make it hard to unit test as a whole, so testable logic is pulled into small standalone modules.
- Kept the override unconditional on the document kind (video/audio/web/HLS), matching the prior behavior which ran before the kind-based branch in `loadPage`.

## Testing performed

- New `visibilityOverride.test.ts` (happy-dom environment): verifies `overrideVisibility()` actually flips `document.visibilityState`/`hidden` and dispatches `visibilitychange`, and that `installVisibilityOverride` invokes `webFrame.executeJavaScript` with the expected script.
- Full quality gate, all green:
  - `npx eslint .`
  - `npx prettier --check .`
  - `npm run typecheck` (all workspaces)
  - `npx vitest run` in `packages/streamwall` (25 files / 242 tests passing)
  - `npm run make` in `packages/streamwall` (app packages and builds successfully)

## Risks / breaking changes

None expected. This only changes *where* an existing (previously non-functional) visibility spoof runs; no public API changes.

Closes #25