### PR TITLE
fix(streamwall): stop rotate-stream overlay patches from overwriting a stream's kind

### DIFF
--- a/packages/streamwall/src/main/data.test.ts
+++ b/packages/streamwall/src/main/data.test.ts
@@ -6,7 +6,14 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import type { StreamDataContent } from 'streamwall-shared'
 import { afterEach, describe, expect, test, vi } from 'vitest'
-import { pollDataURL, watchDataFile } from './data'
+import {
+  combineDataSources,
+  LocalStreamData,
+  markDataSource,
+  pollDataURL,
+  StreamIDGenerator,
+  watchDataFile,
+} from './data'
 
 class FakeWatcher extends EventEmitter {
   close = vi.fn(async () => {})
@@ -322,5 +329,53 @@ describe('pollDataURL', () => {
     } finally {
       await gen.return(undefined)
     }
+  })
+})
+
+describe('combineDataSources', () => {
+  // combineDataSources() runs for the app's lifetime in production and is
+  // never torn down, so its generator's .return() path is untested upstream
+  // and currently never resolves (Repeater.latest appears not to propagate
+  // return() to contenders once multiple sources are involved). Reading a
+  // single value and letting the generator get garbage-collected avoids
+  // that hang; see the follow-up issue for the cleanup bug itself.
+  test('keeps a stream kind when an overlay rotation patch is applied on top of it', async () => {
+    const realData = new LocalStreamData([
+      { link: 'https://a.example/s', kind: 'web' },
+    ])
+    const overlayData = new LocalStreamData()
+    // Applied before the sources are read, so the merge below observes the
+    // patch on the very first yield rather than racing a live update.
+    overlayData.update('https://a.example/s', { rotation: 90 })
+
+    const gen = combineDataSources(
+      [
+        markDataSource(realData.gen(), 'custom'),
+        markDataSource(overlayData.gen(), 'overlay'),
+      ],
+      new StreamIDGenerator(),
+    )
+    const { value } = await gen.next()
+    expect(value?.byURL?.get('https://a.example/s')).toMatchObject({
+      kind: 'web',
+      rotation: 90,
+    })
+  })
+
+  test('does not fabricate a stream from an overlay-only rotation patch', async () => {
+    const realData = new LocalStreamData([])
+    const overlayData = new LocalStreamData()
+    overlayData.update('https://ghost.example/s', { rotation: 180 })
+
+    const gen = combineDataSources(
+      [
+        markDataSource(realData.gen(), 'custom'),
+        markDataSource(overlayData.gen(), 'overlay'),
+      ],
+      new StreamIDGenerator(),
+    )
+    const { value } = await gen.next()
+    expect(value).toHaveLength(0)
+    expect(value?.byURL?.has('https://ghost.example/s')).toBe(false)
   })
 })

--- a/packages/streamwall/src/main/data.ts
+++ b/packages/streamwall/src/main/data.ts
@@ -118,6 +118,9 @@ export async function* markDataSource(dataSource: DataSource, name: string) {
   }
 }
 
+/** Name passed to `markDataSource` for the overlay (rotate-stream) source. */
+export const OVERLAY_DATA_SOURCE_NAME = 'overlay'
+
 export async function* combineDataSources(
   dataSources: DataSource[],
   idGen: StreamIDGenerator,
@@ -127,6 +130,20 @@ export async function* combineDataSources(
     for (const list of streamLists) {
       for (const data of list) {
         const existing = dataByURL.get(data.link)
+        if (data._dataSource === OVERLAY_DATA_SOURCE_NAME) {
+          // Overlay entries only ever carry display-only patch fields (e.g.
+          // rotation) applied via LocalStreamData.update(), which also fills
+          // in a `kind` because StreamDataContent requires one - that value
+          // is never meaningful and must not clobber the stream's real kind
+          // (or its `_dataSource`, provenance). Drop the entry outright if
+          // there's no real stream to patch, rather than fabricating one for
+          // a URL no other source knows about.
+          if (existing) {
+            const { kind: _kind, _dataSource: _source, ...patch } = data
+            dataByURL.set(data.link, { ...existing, ...patch } as StreamData)
+          }
+          continue
+        }
         dataByURL.set(data.link, { ...existing, ...data } as StreamData)
       }
     }

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -36,6 +36,7 @@ import {
 import ControlWindow from './ControlWindow'
 import {
   LocalStreamData,
+  OVERLAY_DATA_SOURCE_NAME,
   StreamIDGenerator,
   combineDataSources,
   markDataSource,
@@ -912,7 +913,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
       )
     }),
     markDataSource(localStreamData.gen(), 'custom'),
-    markDataSource(overlayStreamData.gen(), 'overlay'),
+    markDataSource(overlayStreamData.gen(), OVERLAY_DATA_SOURCE_NAME),
   ]
 
   for await (const streams of combineDataSources(dataSources, idGen)) {


### PR DESCRIPTION
## Problem

Rotating a stream (the `rotate-stream` control command) stores the requested rotation in a separate overlay `LocalStreamData` instance (`overlayStreamData`), which `combineDataSources()` merges over the real stream data last. `LocalStreamData.update()` always fills in a `kind` field (defaulting to `'video'`) because `StreamDataContent.kind` is required — but the overlay entry it creates for a rotation patch never has a real `kind`.

Two consequences:
- Rotating a `kind: 'web'` or `kind: 'audio'` stream silently rewrote its `kind` to `'video'` once the overlay entry was merged on top, changing how the renderer treats it.
- If a stream's URL is later removed from every real data source, the leftover overlay rotation patch fabricated a phantom stream entry (with only `link`, `rotation`, and a fake `kind`) that showed up in the merged stream list.

## Solution

`combineDataSources()` (`packages/streamwall/src/main/data.ts`) now special-cases entries tagged with the overlay data source name (`OVERLAY_DATA_SOURCE_NAME`, exported to avoid a duplicated magic string between `data.ts` and `index.ts`):

- It merges only the overlay's actual patch fields (e.g. `rotation`) onto an existing entry, explicitly excluding `kind` and `_dataSource` so the overlay can never override a stream's real kind or provenance.
- If there's no existing entry for that URL from a real source, the overlay patch is dropped instead of fabricating a stream.

No changes were needed to `LocalStreamData` itself — its default-`kind` behavior is dead code for the only other caller (`update-custom-stream`, whose payload always carries an explicit `kind` per `localStreamDataSchema`), so scoping the fix to the merge step in `combineDataSources` is the smallest correct change.

## Testing

Added two `combineDataSources` tests in `packages/streamwall/src/main/data.test.ts` (TDD: both fail against the old code, reproducing the bug, and pass against the fix):
- An overlay rotation patch preserves the underlying stream's real `kind`.
- An overlay-only patch for a URL unknown to any real source does not fabricate a stream.

Quality gate, all green: `npm run format:check`, `npm run lint`, `npm run typecheck` (all workspaces), `npm test` (all workspaces — 240+209+90+77 tests), and `npm -w streamwall-control-client run build`.

## Risks / breaking changes

None expected. This only changes how the overlay (rotate-stream) data source is merged; other data sources (JSON URL, TOML file, custom streams) are unaffected.

## Notes

While writing the regression tests, I found that `combineDataSources()`'s generator never resolves `.return()` once multiple sources have each produced a value — reproducible outside Vitest too. It has no production impact (the app's main loop consumes this generator for its whole lifetime and never calls `.return()`), so it's out of scope here; the new tests avoid triggering it (documented inline) and it's tracked in #264.

Closes #23