### PR TITLE
fix(control-ui): don't blank the wall or replay stale commands on disconnect

### DIFF
--- a/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.test.tsx
+++ b/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.test.tsx
@@ -217,4 +217,106 @@ describe('useStreamwallWebsocketConnection', () => {
 
     expect(getConnection().isConnected).toBe(true)
   })
+
+  // A blip previously wiped `streamwallState` entirely on close, which
+  // unmounted the grid and blanked the sidebar in streamwall-control-ui
+  // (issue #37). These lock in that a reconnect only flips `isConnected`.
+  describe('state across a disconnect (issue #37)', () => {
+    it('keeps the last-known state instead of blanking it on close', () => {
+      const { getConnection } = mount()
+      const socket = instances[0]!
+
+      act(() => {
+        socket.dispatch('message', stateMessage())
+      })
+      expect(getConnection().role).toBe('admin')
+
+      act(() => {
+        socket.dispatch('close')
+      })
+
+      expect(getConnection().isConnected).toBe(false)
+      expect(getConnection().role).toBe('admin')
+      expect(getConnection().config).toEqual(minimalState.config)
+    })
+
+    it('still swaps in a fresh Yjs doc on close, to avoid merging a local-only offline edit into the next resync', () => {
+      const { getConnection } = mount()
+      const socket = instances[0]!
+      const docBeforeClose = getConnection().stateDoc
+
+      act(() => {
+        socket.dispatch('close')
+      })
+
+      expect(getConnection().stateDoc).not.toBe(docBeforeClose)
+    })
+  })
+
+  describe('disconnectReason (issue #37)', () => {
+    it('is null while connected', () => {
+      const { getConnection } = mount()
+      expect(getConnection().disconnectReason).toBeNull()
+    })
+
+    it('is set from an unauthorized error message instead of being dropped as unexpected', () => {
+      const { getConnection } = mount()
+      const socket = instances[0]!
+
+      act(() => {
+        socket.dispatch('message', {
+          data: JSON.stringify({ error: 'unauthorized' }),
+        })
+      })
+
+      expect(getConnection().disconnectReason).toBe('unauthorized')
+    })
+
+    it('is set from a streamwall-disconnected error message', () => {
+      const { getConnection } = mount()
+      const socket = instances[0]!
+
+      act(() => {
+        socket.dispatch('message', {
+          data: JSON.stringify({ error: 'streamwall disconnected' }),
+        })
+      })
+
+      expect(getConnection().disconnectReason).toBe('streamwall-disconnected')
+    })
+
+    it('clears on a fresh connection attempt (open) so a stale reason does not linger', () => {
+      const { getConnection } = mount()
+      const socket = instances[0]!
+
+      act(() => {
+        socket.dispatch('message', {
+          data: JSON.stringify({ error: 'unauthorized' }),
+        })
+      })
+      expect(getConnection().disconnectReason).toBe('unauthorized')
+
+      act(() => {
+        socket.dispatch('open')
+      })
+
+      expect(getConnection().disconnectReason).toBeNull()
+    })
+
+    it('clears once a full state message confirms a successful reconnect', () => {
+      const { getConnection } = mount()
+      const socket = instances[0]!
+
+      act(() => {
+        socket.dispatch('message', {
+          data: JSON.stringify({ error: 'unauthorized' }),
+        })
+      })
+      act(() => {
+        socket.dispatch('message', stateMessage())
+      })
+
+      expect(getConnection().disconnectReason).toBeNull()
+    })
+  })
 })

--- a/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.ts
+++ b/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.ts
@@ -8,7 +8,9 @@ import {
 } from 'streamwall-control-ui'
 import {
   type ControlCommand,
+  type DisconnectReason,
   isSocketOpen,
+  parseDisconnectReason,
   stateDiff,
   type StreamwallState,
 } from 'streamwall-shared'
@@ -23,6 +25,8 @@ export function useStreamwallWebsocketConnection(
     responseMap: Map<number, (msg: object) => void>
   }>()
   const [isConnected, setIsConnected] = useState(false)
+  const [disconnectReason, setDisconnectReason] =
+    useState<DisconnectReason | null>(null)
   const {
     docValue: sharedState,
     doc: stateDoc,
@@ -47,9 +51,17 @@ export function useStreamwallWebsocketConnection(
     })
     ws.binaryType = 'arraybuffer'
 
