### PR TITLE
fix(control-ui): fix tab order, aria-labels, keyboard resize, and language

### DIFF
--- a/packages/streamwall-control-client/dev.html
+++ b/packages/streamwall-control-client/dev.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/streamwall-control-client/index.html
+++ b/packages/streamwall-control-client/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/streamwall-control-ui/src/GridControls.test.tsx
+++ b/packages/streamwall-control-ui/src/GridControls.test.tsx
@@ -92,3 +92,69 @@ describe('GridControls volume slider', () => {
     expect(onSetVolume).toHaveBeenCalledWith(3, 0.3)
   })
 })
+
+describe('GridControls accessible names', () => {
+  test('gives every icon-only button a descriptive aria-label', () => {
+    const box = renderControls({ role: 'admin', showDebug: true })
+
+    expect(
+      box.querySelector('button[aria-label="Reload stream"]'),
+    ).not.toBeNull()
+    expect(
+      box.querySelector('button[aria-label="Open stream in browser"]'),
+    ).not.toBeNull()
+    expect(
+      box.querySelector('button[aria-label="Open developer tools"]'),
+    ).not.toBeNull()
+  })
+
+  test('labels the swap and rotate buttons outside debug mode', () => {
+    const box = renderControls({ showDebug: false })
+
+    expect(box.querySelector('button[aria-label="Swap stream"]')).not.toBeNull()
+    expect(
+      box.querySelector('button[aria-label="Rotate stream"]'),
+    ).not.toBeNull()
+  })
+
+  test('flips the swap button label to "Cancel swap" while swapping', () => {
+    const box = renderControls({ isSwapping: true })
+
+    expect(box.querySelector('button[aria-label="Cancel swap"]')).not.toBeNull()
+    expect(box.querySelector('button[aria-label="Swap stream"]')).toBeNull()
+  })
+
+  test('labels the blur toggle button by its current state', () => {
+    let box = renderControls({ isBlurred: false })
+    expect(box.querySelector('button[aria-label="Blur video"]')).not.toBeNull()
+
+    box = renderControls({ isBlurred: true })
+    expect(
+      box.querySelector('button[aria-label="Unblur video"]'),
+    ).not.toBeNull()
+  })
+
+  test('labels the listening toggle button by its current state', () => {
+    let box = renderControls({
+      isListening: false,
+      isBackgroundListening: false,
+    })
+    expect(
+      box.querySelector('button[aria-label="Listen to audio"]'),
+    ).not.toBeNull()
+
+    box = renderControls({ isListening: true })
+    expect(box.querySelector('button[aria-label="Mute audio"]')).not.toBeNull()
+
+    box = renderControls({ isBackgroundListening: true })
+    expect(box.querySelector('button[aria-label="Mute audio"]')).not.toBeNull()
+  })
+
+  test('does not set a positive tabIndex on any button, relying on native DOM order', () => {
+    const box = renderControls({ isBlurred: true })
+
+    for (const button of Array.from(box.querySelectorAll('button'))) {
+      expect(button.getAttribute('tabindex')).not.toBe('1')
+    }
+  })
+})

