### PR TITLE
docs: document the swap/move race between concurrent operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,15 @@ See
 for environment variable configuration (hostname/port, storage location, rate
 limits) and a production deployment walkthrough.
 
+**Known limitation:** grid edits (swap, drag-move, resize) sync as
+independent per-cell updates in the shared Yjs document. If two operators
+swap or move overlapping tiles at nearly the same instant, the last-writer-wins
+merge can duplicate one stream into both tiles while dropping the other,
+instead of leaving a consistent swap. This is inherent to modeling the grid as
+independent per-cell values rather than one atomically-swapped unit, and is
+low-impact in practice since concurrent operators rarely target the same
+cells simultaneously.
+
 ## Data sources
 
 Streamwall can load stream data from both JSON APIs and TOML files. Data sources can be specified in a config file (see `example.config.toml` for an example) or the command line:

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -661,6 +661,20 @@ export function ControlUI({
     },
     [stateIdxMap],
   )
+  // Used by both the swap gesture (`handleSwap`) and the drag-move gesture
+  // (`endMove` below) to commit a two-box exchange.
+  //
+  // Known limitation: this reads each box's current streamId and writes both
+  // boxes' new streamIds as independent keys in the shared Yjs map. Yjs
+  // resolves concurrent edits per key (last-writer-wins), not across the pair
+  // atomically. If two operators swap/move overlapping boxes at nearly the
+  // same time, each computes its reassignment from a state the other is also
+  // about to overwrite — the merged result can duplicate one stream into both
+  // boxes while dropping the other. This is inherent to modeling the grid as
+  // independent per-cell keys rather than a single atomically-swapped value;
+  // a real fix would need a server-side or CRDT-level guard (e.g. rejecting a
+  // swap whose read boxes changed since it started). Low impact in practice
+  // since concurrent operators rarely target the same cells simultaneously.
   const swapBoxes = useCallback(
     (fromIdx: number, toIdx: number) => {
       stateDoc.transact(() => {


### PR DESCRIPTION
## Problem

`swapBoxes` in `packages/streamwall-control-ui/src/index.tsx` commits a grid
swap/drag-move as a read-modify-write over independent keys in the shared
Yjs `views` map (one `.set('streamId', ...)` per affected cell). Yjs resolves
concurrent edits per key (last-writer-wins), not atomically across a pair of
keys.

If two operators swap or move overlapping tiles at nearly the same instant,
each computes its reassignment from a doc state the other is about to
overwrite. The merged result can duplicate one stream into both tiles while
dropping the other, instead of leaving a consistent swap.

## Technical solution

This is inherent to modeling the grid as independent per-cell Yjs keys
rather than one atomically-swapped value — a real fix would need a
server-side or CRDT-level guard (e.g. the control server rejecting a swap
whose read boxes changed since the gesture started). Per the issue's own
assessment (severity: low, inherent to the data model), the change here is
the documented minimum:

- A comment on `swapBoxes` in `index.tsx` explaining the race and why it
  exists, for future maintainers touching this code path.
- A "Known limitation" note in the README's "Remote control server" section,
  visible to operators running multi-operator setups.

No behavior changes; the existing swap/move/resize logic and its test
coverage (`gridInteractions.test.ts`) are untouched.

## Testing performed

- `npm run format:check` — pass
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm test` (all workspaces) — pass (control-ui: 87/87, control-server: 90/90, streamwall: pass)
- `npm -w streamwall-control-client run build` — pass

No new tests were added: this is a documentation-only change with no
testable behavior (per the resolve-issue TDD exception for docs/comments).

## Risks / breaking changes

None — no runtime code paths changed, only comments and README prose.

Closes #43