### PR TITLE
chore: ignore local design/ mockups in .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,9 @@ build/
 .vite/
 .webpack/
 
+# Local design mockups / render artifacts (mirrors .gitignore)
+design/
+
 # Coverage / logs / caches
 coverage/
 *.log


### PR DESCRIPTION
## Problem

Issue #62 asked for a root `format`/`format:check` script wired into CI, plus a `.prettierignore` covering `out/`, `dist/`, `.vite/`, and `design/`.

Most of this was already delivered by prior work already on `main`:
- `format` / `format:check` scripts in the root `package.json` (#120)
- `format:check` running as a required CI step (#120)
- `.prettierignore` covering `out/`, `dist/`, `.vite/`, and other build-output paths (#183, merged earlier today)

The one remaining gap: `.prettierignore` did not list `design/`, even though `.gitignore` already treats `design/` as a local, untracked directory for design mockups/render artifacts.

## Solution

Add a `design/` entry to `.prettierignore`, mirroring the existing pattern used for `dist/`, `out/`, `.vite/`, etc. (each of those is also already covered by `.gitignore`, but is listed explicitly for robustness/clarity — `design/` now follows the same convention).

## Testing performed

- Manually verified Prettier's behavior on a scratch `design/` directory with a deliberately malformed file, both with the file force-added to git and left untracked — confirmed no regression and that the entry now matches the intent documented in the issue.
- Full quality gate run locally:
  - `npm run format:check` — pass
  - `npm run lint` — pass
  - `npm run typecheck` — pass
  - `npm test` — 90/90 (streamwall), 87/87 (control-ui), all workspaces pass
  - `npm -w streamwall-control-client run build` — pass

This is a config-only change (an ignore-file entry) with no executable behavior, so per the repo's TDD exception for non-testable changes, no new automated test was added.

## Risks / breaking changes

None — this only affects which paths Prettier considers when formatting/checking; `design/` is a local-only, gitignored directory that never contains committed files.

Closes #62