### PR TITLE
fix: hoist StreamList to module scope and fix missing/unstable list keys

### DIFF
--- a/packages/streamwall-control-ui/src/CustomStreamInput.test.tsx
+++ b/packages/streamwall-control-ui/src/CustomStreamInput.test.tsx
@@ -1,0 +1,123 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import type { StreamData, StreamDelayStatus } from 'streamwall-shared'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import * as Y from 'yjs'
+import { ControlUI, type StreamwallConnection } from './index.tsx'
+
+vi.mock('react-icons/fa', () => ({
+  FaExchangeAlt: () => null,
+  FaExclamationTriangle: () => null,
+  FaRedoAlt: () => null,
+  FaRegLifeRing: () => null,
+  FaRegWindowMaximize: () => null,
+  FaSyncAlt: () => null,
+  FaVideoSlash: () => null,
+  FaVolumeUp: () => null,
+}))
+vi.mock('react-icons/md', () => ({
+  MdOutlineStayCurrentLandscape: () => null,
+  MdOutlineStayCurrentPortrait: () => null,
+}))
+vi.mock('react-hotkeys-hook', () => ({
+  useHotkeys: () => {},
+}))
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+function makeCustomStream(link: string, label: string): StreamData {
+  return {
+    _id: link,
+    _dataSource: 'custom',
+    kind: 'video',
+    link,
+    label,
+  }
+}
+
+function makeConnection(customStreams: StreamData[]): StreamwallConnection {
+  const delayState: StreamDelayStatus = {
+    isConnected: true,
+    delaySeconds: 0,
+    restartSeconds: 0,
+    isCensored: false,
+    isStreamRunning: true,
+    startTime: 0,
+    state: 'idle',
+  }
+
+  return {
+    isConnected: true,
+    role: 'operator',
+    send: () => {},
+    sharedState: { views: {} },
+    stateDoc: new Y.Doc(),
+    config: undefined,
+    streams: [],
+    customStreams,
+    views: [],
+    stateIdxMap: new Map(),
+    delayState,
+    authState: undefined,
+    layoutPresets: [],
+    dataSourceHealth: [],
+  }
+}
+
+function renderControlUI(customStreams: StreamData[]): HTMLDivElement {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    render(<ControlUI connection={makeConnection(customStreams)} />, container!)
+  })
+  return container
+}
+
+function labelInputs(root: HTMLDivElement): HTMLInputElement[] {
+  return [
+    ...root.querySelectorAll<HTMLInputElement>(
+      'input[placeholder="Label (optional)"]',
+    ),
+  ]
+}
+
+// Custom streams used to be keyed by their array index. Deleting an earlier
+// entry shifts every later entry's index down a slot, so Preact matched the
+// surviving stream's props onto the DOM node (and any in-progress edit) that
+// belonged to the deleted entry instead - see #39. Keying by the stream's
+// (stable, unique) `link` fixes this.
+describe('custom stream input identity across deletion', () => {
+  test("a surviving custom stream's input keeps its own DOM node after an earlier entry is removed", () => {
+    const root = renderControlUI([
+      makeCustomStream('https://a.example', 'A'),
+      makeCustomStream('https://b.example', 'B'),
+    ])
+
+    const [inputA, inputB] = labelInputs(root)
+    expect(inputA.value).toBe('A')
+    expect(inputB.value).toBe('B')
+
+    act(() => {
+      render(
+        <ControlUI
+          connection={makeConnection([
+            makeCustomStream('https://b.example', 'B'),
+          ])}
+        />,
+        root,
+      )
+    })
+
+    const [survivingInput] = labelInputs(root)
+    expect(survivingInput.value).toBe('B')
+    expect(survivingInput).toBe(inputB)
+  })
+})

