### PR TITLE
fix(electron): apply deferred MUTE/BLUR/BACKGROUND requests on running

### DIFF
--- a/packages/streamwall/src/main/viewStateMachine.test.ts
+++ b/packages/streamwall/src/main/viewStateMachine.test.ts
@@ -552,3 +552,152 @@ describe('viewStateMachine loadPage navigation', () => {
     expect(executeJavaScript).not.toHaveBeenCalled()
   })
 })
+
+describe('viewStateMachine deferred MUTE/BLUR/BACKGROUND requests', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('defaults desiredAudio to muted and desiredBlurred to false', () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+
+    expect(actor.getSnapshot().context.desiredAudio).toBe('muted')
+    expect(actor.getSnapshot().context.desiredBlurred).toBe(false)
+  })
+
+  it('applies a deferred UNMUTE requested while still loading once running is reached', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    display(actor)
+    expect(matchesState('displaying.loading', actor.getSnapshot().value)).toBe(
+      true,
+    )
+
+    actor.send({ type: 'UNMUTE' })
+    // Still loading: the audio region doesn't exist yet, so nothing visible
+    // changes yet -- the request is only recorded.
+    expect(matchesState('displaying.loading', actor.getSnapshot().value)).toBe(
+      true,
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'VIEW_INIT' })
+    actor.send({ type: 'VIEW_LOADED' })
+
+    expect(
+      matchesState(
+        'displaying.running.audio.listening',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+  })
+
+  it('applies a deferred BACKGROUND requested while still loading once running is reached', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    display(actor)
+
+    actor.send({ type: 'BACKGROUND' })
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'VIEW_INIT' })
+    actor.send({ type: 'VIEW_LOADED' })
+
+    expect(
+      matchesState(
+        'displaying.running.audio.background',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+  })
+
+  it('applies a deferred BLUR requested while still loading once running is reached', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    display(actor)
+
+    actor.send({ type: 'BLUR' })
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'VIEW_INIT' })
+    actor.send({ type: 'VIEW_LOADED' })
+
+    expect(
+      matchesState(
+        'displaying.running.video.blurred',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+  })
+
+  it('applies a deferred UNMUTE requested while recovering from an error', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    display(actor)
+    actor.send({ type: 'VIEW_ERROR', error: new Error('boom') })
+    expect(matchesState('displaying.error', actor.getSnapshot().value)).toBe(
+      true,
+    )
+
+    actor.send({ type: 'UNMUTE' })
+
+    await vi.advanceTimersByTimeAsync(1000) // delay * 2^0 -> back to loading
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'VIEW_INIT' })
+    actor.send({ type: 'VIEW_LOADED' })
+
+    expect(
+      matchesState(
+        'displaying.running.audio.listening',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+  })
+
+  it('keeps a backgrounded view backgrounded across an automatic stalled reload', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'BACKGROUND' })
+    expect(
+      matchesState(
+        'displaying.running.audio.background',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+
+    actor.send({ type: 'VIEW_STALLED' })
+    await vi.advanceTimersByTimeAsync(2000) // stalledTimeout -> reload
+    expect(matchesState('displaying.loading', actor.getSnapshot().value)).toBe(
+      true,
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'VIEW_INIT' })
+    actor.send({ type: 'VIEW_LOADED' })
+
+    expect(
+      matchesState(
+        'displaying.running.audio.background',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+  })
+
+  it('still ignores MUTE while backgrounded and keeps the desired state as background', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'BACKGROUND' })
+
+    actor.send({ type: 'MUTE' })
+
+    const snapshot = actor.getSnapshot()
+    expect(
+      matchesState('displaying.running.audio.background', snapshot.value),
+    ).toBe(true)
+    expect(snapshot.context.desiredAudio).toBe('background')
+  })
+})

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -89,6 +89,13 @@ const viewStateMachine = setup({
       error: string | null
       // Number of automatic reloads already spent on the current failure streak.
       retryCount: number
+      // The MUTE/UNMUTE/BACKGROUND state most recently requested for this
+      // view. Tracked independent of `displaying.running.audio` so a request
+      // made while the view is still loading (or recovering from an error) is
+      // applied as soon as `running` is (re-)entered instead of being dropped.
+      desiredAudio: 'muted' | 'listening' | 'background'
+      // Same idea as `desiredAudio`, for BLUR/UNBLUR.
+      desiredBlurred: boolean
     },
 
     events: {} as
@@ -226,6 +233,12 @@ const viewStateMachine = setup({
     // Whether the view is still allowed to reload itself automatically.
     canRetry: ({ context }) =>
       context.retry.enabled && context.retryCount < context.retry.maxRetries,
+
+    desiredAudioIsListening: ({ context }) =>
+      context.desiredAudio === 'listening',
+    desiredAudioIsBackground: ({ context }) =>
+      context.desiredAudio === 'background',
+    desiredVideoIsBlurred: ({ context }) => context.desiredBlurred,
   },
 
   delays: {
@@ -282,6 +295,8 @@ const viewStateMachine = setup({
     error: null,
     retryCount: 0,
     volume: 1,
+    desiredAudio: 'muted',
+    desiredBlurred: false,
   }),
   on: {
     DISPLAY: {
@@ -373,6 +388,18 @@ const viewStateMachine = setup({
       states: {
         loading: {
           initial: 'navigate',
+          // MUTE/UNMUTE/BACKGROUND/UNBACKGROUND/BLUR/UNBLUR only change
+          // behavior once `running`'s own `audio`/`video` regions exist (see
+          // below). Record the request instead of silently dropping it, so it
+          // is applied as soon as `running` is reached.
+          on: {
+            MUTE: { actions: assign({ desiredAudio: 'muted' }) },
+            UNMUTE: { actions: assign({ desiredAudio: 'listening' }) },
+            BACKGROUND: { actions: assign({ desiredAudio: 'background' }) },
+            UNBACKGROUND: { actions: assign({ desiredAudio: 'muted' }) },
+            BLUR: { actions: assign({ desiredBlurred: true }) },
+            UNBLUR: { actions: assign({ desiredBlurred: false }) },
+          },
           // If the whole loading phase stalls (e.g. the renderer never sends
           // VIEW_INIT/VIEW_LOADED), fail the view instead of hanging forever.
           after: {
@@ -497,14 +524,39 @@ const viewStateMachine = setup({
             audio: {
               initial: 'muted',
               on: {
-                MUTE: '.muted',
-                UNMUTE: '.listening',
-                BACKGROUND: '.background',
-                UNBACKGROUND: '.muted',
+                MUTE: {
+                  target: '.muted',
+                  actions: assign({ desiredAudio: 'muted' }),
+                },
+                UNMUTE: {
+                  target: '.listening',
+                  actions: assign({ desiredAudio: 'listening' }),
+                },
+                BACKGROUND: {
+                  target: '.background',
+                  actions: assign({ desiredAudio: 'background' }),
+                },
+                UNBACKGROUND: {
+                  target: '.muted',
+                  actions: assign({ desiredAudio: 'muted' }),
+                },
               },
               states: {
                 muted: {
                   entry: 'muteAudio',
+                  // Applies a MUTE/UNMUTE/BACKGROUND requested while the view
+                  // was still loading (or recovering from an error), instead
+                  // of leaving it stuck muted until explicitly toggled again.
+                  always: [
+                    {
+                      target: 'listening',
+                      guard: 'desiredAudioIsListening',
+                    },
+                    {
+                      target: 'background',
+                      guard: 'desiredAudioIsBackground',
+                    },
+                  ],
                 },
                 listening: {
                   entry: 'unmuteAudio',
@@ -521,17 +573,41 @@ const viewStateMachine = setup({
             video: {
               initial: 'normal',
               on: {
-                BLUR: '.blurred',
-                UNBLUR: '.normal',
+                BLUR: {
+                  target: '.blurred',
+                  actions: assign({ desiredBlurred: true }),
+                },
+                UNBLUR: {
+                  target: '.normal',
+                  actions: assign({ desiredBlurred: false }),
+                },
               },
               states: {
-                normal: {},
+                normal: {
+                  // Applies a BLUR requested while the view was still loading
+                  // (or recovering from an error).
+                  always: {
+                    target: 'blurred',
+                    guard: 'desiredVideoIsBlurred',
+                  },
+                },
                 blurred: {},
               },
             },
           },
         },
         error: {
+          // MUTE/UNMUTE/BACKGROUND/UNBACKGROUND/BLUR/UNBLUR requested while
+          // recovering from an error are recorded the same way as in
+          // `loading` (see above) and applied once `running` is reached.
+          on: {
+            MUTE: { actions: assign({ desiredAudio: 'muted' }) },
+            UNMUTE: { actions: assign({ desiredAudio: 'listening' }) },
+            BACKGROUND: { actions: assign({ desiredAudio: 'background' }) },
+            UNBACKGROUND: { actions: assign({ desiredAudio: 'muted' }) },
+            BLUR: { actions: assign({ desiredBlurred: true }) },
+            UNBLUR: { actions: assign({ desiredBlurred: false }) },
+          },
           // Automatically reload after the backoff delay until the retry budget
           // is spent; then this is a terminal state surfaced to the operator.
           after: {


### PR DESCRIPTION
## Problem

`MUTE`/`UNMUTE`/`BACKGROUND`/`UNBACKGROUND`/`BLUR`/`UNBLUR` are only handled inside `displaying.running`'s `audio`/`video` parallel regions. A request sent while a view is still in `displaying.loading` or `displaying.error` has no matching transition anywhere in its active state, so it's silently dropped.

**Failure scenario:** operator clicks "listen" on a tile that's still loading. `setListeningView` (`packages/streamwall/src/main/StreamWindow.ts`) sends `UNMUTE` to every `displaying` view, including ones still loading. The event is dropped; once the view reaches `running`, `audio` starts at its default `muted` substate, so the selected tile stays silent until the operator toggles it again. Same issue for `BLUR`/`BACKGROUND`.

This also affects **every automatic reload while already running** (a stalled-view retry, an error retry, or a content swap on the same tile): re-entering `running` always resets `audio`/`video` to their initial substates (`muted`/`normal`), regardless of what was active before the reload, since there is no XState history state involved.

## Solution

Added two context fields, `desiredAudio: 'muted' | 'listening' | 'background'` and `desiredBlurred: boolean`, that track the last-requested state independent of the view's current substate:

- `displaying.loading` and `displaying.error` each got an `on` block for the six events that just records the request in context (no visible state change, since the `audio`/`video` regions don't exist yet in those states).
- The existing `running.audio`/`running.video` handlers now also update the same context fields when the request is applied live.
- The `audio.muted` and `video.normal` initial substates gained guarded eventless (`always`) transitions that redirect to the desired substate as soon as `running` is (re-)entered, using three new named guards (`desiredAudioIsListening`, `desiredAudioIsBackground`, `desiredVideoIsBlurred`).

This is the "store desired flags in context, apply on entering running" pattern suggested in the issue. The existing `background` substate's `on: { MUTE: {} }` override (ignore normal audio swapping while backgrounded) is untouched and still takes precedence over the parent-level `audio.on.MUTE` handler, so it keeps ignoring `MUTE` while backgrounded, including across reloads.

## Testing

Added 7 new `vitest` cases to `viewStateMachine.test.ts` covering:
- Default `desiredAudio`/`desiredBlurred` values
- Deferred `UNMUTE`/`BACKGROUND`/`BLUR` requested while still loading, applied once `running` is reached
- Deferred `UNMUTE` requested while recovering from an error
- A backgrounded view staying backgrounded across an automatic stalled reload
- `MUTE` still being ignored while backgrounded (regression check for the existing override)

Full local quality gate green: `prettier --check`, `eslint`, `tsc --noEmit` across all workspaces, and the full `npm test` suite (245 streamwall tests + control-server/control-ui suites), all passing.

## Risks / breaking changes

None expected. The change is additive (new context fields, new guarded transitions); default behavior for a freshly-displayed view is unchanged since the new fields default to `muted`/`false`, matching the prior hardcoded initial substates.

Closes #24