### PR TITLE
fix(control-ui): clipboard rejection handling and Y.Doc lazy init/cleanup

### DIFF
--- a/packages/streamwall-control-ui/src/clipboard.test.ts
+++ b/packages/streamwall-control-ui/src/clipboard.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { copyTextToClipboard } from './clipboard.ts'
+
+describe('copyTextToClipboard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('writes the given text to the clipboard', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+
+    copyTextToClipboard('abc')
+
+    expect(writeText).toHaveBeenCalledWith('abc')
+  })
+
+  it('logs a warning instead of throwing when the write is rejected asynchronously', async () => {
+    const rejection = new Error('permission denied')
+    const writeText = vi.fn().mockRejectedValue(rejection)
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(() => copyTextToClipboard('abc')).not.toThrow()
+    // Flush the microtask queue so the promise rejection reaches `.catch`.
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Unable to copy stream id to clipboard:',
+      rejection,
+    )
+  })
+})

--- a/packages/streamwall-control-ui/src/clipboard.ts
+++ b/packages/streamwall-control-ui/src/clipboard.ts
@@ -1,0 +1,8 @@
+// `navigator.clipboard.writeText` returns a promise that rejects (e.g. when
+// clipboard permission is denied); a synchronous try/catch around the call
+// does not observe that rejection, so it must be handled via `.catch`.
+export function copyTextToClipboard(text: string): void {
+  navigator.clipboard.writeText(text).catch((err: unknown) => {
+    console.warn('Unable to copy stream id to clipboard:', err)
+  })
+}

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -83,7 +83,6 @@ import {
   resolveEagerWriteStreamId,
   resolveTargetViewIdx,
 } from './viewPlacement.ts'
-import { createSharedUndoManager } from './yUndo.ts'
 
 // `import { Color } from 'streamwall-shared'` binds only the value; alias
 // the instance type (as returned by the Color factory) for use in
@@ -466,55 +465,7 @@ function filterStreams(
   return [wallStreams, liveStreams, otherStreams]
 }
 