--- a/packages/streamwall-control-ui/src/GridViewIdentity.test.tsx
+++ b/packages/streamwall-control-ui/src/GridViewIdentity.test.tsx
@@ -1,0 +1,178 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import type {
+  StreamData,
+  StreamDelayStatus,
+  StreamWindowConfig,
+} from 'streamwall-shared'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import * as Y from 'yjs'
+import {
+  ControlUI,
+  type StreamwallConnection,
+  type ViewInfo,
+} from './index.tsx'
+
+vi.mock('react-icons/fa', () => ({
+  FaExchangeAlt: () => null,
+  FaExclamationTriangle: () => null,
+  FaRedoAlt: () => null,
+  FaRegLifeRing: () => null,
+  FaRegWindowMaximize: () => null,
+  FaSyncAlt: () => null,
+  FaVideoSlash: () => null,
+  FaVolumeUp: () => null,
+}))
+vi.mock('react-icons/md', () => ({
+  MdOutlineStayCurrentLandscape: () => null,
+  MdOutlineStayCurrentPortrait: () => null,
+}))
+vi.mock('react-hotkeys-hook', () => ({
+  useHotkeys: () => {},
+}))
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+function makeStream(id: string): StreamData {
+  return {
+    _id: id,
+    _dataSource: 'test',
+    kind: 'video',
+    link: `https://example.com/${id}`,
+  }
+}
+
+function makeView(streamIdx: number, spaces: number[]): ViewInfo {
+  return {
+    state: {
+      state: {
+        displaying: {
+          running: { playback: 'playing', video: 'normal', audio: 'muted' },
+        },
+      },
+      context: {
+        id: streamIdx,
+        content: { url: `https://example.com/s${streamIdx}`, kind: 'video' },
+        info: null,
+        pos: { x: spaces[0] * 100, y: 0, width: 100, height: 100, spaces },
+        error: null,
+        volume: 1,
+      },
+    },
+    isListening: false,
+    isBackgroundListening: false,
+    isBlurred: false,
+    volume: 1,
+    spaces,
+  }
+}
+
+function makeConnection(viewCount: number): StreamwallConnection {
+  const delayState: StreamDelayStatus = {
+    isConnected: true,
+    delaySeconds: 0,
+    restartSeconds: 0,
+    isCensored: false,
+    isStreamRunning: true,
+    startTime: 0,
+    state: 'idle',
+  }
+  const config: StreamWindowConfig = {
+    cols: viewCount,
+    rows: 1,
+    width: 100 * viewCount,
+    height: 100,
+    frameless: false,
+    fullscreen: false,
+    activeColor: '#0f0',
+    backgroundColor: '#000',
+  }
+
+  const streams = Array.from({ length: viewCount }, (_, i) =>
+    makeStream(`s${i}`),
+  )
+  const views = Array.from({ length: viewCount }, (_, i) => makeView(i, [i]))
+  const stateIdxMap = new Map<number, ViewInfo>()
+  views.forEach((v, i) => stateIdxMap.set(i, v))
+
+  return {
+    isConnected: true,
+    role: 'operator',
+    send: () => {},
+    sharedState: {
+      views: Object.fromEntries(
+        streams.map((s, i) => [i, { streamId: s._id }]),
+      ),
+    },
+    stateDoc: new Y.Doc(),
+    config,
+    streams,
+    customStreams: [],
+    views,
+    stateIdxMap,
+    delayState,
+    authState: undefined,
+    layoutPresets: [],
+    dataSourceHealth: [],
+  }
+}
+
+function renderControlUI(viewCount: number): HTMLDivElement {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    render(<ControlUI connection={makeConnection(viewCount)} />, container!)
+  })
+  return container
+}
+
+function findPreviewBox(
+  root: HTMLDivElement,
+  streamId: string,
+): Element | undefined {
+  const label = [...root.querySelectorAll('.grid *')].find(
+    (el) => el.children.length === 0 && el.textContent === streamId,
+  )
+  return label?.parentElement?.parentElement ?? undefined
+}
+
+// Grid preview boxes and controls used to be rendered without a `key`, so
+// Preact matched them purely by position. When a cell earlier in the grid
+// disappears, every later cell's position shifts down a slot and Preact
+// grafts the surviving view's data onto the DOM node (and any transient
+// state, like a hover) that belonged to a different view - see #39. Keying
+// each box by its view's stable grid position fixes this.
+describe('grid view identity across a shrinking view list', () => {
+  test('a surviving preview box keeps its own DOM node after an earlier view disappears', () => {
+    const root = renderControlUI(2)
+    const boxBefore = findPreviewBox(root, 's1')
+    expect(
+      boxBefore,
+      'expected to find a preview box for stream s1',
+    ).not.toBeUndefined()
+
+    act(() => {
+      const connection = makeConnection(2)
+      // Simulate the first cell's view disappearing (e.g. it's stream
+      // stopped): only the second view remains, now at array position 0.
+      connection.views = [connection.views[1]]
+      connection.stateIdxMap = new Map([[1, connection.views[0]]])
+      render(<ControlUI connection={connection} />, root)
+    })
+
+    const boxAfter = findPreviewBox(root, 's1')
+    expect(
+      boxAfter,
+      'expected to still find a preview box for stream s1',
+    ).not.toBeUndefined()
+    expect(boxAfter).toBe(boxBefore)
+  })
+})

