### PR TITLE
test(streamwall): cover StreamIDGenerator, LocalStreamData, and data-source combinators

### DIFF
--- a/packages/streamwall/src/main/data.test.ts
+++ b/packages/streamwall/src/main/data.test.ts
@@ -6,7 +6,14 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import type { StreamDataContent } from 'streamwall-shared'
 import { afterEach, describe, expect, test, vi } from 'vitest'
-import { pollDataURL, watchDataFile } from './data'
+import {
+  combineDataSources,
+  LocalStreamData,
+  markDataSource,
+  pollDataURL,
+  StreamIDGenerator,
+  watchDataFile,
+} from './data'
 
 class FakeWatcher extends EventEmitter {
   close = vi.fn(async () => {})
@@ -321,6 +328,296 @@ describe('pollDataURL', () => {
       expect(onHealth).toHaveBeenCalledWith(false, expect.any(String))
     } finally {
       await gen.return(undefined)
+    }
+  })
+
+  test('retains the last successful batch and keeps polling after an empty response', async () => {
+    let body: unknown[] = [{ link: 'https://a.example/s', kind: 'video' }]
+    server = createServer((_req, res) => {
+      res.setHeader('content-type', 'application/json')
+      res.end(JSON.stringify(body))
+    })
+    await new Promise<void>((resolve) =>
+      server!.listen(0, '127.0.0.1', resolve),
+    )
+    const { port } = server.address() as AddressInfo
+    const url = `http://127.0.0.1:${port}/`
+
+    const gen = pollDataURL(url, 0.1)
+    try {
+      const first = await gen.next()
+      expect(first.value?.map((s: StreamDataContent) => s.link)).toEqual([
+        'https://a.example/s',
+      ])
+
+      // The endpoint now returns no streams. The cached batch must not be
+      // surfaced as wiped out; the outstanding next() should still be
+      // unresolved while polling continues in the background.
+      body = []
+      const pending = gen.next()
+
+      const stillPending = Symbol('pending')
+      const raceResult = await Promise.race([
+        pending,
+        new Promise((resolve) => setTimeout(() => resolve(stillPending), 150)),
+      ])
+      expect(raceResult).toBe(stillPending)
+
+      body = [{ link: 'https://b.example/s', kind: 'video' }]
+      const second = await pending
+      expect(second.value?.map((s: StreamDataContent) => s.link)).toEqual([
+        'https://b.example/s',
+      ])
+    } finally {
+      await gen.return(undefined)
+    }
+  })
+})
+
+describe('StreamIDGenerator', () => {
+  function stream(
+    overrides: Partial<StreamDataContent> & { link: string },
+  ): StreamDataContent {
+    return { kind: 'video', ...overrides }
+  }
+
+  test('derives a 3-character id from the source/label/link', () => {
+    const gen = new StreamIDGenerator()
+    const streams = [
+      stream({ link: 'https://a.example/s', source: 'Example Source' }),
+    ]
+    gen.process(streams)
+    expect(streams[0]._id).toBe('exa')
+  })
+
+  test('resolves collisions with an incrementing numeric suffix', () => {
+    const gen = new StreamIDGenerator()
+    const streams = [
+      stream({ link: 'https://a.example/s', source: 'Example' }),
+      stream({ link: 'https://b.example/s', source: 'Example' }),
+      stream({ link: 'https://c.example/s', source: 'Example' }),
+    ]
+    gen.process(streams)
+    expect(streams.map((s) => s._id)).toEqual(['exa', 'exa1', 'exa2'])
+  })
+
+  test('strips a leading "the" prefix before deriving the id', () => {
+    const gen = new StreamIDGenerator()
+    const streams = [
+      stream({ link: 'https://a.example/s', source: 'The Stream' }),
+    ]
+    gen.process(streams)
+    expect(streams[0]._id).toBe('str')
+  })
+
+  test('strips a leading http(s)/www prefix before deriving the id', () => {
+    const gen = new StreamIDGenerator()
+    const streams = [
+      stream({
+        link: 'https://ignored.example/s',
+        source: 'http://www.Example.com',
+      }),
+    ]
+    gen.process(streams)
+    expect(streams[0]._id).toBe('exa')
+  })
+
+  test('skips a stream with no usable id base and leaves it without an id', () => {
+    const gen = new StreamIDGenerator()
+    const streams = [stream({ link: '' })]
+    gen.process(streams)
+    expect(streams[0]._id).toBeUndefined()
+  })
+
+  test('keeps a stable id for the same link across repeated process() calls', () => {
+    const gen = new StreamIDGenerator()
+    const first = [stream({ link: 'https://a.example/s', source: 'Example' })]
+    gen.process(first)
+    expect(first[0]._id).toBe('exa')
+
+    const second = [
+      stream({ link: 'https://a.example/s', source: 'Example' }),
+      stream({ link: 'https://b.example/s', source: 'Example' }),
+    ]
+    gen.process(second)
+    expect(second[0]._id).toBe('exa')
+    expect(second[1]._id).toBe('exa1')
+  })
+})
+
+describe('LocalStreamData', () => {
+  test('indexes entries by link and drops entries without a link', () => {
+    const data = new LocalStreamData([
+      { kind: 'video', link: 'https://a.example/s' },
+      { kind: 'video', link: '' },
+    ])
+    expect([...data.dataByURL.keys()]).toEqual(['https://a.example/s'])
+  })
+
+  test('update() defaults kind to "video" for a brand new entry', () => {
+    const data = new LocalStreamData()
+    data.update('https://a.example/s', {})
+    expect(data.dataByURL.get('https://a.example/s')).toMatchObject({
+      kind: 'video',
+      link: 'https://a.example/s',
+    })
+  })
+
+  test('update() preserves the existing kind when not overridden', () => {
+    const data = new LocalStreamData([
+      { kind: 'audio', link: 'https://a.example/s' },
+    ])
+    data.update('https://a.example/s', { label: 'Renamed' })
+    expect(data.dataByURL.get('https://a.example/s')).toMatchObject({
+      kind: 'audio',
+      label: 'Renamed',
+    })
+  })
+
+  // Only the Map key move is asserted here: the stored entry's own `.link`
+  // field is left stale (the old url) after a rekey, tracked as a separate
+  // bug in issue #274.
+  test('update() rekeys the entry when data.link differs from the lookup url', () => {
+    const data = new LocalStreamData([
+      { kind: 'video', link: 'https://a.example/s' },
+    ])
+    data.update('https://a.example/s', { link: 'https://b.example/s' })
+    expect(data.dataByURL.has('https://a.example/s')).toBe(false)
+    expect(data.dataByURL.has('https://b.example/s')).toBe(true)
+  })
+
+  test('update() emits the full entry list on the "update" event', () => {
+    const data = new LocalStreamData()
+    const onUpdate = vi.fn()
+    data.on('update', onUpdate)
+    data.update('https://a.example/s', { kind: 'video' })
+    expect(onUpdate).toHaveBeenCalledWith([
+      expect.objectContaining({ link: 'https://a.example/s' }),
+    ])
+  })
+
+  test('delete() removes the entry and emits the update event', () => {
+    const data = new LocalStreamData([
+      { kind: 'video', link: 'https://a.example/s' },
+    ])
+    const onUpdate = vi.fn()
+    data.on('update', onUpdate)
+    data.delete('https://a.example/s')
+    expect(data.dataByURL.has('https://a.example/s')).toBe(false)
+    expect(onUpdate).toHaveBeenCalledWith([])
+  })
+
+  test('gen() yields the current snapshot immediately and again after an update', async () => {
+    const data = new LocalStreamData([
+      { kind: 'video', link: 'https://a.example/s' },
+    ])
+    const iterator = data.gen()
+    try {
+      const first = await iterator.next()
+      expect(first.value?.map((s) => s.link)).toEqual(['https://a.example/s'])
+
+      // Starting the next pull is what lets the generator's buffered push()
+      // resolve and reach the `this.on('update', push)` line (the Repeater's
+      // zero-capacity buffer only frees up once a subsequent pull begins).
+      const pending = iterator.next()
+      await waitForListener(data, 'update')
+      data.update('https://b.example/s', { kind: 'video' })
+      const second = await pending
+      expect(second.value?.map((s) => s.link)).toEqual([
+        'https://a.example/s',
+        'https://b.example/s',
+      ])
+    } finally {
+      await iterator.return?.(undefined)
+    }
+  })
+})
+
+describe('combineDataSources', () => {
+  test('merges entries from multiple sources by link, letting later sources override fields', async () => {
+    async function* sourceA() {
+      yield [{ kind: 'video', link: 'https://a.example/s', label: 'From A' }]
+    }
+    async function* sourceB() {
+      yield [
+        {
+          kind: 'video',
+          link: 'https://a.example/s',
+          label: 'From B',
+          notes: 'extra',
+        },
+      ]
+    }
+    const gen = combineDataSources(
+      [sourceA(), sourceB()],
+      new StreamIDGenerator(),
+    )
+    try {
+      const { value } = await gen.next()
+      expect(value).toHaveLength(1)
+      expect(value?.[0]).toMatchObject({
+        link: 'https://a.example/s',
+        label: 'From B',
+        notes: 'extra',
+      })
+    } finally {
+      await gen.return?.(undefined)
+    }
+  })
+
+  test('attaches a byURL index to the yielded list for quick lookups', async () => {
+    async function* sourceA() {
+      yield [{ kind: 'video', link: 'https://a.example/s' }]
+    }
+    const gen = combineDataSources([sourceA()], new StreamIDGenerator())
+    try {
+      const { value } = await gen.next()
+      expect(value?.byURL?.get('https://a.example/s')).toMatchObject({
+        link: 'https://a.example/s',
+      })
+    } finally {
+      await gen.return?.(undefined)
+    }
+  })
+
+  test('assigns stream ids via the provided StreamIDGenerator', async () => {
+    async function* sourceA() {
+      yield [{ kind: 'video', link: 'https://a.example/s', source: 'Example' }]
+    }
+    const gen = combineDataSources([sourceA()], new StreamIDGenerator())
+    try {
+      const { value } = await gen.next()
+      expect(value?.[0]._id).toBe('exa')
+    } finally {
+      await gen.return?.(undefined)
+    }
+  })
+})
+
+describe('markDataSource', () => {
+  test('tags every stream in every yielded batch with the data source name', async () => {
+    async function* source() {
+      yield [{ kind: 'video', link: 'https://a.example/s' }]
+      yield [
+        { kind: 'video', link: 'https://a.example/s' },
+        { kind: 'video', link: 'https://b.example/s' },
+      ]
+    }
+    const marked = markDataSource(source(), 'my-source')
+    try {
+      const first = await marked.next()
+      expect(
+        first.value?.every(
+          (s: StreamDataContent) => s._dataSource === 'my-source',
+        ),
+      ).toBe(true)
+
+      const second = await marked.next()
+      expect(
+        second.value?.map((s: StreamDataContent) => s._dataSource),
+      ).toEqual(['my-source', 'my-source'])
+    } finally {
+      await marked.return?.(undefined)
     }
   })
 })


