### PR TITLE
test(streamwall): close remaining coverage gaps in the set-grid-size Yjs remap pipeline

### DIFF
--- a/packages/streamwall/src/main/gridResize.test.ts
+++ b/packages/streamwall/src/main/gridResize.test.ts
@@ -1,6 +1,7 @@
 import {
   boxesFromViewContentMap,
   GRID_MAX,
+  GRID_MIN,
   type ViewContentMap,
 } from 'streamwall-shared'
 import { describe, expect, it } from 'vitest'
@@ -182,6 +183,35 @@ describe('applyGridResize', () => {
     expect(viewsState.get('4')?.get('streamId')).toBe('stream-b')
   })
 
+  it('grows only the column count, preserving the row count', () => {
+    const { viewsState, ctx } = setupWall(2, 3)
+    // cell 4 = (x=0, y=2), only reachable with a 2-col grid at 3+ rows.
+    seedAssignments(viewsState, 2, 3, { 4: 'stream-a' })
+
+    const applied = applyGridResize(ctx, 4, 3)
+
+    expect(applied).toEqual({ cols: 4, rows: 3 })
+    // (0,2) -> 4*2 + 0 = 8 in the new 4-col grid.
+    expect(viewsState.get('8')?.get('streamId')).toBe('stream-a')
+    expect([...viewsState.keys()]).toHaveLength(12)
+  })
+
+  it('shrinks only the row count, dropping assignments that fall outside', () => {
+    const { viewsState, wall, updateViewsFromStateDoc, ctx } = setupWall(2, 4)
+    // cell 6 = (x=0, y=3), only reachable with 4+ rows.
+    seedAssignments(viewsState, 2, 4, { 6: 'stream-a', 0: 'stream-b' })
+
+    updateViewsFromStateDoc()
+    viewsState.observeDeep(updateViewsFromStateDoc)
+
+    const applied = applyGridResize(ctx, 2, 2)
+
+    expect(applied).toEqual({ cols: 2, rows: 2 })
+    expect(wall.live.has('stream-a')).toBe(false)
+    expect(viewsState.get('0')?.get('streamId')).toBe('stream-b')
+    expect([...viewsState.keys()]).toHaveLength(4)
+  })
+
   it('drops and destroys a stream that falls outside a shrunk grid', () => {
     const { viewsState, wall, updateViewsFromStateDoc, ctx } = setupWall(3, 3)
     // cell 8 = (x=2, y=2), only reachable in a 3x3 (or larger) grid.
@@ -223,6 +253,33 @@ describe('applyGridResize', () => {
 
     expect(applied).toEqual({ cols: 1, rows: GRID_MAX })
     expect(viewsState.size).toBe(1 * GRID_MAX)
+  })
+
+  it('clamps a NaN/non-finite request to the minimum dimension', () => {
+    const { viewsState, ctx } = setupWall(2, 2)
+    seedAssignments(viewsState, 2, 2, {})
+
+    const applied = applyGridResize(ctx, Number.NaN, Number.POSITIVE_INFINITY)
+
+    expect(applied).toEqual({ cols: GRID_MIN, rows: GRID_MIN })
+    expect(viewsState.size).toBe(GRID_MIN * GRID_MIN)
+  })
+
+  it('rebuilds viewsState as a single atomic Yjs update', () => {
+    const { doc, viewsState, ctx } = setupWall(2, 2)
+    seedAssignments(viewsState, 2, 2, { 0: 'stream-a', 3: 'stream-b' })
+
+    let updateCount = 0
+    doc.on('update', () => {
+      updateCount++
+    })
+
+    applyGridResize(ctx, 3, 3)
+
+    // The delete-all + rebuild must land in one transact, not one update per
+    // key, so observers (e.g. updateViewsFromStateDoc) never see a
+    // partially-rebuilt viewsState.
+    expect(updateCount).toBe(1)
   })
 
   it('does not resurrect a stale viewsState key left over from a larger grid (issue #17)', () => {


### PR DESCRIPTION
## Problem

Issue #51 asked to extract `handleSetGridSize`-style logic out of the main-process `set-grid-size` control-command handler (`packages/streamwall/src/main/index.ts`) into a testable module, then cover it against a bare `Y.Doc` for: growing columns, shrinking rows, shrinking both (dropped assignments), clamping of NaN/out-of-range input, the rebuilt map covering exactly `cols*rows` keys, and single-update atomicity.

The extraction itself (`applyGridResize` in `packages/streamwall/src/main/gridResize.ts`) already existed from prior, unrelated grid-resize bug fixes (#117, #255), along with a `gridResize.test.ts` suite. Checking that suite against the issue's checklist showed most cases were already covered, but four were not:

- growing only the column count while rows stay fixed
- shrinking only the row count while columns stay fixed
- clamping a non-finite (`NaN`/`Infinity`) request through the full `applyGridResize` integration (only the underlying `clampGridDimension` helper had a unit test for this)
- the delete-all + rebuild landing as a single atomic Yjs update, rather than one update per key (which would let observers see a partially-rebuilt `viewsState`)

## Solution

Added the four missing test cases to `packages/streamwall/src/main/gridResize.test.ts`, closing out the coverage checklist from the issue. No production code changes were needed — `applyGridResize` already implements this generically via `remapGridAssignments`/`clampGridDimension`, so the new tests pass against the existing implementation.

## Testing performed

- Added the new tests and confirmed all 11 tests in `gridResize.test.ts` pass.
- Verified the new tests are not vacuous: temporarily split the single `ctx.transact(...)` rebuild into two separate transacts and reran the suite — both the new atomicity test and the pre-existing issue #15 regression test failed as expected, then reverted the change to confirm green again.
- Full quality gate: `prettier --check .`, `eslint .`, `npm run typecheck --workspaces`, and `npm run test --workspaces` (streamwall 290/290, streamwall-shared 223/223, streamwall-control-server 90/90, streamwall-control-ui 87/87) all pass.

## Risks / breaking changes

None — test-only change, no production code touched.

Closes #51