--- a/packages/streamwall-control-ui/src/StreamList.test.tsx
+++ b/packages/streamwall-control-ui/src/StreamList.test.tsx
@@ -1,0 +1,133 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import type { StreamData, StreamDelayStatus } from 'streamwall-shared'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import * as Y from 'yjs'
+import { ControlUI, type StreamwallConnection } from './index.tsx'
+
+// react-icons renders through preact/compat's Context.Consumer, which currently
+// crashes under this package's happy-dom test environment (unrelated to the
+// list rendering under test here) - stub the icons out so ControlUI's own
+// rendering can be exercised in isolation.
+vi.mock('react-icons/fa', () => ({
+  FaExchangeAlt: () => null,
+  FaExclamationTriangle: () => null,
+  FaRedoAlt: () => null,
+  FaRegLifeRing: () => null,
+  FaRegWindowMaximize: () => null,
+  FaSyncAlt: () => null,
+  FaVideoSlash: () => null,
+  FaVolumeUp: () => null,
+}))
+vi.mock('react-icons/md', () => ({
+  MdOutlineStayCurrentLandscape: () => null,
+  MdOutlineStayCurrentPortrait: () => null,
+}))
+// react-hotkeys-hook resolves its own copy of `react` (bypassing this package's
+// `react` -> `preact/compat` test alias), which crashes under happy-dom - stub
+// it out so the component's own rendering logic can be exercised in isolation.
+vi.mock('react-hotkeys-hook', () => ({
+  useHotkeys: () => {},
+}))
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+function makeStream(id: string): StreamData {
+  return {
+    _id: id,
+    _dataSource: 'test',
+    kind: 'video',
+    link: `https://example.com/${id}`,
+  }
+}
+
+function makeConnection(streams: StreamData[]): StreamwallConnection {
+  const delayState: StreamDelayStatus = {
+    isConnected: true,
+    delaySeconds: 0,
+    restartSeconds: 0,
+    isCensored: false,
+    isStreamRunning: true,
+    startTime: 0,
+    state: 'idle',
+  }
+
+  return {
+    isConnected: true,
+    role: 'operator',
+    send: () => {},
+    sharedState: { views: {} },
+    stateDoc: new Y.Doc(),
+    config: undefined,
+    streams,
+    customStreams: [],
+    views: [],
+    stateIdxMap: new Map(),
+    delayState,
+    authState: undefined,
+    layoutPresets: [],
+    dataSourceHealth: [],
+  }
+}
+
+function renderControlUI(streams: StreamData[]): HTMLDivElement {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    render(<ControlUI connection={makeConnection(streams)} />, container!)
+  })
+  return container
+}
+
+function findIdNode(root: HTMLDivElement, id: string): Element | undefined {
+  return [...root.querySelectorAll('.stream-list div')].find(
+    (el) => el.children.length === 0 && el.textContent === id,
+  )
+}
+
+// The app re-renders <ControlUI connection={...} /> with a fresh `connection`
+// object on every state message (they arrive continuously - see #39). If a
+// list component is redeclared inside ControlUI's body, each such re-render
+// produces a brand-new component reference at that position, forcing Preact
+// to unmount and remount the whole stream-list subtree even though nothing
+// about the rendered rows actually changed.
+describe('stream list identity across ControlUI re-renders', () => {
+  test('does not remount stream rows when the app re-renders with a fresh connection object', () => {
+    const root = renderControlUI([
+      makeStream('stream-a'),
+      makeStream('stream-b'),
+    ])
+    const before = findIdNode(root, 'stream-a')
+    expect(
+      before,
+      'expected to find a rendered row for stream-a',
+    ).not.toBeUndefined()
+
+    act(() => {
+      render(
+        <ControlUI
+          connection={makeConnection([
+            makeStream('stream-a'),
+            makeStream('stream-b'),
+          ])}
+        />,
+        root,
+      )
+    })
+
+    const after = findIdNode(root, 'stream-a')
+    expect(
+      after,
+      'expected to still find a rendered row for stream-a',
+    ).not.toBeUndefined()
+    expect(after).toBe(before)
+  })
+})

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -1221,17 +1221,6 @@ export function ControlUI({
     () => filterStreams(streams, wallStreamIds, streamFilter),
     [streams, wallStreamIds, streamFilter],
   )
-  function StreamList({ rows }: { rows: StreamData[] }) {
-    return rows.map((row) => (
-      <StreamLine
-        id={row._id}
-        row={row}
-        disabled={!roleCan(role, 'mutate-state-doc')}
-        onClickId={handleClickId}
-      />
-    ))
-  }
-
   return (
     <AppShell className="app-shell">
       <Stack className="grid-container">
@@ -1324,6 +1313,7 @@ export function ControlUI({
                     const isHighlighted = isMoveHighlight || isResizeHighlight
                     return (
                       <GridInput
+                        key={idx}
                         style={{
                           width: `${100 / cols}%`,
                           height: `${100 / rows}%`,
@@ -1410,6 +1400,7 @@ export function ControlUI({
                   const errorReason = state.context.error
                   return (
                     <GridPreviewBox
+                      key={pos.spaces[0]}
                       streamId={streamId}
                       color={idColor(streamId)}
                       style={{
@@ -1451,6 +1442,7 @@ export function ControlUI({
                   }
                   return (
                     <GridControls
+                      key={pos.spaces[0]}
                       idx={pos.spaces[0]}
                       streamId={streamId}
                       style={{
@@ -1517,16 +1509,28 @@ export function ControlUI({
               <h3>
                 Viewing <span className="ct">{wallStreams.length}</span>
               </h3>
-              <StreamList rows={wallStreams} />
+              <StreamList
+                rows={wallStreams}
+                disabled={!roleCan(role, 'mutate-state-doc')}
+                onClickId={handleClickId}
+              />
               <h3>
                 Live <span className="ct">{liveStreams.length}</span>
               </h3>
-              <StreamList rows={liveStreams} />
+              <StreamList
+                rows={liveStreams}
+                disabled={!roleCan(role, 'mutate-state-doc')}
+                onClickId={handleClickId}
+              />
               <h3>
                 Offline / Unknown{' '}
                 <span className="ct">{otherStreams.length}</span>
               </h3>
-              <StreamList rows={otherStreams} />
+              <StreamList
+                rows={otherStreams}
+                disabled={!roleCan(role, 'mutate-state-doc')}
+                onClickId={handleClickId}
+              />
             </div>
           ) : (
             <div>loading...</div>
@@ -1537,12 +1541,13 @@ export function ControlUI({
                 <h2>Custom Streams</h2>
                 <div>
                   {/*
-                    Include an empty object at the end to create an extra input for a new custom stream.
-                    We need it to be part of the array (rather than JSX below) for DOM diffing to match the key and retain focus.
+                    Keyed by `link` (each custom stream's stable id) rather
+                    than array index, so deleting an earlier entry doesn't
+                    shift later entries onto a different DOM node mid-edit.
                   */}
-                  {customStreams.map(({ link, label, kind }, idx) => (
+                  {customStreams.map(({ link, label, kind }) => (
                     <CustomStreamInput
-                      key={idx}
+                      key={link}
                       link={link}
                       label={label}
                       kind={kind}
@@ -1579,6 +1584,7 @@ export function ControlUI({
                   )}
                   {authState.invites.map(({ tokenId, name, role }) => (
                     <AuthTokenLine
+                      key={tokenId}
                       id={tokenId}
                       name={name}
                       role={role}
@@ -1588,6 +1594,7 @@ export function ControlUI({
                   <h3>Sessions</h3>
                   {authState.sessions.map(({ tokenId, name, role }) => (
                     <AuthTokenLine
+                      key={tokenId}
                       id={tokenId}
                       name={name}
                       role={role}
@@ -1838,6 +1845,26 @@ export function GridPreviewBox({
       </StyledGridInfo>
     </StyledGridPreviewBox>
   )
+}
+
+export function StreamList({
+  rows,
+  disabled,
+  onClickId,
+}: {
+  rows: StreamData[]
+  disabled: boolean
+  onClickId: (id: string) => void
+}) {
+  return rows.map((row) => (
+    <StreamLine
+      key={row._id}
+      id={row._id}
+      row={row}
+      disabled={disabled}
+      onClickId={onClickId}
+    />
+  ))
 }
 
 function StreamLine({

--- a/packages/streamwall/src/renderer/OverlayRoot.test.tsx
+++ b/packages/streamwall/src/renderer/OverlayRoot.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment happy-dom
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import type {
+  StreamData,
+  StreamWindowConfig,
+  ViewState,
+} from 'streamwall-shared'
+import { afterEach, describe, expect, test } from 'vitest'
+import { Overlay } from './OverlayRoot'
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+function makeConfig(cols: number): StreamWindowConfig {
+  return {
+    cols,
+    rows: 1,
+    width: 100 * cols,
+    height: 100,
+    frameless: false,
+    fullscreen: false,
+    activeColor: '#0f0',
+    backgroundColor: '#000',
+  }
+}
+
+function makeView(idx: number, label: string): ViewState {
+  return {
+    state: {
+      displaying: {
+        running: { playback: 'playing', video: 'normal', audio: 'muted' },
+      },
+    },
+    context: {
+      id: idx,
+      content: { url: `https://example.com/${label}`, kind: 'video' },
+      info: null,
+      pos: { x: idx * 100, y: 0, width: 100, height: 100, spaces: [idx] },
+      error: null,
+      volume: 1,
+    },
+  }
+}
+
+function makeStream(label: string): StreamData {
+  return {
+    _id: label,
+    _dataSource: 'test',
+    kind: 'video',
+    link: `https://example.com/${label}`,
+    label,
+  }
+}
+
+function renderOverlay(
+  views: ViewState[],
+  streams: StreamData[],
+): HTMLDivElement {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    render(
+      <Overlay
+        config={makeConfig(views.length)}
+        views={views}
+        streams={streams}
+      />,
+      container!,
+    )
+  })
+  return container
+}
+
+// Walks up from the matched label span to the tile element that is a direct
+// child of the overlay container (i.e. the `SpaceBorder` for that view),
+// rather than stopping at the shared container itself.
+function findTile(root: HTMLDivElement, label: string): Element | undefined {
+  const overlayContainer = root.firstElementChild
+  const span = [...root.querySelectorAll('span')].find(
+    (el) => el.textContent === label,
+  )
+  let node: Element | null = span ?? null
+  while (node && node.parentElement !== overlayContainer) {
+    node = node.parentElement
+  }
+  return node ?? undefined
+}
+
+// Each active view's border/tile used to be rendered without a `key`, so
+// Preact matched them purely by position. When an earlier view disappears,
+// every later view's position shifts down a slot and Preact grafts the
+// surviving view's content onto the wrong DOM node - see #39. Keying each
+// tile by its stable grid position fixes this.
+describe('overlay view identity across a shrinking view list', () => {
+  test('a surviving tile keeps its own DOM node after an earlier view disappears', () => {
+    const streams = [makeStream('view-0'), makeStream('view-1')]
+    const root = renderOverlay(
+      [makeView(0, 'view-0'), makeView(1, 'view-1')],
+      streams,
+    )
+    const tileBefore = findTile(root, 'view-1')
+    expect(tileBefore, 'expected to find a tile for view-1').not.toBeUndefined()
+
+    act(() => {
+      render(
+        <Overlay
+          config={makeConfig(1)}
+          views={[makeView(1, 'view-1')]}
+          streams={streams}
+        />,
+        root,
+      )
+    })
+
+    const tileAfter = findTile(root, 'view-1')
+    expect(
+      tileAfter,
+      'expected to still find a tile for view-1',
+    ).not.toBeUndefined()
+    expect(tileAfter).toBe(tileBefore)
+  })
+})

--- a/packages/streamwall/src/renderer/OverlayRoot.tsx
+++ b/packages/streamwall/src/renderer/OverlayRoot.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useState } from 'preact/hooks'
+import { StreamwallState, type ViewPos } from 'streamwall-shared'
+import { styled } from 'styled-components'
+import { matchesState } from 'xstate'
+import packageInfo from '../../package.json'
+import { LAYER_FRAME_SANDBOX } from './layerFrameSandbox'
+import { OverlayViewTile } from './OverlayViewTile'
+
+// Extracted from overlay.tsx so it can be rendered and tested in isolation,
+// without pulling in the module-level `render(<App />, document.body)` call.
+export function Overlay({
+  config,
+  views,
+  streams,
+}: Pick<StreamwallState, 'config' | 'views' | 'streams'>) {
+  const { width, height, activeColor } = config
+  // Keep error views on the wall (instead of leaving a silent black cell) so the
+  // failure and its reason are visible; they are rendered as an error tile below.
+  const activeViews = views.filter(({ state }) =>
+    matchesState('displaying', state),
+  )
+  const overlays = streams.filter((s) => s.kind === 'overlay')
+  return (
+    <OverlayContainer>
+      <VersionFooter />
+      {activeViews.map(({ state, context }) => {
+        const { content, pos } = context
+        if (!content || !pos) {
+          return
+        }
+
+        const data = streams.find((d) => content.url === d.link)
+        const isError = matchesState('displaying.error', state)
+        const isListening = matchesState(
+          'displaying.running.audio.listening',
+          state,
+        )
+        const isBackgroundListening = matchesState(
+          'displaying.running.audio.background',
+          state,
+        )
+        const isBlurred = matchesState(
+          'displaying.running.video.blurred',
+          state,
+        )
+        const isLoading =
+          matchesState('displaying.loading', state) ||
+          matchesState('displaying.running.playback.stalled', state)
+        return (
+          <SpaceBorder
+            key={pos.spaces[0]}
+            $pos={pos}
+            $windowWidth={width}
+            $windowHeight={height}
+            $activeColor={activeColor}
+            $isListening={isListening}
+            $isError={isError}
+          >
+            <OverlayViewTile
+              url={content.url}
+              data={data}
+              isError={isError}
+              errorReason={context.error}
+              isListening={isListening}
+              isBackgroundListening={isBackgroundListening}
+              isBlurred={isBlurred}
+              isLoading={isLoading}
+              activeColor={activeColor}
+            />
+          </SpaceBorder>
+        )
+      })}
+      {overlays.map((s) => (
+        <OverlayIFrame
+          key={s._id}
+          src={s.link}
+          sandbox={LAYER_FRAME_SANDBOX}
+          allow="autoplay"
+          scrolling="no"
+        />
+      ))}
+    </OverlayContainer>
+  )
+}
+
+function VersionFooter() {
+  const [isShowing, setShowing] = useState(false)
+  useEffect(() => {
+    let timeout: ReturnType<typeof setTimeout> | undefined = undefined
+    const interval = setInterval(() => {
+      setShowing(true)
+      timeout = setTimeout(() => {
+        setShowing(false)
+      }, 5000)
+    }, 30 * 1000)
+    return () => {
+      clearInterval(interval)
+      clearTimeout(timeout)
+    }
+  }, [])
+  return (
+    <VersionText $isShowing={isShowing}>
+      <strong>streamwall</strong> {packageInfo.version}
+    </VersionText>
+  )
+}
+
+const OverlayContainer = styled.div`
+  overflow: hidden;
+`
+
+const SpaceBorder = styled.div.attrs<{
+  $pos: ViewPos
+  $windowWidth: number
+  $windowHeight: number
+  $activeColor: string
+  $isListening: boolean
+  $isError?: boolean
+  $borderWidth?: number
+}>(() => ({
+  $borderWidth: 2,
+}))`
+  display: flex;
+  align-items: flex-start;
+  position: fixed;
+  left: ${({ $pos }) => $pos.x}px;
+  top: ${({ $pos }) => $pos.y}px;
+  width: ${({ $pos }) => $pos.width}px;
+  height: ${({ $pos }) => $pos.height}px;
+  border: 0 solid ${({ $isError }) => ($isError ? 'red' : 'black')};
+  border-left-width: ${({ $pos, $borderWidth }) =>
+    $pos.x === 0 ? 0 : $borderWidth}px;
+  border-right-width: ${({ $pos, $borderWidth, $windowWidth }) =>
+    $pos.x + $pos.width === $windowWidth ? 0 : $borderWidth}px;
+  border-top-width: ${({ $pos, $borderWidth }) =>
+    $pos.y === 0 ? 0 : $borderWidth}px;
+  border-bottom-width: ${({ $pos, $borderWidth, $windowHeight }) =>
+    $pos.y + $pos.height === $windowHeight ? 0 : $borderWidth}px;
+  box-shadow: ${({ $isListening, $activeColor }) =>
+    $isListening ? `0 0 10px ${$activeColor} inset` : 'none'};
+  box-sizing: border-box;
+  pointer-events: none;
+  user-select: none;
+`
+
+const VersionText = styled.div<{ $isShowing: boolean }>`
+  position: fixed;
+  bottom: 4px;
+  right: 4px;
+  color: white;
+  font-size: 12px;
+  text-shadow:
+    0 0 1px rgba(0, 0, 0, 0.5),
+    1px 0 1px rgba(0, 0, 0, 0.5),
+    0 1px 1px rgba(0, 0, 0, 0.5),
+    1px 1px 1px rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(30px);
+  padding: 1px 4px;
+  border-bottom-left-radius: 4px;
+  opacity: ${({ $isShowing }) => ($isShowing ? '.65' : '.35')};
+  transition: ease-out 500ms all;
+`
+
+const OverlayIFrame = styled.iframe`
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100vw;
+  height: 100vh;
+  border: none;
+  pointer-events: none;
+`

--- a/packages/streamwall/src/renderer/layerFrameSandbox.sources.test.ts
+++ b/packages/streamwall/src/renderer/layerFrameSandbox.sources.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from 'vitest'
  * apply the shared LAYER_FRAME_SANDBOX policy to their iframe.
  */
 describe('layer renderer iframe sandbox', () => {
-  for (const file of ['overlay.tsx', 'background.tsx']) {
+  for (const file of ['OverlayRoot.tsx', 'background.tsx']) {
     const source = readFileSync(new URL(`./${file}`, import.meta.url), 'utf8')
 
     it(`${file} does not hardcode the ineffective allow-same-origin sandbox`, () => {

--- a/packages/streamwall/src/renderer/overlay.tsx
+++ b/packages/streamwall/src/renderer/overlay.tsx
@@ -1,14 +1,10 @@
 import { render } from 'preact'
 import { useEffect, useState } from 'preact/hooks'
 import { useHotkeys } from 'react-hotkeys-hook'
-import { StreamwallState, type ViewPos } from 'streamwall-shared'
-import { styled } from 'styled-components'
-import { matchesState } from 'xstate'
-import packageInfo from '../../package.json'
+import { StreamwallState } from 'streamwall-shared'
 import { StreamwallLayerGlobal } from '../preload/layerPreload'
 import { initRendererSentry } from './initSentry'
-import { LAYER_FRAME_SANDBOX } from './layerFrameSandbox'
-import { OverlayViewTile } from './OverlayViewTile'
+import { Overlay } from './OverlayRoot'
 
 import '@fontsource/noto-sans'
 import 'streamwall-control-ui/src/index.css'
@@ -20,80 +16,6 @@ declare global {
 }
 
 initRendererSentry()
-
-function Overlay({
-  config,
-  views,
-  streams,
-}: Pick<StreamwallState, 'config' | 'views' | 'streams'>) {
-  const { width, height, activeColor } = config
-  // Keep error views on the wall (instead of leaving a silent black cell) so the
-  // failure and its reason are visible; they are rendered as an error tile below.
-  const activeViews = views.filter(({ state }) =>
-    matchesState('displaying', state),
-  )
-  const overlays = streams.filter((s) => s.kind === 'overlay')
-  return (
-    <OverlayContainer>
-      <VersionFooter />
-      {activeViews.map(({ state, context }) => {
-        const { content, pos } = context
-        if (!content || !pos) {
-          return
-        }
-
-        const data = streams.find((d) => content.url === d.link)
-        const isError = matchesState('displaying.error', state)
-        const isListening = matchesState(
-          'displaying.running.audio.listening',
-          state,
-        )
-        const isBackgroundListening = matchesState(
-          'displaying.running.audio.background',
-          state,
-        )
-        const isBlurred = matchesState(
-          'displaying.running.video.blurred',
-          state,
-        )
-        const isLoading =
-          matchesState('displaying.loading', state) ||
-          matchesState('displaying.running.playback.stalled', state)
-        return (
-          <SpaceBorder
-            $pos={pos}
-            $windowWidth={width}
-            $windowHeight={height}
-            $activeColor={activeColor}
-            $isListening={isListening}
-            $isError={isError}
-          >
-            <OverlayViewTile
-              url={content.url}
-              data={data}
-              isError={isError}
-              errorReason={context.error}
-              isListening={isListening}
-              isBackgroundListening={isBackgroundListening}
-              isBlurred={isBlurred}
-              isLoading={isLoading}
-              activeColor={activeColor}
-            />
-          </SpaceBorder>
-        )
-      })}
-      {overlays.map((s) => (
-        <OverlayIFrame
-          key={s._id}
-          src={s.link}
-          sandbox={LAYER_FRAME_SANDBOX}
-          allow="autoplay"
-          scrolling="no"
-        />
-      ))}
-    </OverlayContainer>
-  )
-}
 
 function App() {
   const [state, setState] = useState<StreamwallState | undefined>()
@@ -115,93 +37,5 @@ function App() {
   const { config, views, streams } = state
   return <Overlay config={config} views={views} streams={streams} />
 }
-
-function VersionFooter() {
-  const [isShowing, setShowing] = useState(false)
-  useEffect(() => {
-    let timeout: ReturnType<typeof setTimeout> | undefined = undefined
-    const interval = setInterval(() => {
-      setShowing(true)
-      timeout = setTimeout(() => {
-        setShowing(false)
-      }, 5000)
-    }, 30 * 1000)
-    return () => {
-      clearInterval(interval)
-      clearTimeout(timeout)
-    }
-  }, [])
-  return (
-    <VersionText $isShowing={isShowing}>
-      <strong>streamwall</strong> {packageInfo.version}
-    </VersionText>
-  )
-}
-
-const OverlayContainer = styled.div`
-  overflow: hidden;
-`
-
-const SpaceBorder = styled.div.attrs<{
-  $pos: ViewPos
-  $windowWidth: number
-  $windowHeight: number
-  $activeColor: string
-  $isListening: boolean
-  $isError?: boolean
-  $borderWidth?: number
-}>(() => ({
-  $borderWidth: 2,
-}))`
-  display: flex;
-  align-items: flex-start;
-  position: fixed;
-  left: ${({ $pos }) => $pos.x}px;
-  top: ${({ $pos }) => $pos.y}px;
-  width: ${({ $pos }) => $pos.width}px;
-  height: ${({ $pos }) => $pos.height}px;
-  border: 0 solid ${({ $isError }) => ($isError ? 'red' : 'black')};
-  border-left-width: ${({ $pos, $borderWidth }) =>
-    $pos.x === 0 ? 0 : $borderWidth}px;
-  border-right-width: ${({ $pos, $borderWidth, $windowWidth }) =>
-    $pos.x + $pos.width === $windowWidth ? 0 : $borderWidth}px;
-  border-top-width: ${({ $pos, $borderWidth }) =>
-    $pos.y === 0 ? 0 : $borderWidth}px;
-  border-bottom-width: ${({ $pos, $borderWidth, $windowHeight }) =>
-    $pos.y + $pos.height === $windowHeight ? 0 : $borderWidth}px;
-  box-shadow: ${({ $isListening, $activeColor }) =>
-    $isListening ? `0 0 10px ${$activeColor} inset` : 'none'};
-  box-sizing: border-box;
-  pointer-events: none;
-  user-select: none;
-`
-
-const VersionText = styled.div<{ $isShowing: boolean }>`
-  position: fixed;
-  bottom: 4px;
-  right: 4px;
-  color: white;
-  font-size: 12px;
-  text-shadow:
-    0 0 1px rgba(0, 0, 0, 0.5),
-    1px 0 1px rgba(0, 0, 0, 0.5),
-    0 1px 1px rgba(0, 0, 0, 0.5),
-    1px 1px 1px rgba(0, 0, 0, 0.5);
-  backdrop-filter: blur(30px);
-  padding: 1px 4px;
-  border-bottom-left-radius: 4px;
-  opacity: ${({ $isShowing }) => ($isShowing ? '.65' : '.35')};
-  transition: ease-out 500ms all;
-`
-
-const OverlayIFrame = styled.iframe`
-  position: fixed;
-  left: 0;
-  top: 0;
-  width: 100vw;
-  height: 100vh;
-  border: none;
-  pointer-events: none;
-`
 
 render(<App />, document.body)


### PR DESCRIPTION
## Problem

`StreamList` was declared inside `ControlUI`'s render body. `ControlUI` re-renders on every incoming state message (they arrive continuously), so each re-render produced a brand-new `StreamList` function reference at that JSX position. Preact treats a changed component reference as a different component type, so it unmounted and remounted the entire stream sidebar's DOM on every message instead of patching it in place - a real perf/UX cost given how often state messages arrive.

Several list-rendering spots also had missing or unstable (index-based) `key`s, causing the same class of bug (Preact matches children by position instead of identity), most notably custom stream inputs keyed by array index: deleting an earlier entry shifted every later entry's index down a slot, so an in-progress edit jumped onto the wrong row.

## Solution

- Hoisted `StreamList` out of `ControlUI` to module scope (`packages/streamwall-control-ui/src/index.tsx`), passing `disabled`/`onClickId` as props instead of closing over `role`/`handleClickId`. Rows are now keyed by `row._id`.
- Custom stream inputs are now keyed by their stable `link` instead of array index.
- Grid cell inputs, preview boxes, and controls (previously unkeyed) are now keyed by cell index / view position (`pos.spaces[0]`).
- Invite/session rows are now keyed by `tokenId`.
- In the transparent overlay renderer (`packages/streamwall/src/renderer/overlay.tsx`), each view's border/tile was also unkeyed; same bug, same fix (keyed by `pos.spaces[0]`). Extracted `Overlay` (and its supporting styled-components/`VersionFooter`) into a new `OverlayRoot.tsx`, mirroring the existing `OverlayViewTile.tsx` split, so it can be rendered directly in a test without pulling in the module-level `render(<App />, document.body)` bootstrap.

## Testing

Added regression tests that render the real components end-to-end and assert DOM node *identity* is preserved across a re-render/shrink (all fail without the corresponding fix, verified locally before applying it):
- `StreamList.test.tsx` - a stream row's DOM node survives `ControlUI` re-rendering with a fresh `connection` prop (simulating a continuous state message).
- `CustomStreamInput.test.tsx` - a surviving custom stream's input keeps its own DOM node (and value) after an earlier entry is deleted.
- `GridViewIdentity.test.tsx` - a surviving grid preview box keeps its own DOM node after an earlier view disappears.
- `OverlayRoot.test.tsx` - a surviving overlay tile keeps its own DOM node after an earlier view disappears.

Full quality gate run locally: Prettier, ESLint, `tsc --noEmit` (all packages), full test suite (`streamwall` 287, `streamwall-shared` 223, `streamwall-control-server` 90, `streamwall-control-ui` 90 - all passing), and `streamwall-control-client` production build.

## Risks / breaking changes

None expected - purely a rendering-identity/perf fix with no behavior change to what's displayed. `Overlay` is now exported from a new file (`OverlayRoot.tsx`) instead of being private to `overlay.tsx`; no other consumers existed.

Closes #39