### PR TITLE
fix: grid residual-pixel gaps and numeric-sort ordering

### DIFF
--- a/packages/streamwall-shared/src/geometry.test.ts
+++ b/packages/streamwall-shared/src/geometry.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
+import type { ViewContent } from './geometry.ts'
 import {
+  boxesFromViewContentMap,
   clampGridDimension,
   GRID_MAX,
   GRID_MIN,
@@ -13,6 +15,24 @@ import {
 describe('idxToCoords', () => {
   it('maps an index to grid coordinates', () => {
     expect(idxToCoords(3, 4)).toEqual({ x: 1, y: 1 })
+  })
+})
+
+describe('boxesFromViewContentMap', () => {
+  it('sorts a box spaces numerically so spaces[0] stays the top-left cell', () => {
+    // 8 cols: a box spanning (x=2,y=0) and (x=2,y=1) covers indices 2 and 10.
+    // A lexicographic sort would order these as ["10", "2"] -> [10, 2],
+    // making spaces[0] (used as the box's "top-left" index) wrong.
+    const content: ViewContent = { url: 'https://example.com', kind: 'video' }
+    const viewContentMap = new Map([
+      ['2', content],
+      ['10', content],
+    ])
+
+    const boxes = boxesFromViewContentMap(8, 8, viewContentMap)
+
+    expect(boxes).toHaveLength(1)
+    expect(boxes[0].spaces).toEqual([2, 10])
   })
 })
 

--- a/packages/streamwall-shared/src/geometry.test.ts
+++ b/packages/streamwall-shared/src/geometry.test.ts
@@ -3,6 +3,7 @@ import type { ViewContent } from './geometry.ts'
 import {
   boxesFromViewContentMap,
   clampGridDimension,
+  computeBoxRect,
   GRID_MAX,
   GRID_MIN,
   gridWouldDropAssignments,
@@ -33,6 +34,45 @@ describe('boxesFromViewContentMap', () => {
 
     expect(boxes).toHaveLength(1)
     expect(boxes[0].spaces).toEqual([2, 10])
+  })
+})
+
+describe('computeBoxRect', () => {
+  it('gives an interior box the plain floor-divided space size', () => {
+    // 1000 / 7 = 142.86 -> floors to 142 per cell.
+    const rect = computeBoxRect(7, 7, 1000, 1000, { x: 0, y: 0, w: 1, h: 1 })
+    expect(rect).toEqual({ x: 0, y: 0, width: 142, height: 142 })
+  })
+
+  it('extends the last column to the right edge, absorbing the residual pixels', () => {
+    // spaceWidth=142, 7*142=994, so column 6 would normally stop 6px short.
+    const rect = computeBoxRect(7, 7, 1000, 1000, { x: 6, y: 0, w: 1, h: 1 })
+    expect(rect.x).toBe(852) // 142 * 6
+    expect(rect.width).toBe(148) // 1000 - 852, not 142
+  })
+
+  it('extends the last row to the bottom edge, absorbing the residual pixels', () => {
+    const rect = computeBoxRect(7, 7, 1000, 1000, { x: 0, y: 6, w: 1, h: 1 })
+    expect(rect.y).toBe(852) // 142 * 6
+    expect(rect.height).toBe(148) // 1000 - 852, not 142
+  })
+
+  it('gives a multi-cell box that reaches the edge the full residual width', () => {
+    // Box spans x=5..6 (w=2), reaching the right edge at cols=7.
+    const rect = computeBoxRect(7, 7, 1000, 1000, { x: 5, y: 0, w: 2, h: 1 })
+    expect(rect.x).toBe(710) // 142 * 5
+    expect(rect.width).toBe(290) // 1000 - 710, not 142 * 2 (284)
+  })
+
+  it('does not extend a box that does not reach the last column/row', () => {
+    const rect = computeBoxRect(7, 7, 1000, 1000, { x: 0, y: 0, w: 2, h: 2 })
+    expect(rect).toEqual({ x: 0, y: 0, width: 284, height: 284 })
+  })
+
+  it('leaves exact divisions untouched', () => {
+    // 8 cols into 1920px divides evenly (240 per cell).
+    const rect = computeBoxRect(8, 8, 1920, 1080, { x: 7, y: 0, w: 1, h: 1 })
+    expect(rect).toEqual({ x: 1680, y: 0, width: 240, height: 135 })
   })
 })
 

--- a/packages/streamwall-shared/src/geometry.ts
+++ b/packages/streamwall-shared/src/geometry.ts
@@ -95,6 +95,41 @@ export function boxesFromViewContentMap(
   return boxes
 }
 
+/** A box's position and size in grid-cell units, as produced by {@link boxesFromViewContentMap}. */
+export interface GridBox {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+/**
+ * Converts a box's grid-cell coordinates into a pixel rectangle. Flooring
+ * width/height by cols/rows (needed since cells must be whole pixels) leaves
+ * up to `cols-1`/`rows-1` residual pixels uncovered at the right/bottom edge;
+ * a box that reaches the last column/row absorbs that remainder instead of
+ * leaving a gap.
+ */
+export function computeBoxRect(
+  cols: number,
+  rows: number,
+  width: number,
+  height: number,
+  box: GridBox,
+): Rectangle {
+  const spaceWidth = Math.floor(width / cols)
+  const spaceHeight = Math.floor(height / rows)
+  const { x, y, w, h } = box
+  const reachesRightEdge = x + w >= cols
+  const reachesBottomEdge = y + h >= rows
+  return {
+    x: spaceWidth * x,
+    y: spaceHeight * y,
+    width: reachesRightEdge ? width - spaceWidth * x : spaceWidth * w,
+    height: reachesBottomEdge ? height - spaceHeight * y : spaceHeight * h,
+  }
+}
+
 export function idxToCoords(cols: number, idx: number) {
   const x = idx % cols
   const y = Math.floor(idx / cols)

--- a/packages/streamwall-shared/src/geometry.ts
+++ b/packages/streamwall-shared/src/geometry.ts
@@ -73,7 +73,7 @@ export function boxesFromViewContentMap(
     }
     const w = cx - x
     const h = maxY - y
-    spaces.sort()
+    spaces.sort((a, b) => a - b)
     return { content, x, y, w, h, spaces }
   }
 

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -13,6 +13,7 @@ import isEqual from 'lodash/isEqual'
 import path from 'path'
 import {
   boxesFromViewContentMap,
+  computeBoxRect,
   ContentDisplayOptions,
   StreamData,
   StreamList,
@@ -318,8 +319,6 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
 
   setViews(viewContentMap: ViewContentMap, streams: StreamList) {
     const { width, height, cols, rows } = this.config
-    const spaceWidth = Math.floor(width / cols)
-    const spaceHeight = Math.floor(height / rows)
     const { win, views } = this
     const boxes = boxesFromViewContentMap(cols, rows, viewContentMap)
     const remainingBoxes = new Set(boxes)
@@ -373,7 +372,7 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
 
     const newViews = new Map()
     for (const { box, view } of viewsToDisplay) {
-      const { content, x, y, w, h, spaces } = box
+      const { content, spaces } = box
       if (!content) {
         continue
       }
@@ -384,10 +383,7 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
       }
 
       const pos = {
-        x: spaceWidth * x,
-        y: spaceHeight * y,
-        width: spaceWidth * w,
-        height: spaceHeight * h,
+        ...computeBoxRect(cols, rows, width, height, box),
         spaces,
       }
 


### PR DESCRIPTION
## Problem

Issue #26 flagged two small bugs surfaced by a main-process review, both related to grid layout math (`packages/streamwall-shared/src/geometry.ts` and `packages/streamwall/src/main/StreamWindow.ts`):

1. **Residual-pixel tile gaps.** `StreamWindow.setViews` computed each grid cell's pixel size with `Math.floor(width / cols)` / `Math.floor(height / rows)`. Flooring is necessary (cells must land on whole pixels), but when `width`/`height` isn't evenly divisible by `cols`/`rows`, up to `cols-1`/`rows-1` pixels are left uncovered at the right/bottom edge of the wall. Visible when chroma-keying.
2. **Lexicographic sort of numeric grid indices.** `boxesFromViewContentMap` sorted a box's `spaces` array with the default `Array.prototype.sort()`, which compares elements as strings (`[2, 10]` sorts to `[10, 2]`). Several consumers (hotkey labels, the active-stream lookup in the control UI) rely on `spaces[0]` being the box's numerically-lowest ("top-left") cell. This was harmless on small grids but breaks on any grid reaching double-digit indices, which the 8x8 grid-resize feature made reachable.

## Solution

- `boxesFromViewContentMap`: sort `spaces` with an explicit numeric comparator (`(a, b) => a - b`) instead of the default lexicographic sort.
- Extracted the box→pixel-rect math out of `StreamWindow.setViews` into a new pure, independently-testable function, `computeBoxRect` (in `streamwall-shared/geometry.ts`). It still floors width/height per cell, but a box whose right/bottom edge reaches the last column/row now absorbs the residual pixels instead of leaving a gap.
- `StreamWindow.setViews` now calls `computeBoxRect` instead of inlining the (buggy) math.

## Testing

TDD throughout — each fix has a red/green cycle:
- `packages/streamwall-shared/src/geometry.test.ts`: added coverage for `boxesFromViewContentMap`'s numeric sort (a box spanning grid indices 2 and 10 must stay `[2, 10]`, not `[10, 2]`), and 6 cases for `computeBoxRect` (interior cells, last-column/last-row extension, a multi-cell box reaching the edge, non-edge boxes staying untouched, and exact/no-remainder divisions).
- Full quality gate green locally: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm run test` (all workspaces), and the `streamwall-control-client` build.

## Risks / breaking changes

None. Both fixes are internal layout-math corrections with no API changes; `computeBoxRect`'s output is identical to the old math except at grid edges where it now covers the previously-missing pixels.

Closes #26
