### PR TITLE
fix(control-ui): surface command error responses instead of dropping them

### DIFF
--- a/packages/streamwall-control-ui/src/CommandErrorBanner.test.tsx
+++ b/packages/streamwall-control-ui/src/CommandErrorBanner.test.tsx
@@ -1,0 +1,55 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { CommandErrorBanner } from './CommandErrorBanner.tsx'
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+function renderBanner(
+  error: string | null,
+  onDismiss: () => void = () => {},
+): HTMLDivElement {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    render(
+      <CommandErrorBanner error={error} onDismiss={onDismiss} />,
+      container!,
+    )
+  })
+  return container
+}
+
+describe('CommandErrorBanner', () => {
+  test('renders nothing when there is no error', () => {
+    const el = renderBanner(null)
+    expect(el.querySelector('.command-error-banner')).toBeNull()
+  })
+
+  test('shows the error message when set', () => {
+    const el = renderBanner('unauthorized')
+    expect(el.querySelector('.command-error-banner')?.textContent).toContain(
+      'unauthorized',
+    )
+  })
+
+  test('calls onDismiss when the dismiss control is clicked', () => {
+    const onDismiss = vi.fn()
+    const el = renderBanner('unauthorized', onDismiss)
+    const dismissButton = el.querySelector(
+      '.command-error-banner button',
+    ) as HTMLButtonElement
+    act(() => {
+      dismissButton.click()
+    })
+    expect(onDismiss).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/streamwall-control-ui/src/CommandErrorBanner.tsx
+++ b/packages/streamwall-control-ui/src/CommandErrorBanner.tsx
@@ -1,0 +1,47 @@
+import { FaExclamationTriangle } from 'react-icons/fa'
+import { styled } from 'styled-components'
+
+const StyledCommandErrorBanner = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #e0a800;
+
+  button {
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    font-size: 12px;
+    padding: 0;
+    text-decoration: underline;
+  }
+`
+
+/**
+ * Surfaces a control-server command error (e.g. `unauthorized`) that would
+ * otherwise be dropped silently by callers that don't pass a response
+ * callback to `send` (issue #35).
+ */
+export function CommandErrorBanner({
+  error,
+  onDismiss,
+}: {
+  error: string | null
+  onDismiss: () => void
+}) {
+  if (error == null) {
+    return null
+  }
+
+  return (
+    <StyledCommandErrorBanner className="command-error-banner">
+      <FaExclamationTriangle />
+      <span>Aktion fehlgeschlagen: {error}</span>
+      <button type="button" onClick={onDismiss}>
+        Ausblenden
+      </button>
+    </StyledCommandErrorBanner>
+  )
+}

--- a/packages/streamwall-control-ui/src/commandError.test.ts
+++ b/packages/streamwall-control-ui/src/commandError.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test, vi } from 'vitest'
+import { createErrorSurfacingSend, isErrorResponse } from './commandError'
+
+describe('isErrorResponse', () => {
+  test('recognizes a response carrying a string error', () => {
+    expect(isErrorResponse({ error: 'unauthorized' })).toBe(true)
+  })
+
+  test('recognizes an error response alongside other fields', () => {
+    expect(
+      isErrorResponse({ response: true, id: 3, error: 'invalid message' }),
+    ).toBe(true)
+  })
+
+  test('rejects a successful response with no error field', () => {
+    expect(isErrorResponse({ response: true, id: 3 })).toBe(false)
+  })
+
+  test('rejects a response whose error field is not a string', () => {
+    expect(isErrorResponse({ error: 42 })).toBe(false)
+  })
+
+  test('rejects undefined', () => {
+    expect(isErrorResponse(undefined)).toBe(false)
+  })
+
+  test('rejects null', () => {
+    expect(isErrorResponse(null)).toBe(false)
+  })
+
+  test('rejects primitives', () => {
+    expect(isErrorResponse('unauthorized')).toBe(false)
+    expect(isErrorResponse(42)).toBe(false)
+  })
+})
+
+describe('createErrorSurfacingSend', () => {
+  test('reports the error and does not invoke the caller callback', () => {
+    const rawSend = vi.fn((_msg, cb?: (msg: unknown) => void) => {
+      cb?.({ response: true, id: 0, error: 'unauthorized' })
+    })
+    const onError = vi.fn()
+    const callerCb = vi.fn()
+
+    const send = createErrorSurfacingSend(rawSend, onError)
+    send({ type: 'set-grid-size', cols: 3, rows: 3 }, callerCb)
+
+    expect(onError).toHaveBeenCalledWith('unauthorized')
+    expect(callerCb).not.toHaveBeenCalled()
+  })
+
+  test('surfaces the error even when the caller passed no callback at all', () => {
+    const rawSend = vi.fn((_msg, cb?: (msg: unknown) => void) => {
+      cb?.({ response: true, id: 0, error: 'unauthorized' })
+    })
+    const onError = vi.fn()
+
+    const send = createErrorSurfacingSend(rawSend, onError)
+    send({ type: 'set-grid-size', cols: 3, rows: 3 })
+
+    expect(onError).toHaveBeenCalledWith('unauthorized')
+  })
+
+  test('forwards a successful response to the caller callback without reporting an error', () => {
+    const rawSend = vi.fn((_msg, cb?: (msg: unknown) => void) => {
+      cb?.({ response: true, id: 0, name: 'ops', secret: 's', tokenId: 't' })
+    })
+    const onError = vi.fn()
+    const callerCb = vi.fn()
+
+    const send = createErrorSurfacingSend(rawSend, onError)
+    send({ type: 'create-invite', name: 'ops', role: 'operator' }, callerCb)
+
+    expect(onError).not.toHaveBeenCalled()
+    expect(callerCb).toHaveBeenCalledWith({
+      response: true,
+      id: 0,
+      name: 'ops',
+      secret: 's',
+      tokenId: 't',
+    })
+  })
+
+  test('does nothing when the underlying send never calls back', () => {
+    const rawSend = vi.fn()
+    const onError = vi.fn()
+    const callerCb = vi.fn()
+
+    const send = createErrorSurfacingSend(rawSend, onError)
+    send({ type: 'set-grid-size', cols: 3, rows: 3 }, callerCb)
+
+    expect(rawSend).toHaveBeenCalledOnce()
+    expect(onError).not.toHaveBeenCalled()
+    expect(callerCb).not.toHaveBeenCalled()
+  })
+})

--- a/packages/streamwall-control-ui/src/commandError.ts
+++ b/packages/streamwall-control-ui/src/commandError.ts
@@ -1,0 +1,41 @@
+import { type ControlCommand } from 'streamwall-shared'
+
+/**
+ * Type guard for a control-server command response carrying an `error`
+ * (e.g. `{ error: 'unauthorized' }`), as opposed to a successful reply or a
+ * fire-and-forget command with no meaningful response payload.
+ */
+export function isErrorResponse(
+  response: unknown,
+): response is { error: string } {
+  return (
+    typeof response === 'object' &&
+    response !== null &&
+    typeof (response as { error?: unknown }).error === 'string'
+  )
+}
+
+type Send = (msg: ControlCommand, cb?: (msg: unknown) => void) => void
+
+/**
+ * Wraps a `StreamwallConnection['send']` so a command's `{ error }` response
+ * always reaches `onError`, regardless of whether the caller passed its own
+ * response callback. Without this, an unauthorized or rejected command sent
+ * without a callback (the common case) fails on the server while the UI
+ * shows nothing (issue #35). On success, the caller's callback still
+ * receives the response as before.
+ */
+export function createErrorSurfacingSend(
+  send: Send,
+  onError: (error: string) => void,
+): Send {
+  return (msg, cb) => {
+    send(msg, (response) => {
+      if (isErrorResponse(response)) {
+        onError(response.error)
+        return
+      }
+      cb?.(response)
+    })
+  }
+}

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -59,6 +59,8 @@ import {
 import { createGlobalStyle, styled } from 'styled-components'
 import { matchesState } from 'xstate'
 import * as Y from 'yjs'
+import { createErrorSurfacingSend } from './commandError.ts'
+import { CommandErrorBanner } from './CommandErrorBanner.tsx'
 import { DataSourceHealthBanner } from './DataSourceHealthBanner.tsx'
 import {
   computeHoveringIdx,
@@ -617,7 +619,7 @@ export function ControlUI({
 }) {
   const {
     isConnected,
-    send,
+    send: connectionSend,
     sharedState,
     stateDoc,
     undoManager,
@@ -638,6 +640,15 @@ export function ControlUI({
     width: windowWidth,
     height: windowHeight,
   } = config ?? { cols: null, rows: null, width: null, height: null }
+
+  // Surfaces `{ error }` command responses that would otherwise be dropped
+  // silently by the many call sites below that don't pass their own
+  // response callback (issue #35).
+  const [commandError, setCommandError] = useState<string | null>(null)
+  const send = useMemo(
+    () => createErrorSurfacingSend(connectionSend, setCommandError),
+    [connectionSend],
+  )
 
   const [showDebug, setShowDebug] = useState(false)
   const handleChangeShowDebug = useCallback<
@@ -1270,6 +1281,10 @@ export function ControlUI({
           <ThemeToggle />
         </StyledHeader>
         <DataSourceHealthBanner dataSourceHealth={dataSourceHealth} />
+        <CommandErrorBanner
+          error={commandError}
+          onDismiss={() => setCommandError(null)}
+        />
         {delayState && (
           <StreamDelayBox
             role={role}


### PR DESCRIPTION
## Summary

`set-grid-size` was already fixed to be in the operator role's allowed action list in #111 — that part of the bug is no longer reproducible. The remaining part of the issue is still present: the control-UI's `send(msg, cb)` only registers a response handler when the caller passes a callback. Most call sites (e.g. `handleSetGridSize`) don't, so whenever the control server rejects a command with `{ error: '...' }` (unauthorized, invalid message, streamwall disconnected), the response is silently dropped and the control just appears to do nothing.

## Technical solution

- Added `createErrorSurfacingSend` (`packages/streamwall-control-ui/src/commandError.ts`), which wraps `StreamwallConnection['send']` so every response is inspected: if it carries a string `error`, a shared `onError` handler fires and the caller's own callback is skipped; otherwise the caller's callback runs unchanged.
- `ControlUI` now wraps `connection.send` with this helper and renders a new `CommandErrorBanner` (mirroring the existing `DataSourceHealthBanner`) whenever a command is rejected, with a dismiss control.
- This is generic: it doesn't special-case `set-grid-size` or any other command, so any future unauthorized/rejected command is surfaced the same way instead of needing per-call-site plumbing.

## Testing performed

- `commandError.test.ts`: unit tests for `isErrorResponse` and `createErrorSurfacingSend` (error surfaced without a caller callback, error suppresses the caller callback, success still forwards to the caller callback, no-op when the underlying send never calls back).
- `CommandErrorBanner.test.tsx`: renders nothing without an error, shows the message when set, calls `onDismiss` on click.
- Full quality gate (format, lint, typecheck, test, build) run against the isolated committed tree: all packages pass (`streamwall` 286 tests, `streamwall-shared` 223, `streamwall-control-server` 90, `streamwall-control-ui` 101).

## Risks / breaking changes

None. The change only adds error visibility; successful command flows (including `create-invite`, which already passed its own callback) are unaffected since a non-error response is still forwarded to the original caller's callback exactly as before.

Closes #35