-export function useYDoc<T>(
-  keys: string[],
-  // Origin string used by this connection when applying remote updates to
-  // `doc` (e.g. `'server'` for the websocket client, `'app'` for the
-  // Electron IPC renderer). Passed through to the doc's `Y.UndoManager` so
-  // that remotely-applied changes - notably a destructive grid-shrink remap,
-  // which runs on the main process's doc and only reaches here as a
-  // remote-origin update - are undoable too (issue #79).
-  remoteOrigin?: string,
-): {
-  docValue: T | undefined
-  doc: Y.Doc
-  setDoc: (doc: Y.Doc) => void
-  undoManager: Y.UndoManager | undefined
-} {
-  const [doc, setDoc] = useState(new Y.Doc())
-  const [docValue, setDocValue] = useState<T>()
-  useEffect(() => {
-    function updateDocValue() {
-      const valueCopy = Object.fromEntries(
-        keys.map((k) => [k, doc.getMap(k).toJSON()]),
-      )
-      // TODO: validate using zod
-      setDocValue(valueCopy as T)
-    }
-    updateDocValue()
-    doc.on('update', updateDocValue)
-    return () => {
-      doc.off('update', updateDocValue)
-    }
-    // `keys` is deliberately omitted: every caller passes a literal array,
-    // so including it would re-subscribe the listener on every render
-    // without any behavioral benefit.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [doc])
-
-  const [undoManager, setUndoManager] = useState<Y.UndoManager>()
-  useEffect(() => {
-    const manager = createSharedUndoManager(doc, keys, remoteOrigin)
-    setUndoManager(manager)
-    return () => {
-      manager.destroy()
-    }
-    // `keys` is deliberately omitted for the same reason as above.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [doc, remoteOrigin])
-
-  return { docValue, doc, setDoc, undoManager }
-}
+export { useYDoc } from './useYDoc.ts'
 
 export interface CollabData {
   views: { [viewIdx: string]: { streamId: string | undefined } }

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -59,6 +59,7 @@ import {
 import { createGlobalStyle, styled } from 'styled-components'
 import { matchesState } from 'xstate'
 import * as Y from 'yjs'
+import { copyTextToClipboard } from './clipboard.ts'
 import { createErrorSurfacingSend } from './commandError.ts'
 import { CommandErrorBanner } from './CommandErrorBanner.tsx'
 import { DataSourceHealthBanner } from './DataSourceHealthBanner.tsx'
@@ -1079,11 +1080,7 @@ export function ControlUI({
         return
       }
 
-      try {
-        navigator.clipboard.writeText(streamId)
-      } catch (err) {
-        console.warn('Unable to copy stream id to clipboard:', err)
-      }
+      copyTextToClipboard(streamId)
 
       const targetIdx = resolveTargetViewIdx({
         views: sharedState.views,

--- a/packages/streamwall-control-ui/src/useYDoc.test.tsx
+++ b/packages/streamwall-control-ui/src/useYDoc.test.tsx
@@ -1,0 +1,82 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import * as Y from 'yjs'
+import { useYDoc } from './useYDoc.ts'
+
+const { docConstructorSpy } = vi.hoisted(() => ({
+  docConstructorSpy: vi.fn(),
+}))
+
+vi.mock('yjs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('yjs')>()
+  function Doc(...args: ConstructorParameters<typeof actual.Doc>) {
+    docConstructorSpy()
+    return new actual.Doc(...args)
+  }
+  Doc.prototype = actual.Doc.prototype
+  return { ...actual, Doc }
+})
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  docConstructorSpy.mockClear()
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+function renderUseYDoc(): {
+  get: () => ReturnType<typeof useYDoc<{ views: unknown }>>
+  rerender: () => void
+} {
+  let latest: ReturnType<typeof useYDoc<{ views: unknown }>> | undefined
+  function Harness() {
+    latest = useYDoc<{ views: unknown }>(['views'])
+    return null
+  }
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    render(<Harness />, container!)
+  })
+  return {
+    get: () => latest!,
+    rerender: () => {
+      act(() => {
+        render(<Harness />, container!)
+      })
+    },
+  }
+}
+
+describe('useYDoc', () => {
+  it('creates exactly one Y.Doc across re-renders', () => {
+    const harness = renderUseYDoc()
+    expect(docConstructorSpy).toHaveBeenCalledTimes(1)
+    const firstDoc = harness.get().doc
+
+    harness.rerender()
+    harness.rerender()
+
+    expect(docConstructorSpy).toHaveBeenCalledTimes(1)
+    expect(harness.get().doc).toBe(firstDoc)
+  })
+
+  it('destroys the previous doc when setDoc replaces it', () => {
+    const harness = renderUseYDoc()
+    const firstDoc = harness.get().doc
+    const destroySpy = vi.spyOn(firstDoc, 'destroy')
+
+    const replacementDoc = new Y.Doc()
+    act(() => {
+      harness.get().setDoc(replacementDoc)
+    })
+
+    expect(destroySpy).toHaveBeenCalledTimes(1)
+    expect(harness.get().doc).toBe(replacementDoc)
+  })
+})

--- a/packages/streamwall-control-ui/src/useYDoc.ts
+++ b/packages/streamwall-control-ui/src/useYDoc.ts
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useState } from 'preact/hooks'
+import * as Y from 'yjs'
+import { createSharedUndoManager } from './yUndo.ts'
+
+export function useYDoc<T>(
+  keys: string[],
+  // Origin string used by this connection when applying remote updates to
+  // `doc` (e.g. `'server'` for the websocket client, `'app'` for the
+  // Electron IPC renderer). Passed through to the doc's `Y.UndoManager` so
+  // that remotely-applied changes - notably a destructive grid-shrink remap,
+  // which runs on the main process's doc and only reaches here as a
+  // remote-origin update - are undoable too (issue #79).
+  remoteOrigin?: string,
+): {
+  docValue: T | undefined
+  doc: Y.Doc
+  setDoc: (doc: Y.Doc) => void
+  undoManager: Y.UndoManager | undefined
+} {
+  const [doc, setDocState] = useState(() => new Y.Doc())
+  // Callers (e.g. re-establishing a connection) replace the doc wholesale.
+  // Free the outgoing doc's listeners/structs rather than leaking it.
+  const setDoc = useCallback((newDoc: Y.Doc) => {
+    setDocState((oldDoc) => {
+      if (oldDoc !== newDoc) {
+        oldDoc.destroy()
+      }
+      return newDoc
+    })
+  }, [])
+  const [docValue, setDocValue] = useState<T>()
+  useEffect(() => {
+    function updateDocValue() {
+      const valueCopy = Object.fromEntries(
+        keys.map((k) => [k, doc.getMap(k).toJSON()]),
+      )
+      // TODO: validate using zod
+      setDocValue(valueCopy as T)
+    }
+    updateDocValue()
+    doc.on('update', updateDocValue)
+    return () => {
+      doc.off('update', updateDocValue)
+    }
+    // `keys` is deliberately omitted: every caller passes a literal array,
+    // so including it would re-subscribe the listener on every render
+    // without any behavioral benefit.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [doc])
+
+  const [undoManager, setUndoManager] = useState<Y.UndoManager>()
+  useEffect(() => {
+    const manager = createSharedUndoManager(doc, keys, remoteOrigin)
+    setUndoManager(manager)
+    return () => {
+      manager.destroy()
+    }
+    // `keys` is deliberately omitted for the same reason as above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [doc, remoteOrigin])
+
+  return { docValue, doc, setDoc, undoManager }
+}


### PR DESCRIPTION
## Problem

Issue #41 flagged three small correctness bugs in `packages/streamwall-control-ui/src/index.tsx`:

1. `if (streamId == null || !data == null)` — `(!data) == null` is always `false`, so the "skip when data missing" guard never triggers.
2. `try/catch` around `navigator.clipboard.writeText` only catches synchronous throws; permission-denied rejections become unhandled.
3. `useState(new Y.Doc())` constructs and discards a doc every render; replaced docs are never `destroy()`-ed.

## Technical solution

Finding 1 (the preview-guard null check) was already fixed on `main` in #120, before this issue was filed — no code change needed there.

For the remaining two findings:

- **Clipboard rejection handling**: extracted the copy call into `copyTextToClipboard` (`clipboard.ts`), which chains `.catch` instead of relying on a synchronous `try/catch`. `handleClickId` now calls this helper.
- **Y.Doc lazy init + cleanup**: extracted `useYDoc` into its own module (`useYDoc.ts`) and switched `useState(new Y.Doc())` to the lazy initializer form `useState(() => new Y.Doc())`. Wrapped the `setDoc` setter so the outgoing doc is `destroy()`-ed whenever a caller replaces it — this fixes both `control-ui`'s hook and `control-client`'s `setStateDoc(new Y.Doc())` reconnect path, since the latter goes through the same setter.

## Architecture decisions

`useYDoc` was moved to its own file rather than patched in place, following the existing pattern in this package (`viewPlacement.ts`, `yUndo.ts`, `gestures.ts`) of extracting testable logic out of the large `index.tsx` entry point. This made the fix directly unit-testable without needing to drive it through the full `ControlUI` component tree.

## Testing performed

- `clipboard.test.ts`: covers a successful write and an asynchronous rejection (asserts no throw, and that `console.warn` is called instead).
- `useYDoc.test.tsx`: covers that exactly one `Y.Doc` is constructed across re-renders (via a mocked `Y.Doc` constructor spy), and that the previous doc's `destroy()` is called when `setDoc` replaces it.
- Both new tests were verified to fail against the pre-fix code before the fix was applied (red/green).
- Full quality gate passes locally: `prettier --check`, `eslint`, `tsc --noEmit` (all packages), full test suite (all packages), and the control-client production build.

## Risks / breaking changes

None. Both fixes are internal correctness fixes with no API surface change — `useYDoc`'s exported signature and return shape are unchanged, only re-exported from a new module.

Closes #41