### PR DESCRIPTION
## Problem

`packages/streamwall/src/main/data.ts` is Node-pure and highly testable, but `StreamIDGenerator`, `LocalStreamData`, and `combineDataSources`/`markDataSource` had no test coverage. ID instability in particular renames streams mid-broadcast, since a stream's `_id` drives its grid position and hotkey assignment. `vitest` and the package `test` script already existed (added in a prior change), so this is purely additive test coverage.

## Technical solution

Added test cases in `packages/streamwall/src/main/data.test.ts`:

- **`StreamIDGenerator`**: 3-char prefix derivation from `source`/`label`/`link`, collision resolution via an incrementing numeric suffix (`abc`/`abc1`/`abc2`), stripping a leading `the`/`http(s)`/`www` prefix, skipping a stream with no usable id base (leaving it without an `_id`), and id stability for the same link across repeated `process()` calls.
- **`LocalStreamData`**: link-keyed indexing (dropping entries without a `link`), `update()`'s default-to-`video` `kind` and preservation of an existing `kind`, `delete()`, the `update` event payload, and `gen()`'s async-generator snapshot + live-update behavior.
- **`combineDataSources`**: merging multiple hand-rolled async-generator sources by link (later sources override fields), the attached `byURL` index, and `StreamIDGenerator` wiring.
- **`markDataSource`**: tagging every stream in every yielded batch with the data-source name.
- **`pollDataURL`**: the previously-untested keep-cache-on-empty-response behavior (this existed already for `watchDataFile` but not for `pollDataURL`).