+    // A blip only closes the *transport*: `streamwallState` (cols/rows,
+    // streams, role, ...) is left as-is so the grid and stream list keep
+    // rendering their last-known content (dimmed via `isConnected`) instead
+    // of unmounting/showing "loading..." (issue #37). `stateDoc` still gets
+    // reset, though - it's the CRDT clients write grid assignments into
+    // locally, and the server always pushes a full resync on reconnect (see
+    // the `type: 'state'` branch below), so any local-only edit made while
+    // offline would otherwise survive a Yjs merge into that resync and
+    // silently diverge from what the server (and every other client)
+    // actually has.
     function handleClose() {
-      setStreamwallState(undefined)
-      lastStateData = undefined
       setStateDoc(new Y.Doc())
       setIsConnected(false)
       // Any command awaiting a response will never hear back from this
@@ -62,6 +74,15 @@ export function useStreamwallWebsocketConnection(
         }
         responseMap.clear()
       }
+    }
+
+    function handleOpen() {
+      // A fresh connection attempt may still fail (e.g. an expired session);
+      // clear the previous reason optimistically so a stale "unauthorized"
+      // banner doesn't linger if this attempt instead just keeps retrying for
+      // an unrelated reason. The server's next message sets it again if the
+      // same failure recurs.
+      setDisconnectReason(null)
     }
 
     function handleMessage(ev: MessageEvent) {
@@ -81,6 +102,7 @@ export function useStreamwallWebsocketConnection(
         if (msg.type === 'state') {
           state = msg.state
           setIsConnected(true)
+          setDisconnectReason(null)
         } else {
           // Clone so updated object triggers React renders
           state = stateDiff.clone(
@@ -90,16 +112,23 @@ export function useStreamwallWebsocketConnection(
         lastStateData = state
         setStreamwallState(state)
       } else {
-        console.warn('unexpected ws message', msg)
+        const reason = parseDisconnectReason(msg)
+        if (reason) {
+          setDisconnectReason(reason)
+        } else {
+          console.warn('unexpected ws message', msg)
+        }
       }
     }
 
     ws.addEventListener('close', handleClose)
+    ws.addEventListener('open', handleOpen)
     ws.addEventListener('message', handleMessage)
     wsRef.current = { ws, msgId: 0, responseMap: new Map() }
 
     return () => {
       ws.removeEventListener('close', handleClose)
+      ws.removeEventListener('open', handleOpen)
       ws.removeEventListener('message', handleMessage)
       ws.close()
       wsRef.current = undefined
@@ -161,6 +190,7 @@ export function useStreamwallWebsocketConnection(
   return {
     ...appState,
     isConnected,
+    disconnectReason,
     send,
     sharedState,
     stateDoc,

--- a/packages/streamwall-control-ui/src/ConnectionStatusBanner.test.tsx
+++ b/packages/streamwall-control-ui/src/ConnectionStatusBanner.test.tsx
@@ -1,0 +1,64 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { ConnectionStatusBanner } from './ConnectionStatusBanner.tsx'
+
+vi.mock('react-icons/fa', () => ({
+  FaExclamationTriangle: () => null,
+}))
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+function renderBanner(
+  props: Parameters<typeof ConnectionStatusBanner>[0],
+): HTMLDivElement {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    render(<ConnectionStatusBanner {...props} />, container!)
+  })
+  return container
+}
+
+describe('ConnectionStatusBanner', () => {
+  test('renders nothing while connected', () => {
+    const el = renderBanner({ isConnected: true, reason: null })
+    expect(el.querySelector('[role="status"]')).toBeNull()
+  })
+
+  test('shows a generic reconnecting message with no reason', () => {
+    const el = renderBanner({ isConnected: false, reason: null })
+    const banner = el.querySelector('[role="status"]')
+    expect(banner?.textContent).toContain('reconnecting')
+  })
+
+  test('shows a generic reconnecting message when reason is undefined', () => {
+    const el = renderBanner({ isConnected: false, reason: undefined })
+    const banner = el.querySelector('[role="status"]')
+    expect(banner?.textContent).toContain('reconnecting')
+  })
+
+  test('distinguishes an unauthorized session from a generic disconnect', () => {
+    const el = renderBanner({ isConnected: false, reason: 'unauthorized' })
+    const banner = el.querySelector('[role="status"]')
+    expect(banner?.textContent).toContain('Session invalid')
+    expect(banner?.className).toContain('unauthorized')
+  })
+
+  test('distinguishes the Streamwall app being disconnected', () => {
+    const el = renderBanner({
+      isConnected: false,
+      reason: 'streamwall-disconnected',
+    })
+    const banner = el.querySelector('[role="status"]')
+    expect(banner?.textContent).toContain('Streamwall app disconnected')
+  })
+})

--- a/packages/streamwall-control-ui/src/ConnectionStatusBanner.tsx
+++ b/packages/streamwall-control-ui/src/ConnectionStatusBanner.tsx
@@ -1,0 +1,49 @@
+import { FaExclamationTriangle } from 'react-icons/fa'
+import type { DisconnectReason } from 'streamwall-shared'
+import { styled } from 'styled-components'
+
+const StyledConnectionStatusBanner = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #e0a800;
+
+  &.unauthorized {
+    color: #dc3545;
+  }
+`
+
+const MESSAGE_BY_REASON: Record<DisconnectReason, string> = {
+  unauthorized: 'Session invalid - please sign in again.',
+  'streamwall-disconnected': 'Streamwall app disconnected - reconnecting...',
+}
+
+const GENERIC_MESSAGE = 'Connection lost - reconnecting...'
+
+/**
+ * Replaces blanking the wall/list on any websocket blip (issue #37): the
+ * grid and stream list now keep rendering their last-known state (dimmed via
+ * `StyledDataContainer`'s `$isConnected`) instead of unmounting, so this
+ * banner is the explicit "why" that previously only a small header dot
+ * hinted at - and it distinguishes an invalid session from the Streamwall
+ * app itself being unreachable, rather than a single generic message.
+ */
+export function ConnectionStatusBanner({
+  isConnected,
+  reason,
+}: {
+  isConnected: boolean
+  reason: DisconnectReason | null | undefined
+}) {
+  if (isConnected) {
+    return null
+  }
+
+  return (
+    <StyledConnectionStatusBanner className={reason ?? undefined} role="status">
+      <FaExclamationTriangle />
+      {reason ? MESSAGE_BY_REASON[reason] : GENERIC_MESSAGE}
+    </StyledConnectionStatusBanner>
+  )
+}

--- a/packages/streamwall-control-ui/src/disconnectRendering.test.tsx
+++ b/packages/streamwall-control-ui/src/disconnectRendering.test.tsx
@@ -1,0 +1,187 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import type {
+  DisconnectReason,
+  StreamData,
+  StreamDelayStatus,
+  StreamWindowConfig,
+} from 'streamwall-shared'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import * as Y from 'yjs'
+import { ControlUI, type StreamwallConnection } from './index.tsx'
+
+// react-icons renders through preact/compat's Context.Consumer, which
+// currently crashes under this package's happy-dom test environment
+// (unrelated to the disconnect rendering under test here) - stub the icons
+// out so ControlUI's own rendering can be exercised in isolation.
+vi.mock('react-icons/fa', () => ({
+  FaExchangeAlt: () => null,
+  FaExclamationTriangle: () => null,
+  FaRedoAlt: () => null,
+  FaRegLifeRing: () => null,
+  FaRegWindowMaximize: () => null,
+  FaSyncAlt: () => null,
+  FaVideoSlash: () => null,
+  FaVolumeUp: () => null,
+}))
+vi.mock('react-icons/md', () => ({
+  MdOutlineStayCurrentLandscape: () => null,
+  MdOutlineStayCurrentPortrait: () => null,
+}))
+vi.mock('react-hotkeys-hook', () => ({
+  useHotkeys: () => {},
+}))
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+function renderControlUI(
+  connectionOverrides: Partial<StreamwallConnection>,
+): HTMLDivElement {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+
+  const delayState: StreamDelayStatus = {
+    isConnected: true,
+    delaySeconds: 0,
+    restartSeconds: 0,
+    isCensored: false,
+    isStreamRunning: true,
+    startTime: 0,
+    state: 'idle',
+  }
+
+  const connection: StreamwallConnection = {
+    isConnected: true,
+    role: 'operator',
+    send: () => {},
+    sharedState: { views: {} },
+    stateDoc: new Y.Doc(),
+    config: undefined,
+    streams: [],
+    customStreams: [],
+    views: [],
+    stateIdxMap: new Map(),
+    delayState,
+    authState: undefined,
+    layoutPresets: [],
+    dataSourceHealth: [],
+    ...connectionOverrides,
+  }
+
+  act(() => {
+    render(<ControlUI connection={connection} />, container!)
+  })
+  return container
+}
+
+const config: StreamWindowConfig = {
+  cols: 2,
+  rows: 1,
+  width: 800,
+  height: 400,
+  frameless: false,
+  fullscreen: false,
+  activeColor: '#fff',
+  backgroundColor: '#000',
+}
+
+const stream: StreamData = {
+  _id: 'abc',
+  _dataSource: 'custom',
+  kind: 'video',
+  link: 'https://example.com/abc',
+  label: 'Example stream',
+}
+
+// A brief websocket blip previously wiped `streamwallState` in
+// streamwall-control-client, which unmounted the grid (`cols`/`rows` go
+// null) and made the sidebar show "loading..." (issue #37). These tests lock
+// in the fix: a `StreamwallConnection` that was connected before (`role` is
+// set) keeps rendering its last-known content, dimmed, instead of blanking.
+describe('rendering across a disconnect', () => {
+  test('keeps the grid mounted with its last-known assignment while reconnecting', () => {
+    const root = renderControlUI({
+      isConnected: false,
+      role: 'operator',
+      config,
+      streams: [stream],
+      sharedState: { views: { '0': { streamId: 'abc' } } },
+    })
+
+    const grid = root.querySelector('.grid')
+    expect(grid, 'grid should stay mounted during a reconnect').not.toBeNull()
+
+    const cellInput = grid!.querySelector('input') as HTMLInputElement | null
+    expect(cellInput?.value).toBe('abc')
+  })
+
+  test('dims the grid/list container while disconnected', () => {
+    const root = renderControlUI({
+      isConnected: false,
+      role: 'operator',
+      config,
+      streams: [stream],
+    })
+
+    const containers = [...root.querySelectorAll('div')].filter(
+      (el) => getComputedStyle(el).opacity === '0.5',
+    )
+    expect(containers.length).toBeGreaterThan(0)
+  })
+
+  test('keeps showing the last-known stream list instead of "loading..."', () => {
+    const root = renderControlUI({
+      isConnected: false,
+      role: 'operator',
+      config,
+      streams: [stream],
+    })
+
+    expect(root.textContent).toContain('Example stream')
+    expect(root.textContent).not.toContain('loading...')
+  })
+
+  test('shows "loading..." only before any state has ever arrived', () => {
+    const root = renderControlUI({
+      isConnected: false,
+      role: null,
+      config: undefined,
+      streams: [],
+    })
+
+    expect(root.textContent).toContain('loading...')
+    expect(root.querySelector('.grid')).toBeNull()
+  })
+
+  test.each<[DisconnectReason | null | undefined, string]>([
+    ['unauthorized', 'Session invalid'],
+    ['streamwall-disconnected', 'Streamwall app disconnected'],
+    [null, 'Connection lost'],
+    [undefined, 'Connection lost'],
+  ])('shows the right banner for reason %p', (reason, expectedText) => {
+    const root = renderControlUI({
+      isConnected: false,
+      disconnectReason: reason,
+      role: 'operator',
+      config,
+      streams: [stream],
+    })
+
+    expect(root.querySelector('[role="status"]')?.textContent).toContain(
+      expectedText,
+    )
+  })
+
+  test('renders no banner while connected', () => {
+    const root = renderControlUI({ isConnected: true, disconnectReason: null })
+    expect(root.querySelector('[role="status"]')).toBeNull()
+  })
+})

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -38,6 +38,7 @@ import {
   type ContentKind,
   type ControlCommand,
   type DataSourceHealth,
+  type DisconnectReason,
   GRID_MAX,
   GRID_MIN,
   gridWouldDropAssignments,
@@ -61,6 +62,7 @@ import { matchesState } from 'xstate'
 import * as Y from 'yjs'
 import { createErrorSurfacingSend } from './commandError.ts'
 import { CommandErrorBanner } from './CommandErrorBanner.tsx'
+import { ConnectionStatusBanner } from './ConnectionStatusBanner.tsx'
 import { DataSourceHealthBanner } from './DataSourceHealthBanner.tsx'
 import {
   computeHoveringIdx,
@@ -521,6 +523,12 @@ export interface CollabData {
 
 export interface StreamwallConnection {
   isConnected: boolean
+  /**
+   * Why the websocket is currently closed, when the server said so before
+   * closing it. `undefined`/`null` while connected, or while disconnected
+   * for an unexplained reason (network blip, generic retry).
+   */
+  disconnectReason?: DisconnectReason | null
   role: StreamwallRole | null
   send: (msg: ControlCommand, cb?: (msg: unknown) => void) => void
   sharedState: CollabData | undefined
@@ -623,6 +631,7 @@ export function ControlUI({
 }) {
   const {
     isConnected,
+    disconnectReason,
     send: connectionSend,
     sharedState,
     stateDoc,
@@ -1347,6 +1356,10 @@ export function ControlUI({
           )}
           <ThemeToggle />
         </StyledHeader>
+        <ConnectionStatusBanner
+          isConnected={isConnected}
+          reason={disconnectReason}
+        />
         <DataSourceHealthBanner dataSourceHealth={dataSourceHealth} />
         <CommandErrorBanner
           error={commandError}
@@ -1605,8 +1618,15 @@ export function ControlUI({
         </StyledStatusBar>
       </Stack>
       <Stack className="stream-list" $scroll={true} $minHeight={200}>
+        {
+          // Keyed on `role` (persists across a reconnect, see
+          // `StreamwallConnection`) rather than `isConnected`, so a brief
+          // disconnect dims the last-known list instead of replacing it with
+          // "loading..." (issue #37). Only the very first load, before any
+          // state has ever arrived, shows the loading placeholder.
+        }
         <StyledDataContainer $isConnected={isConnected}>
-          {isConnected ? (
+          {role != null ? (
             <div>
               <input
                 className="filter-input"

--- a/packages/streamwall-shared/src/connectionStatus.test.ts
+++ b/packages/streamwall-shared/src/connectionStatus.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'vitest'
+import { parseDisconnectReason } from './connectionStatus.ts'
+
+describe('parseDisconnectReason', () => {
+  test('recognizes an unauthorized session', () => {
+    expect(parseDisconnectReason({ error: 'unauthorized' })).toBe(
+      'unauthorized',
+    )
+  })
+
+  test('recognizes the Streamwall app being disconnected', () => {
+    expect(parseDisconnectReason({ error: 'streamwall disconnected' })).toBe(
+      'streamwall-disconnected',
+    )
+  })
+
+  test('returns null for an unrelated server error', () => {
+    expect(
+      parseDisconnectReason({ error: 'streamwall already connected' }),
+    ).toBeNull()
+  })
+
+  test('returns null for a state push', () => {
+    expect(parseDisconnectReason({ type: 'state', state: {} })).toBeNull()
+  })
+
+  test('returns null for a state delta', () => {
+    expect(parseDisconnectReason({ type: 'state-delta', delta: {} })).toBeNull()
+  })
+
+  test('returns null for a command response', () => {
+    expect(
+      parseDisconnectReason({ response: true, id: 1, tokenId: 'abc' }),
+    ).toBeNull()
+  })
+
+  test.each([null, undefined, 'unauthorized', 42, ['unauthorized'], true])(
+    'returns null for non-object input %p',
+    (input) => {
+      expect(parseDisconnectReason(input)).toBeNull()
+    },
+  )
+
+  test('returns null when the error field is not a string', () => {
+    expect(parseDisconnectReason({ error: 42 })).toBeNull()
+  })
+})

--- a/packages/streamwall-shared/src/connectionStatus.ts
+++ b/packages/streamwall-shared/src/connectionStatus.ts
@@ -1,0 +1,37 @@
+/**
+ * Reason the control-client's websocket to the control server is currently
+ * closed, when the server explained why before closing it (see `/client/ws`
+ * in streamwall-control-server). Not exhaustive by design - callers should
+ * treat "no reason" (a `null` return from `parseDisconnectReason`) as a
+ * generic, still-retrying disconnect (most likely a transient network blip).
+ */
+export type DisconnectReason = 'unauthorized' | 'streamwall-disconnected'
+
+const REASON_BY_SERVER_ERROR: Record<string, DisconnectReason> = {
+  unauthorized: 'unauthorized',
+  'streamwall disconnected': 'streamwall-disconnected',
+}
+
+/**
+ * Reads the disconnect reason out of a parsed control-server websocket
+ * message. The server sends `{error: '...'}` immediately before closing the
+ * socket when the session is invalid or the Streamwall app itself isn't
+ * connected; every other message (state pushes, command responses, or an
+ * unrelated error like "streamwall already connected") returns `null`.
+ */
+export function parseDisconnectReason(
+  message: unknown,
+): DisconnectReason | null {
+  if (
+    typeof message !== 'object' ||
+    message === null ||
+    !('error' in message)
+  ) {
+    return null
+  }
+  const { error } = message as { error: unknown }
+  if (typeof error !== 'string') {
+    return null
+  }
+  return REASON_BY_SERVER_ERROR[error] ?? null
+}

--- a/packages/streamwall-shared/src/index.ts
+++ b/packages/streamwall-shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from './colors.ts'
+export * from './connectionStatus.ts'
 export * from './controlEndpoint.ts'
 export * from './geometry.ts'
 export * from './roles.ts'


### PR DESCRIPTION
## Problem

A brief websocket blip to the control server discarded all local state in the browser control client: the grid unmounted entirely (`cols`/`rows` went `null`), the stream sidebar fell back to a bare "loading...", and the only hint anything was wrong was a small grey "verbinde…" dot. The client also couldn't tell an invalid session apart from the Streamwall app itself being unreachable - both cases produced the same generic disconnected state.

## Solution

- **`streamwall-shared`**: added `parseDisconnectReason`, a pure helper that classifies the server's `{error: 'unauthorized'}` / `{error: 'streamwall disconnected'}` messages (previously swallowed by a generic `console.warn`) into a `DisconnectReason`.
- **`streamwall-control-client`**: on a websocket `close`, `streamwallState` is left untouched instead of being wiped - the server always pushes a full `state` message on reconnect anyway, so there's nothing to gain from blanking it in between. `disconnectReason` is now surfaced on the connection object, cleared on a fresh `open`/successful `state` push.
- **`streamwall-control-ui`**: the sidebar's loading state is now keyed off `role` (persists across a reconnect) instead of `isConnected`, so a blip dims the last-known grid/list (via the existing `$isConnected` opacity) instead of replacing it. Added `ConnectionStatusBanner`, rendered next to `DataSourceHealthBanner`, which explains *why* the wall is disconnected instead of leaving only the header dot as a clue.

## Architecture decisions

- `stateDoc` (the Yjs CRDT the grid's stream assignments live in) is **still reset** to a fresh `Y.Doc()` on close, unlike `streamwallState`. If it weren't, and an operator dragged an assignment while offline, that edit would apply to the local doc immediately (Yjs is optimistic/local-first) but never reach the server. On reconnect, the server's full-state resync is *merged* into the doc via `Y.applyUpdate` rather than replacing it - so the offline-only edit could survive the merge and silently diverge from what the server (and every other client) actually has. Resetting the doc avoids that at the cost of grid cell *assignments* (not the grid's structure/sizing/stream list) still flashing empty for the duration of a blip. Filed as a follow-up (see below) since fixing it properly means decoupling a "last-known" display snapshot from the live editable doc.
- The queued-command-replay half of the original report ("commands clicked during the outage are queued by RWS and all fire at once on reconnect") was already fixed by #260 (`maxEnqueuedMessages: 0`), confirmed by reading `reconnecting-websocket`'s send() implementation - this PR only addresses the remaining state-blanking and failure-mode-distinction points.

## Testing

- New unit tests for `parseDisconnectReason` (`streamwall-shared`).
- New component tests for `ConnectionStatusBanner` (`streamwall-control-ui`).
- New regression tests (`disconnectRendering.test.tsx`) asserting the grid stays mounted with its last-known assignment, the container dims, the sidebar keeps showing the last-known list instead of "loading...", and the banner text matches each disconnect reason. Verified these fail against the pre-fix sidebar condition before restoring the fix.
- New unit tests in `useStreamwallWebsocketConnection.test.tsx` (`streamwall-control-client`, test harness added by #280 while this branch was in flight - rebased onto it) covering: state/role survive a close, `stateDoc` still gets swapped for a fresh one, and `disconnectReason` is set/cleared correctly across `unauthorized`, `streamwall disconnected`, `open`, and a successful `state` push. Verified the state-preservation test fails against the pre-fix close handler before restoring the fix.
- Full quality gate green: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm run test` (all workspaces), `streamwall-control-client`'s `vite build`.

## Risks / breaking changes

None expected. `StreamwallConnection.disconnectReason` is an optional field, so existing connection mocks/consumers are unaffected. Rebased onto main after #280 restructured `streamwall-control-client` (extracted `useStreamwallWebsocketConnection.ts`, added response-map cleanup on close) - this PR's changes were moved into the new module and its new tests build on #280's fake-socket test harness.

Closes #37

---

Follow-up: #283 (grid cell assignments briefly flash empty during a reconnect, tracked separately - see architecture decisions above).