--- a/packages/streamwall-control-ui/src/connectionStatus.test.tsx
+++ b/packages/streamwall-control-ui/src/connectionStatus.test.tsx
@@ -1,0 +1,96 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import type { StreamDelayStatus } from 'streamwall-shared'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import * as Y from 'yjs'
+import type { StreamwallConnection } from './index.tsx'
+import { ControlUI } from './index.tsx'
+
+// react-icons renders through preact/compat's Context.Consumer, which
+// currently crashes under this package's happy-dom test environment
+// (unrelated to the connection status under test here) - stub the icons out
+// so the component can render.
+vi.mock('react-icons/fa', () => ({
+  FaExchangeAlt: () => null,
+  FaExclamationTriangle: () => null,
+  FaRedoAlt: () => null,
+  FaRegLifeRing: () => null,
+  FaRegWindowMaximize: () => null,
+  FaSyncAlt: () => null,
+  FaVideoSlash: () => null,
+  FaVolumeUp: () => null,
+}))
+vi.mock('react-icons/md', () => ({
+  MdOutlineStayCurrentLandscape: () => null,
+  MdOutlineStayCurrentPortrait: () => null,
+}))
+// react-hotkeys-hook calls into React internals that don't cooperate with
+// this package's Preact/compat test environment (unrelated to the
+// connection status under test here) - stub it out so the component can
+// render.
+vi.mock('react-hotkeys-hook', () => ({
+  useHotkeys: () => {},
+}))
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+function renderControlUI(isConnected: boolean): HTMLDivElement {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+
+  const delayState: StreamDelayStatus = {
+    isConnected: true,
+    delaySeconds: 0,
+    restartSeconds: 0,
+    isCensored: false,
+    isStreamRunning: true,
+    startTime: 0,
+    state: 'idle',
+  }
+
+  const connection: StreamwallConnection = {
+    isConnected,
+    role: 'operator',
+    send: () => {},
+    sharedState: { views: {} },
+    stateDoc: new Y.Doc(),
+    config: undefined,
+    streams: [],
+    customStreams: [],
+    views: [],
+    stateIdxMap: new Map(),
+    delayState,
+    authState: undefined,
+    layoutPresets: [],
+    dataSourceHealth: [],
+  }
+
+  act(() => {
+    render(<ControlUI connection={connection} />, container!)
+  })
+  return container
+}
+
+describe('connection status text', () => {
+  test('renders the connected state in English', () => {
+    const container = renderControlUI(true)
+    expect(container.querySelector('.status')?.textContent).toBe(
+      'connected · operator',
+    )
+  })
+
+  test('renders the connecting state in English', () => {
+    const container = renderControlUI(false)
+    expect(container.querySelector('.status')?.textContent).toBe(
+      'connecting... · operator',
+    )
+  })
+})

--- a/packages/streamwall-control-ui/src/gridInteractions.test.ts
+++ b/packages/streamwall-control-ui/src/gridInteractions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  computeKeyboardResizeHoverIdx,
   computeResizeAssignments,
   computeSwap,
   isIdxInResizeBox,
@@ -242,6 +243,98 @@ describe('computeResizeAssignments', () => {
         [9, 'stream-a'],
       ]),
     )
+  })
+})
+
+describe('computeKeyboardResizeHoverIdx', () => {
+  // 4-col, 4-row grid; a 1x1 box anchored (and living) at idx 0.
+  const cols = 4
+  const rows = 4
+
+  it('grows the east handle one cell to the right on ArrowRight', () => {
+    expect(
+      computeKeyboardResizeHoverIdx(cols, rows, 0, 'e', [0], 'ArrowRight'),
+    ).toBe(1)
+  })
+
+  it('grows the south handle one cell down on ArrowDown', () => {
+    expect(
+      computeKeyboardResizeHoverIdx(cols, rows, 0, 's', [0], 'ArrowDown'),
+    ).toBe(4)
+  })
+
+  it('shrinks a wider east box by one column on ArrowLeft', () => {
+    // Box anchored at idx 0 currently spans { 0, 1, 2 } (width 3).
+    expect(
+      computeKeyboardResizeHoverIdx(cols, rows, 0, 'e', [0, 1, 2], 'ArrowLeft'),
+    ).toBe(1)
+  })
+
+  it('ignores the cross-axis key for an east handle', () => {
+    expect(
+      computeKeyboardResizeHoverIdx(cols, rows, 0, 'e', [0], 'ArrowDown'),
+    ).toBeUndefined()
+    expect(
+      computeKeyboardResizeHoverIdx(cols, rows, 0, 'e', [0], 'ArrowUp'),
+    ).toBeUndefined()
+  })
+
+  it('ignores the cross-axis key for a south handle', () => {
+    expect(
+      computeKeyboardResizeHoverIdx(cols, rows, 0, 's', [0], 'ArrowRight'),
+    ).toBeUndefined()
+    expect(
+      computeKeyboardResizeHoverIdx(cols, rows, 0, 's', [0], 'ArrowLeft'),
+    ).toBeUndefined()
+  })
+
+  it('moves either axis, one cell at a time, for a se (corner) handle', () => {
+    expect(
+      computeKeyboardResizeHoverIdx(cols, rows, 0, 'se', [0], 'ArrowRight'),
+    ).toBe(1)
+    expect(
+      computeKeyboardResizeHoverIdx(cols, rows, 0, 'se', [0], 'ArrowDown'),
+    ).toBe(4)
+  })
+
+  it('clamps to the anchor and refuses to shrink past a 1-cell box', () => {
+    expect(
+      computeKeyboardResizeHoverIdx(cols, rows, 0, 'e', [0], 'ArrowLeft'),
+    ).toBeUndefined()
+    expect(
+      computeKeyboardResizeHoverIdx(cols, rows, 0, 's', [0], 'ArrowUp'),
+    ).toBeUndefined()
+  })
+
+  it('clamps to the grid bounds and refuses to grow past the last column/row', () => {
+    // Box already spans the full width (cols=4: x 0..3).
+    expect(
+      computeKeyboardResizeHoverIdx(
+        cols,
+        rows,
+        0,
+        'e',
+        [0, 1, 2, 3],
+        'ArrowRight',
+      ),
+    ).toBeUndefined()
+    // Box already spans the full height (rows=4: y 0..3).
+    expect(
+      computeKeyboardResizeHoverIdx(
+        cols,
+        rows,
+        0,
+        's',
+        [0, 4, 8, 12],
+        'ArrowDown',
+      ),
+    ).toBeUndefined()
+  })
+
+  it('returns undefined for a non-arrow key', () => {
+    expect(
+      computeKeyboardResizeHoverIdx(cols, rows, 0, 'se', [0], 'Enter'),
+    ).toBeUndefined()
   })
 })
 

