### PR TITLE
fix(control-ui): preserve tile footprint when drag-moving onto an empty cell

### DIFF
--- a/packages/streamwall-control-ui/src/gridInteractions.test.ts
+++ b/packages/streamwall-control-ui/src/gridInteractions.test.ts
@@ -14,7 +14,7 @@ describe('computeSwap', () => {
       [1, { spaces: [1], streamId: 'stream-b' }],
     ])
 
-    expect(computeSwap(boxes, 0, 1)).toEqual(
+    expect(computeSwap(boxes, 0, 1, 3, 3)).toEqual(
       new Map([
         [0, 'stream-b'],
         [1, 'stream-a'],
@@ -29,7 +29,7 @@ describe('computeSwap', () => {
       [1, { spaces: [1, 2], streamId: 'stream-b' }],
     ])
 
-    expect(computeSwap(boxes, 0, 1)).toEqual(
+    expect(computeSwap(boxes, 0, 1, 3, 3)).toEqual(
       new Map([
         [0, 'stream-b'],
         [1, 'stream-a'],
@@ -43,7 +43,7 @@ describe('computeSwap', () => {
       [0, { spaces: [0], streamId: 'stream-a' }],
     ])
 
-    expect(computeSwap(boxes, 0, 0)).toEqual(new Map())
+    expect(computeSwap(boxes, 0, 0, 3, 3)).toEqual(new Map())
   })
 
   it('treats a box missing from the map as a single space at its own index', () => {
@@ -51,7 +51,7 @@ describe('computeSwap', () => {
       [1, { spaces: [1], streamId: 'stream-b' }],
     ])
 
-    expect(computeSwap(boxes, 0, 1)).toEqual(
+    expect(computeSwap(boxes, 0, 1, 3, 3)).toEqual(
       new Map([
         [0, 'stream-b'],
         [1, undefined],
@@ -65,10 +65,77 @@ describe('computeSwap', () => {
       [1, { spaces: [1], streamId: 'stream-b' }],
     ])
 
-    expect(computeSwap(boxes, 0, 1)).toEqual(
+    expect(computeSwap(boxes, 0, 1, 3, 3)).toEqual(
       new Map([
         [0, 'stream-b'],
         [1, undefined],
+      ]),
+    )
+  })
+
+  it('translates a merged box onto an empty target instead of collapsing it to one cell', () => {
+    // 4-col grid; a 2x2 box anchored at idx 0 occupies { 0,1, 4,5 }. Dragging
+    // it (from its anchor) onto empty idx 10 (x2,y2) must move the whole
+    // footprint there — { 10,11, 14,15 } — not just fill idx 10 alone while
+    // clearing the other three source cells for nothing.
+    const boxes = new Map<number, SwapBox>([
+      [0, { spaces: [0, 1, 4, 5], streamId: 'stream-a' }],
+    ])
+
+    expect(computeSwap(boxes, 0, 10, 4, 4)).toEqual(
+      new Map([
+        [0, undefined],
+        [1, undefined],
+        [4, undefined],
+        [5, undefined],
+        [10, 'stream-a'],
+        [11, 'stream-a'],
+        [14, 'stream-a'],
+        [15, 'stream-a'],
+      ]),
+    )
+  })
+
+  it('clamps the translated footprint to the grid bounds instead of distorting its shape', () => {
+    // Same 2x2 box, but the drag targets idx 15 (x3,y3) — translating the
+    // anchor there by the raw (dx,dy) would push the box half off the
+    // 4x4 grid. The whole box must shift together and clamp so it still
+    // lands fully on-grid as an intact 2x2 shape.
+    const boxes = new Map<number, SwapBox>([
+      [0, { spaces: [0, 1, 4, 5], streamId: 'stream-a' }],
+    ])
+
+    expect(computeSwap(boxes, 0, 15, 4, 4)).toEqual(
+      new Map([
+        [0, undefined],
+        [1, undefined],
+        [4, undefined],
+        [5, undefined],
+        [10, 'stream-a'],
+        [11, 'stream-a'],
+        [14, 'stream-a'],
+        [15, 'stream-a'],
+      ]),
+    )
+  })
+
+  it('translates the footprint using the dragged cell as the reference point, not always the anchor', () => {
+    // The pointer can grab any cell of a merged box, not just its top-left
+    // anchor. Dragging from idx 5 (the box's bottom-right cell, x1y1) onto
+    // empty idx 9 (x1y2) must move the whole box down by one row — landing
+    // at { 4,5, 8,9 } — keeping the dragged cell under the drop target.
+    const boxes = new Map<number, SwapBox>([
+      [5, { spaces: [0, 1, 4, 5], streamId: 'stream-a' }],
+    ])
+
+    expect(computeSwap(boxes, 5, 9, 4, 4)).toEqual(
+      new Map([
+        [0, undefined],
+        [1, undefined],
+        [4, 'stream-a'],
+        [5, 'stream-a'],
+        [8, 'stream-a'],
+        [9, 'stream-a'],
       ]),
     )
   })

--- a/packages/streamwall-control-ui/src/gridInteractions.ts
+++ b/packages/streamwall-control-ui/src/gridInteractions.ts
@@ -15,17 +15,63 @@ export interface SwapBox {
 }
 
 /**
+ * Translate `spaces` (a box's grid-cell footprint) by the offset from
+ * `fromIdx` to `toIdx`, clamping the offset so the whole footprint's
+ * bounding box stays on-grid — the box moves and clamps as a single rigid
+ * shape rather than distorting or having individual cells clamp
+ * independently.
+ */
+function translateFootprint(
+  cols: number,
+  rows: number,
+  spaces: number[],
+  fromIdx: number,
+  toIdx: number,
+): number[] {
+  const coords = spaces.map((idx) => idxToCoords(cols, idx))
+  const { x: fromX, y: fromY } = idxToCoords(cols, fromIdx)
+  const { x: toX, y: toY } = idxToCoords(cols, toIdx)
+  let dx = toX - fromX
+  let dy = toY - fromY
+
+  const minX = Math.min(...coords.map(({ x }) => x))
+  const maxX = Math.max(...coords.map(({ x }) => x))
+  const minY = Math.min(...coords.map(({ y }) => y))
+  const maxY = Math.max(...coords.map(({ y }) => y))
+
+  if (minX + dx < 0) {
+    dx = -minX
+  } else if (maxX + dx > cols - 1) {
+    dx = cols - 1 - maxX
+  }
+  if (minY + dy < 0) {
+    dy = -minY
+  } else if (maxY + dy > rows - 1) {
+    dy = rows - 1 - maxY
+  }
+
+  return coords.map(({ x, y }) => cols * (y + dy) + (x + dx))
+}
+
+/**
  * Compute the streamId reassignment for swapping the box anchored at
  * `fromIdx` with the box anchored at `toIdx`: every space of one box takes on
  * the other box's streamId, so boxes of unequal size swap correctly. A box
  * missing from `boxes` is treated as a single space at its own index (mirrors
  * dropping onto a grid cell that has no box yet). Returns an empty map — a
  * no-op — when `fromIdx` and `toIdx` name the same box.
+ *
+ * Dropping onto a cell with no box (`toBox` missing) is a move, not a swap:
+ * rather than collapsing the source box down to the single target cell, its
+ * whole footprint is translated to the drop location (clamped to the grid)
+ * so a merged tile keeps its size and shape.
  */
 export function computeSwap(
   boxes: Map<number, SwapBox>,
   fromIdx: number,
   toIdx: number,
+  cols: number,
+  rows: number,
 ): Map<number, string | undefined> {
   if (fromIdx === toIdx) {
     return new Map()
@@ -33,6 +79,24 @@ export function computeSwap(
   const fromBox = boxes.get(fromIdx)
   const toBox = boxes.get(toIdx)
   const assignments = new Map<number, string | undefined>()
+
+  if (fromBox !== undefined && toBox === undefined) {
+    const targetSpaces = translateFootprint(
+      cols,
+      rows,
+      fromBox.spaces,
+      fromIdx,
+      toIdx,
+    )
+    for (const idx of fromBox.spaces) {
+      assignments.set(idx, undefined)
+    }
+    for (const idx of targetSpaces) {
+      assignments.set(idx, fromBox.streamId)
+    }
+    return assignments
+  }
+
   for (const idx of fromBox?.spaces ?? [fromIdx]) {
     assignments.set(idx, toBox?.streamId)
   }

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -663,24 +663,33 @@ export function ControlUI({
   )
   const swapBoxes = useCallback(
     (fromIdx: number, toIdx: number) => {
+      if (cols == null || rows == null) {
+        return
+      }
       stateDoc.transact(() => {
         const viewsMap = stateDoc.getMap<Y.Map<string | undefined>>('views')
-        const boxes = new Map<number, SwapBox>(
-          [fromIdx, toIdx].map((idx) => [
-            idx,
-            {
-              spaces: stateIdxMap.get(idx)?.spaces ?? [idx],
-              streamId: viewsMap.get(String(idx))?.get('streamId'),
-            },
-          ]),
-        )
-        const assignments = computeSwap(boxes, fromIdx, toIdx)
+        const boxes = new Map<number, SwapBox>()
+        for (const idx of [fromIdx, toIdx]) {
+          const viewInfo = stateIdxMap.get(idx)
+          if (viewInfo === undefined) {
+            // No box occupies this index — leave it out of `boxes` so
+            // `computeSwap` treats it as a genuinely empty target rather
+            // than a single-space box, letting it translate a merged
+            // source box's whole footprint there instead of collapsing it.
+            continue
+          }
+          boxes.set(idx, {
+            spaces: viewInfo.spaces,
+            streamId: viewsMap.get(String(idx))?.get('streamId'),
+          })
+        }
+        const assignments = computeSwap(boxes, fromIdx, toIdx, cols, rows)
         for (const [idx, streamId] of assignments) {
           viewsMap.get(String(idx))?.set('streamId', streamId)
         }
       })
     },
-    [stateDoc, stateIdxMap],
+    [stateDoc, stateIdxMap, cols, rows],
   )
 
   const handleSwap = useCallback(


### PR DESCRIPTION
## Problem

Dragging a merged multi-cell tile (e.g. a 2×2 tile) onto an empty grid cell silently collapsed it down to a single 1×1 cell instead of moving it as-is: the four source cells were cleared but only the one destination cell received the stream.

Root cause: `computeSwap`'s handling of a drop onto a cell with no existing box fell back to a single-cell target list (`[toIdx]`), regardless of how many cells the dragged box actually occupied. The `swapBoxes` caller compounded this by always inserting a `SwapBox` entry for both the source and target index — even when the target had no view — using `spaces: stateIdxMap.get(idx)?.spaces ?? [idx]` as a fallback, so `computeSwap` could never tell the difference between "a real single-cell box" and "no box at all".

## Fix

- `computeSwap` (`packages/streamwall-control-ui/src/gridInteractions.ts`) now takes the grid's `cols`/`rows` and, when the drop target has no box, translates the source box's whole footprint to the drop location as a single rigid shape (via a new `translateFootprint` helper), clamped to stay fully on-grid rather than distorting the shape.
- The `swapBoxes` callback in `index.tsx` now only adds a `SwapBox` entry to the map for an index that `stateIdxMap` actually has a view for, so an empty target reaches `computeSwap` as a genuine gap instead of an implicit single-cell placeholder.

## Testing

Added unit tests in `gridInteractions.test.ts` covering:
- translating a merged box's full footprint onto an empty target (no more collapsing)
- clamping the translated footprint to the grid bounds instead of distorting its shape
- using whichever cell the pointer grabbed (not always the box's anchor) as the drag reference point

All 90 existing + new tests pass, along with the repo-wide typecheck, lint, and format checks.

## Risk / Breaking changes

None — this only changes drag-move behavior for merged tiles dropped on empty cells; single-cell moves and box-to-box swaps are unaffected (existing tests confirm no regression there).

Closes #33