No production code changed — pure test-coverage addition, so no TDD red/green cycle against new behavior; the "red" phase here was confirming each new test fails without the corresponding `describe` block and passes once written against the existing implementation.

### Architecture / test-design notes

- `LocalStreamData.gen()` returns a `Repeater` with the library's default zero-capacity buffer. Empirically (see commit), the `push()` call inside the generator body only resolves once a *second* `.next()` pull has started — the first pull merely hands off the buffered value. The `gen()` test starts the second `.next()` before waiting for the `'update'` listener to register, matching the existing `waitForListener` pattern already used for `watchDataFile`'s chokidar watcher tests.
- `pollDataURL`'s cache-retention test follows the same real-timer + `Promise.race` "still pending" pattern already used for `watchDataFile`'s equivalent test, rather than mixing `vi.useFakeTimers()` with the real network I/O the existing `pollDataURL` tests rely on (a real ephemeral HTTP server), to avoid flakiness from fake-timer/real-I/O interaction.

## Testing performed

- `vitest run src/main/data.test.ts` — 30/30 passing, run 5x to check for flakiness in the timing-sensitive tests.
- `vitest run` (full `streamwall` package) — 304/304 passing.
- `tsc --noEmit -p tsconfig.json` — clean.
- `eslint` on the changed file — clean.
- `prettier --check` — clean.

## Risks / breaking changes

None — test-only change, no production code modified.

## Follow-up

While writing the `LocalStreamData` rekey test, found that `update()` leaves the stored entry's own `.link` field stale (the old url) after moving it to a new map key, even though the map key itself correctly moves. Currently latent (no caller in `streamwall-control-ui` passes a differing `data.link`), so filed as a separate issue rather than fixed here: #274.

Closes #49