### PR TITLE
fix(control-ui): honor drag direction and clear vacated cells when resizing a tile

### DIFF
--- a/packages/streamwall-control-ui/src/gridInteractions.test.ts
+++ b/packages/streamwall-control-ui/src/gridInteractions.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   computeResizeAssignments,
   computeSwap,
+  isIdxInResizeBox,
   type SwapBox,
 } from './gridInteractions'
 
@@ -75,7 +76,7 @@ describe('computeSwap', () => {
 
 describe('computeResizeAssignments', () => {
   it('assigns a single cell when the anchor and hover are the same', () => {
-    expect(computeResizeAssignments(3, 4, 4, 'stream-a')).toEqual(
+    expect(computeResizeAssignments(3, 4, 4, 'stream-a', 'se', [4])).toEqual(
       new Map([[4, 'stream-a']]),
     )
   })
@@ -84,20 +85,7 @@ describe('computeResizeAssignments', () => {
     // 3-col grid; anchor at idx 0 (x0,y0), hover at idx 4 (x1,y1) spans the
     // 2x2 box { 0, 1, 3, 4 }. Cells 1 and 3 belong to other, unrelated boxes
     // before the resize — they must be overwritten by the anchor's stream.
-    expect(computeResizeAssignments(3, 0, 4, 'stream-a')).toEqual(
-      new Map([
-        [0, 'stream-a'],
-        [1, 'stream-a'],
-        [3, 'stream-a'],
-        [4, 'stream-a'],
-      ]),
-    )
-  })
-
-  it('spans the box the same way regardless of drag direction', () => {
-    // Same 2x2 box as above, but dragged from the bottom-right corner back
-    // up to the top-left anchor.
-    expect(computeResizeAssignments(3, 4, 0, 'stream-a')).toEqual(
+    expect(computeResizeAssignments(3, 0, 4, 'stream-a', 'se', [0])).toEqual(
       new Map([
         [0, 'stream-a'],
         [1, 'stream-a'],
@@ -108,8 +96,100 @@ describe('computeResizeAssignments', () => {
   })
 
   it('does not include cells outside the spanned box', () => {
-    const assignments = computeResizeAssignments(3, 0, 4, 'stream-a')
+    const assignments = computeResizeAssignments(3, 0, 4, 'stream-a', 'se', [0])
     expect(assignments.has(2)).toBe(false)
     expect(assignments.has(5)).toBe(false)
+  })
+
+  it('clamps to the anchor when the hover is dragged past it, instead of spanning backward', () => {
+    // The anchor (top-left corner of the box) never moves. Dragging the 'se'
+    // handle up and to the left of the anchor must not grow the box in that
+    // direction — it must clamp to the anchor cell itself.
+    expect(computeResizeAssignments(3, 4, 0, 'stream-a', 'se', [4])).toEqual(
+      new Map([[4, 'stream-a']]),
+    )
+  })
+
+  it('clears vacated cells when shrinking a box', () => {
+    // 4-col grid; a 3x3 box anchored at idx 0 occupies { 0,1,2, 4,5,6, 8,9,10 }.
+    // Shrinking via the 'se' handle to hover at idx 5 (x1,y1) leaves a 2x2 box
+    // { 0,1, 4,5 } — the other five original cells must be explicitly cleared,
+    // not left with the stale streamId.
+    const originalSpaces = [0, 1, 2, 4, 5, 6, 8, 9, 10]
+    const assignments = computeResizeAssignments(
+      4,
+      0,
+      5,
+      'stream-a',
+      'se',
+      originalSpaces,
+    )
+    expect(assignments).toEqual(
+      new Map([
+        [0, 'stream-a'],
+        [1, 'stream-a'],
+        [4, 'stream-a'],
+        [5, 'stream-a'],
+        [2, undefined],
+        [6, undefined],
+        [8, undefined],
+        [9, undefined],
+        [10, undefined],
+      ]),
+    )
+  })
+
+  it("locks the y-axis to the original box height when dragging the 'e' (east) handle", () => {
+    // 4-col grid; a 1x2 box anchored at idx 0 occupies { 0, 4 } (height 2).
+    // Dragging the east handle to idx 6 (x2,y1) must only grow the width —
+    // the height stays locked at the original 2 rows regardless of hover y.
+    const originalSpaces = [0, 4]
+    expect(
+      computeResizeAssignments(4, 0, 6, 'stream-a', 'e', originalSpaces),
+    ).toEqual(
+      new Map([
+        [0, 'stream-a'],
+        [1, 'stream-a'],
+        [2, 'stream-a'],
+        [4, 'stream-a'],
+        [5, 'stream-a'],
+        [6, 'stream-a'],
+      ]),
+    )
+  })
+
+  it("locks the x-axis to the original box width when dragging the 's' (south) handle", () => {
+    // 4-col grid; a 2x1 box anchored at idx 0 occupies { 0, 1 } (width 2).
+    // Dragging the south handle to idx 9 (x1,y2) must only grow the height —
+    // the width stays locked at the original 2 columns regardless of hover x.
+    const originalSpaces = [0, 1]
+    expect(
+      computeResizeAssignments(4, 0, 9, 'stream-a', 's', originalSpaces),
+    ).toEqual(
+      new Map([
+        [0, 'stream-a'],
+        [1, 'stream-a'],
+        [4, 'stream-a'],
+        [5, 'stream-a'],
+        [8, 'stream-a'],
+        [9, 'stream-a'],
+      ]),
+    )
+  })
+})
+
+describe('isIdxInResizeBox', () => {
+  it('matches the box computeResizeAssignments would commit, including axis locking and clamping', () => {
+    const originalSpaces = [0, 4]
+    // Growing the 'e' handle to idx 6: width grows to x<=2, height stays
+    // locked to the original y<=1 — idx 10 (x2,y2) falls outside the height
+    // lock even though it shares the grown column.
+    expect(isIdxInResizeBox(4, 0, 6, 'e', originalSpaces, 2)).toBe(true)
+    expect(isIdxInResizeBox(4, 0, 6, 'e', originalSpaces, 10)).toBe(false)
+  })
+
+  it('reports only the anchor cell when the hover is dragged past the anchor', () => {
+    expect(isIdxInResizeBox(3, 4, 0, 'se', [4], 4)).toBe(true)
+    expect(isIdxInResizeBox(3, 4, 0, 'se', [4], 0)).toBe(false)
   })
 })

--- a/packages/streamwall-control-ui/src/gridInteractions.ts
+++ b/packages/streamwall-control-ui/src/gridInteractions.ts
@@ -42,28 +42,90 @@ export function computeSwap(
   return assignments
 }
 
+/** Which edge(s) of the box a resize handle drags. */
+export type ResizeHandle = 'e' | 's' | 'se'
+
+/**
+ * The grid rectangle a resize gesture currently spans. `anchorIdx`'s cell is
+ * always the box's fixed top-left corner (`minX`/`minY`), so hover positions
+ * above or left of it clamp back to the anchor instead of spanning backward
+ * past it — that would grow the box in the wrong direction. An edge handle
+ * ('e' or 's') only drags its own axis: the other axis stays locked to the
+ * original box's extent (from `originalSpaces`) regardless of hover.
+ */
+function computeResizeBox(
+  cols: number,
+  anchorIdx: number,
+  hoverIdx: number,
+  handle: ResizeHandle,
+  originalSpaces: number[],
+) {
+  const { x: anchorX, y: anchorY } = idxToCoords(cols, anchorIdx)
+  const { x: hoverX, y: hoverY } = idxToCoords(cols, hoverIdx)
+  const originalCoords = originalSpaces.map((idx) => idxToCoords(cols, idx))
+  const originalMaxX = Math.max(...originalCoords.map(({ x }) => x))
+  const originalMaxY = Math.max(...originalCoords.map(({ y }) => y))
+  return {
+    minX: anchorX,
+    maxX: handle === 's' ? originalMaxX : Math.max(anchorX, hoverX),
+    minY: anchorY,
+    maxY: handle === 'e' ? originalMaxY : Math.max(anchorY, hoverY),
+  }
+}
+
+/** Whether `idx` falls inside the box an in-progress resize gesture spans — used to preview which cells a commit would overwrite. */
+export function isIdxInResizeBox(
+  cols: number,
+  anchorIdx: number,
+  hoverIdx: number,
+  handle: ResizeHandle,
+  originalSpaces: number[],
+  idx: number,
+): boolean {
+  const { minX, maxX, minY, maxY } = computeResizeBox(
+    cols,
+    anchorIdx,
+    hoverIdx,
+    handle,
+    originalSpaces,
+  )
+  const { x, y } = idxToCoords(cols, idx)
+  return x >= minX && x <= maxX && y >= minY && y <= maxY
+}
+
 /**
  * Compute the streamId assignment for a resize gesture: every grid cell in
- * the rectangle spanned by `anchorIdx` and `hoverIdx` (inclusive, in either
- * drag direction) is assigned `streamId`, overwriting whatever stream(s)
- * currently occupy that box.
+ * the box `computeResizeBox` spans is assigned `streamId`, overwriting
+ * whatever stream(s) currently occupy that box. Any cell in `originalSpaces`
+ * (the box's extent before this gesture) that falls outside the new box is
+ * explicitly cleared (set to `undefined`) so a shrink actually vacates it,
+ * rather than leaving a stale streamId that keeps rendering as part of the
+ * (now smaller) box.
  */
 export function computeResizeAssignments(
   cols: number,
   anchorIdx: number,
   hoverIdx: number,
   streamId: string,
-): Map<number, string> {
-  const { x: anchorX, y: anchorY } = idxToCoords(cols, anchorIdx)
-  const { x: hoverX, y: hoverY } = idxToCoords(cols, hoverIdx)
-  const lowX = Math.min(anchorX, hoverX)
-  const highX = Math.max(anchorX, hoverX)
-  const lowY = Math.min(anchorY, hoverY)
-  const highY = Math.max(anchorY, hoverY)
-  const assignments = new Map<number, string>()
-  for (let y = lowY; y <= highY; y++) {
-    for (let x = lowX; x <= highX; x++) {
+  handle: ResizeHandle,
+  originalSpaces: number[],
+): Map<number, string | undefined> {
+  const { minX, maxX, minY, maxY } = computeResizeBox(
+    cols,
+    anchorIdx,
+    hoverIdx,
+    handle,
+    originalSpaces,
+  )
+  const assignments = new Map<number, string | undefined>()
+  for (let y = minY; y <= maxY; y++) {
+    for (let x = minX; x <= maxX; x++) {
       assignments.set(cols * y + x, streamId)
+    }
+  }
+  for (const idx of originalSpaces) {
+    if (!assignments.has(idx)) {
+      assignments.set(idx, undefined)
     }
   }
   return assignments

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -42,7 +42,6 @@ import {
   gridWouldDropAssignments,
   hasGridAssignments,
   idColor,
-  idxInBox,
   inviteLink,
   type LayoutPreset,
   type LocalStreamData,
@@ -67,6 +66,8 @@ import {
 import {
   computeResizeAssignments,
   computeSwap,
+  isIdxInResizeBox,
+  type ResizeHandle,
   type SwapBox,
 } from './gridInteractions'
 import './index.css'
@@ -773,11 +774,22 @@ export function ControlUI({
   }, [moveStart, hoveringIdx, swapBoxes])
 
   const [resize, setResize] = useState<
-    { anchorIdx: number; streamId: string } | undefined
+    | {
+        anchorIdx: number
+        streamId: string
+        handle: ResizeHandle
+        originalSpaces: number[]
+      }
+    | undefined
   >()
 
   const handleResizeStart = useCallback(
-    (anchorIdx: number, ev: PointerEvent) => {
+    (
+      anchorIdx: number,
+      handle: ResizeHandle,
+      originalSpaces: number[],
+      ev: PointerEvent,
+    ) => {
       if (!isPrimaryButton(ev.button)) {
         return
       }
@@ -787,7 +799,7 @@ export function ControlUI({
       if (streamId == null || streamId === '') {
         return
       }
-      setResize({ anchorIdx, streamId })
+      setResize({ anchorIdx, streamId, handle, originalSpaces })
     },
     [sharedState],
   )
@@ -814,6 +826,8 @@ export function ControlUI({
           resize.anchorIdx,
           hoveringIdx,
           resize.streamId,
+          resize.handle,
+          resize.originalSpaces,
         )
         for (const [idx, streamId] of assignments) {
           viewsMap.get(String(idx))?.set('streamId', streamId)
@@ -1291,7 +1305,14 @@ export function ControlUI({
                     const isResizeHighlight =
                       resize != null &&
                       hoveringIdx != null &&
-                      idxInBox(cols, resize.anchorIdx, hoveringIdx, idx)
+                      isIdxInResizeBox(
+                        cols,
+                        resize.anchorIdx,
+                        hoveringIdx,
+                        resize.handle,
+                        resize.originalSpaces,
+                        idx,
+                      )
                     const isHighlighted = isMoveHighlight || isResizeHighlight
                     return (
                       <GridInput
@@ -1343,19 +1364,19 @@ export function ControlUI({
                         <div
                           className="handle e"
                           onPointerDown={(ev) =>
-                            handleResizeStart(anchorIdx, ev)
+                            handleResizeStart(anchorIdx, 'e', pos.spaces, ev)
                           }
                         />
                         <div
                           className="handle s"
                           onPointerDown={(ev) =>
-                            handleResizeStart(anchorIdx, ev)
+                            handleResizeStart(anchorIdx, 's', pos.spaces, ev)
                           }
                         />
                         <div
                           className="handle se"
                           onPointerDown={(ev) =>
-                            handleResizeStart(anchorIdx, ev)
+                            handleResizeStart(anchorIdx, 'se', pos.spaces, ev)
                           }
                         />
                       </StyledResizeHandles>

--- a/packages/streamwall-shared/src/geometry.ts
+++ b/packages/streamwall-shared/src/geometry.ts
@@ -101,24 +101,6 @@ export function idxToCoords(cols: number, idx: number) {
   return { x, y }
 }
 
-export function idxInBox(
-  cols: number,
-  start: number,
-  end: number,
-  idx: number,
-) {
-  const { x: startX, y: startY } = idxToCoords(cols, start)
-  const { x: endX, y: endY } = idxToCoords(cols, end)
-  const { x, y } = idxToCoords(cols, idx)
-  const lowX = Math.min(startX, endX)
-  const highX = Math.max(startX, endX)
-  const lowY = Math.min(startY, endY)
-  const highY = Math.max(startY, endY)
-  const xInBox = x >= lowX && x <= highX
-  const yInBox = y >= lowY && y <= highY
-  return xInBox && yInBox
-}
-
 /** Inclusive bounds for grid dimensions (columns / rows). */
 export const GRID_MIN = 1
 export const GRID_MAX = 8


### PR DESCRIPTION
## Problem

`endResize` computed the resize box by spanning from the anchor (always the tile's fixed top-left cell) to the hovered cell, and only ever *set* streamIds — it never cleared anything. This produced three concrete failure modes:

1. **Cannot shrink** — nothing was cleared, so a 3×3 tile could never be reduced via the handles: the leftover cells kept the old streamId and stayed visually merged with the shrunk box.
2. **Grows the wrong way** — dragging a handle left of/above the anchor spanned backward from the hovered cell to the anchor, growing the box outside the original tile's bounds instead of clamping at the anchor.
3. All three handles (`e`, `s`, `se`) shared the same box-spanning logic, so the edge handles (`e`/`s`, meant to resize only width/height respectively) could also resize the other axis.

## Fix

`computeResizeAssignments` (`packages/streamwall-control-ui/src/gridInteractions.ts`) now takes the dragged handle (`'e' | 's' | 'se'`) and the box's original cells:

- The anchor cell is always the fixed corner; the hovered edge clamps to it instead of spanning backward past it.
- An edge handle (`e`/`s`) only moves its own axis — the other axis stays locked to the box's original extent.
- Any original cell the new box no longer covers is explicitly cleared (`streamId: undefined`) so a shrink actually vacates it.

The in-progress resize highlight (new `isIdxInResizeBox` helper, replacing the ad-hoc `idxInBox` call) uses the same box computation, so the preview always matches what a commit would apply — including which of a neighbor's cells would be overwritten.

## Testing

- Added unit tests in `gridInteractions.test.ts` covering: clamping past the anchor, clearing vacated cells on shrink, per-handle axis locking (`e` locks height, `s` locks width), and that the highlight helper matches the commit box.
- Full quality gate run locally: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` (all workspaces, 619 tests), and `npm -w streamwall-control-client run build` — all green.

## Risks / breaking changes

None expected — this only changes the internal resize-gesture math in `streamwall-control-ui`; no schema, wire-protocol, or public API changes.

Closes #32