--- a/packages/streamwall-control-ui/src/gridInteractions.ts
+++ b/packages/streamwall-control-ui/src/gridInteractions.ts
@@ -166,6 +166,50 @@ export function isIdxInResizeBox(
  * rather than leaving a stale streamId that keeps rendering as part of the
  * (now smaller) box.
  */
+/**
+ * Compute the hover index a single arrow-key press would resize a box to, so
+ * a resize handle can be operated by keyboard as well as pointer drag. Each
+ * press moves one axis by one grid cell, mirroring the axis lock a pointer
+ * drag on the same handle already applies ('e' is width-only, 's' is
+ * height-only, 'se' moves whichever axis the pressed arrow names).
+ *
+ * Returns `undefined` — a no-op — when the key isn't an arrow key, names the
+ * handle's locked cross-axis, or would move past the anchor (shrinking below
+ * a 1-cell box) or past the grid's far edge.
+ */
+export function computeKeyboardResizeHoverIdx(
+  cols: number,
+  rows: number,
+  anchorIdx: number,
+  handle: ResizeHandle,
+  originalSpaces: number[],
+  key: string,
+): number | undefined {
+  const dx = key === 'ArrowRight' ? 1 : key === 'ArrowLeft' ? -1 : 0
+  const dy = key === 'ArrowDown' ? 1 : key === 'ArrowUp' ? -1 : 0
+  if (dx === 0 && dy === 0) {
+    return undefined
+  }
+  if (handle === 'e' && dy !== 0) {
+    return undefined
+  }
+  if (handle === 's' && dx !== 0) {
+    return undefined
+  }
+
+  const { x: anchorX, y: anchorY } = idxToCoords(cols, anchorIdx)
+  const originalCoords = originalSpaces.map((idx) => idxToCoords(cols, idx))
+  const maxX = Math.max(...originalCoords.map(({ x }) => x))
+  const maxY = Math.max(...originalCoords.map(({ y }) => y))
+
+  const newMaxX = Math.min(cols - 1, Math.max(anchorX, maxX + dx))
+  const newMaxY = Math.min(rows - 1, Math.max(anchorY, maxY + dy))
+  if (newMaxX === maxX && newMaxY === maxY) {
+    return undefined
+  }
+  return cols * newMaxY + newMaxX
+}
+
 export function computeResizeAssignments(
   cols: number,
   anchorIdx: number,

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -66,6 +66,7 @@ import {
   resolveMoveTarget,
 } from './gestures'
 import {
+  computeKeyboardResizeHoverIdx,
   computeResizeAssignments,
   computeSwap,
   isIdxInResizeBox,
@@ -837,6 +838,53 @@ export function ControlUI({
     [sharedState],
   )
 
+  // Keyboard equivalent of the pointer-drag resize above: each arrow-key
+  // press commits a one-cell step immediately (there's no keyboard hover
+  // state to preview), rather than opening an in-progress `resize` gesture.
+  const handleResizeKeyDown = useCallback(
+    (
+      anchorIdx: number,
+      handle: ResizeHandle,
+      originalSpaces: number[],
+      ev: KeyboardEvent,
+    ) => {
+      if (cols == null || rows == null) {
+        return
+      }
+      const hoverIdx = computeKeyboardResizeHoverIdx(
+        cols,
+        rows,
+        anchorIdx,
+        handle,
+        originalSpaces,
+        ev.key,
+      )
+      if (hoverIdx == null) {
+        return
+      }
+      ev.preventDefault()
+      const streamId = sharedState?.views?.[anchorIdx]?.streamId ?? undefined
+      if (streamId == null || streamId === '') {
+        return
+      }
+      stateDoc.transact(() => {
+        const viewsMap = stateDoc.getMap<Y.Map<string | undefined>>('views')
+        const assignments = computeResizeAssignments(
+          cols,
+          anchorIdx,
+          hoverIdx,
+          streamId,
+          handle,
+          originalSpaces,
+        )
+        for (const [idx, assignedStreamId] of assignments) {
+          viewsMap.get(String(idx))?.set('streamId', assignedStreamId)
+        }
+      })
+    },
+    [cols, rows, sharedState, stateDoc],
+  )
+
   useLayoutEffect(() => {
     function endResize(ev: PointerEvent) {
       // A resize only commits while the pointer is over the grid; released
@@ -917,7 +965,7 @@ export function ControlUI({
         if (
           gridWouldDropAssignments(cols, targetCols, targetRows, assignments) &&
           !window.confirm(
-            'Das neue Raster ist kleiner und entfernt belegte Kacheln dauerhaft. Fortfahren?',
+            'The new grid is smaller and will permanently remove occupied tiles. Continue?',
           )
         ) {
           return
@@ -1294,7 +1342,7 @@ export function ControlUI({
           {role !== 'local' && (
             <div className="status">
               <span className={`dot ${isConnected ? 'on' : 'off'}`} />
-              {isConnected ? 'verbunden' : 'verbinde…'} · {role}
+              {isConnected ? 'connected' : 'connecting...'} · {role}
             </div>
           )}
           <ThemeToggle />
@@ -1399,22 +1447,37 @@ export function ControlUI({
                       }}
                     >
                       <StyledResizeHandles>
-                        <div
+                        <button
+                          type="button"
                           className="handle e"
+                          aria-label="Resize right edge"
                           onPointerDown={(ev) =>
                             handleResizeStart(anchorIdx, 'e', pos.spaces, ev)
                           }
+                          onKeyDown={(ev) =>
+                            handleResizeKeyDown(anchorIdx, 'e', pos.spaces, ev)
+                          }
                         />
-                        <div
+                        <button
+                          type="button"
                           className="handle s"
+                          aria-label="Resize bottom edge"
                           onPointerDown={(ev) =>
                             handleResizeStart(anchorIdx, 's', pos.spaces, ev)
                           }
+                          onKeyDown={(ev) =>
+                            handleResizeKeyDown(anchorIdx, 's', pos.spaces, ev)
+                          }
                         />
-                        <div
+                        <button
+                          type="button"
                           className="handle se"
+                          aria-label="Resize bottom-right corner"
                           onPointerDown={(ev) =>
                             handleResizeStart(anchorIdx, 'se', pos.spaces, ev)
+                          }
+                          onKeyDown={(ev) =>
+                            handleResizeKeyDown(anchorIdx, 'se', pos.spaces, ev)
                           }
                         />
                       </StyledResizeHandles>
@@ -1759,13 +1822,12 @@ function StreamDelayBox({
               <StyledButton
                 $isActive={delayState.isCensored}
                 onClick={handleToggleStreamCensored}
-                tabIndex={1}
               >
                 {buttonText}
               </StyledButton>
             )}
             {roleCan(role, 'set-stream-running') && (
-              <StyledButton onClick={handleToggleStreamRunning} tabIndex={1}>
+              <StyledButton onClick={handleToggleStreamRunning}>
                 {delayState.isStreamRunning ? 'End stream' : 'Start stream'}
               </StyledButton>
             )}
@@ -1925,6 +1987,10 @@ const StyledResizeHandles = styled.div`
     background: var(--accent, #e23);
     opacity: 0;
     transition: opacity 0.1s;
+    border: 0;
+    margin: 0;
+    padding: 0;
+    appearance: none;
   }
   &:hover .handle {
     opacity: 0.6;
@@ -1935,6 +2001,14 @@ const StyledResizeHandles = styled.div`
     .handle {
       opacity: 0.6;
     }
+  }
+  /* A focused handle needs to be visible even without a hover, so it can be
+     found and operated by keyboard (arrow keys resize, see
+     handleResizeKeyDown). */
+  .handle:focus-visible {
+    opacity: 1;
+    outline: 2px solid var(--accent, #e23);
+    outline-offset: 2px;
   }
   .handle.e {
     top: 20%;
@@ -2247,17 +2321,26 @@ export function GridControls({
           {showDebug ? (
             <>
               {roleCan(role, 'reload-view') && (
-                <StyledSmallButton onClick={handleReloadClick} tabIndex={1}>
+                <StyledSmallButton
+                  onClick={handleReloadClick}
+                  aria-label="Reload stream"
+                >
                   <FaSyncAlt />
                 </StyledSmallButton>
               )}
               {roleCan(role, 'browse') && (
-                <StyledSmallButton onClick={handleBrowseClick} tabIndex={1}>
+                <StyledSmallButton
+                  onClick={handleBrowseClick}
+                  aria-label="Open stream in browser"
+                >
                   <FaRegWindowMaximize />
                 </StyledSmallButton>
               )}
               {roleCan(role, 'dev-tools') && (
-                <StyledSmallButton onClick={handleDevToolsClick} tabIndex={1}>
+                <StyledSmallButton
+                  onClick={handleDevToolsClick}
+                  aria-label="Open developer tools"
+                >
                   <FaRegLifeRing />
                 </StyledSmallButton>
               )}
@@ -2265,7 +2348,10 @@ export function GridControls({
           ) : (
             <>
               {roleCan(role, 'reload-view') && (
-                <StyledSmallButton onClick={handleReloadClick} tabIndex={1}>
+                <StyledSmallButton
+                  onClick={handleReloadClick}
+                  aria-label="Reload stream"
+                >
                   <FaSyncAlt />
                 </StyledSmallButton>
               )}
@@ -2273,13 +2359,16 @@ export function GridControls({
                 <StyledSmallButton
                   $isActive={isSwapping}
                   onClick={handleSwapClick}
-                  tabIndex={1}
+                  aria-label={isSwapping ? 'Cancel swap' : 'Swap stream'}
                 >
                   <FaExchangeAlt />
                 </StyledSmallButton>
               )}
               {roleCan(role, 'rotate-stream') && (
-                <StyledSmallButton onClick={handleRotateClick} tabIndex={1}>
+                <StyledSmallButton
+                  onClick={handleRotateClick}
+                  aria-label="Rotate stream"
+                >
                   <FaRedoAlt />
                 </StyledSmallButton>
               )}
@@ -2292,7 +2381,7 @@ export function GridControls({
           <StyledButton
             $isActive={isBlurred}
             onClick={handleBlurClick}
-            tabIndex={1}
+            aria-label={isBlurred ? 'Unblur video' : 'Blur video'}
           >
             <FaVideoSlash />
           </StyledButton>
@@ -2305,7 +2394,6 @@ export function GridControls({
             step={0.01}
             value={volume}
             onInput={handleVolumeInput}
-            tabIndex={1}
             aria-label="Volume"
           />
         )}
@@ -2316,7 +2404,11 @@ export function GridControls({
               isListening ? 'red' : Color('red').desaturate(0.5).hsl().string()
             }
             onClick={handleListeningClick}
-            tabIndex={1}
+            aria-label={
+              isListening || isBackgroundListening
+                ? 'Mute audio'
+                : 'Listen to audio'
+            }
           >
             <FaVolumeUp />
           </StyledButton>

--- a/packages/streamwall/src/renderer/control.html
+++ b/packages/streamwall/src/renderer/control.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <title>Streamwall Control</title>


### PR DESCRIPTION
## Problem

The control UI (`packages/streamwall-control-ui/src/index.tsx`) had several accessibility gaps:

- Every action button used a positive `tabIndex={1}`, which hijacks the browser's natural tab order instead of following the DOM order.
- Icon-only buttons (reload, browse, dev tools, swap, rotate, blur, listen) had no `aria-label`/`title`, so screen-reader users couldn't tell what they did.
- The tile resize handles were bare, non-focusable `<div>`s driven only by `onMouseDown`/`onPointerDown`, making resizing entirely unreachable by keyboard or screen reader.
- The UI mixed German and English strings (connection status text, a grid-shrink confirm dialog) with no `lang` attribute on the surrounding HTML.

## Solution

- Removed the positive `tabIndex={1}` from every `StyledButton`/`StyledSmallButton`/`StyledVolumeSlider` instance so native DOM tab order applies (all of these render to real `<button>`/`<input>` elements, which are focusable by default).
- Added a descriptive `aria-label` to every icon-only button, including dynamic labels for toggle buttons (e.g. "Blur video" ↔ "Unblur video", "Swap stream" ↔ "Cancel swap", "Listen to audio" ↔ "Mute audio").
- Converted the resize handles to real `<button>` elements with `aria-label`s and wired up arrow-key resizing:
  - New pure helper `computeKeyboardResizeHoverIdx` in `gridInteractions.ts` computes the one-cell-per-keypress resize step, respecting the same axis locking (`e`/`s`/`se`) and anchor/grid-bound clamping as the existing pointer-drag math (`computeResizeAssignments`).
  - `handleResizeKeyDown` in `index.tsx` wires arrow-key presses on a handle to commit that step directly to the shared Yjs doc (each keypress is a discrete, immediately-committed step, since there's no keyboard "hover" preview state the way pointer drag has).
  - Added a `:focus-visible` outline to the (usually hover-only) handles so a keyboard user can see which one is focused.
- Translated the remaining German strings (`verbunden`/`verbinde…` connection status, and the grid-shrink confirm dialog) to English, and added `lang="en"` to the three HTML documents that host the control UI (`packages/streamwall-control-client/index.html`, `dev.html`, and `packages/streamwall/src/renderer/control.html`).

### Out of scope / already resolved

The issue also flagged `useHotkeys(..., { filter: () => true })` as firing hotkeys while typing in form inputs. That specific bug (a no-op v3 `filter` option) was already fixed in #189, which replaced it with the v5 `enableOnFormTags` option, deliberately scoped to alt/mod-modifier hotkeys only (see the comments in `index.tsx` and the existing `hotkeysOptions.test.tsx` coverage). No further change was needed there.

### Follow-up

While verifying the resize handles, I found the resize/drag-move interactions aren't gated by `roleCan(role, 'mutate-state-doc')` the way `GridInput` is — the server rejects unauthorized mutations so this isn't a security bug, but it causes a confusing local-flicker-then-rollback UX for a `monitor`-role client. Filed as #286, out of scope for this PR.

## Testing performed

- Added/extended unit tests:
  - `GridControls.test.tsx`: aria-label coverage for every icon-only button (static and toggle-state-dependent), and a regression test that no button carries a positive `tabIndex`.
  - `gridInteractions.test.ts`: full coverage of `computeKeyboardResizeHoverIdx` (axis locking per handle, anchor/grid-bound clamping, non-arrow keys).
  - New `connectionStatus.test.tsx`: connection status text renders in English for both the connected and connecting states.
- `npm run format:check`, `npm run lint`, `npm run typecheck`, and `npm test` all pass across every workspace.

## Risks / breaking changes

None expected. This only changes UI markup/attributes and adds a new keyboard interaction path alongside the existing pointer-drag resize; no wire protocol or shared-doc schema changes.

Closes #40