### PR TITLE
test(electron): close view state machine and URL-scheme rejection gaps

### DIFF
--- a/packages/streamwall/src/main/viewStateMachine.test.ts
+++ b/packages/streamwall/src/main/viewStateMachine.test.ts
@@ -489,6 +489,44 @@ describe('viewStateMachine content swap while running', () => {
     // inheriting exhaustion from whatever the previous content did.
     expect(actor.getSnapshot().context.retryCount).toBe(0)
   })
+
+  it('ignores a DISPLAY with unchanged content and position while running', async () => {
+    const { actor, offscreenView, positionView } =
+      makeActorWithPlacementSpies(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    positionView.mockClear()
+
+    actor.send({ type: 'DISPLAY', pos: POS, content: CONTENT })
+
+    const snapshot = actor.getSnapshot()
+    expect(matchesState('displaying.running', snapshot.value)).toBe(true)
+    expect(snapshot.context.content).toEqual(CONTENT)
+    expect(snapshot.context.pos).toEqual(POS)
+    // contentPosUnchanged guard: nothing actually changed, so the view must
+    // not be re-shuffled offscreen or repositioned.
+    expect(offscreenView).toHaveBeenCalledTimes(1)
+    expect(positionView).not.toHaveBeenCalled()
+  })
+
+  it('reloads via a manual RELOAD from running without moving the view offscreen again', async () => {
+    const { actor, offscreenView } = makeActorWithPlacementSpies(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    expect(offscreenView).toHaveBeenCalledTimes(1)
+
+    actor.send({ type: 'RELOAD' })
+
+    const snapshot = actor.getSnapshot()
+    expect(matchesState('displaying.loading', snapshot.value)).toBe(true)
+    expect(snapshot.context.content).toEqual(CONTENT)
+    expect(snapshot.context.pos).toEqual(POS)
+    // RELOAD is handled by the ancestor `displaying` state's own `on`
+    // handler, so it is an internal transition from running down into
+    // loading: `displaying`'s entry (which includes offscreenView) must not
+    // re-fire, unlike a fresh DISPLAY from `empty`.
+    expect(offscreenView).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('viewStateMachine loadPage navigation', () => {

--- a/packages/streamwall/src/util.test.ts
+++ b/packages/streamwall/src/util.test.ts
@@ -40,6 +40,14 @@ test('rejects a non-http(s) URL scheme', async () => {
   await assert.rejects(ensureValidURL('file:///etc/passwd'), /non-http/)
 })
 
+test('rejects a javascript: URL', async () => {
+  await assert.rejects(ensureValidURL('javascript:alert(1)'), /non-http/)
+})
+
+test('rejects a chrome: URL', async () => {
+  await assert.rejects(ensureValidURL('chrome://settings'), /non-http/)
+})
+
 test('rejects a URL with no host', async () => {
   await assert.rejects(ensureValidURL('http:///path'), /host/)
 })


### PR DESCRIPTION
## Summary

`packages/streamwall/src/main/viewStateMachine.ts` already had an extensive test suite (`viewStateMachine.test.ts`) covering the empty→displaying→loading→running lifecycle, the audio parallel-state matrix, blur states, auto-retry/backoff, and deferred MUTE/BLUR/BACKGROUND requests. `util.ts`'s `ensureValidURL` also already had broad SSRF-focused coverage. Comparing the existing coverage against the scope described in #50 turned up three narrow, genuinely untested paths:

- The `contentPosUnchanged` no-op guard (a `DISPLAY` while `running` with identical content and position must not re-shuffle the view offscreen or reposition it).
- A manual `RELOAD` sent from `running` (as opposed to from `error`/`loading`, which was already covered) — this exercises the internal-transition semantics where `displaying`'s own entry actions (`offscreenView`) must not re-fire.
- Explicit rejection of `javascript:` and `chrome:` URL schemes in `ensureValidURL` (only `file:` was tested for the non-http rejection path, even though the issue names these schemes specifically).

## Technical solution

Added 4 test cases:
- `packages/streamwall/src/main/viewStateMachine.test.ts`: two new tests in the "content swap while running" describe block, reusing the existing `makeActorWithPlacementSpies` helper to assert on `offscreenView`/`positionView` call counts.
- `packages/streamwall/src/util.test.ts`: two new `ensureValidURL` rejection tests for `javascript:` and `chrome:` URLs.

No production code changes — all four new tests pass against the existing implementation, confirming the behavior was already correct; this PR only closes the test-coverage gap.

## Testing performed

- `npx vitest run` for `packages/streamwall`: 31 test files, 290 tests passed (up from 286).
- `npx tsc --noEmit -p tsconfig.json`, `npx eslint`, `npx prettier --check` on the changed files: all clean.

## Risks / breaking changes

None — test-only change, no production code touched.

Closes #50