### PR TITLE
fix(control-ui): debounce eager grid-input clearing on non-matching partials

### DIFF
--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -75,7 +75,10 @@ import {
 import './index.css'
 import { LayoutPresetControls } from './LayoutPresetControls.tsx'
 import { LazyChangeInput } from './LazyChangeInput.tsx'
-import { resolveTargetViewIdx, resolveWriteStreamId } from './viewPlacement.ts'
+import {
+  resolveEagerWriteStreamId,
+  resolveTargetViewIdx,
+} from './viewPlacement.ts'
 import { createSharedUndoManager } from './yUndo.ts'
 
 // `import { Color } from 'streamwall-shared'` binds only the value; alias
@@ -855,10 +858,14 @@ export function ControlUI({
 
   const handleSetView = useCallback(
     (idx: number, streamId: string) => {
+      const resolved = resolveEagerWriteStreamId(streams, streamId)
+      if (resolved === undefined) {
+        return
+      }
       stateDoc
         .getMap<Y.Map<string | undefined>>('views')
         .get(String(idx))
-        ?.set('streamId', resolveWriteStreamId(streams, streamId))
+        ?.set('streamId', resolved)
     },
     [stateDoc, streams],
   )

--- a/packages/streamwall-control-ui/src/viewPlacement.test.ts
+++ b/packages/streamwall-control-ui/src/viewPlacement.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { resolveTargetViewIdx, resolveWriteStreamId } from './viewPlacement.ts'
+import {
+  resolveEagerWriteStreamId,
+  resolveTargetViewIdx,
+  resolveWriteStreamId,
+} from './viewPlacement.ts'
 
 describe('resolveTargetViewIdx', () => {
   it('targets the focused input cell regardless of occupancy', () => {
@@ -74,5 +78,28 @@ describe('resolveWriteStreamId', () => {
 
   it('clears the cell when there are no streams', () => {
     expect(resolveWriteStreamId([], 'new')).toBe('')
+  })
+})
+
+describe('resolveEagerWriteStreamId', () => {
+  it('commits the streamId once it matches a known stream', () => {
+    expect(
+      resolveEagerWriteStreamId([{ _id: 'old' }, { _id: 'wolf' }], 'wolf'),
+    ).toBe('wolf')
+  })
+
+  it('clears the cell once the input is emptied', () => {
+    expect(resolveEagerWriteStreamId([{ _id: 'wolf' }], '')).toBe('')
+  })
+
+  it('does not commit a partial, non-matching keystroke', () => {
+    // Regression: typing "wolf" character-by-character used to clear the
+    // cell on every non-matching partial ("w", "wo", "wol"), tearing down
+    // the view until the final matching keystroke landed.
+    expect(resolveEagerWriteStreamId([{ _id: 'wolf' }], 'wol')).toBeUndefined()
+  })
+
+  it('does not commit an unknown value that will never match', () => {
+    expect(resolveEagerWriteStreamId([{ _id: 'old' }], 'typo')).toBeUndefined()
   })
 })

--- a/packages/streamwall-control-ui/src/viewPlacement.ts
+++ b/packages/streamwall-control-ui/src/viewPlacement.ts
@@ -44,3 +44,25 @@ export function resolveWriteStreamId(
 ): string {
   return streams.some((stream) => stream._id === streamId) ? streamId : ''
 }
+
+/**
+ * The streamId to write for a per-keystroke (eager) input commit, or
+ * `undefined` when the keystroke shouldn't commit at all.
+ *
+ * Unlike `resolveWriteStreamId`, an unmatched non-empty value returns
+ * `undefined` rather than `''`: while typing a stream id character-by-
+ * character, every partial value is technically "unknown" until the final
+ * matching keystroke, and clearing the cell on each of those would tear
+ * down the view mid-type. Only an explicitly emptied box (the user select-
+ * all-deleted it) should clear the cell immediately.
+ */
+export function resolveEagerWriteStreamId(
+  streams: readonly { _id: string }[],
+  streamId: string,
+): string | undefined {
+  if (streamId === '') {
+    return ''
+  }
+  const resolved = resolveWriteStreamId(streams, streamId)
+  return resolved === '' ? undefined : resolved
+}


### PR DESCRIPTION
## Problem

`GridInput` commits stream-id edits eagerly on every keystroke (`isEager`). The commit path (`handleSetView` → `resolveWriteStreamId`) resolves any value that isn't an exact match against a known stream to `''`. Typing a stream id character-by-character (e.g. "w", "wo", "wol", "wolf") therefore wrote `''` to the shared Yjs doc for every partial, non-matching keystroke before the final match landed — tearing down and re-creating the view on the wall while the operator was still typing.

## Solution

Added `resolveEagerWriteStreamId` in `viewPlacement.ts`, used only by the eager per-keystroke commit path (`handleSetView`):
- an exact match commits the streamId, same as before
- an explicitly emptied input (select-all + delete) still commits `''` immediately, so clearing a cell stays instant
- any other non-matching partial value returns `undefined`, meaning "don't commit yet" — the view keeps its last valid assignment until a full match (or an explicit clear) arrives

`resolveWriteStreamId` itself is unchanged and still backs the click-to-assign path (`handleClickId`), which always passes a real, currently-known stream id, so its behavior there is unaffected.

## Testing

- Added unit tests in `viewPlacement.test.ts` for `resolveEagerWriteStreamId`: exact match commits, empty input clears, partial non-match and unknown-forever values don't commit.
- Verified TDD red→green: new tests failed with `resolveEagerWriteStreamId is not a function` before the implementation existed.
- Full quality gate passed locally: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm run test` (all workspaces), `npm -w streamwall-control-client run build`.

## Risks / breaking changes

None expected. The change only narrows when the eager commit path clears a cell; the click-to-assign path and the underlying Yjs schema are untouched.

Closes #42