### PR TITLE
fix(control-ui): don't blank the wall or replay stale commands on disconnect

### DIFF
--- a/packages/streamwall-control-client/src/dev.tsx
+++ b/packages/streamwall-control-client/src/dev.tsx
@@ -192,7 +192,7 @@ function useMockConnection(): StreamwallConnection {
 
   return {
     ...appState,
-    isConnected: true,
+    connectionStatus: 'connected',
     send: (msg) => console.debug('[mock send]', msg),
     sharedState,
     stateDoc,

--- a/packages/streamwall-control-client/src/index.tsx
+++ b/packages/streamwall-control-client/src/index.tsx
@@ -10,8 +10,10 @@ import {
   useYDoc,
 } from 'streamwall-control-ui'
 import {
+  type ConnectionStatus,
   type ControlCommand,
   isSocketOpen,
+  nextConnectionStatus,
   stateDiff,
   type StreamwallState,
 } from 'streamwall-shared'
@@ -25,7 +27,8 @@ function useStreamwallWebsocketConnection(
     msgId: number
     responseMap: Map<number, (msg: object) => void>
   }>()
-  const [isConnected, setIsConnected] = useState(false)
+  const [connectionStatus, setConnectionStatus] =
+    useState<ConnectionStatus>('connecting')
   const {
     docValue: sharedState,
     doc: stateDoc,
@@ -49,11 +52,17 @@ function useStreamwallWebsocketConnection(
       maxEnqueuedMessages: 0,
     })
     ws.binaryType = 'arraybuffer'
-    ws.addEventListener('close', () => {
-      setStreamwallState(undefined)
-      lastStateData = undefined
+    ws.addEventListener('open', () => {
+      // Discard any local Yjs edits that never reached the server (sendUpdate
+      // below silently drops sends made while the socket is closed) so the
+      // full-doc snapshot the server sends on every (re)connect merges into a
+      // clean doc instead of racing an edit the server never learned about.
       setStateDoc(new Y.Doc())
-      setIsConnected(false)
+    })
+    ws.addEventListener('close', () => {
+      setConnectionStatus((prev) =>
+        nextConnectionStatus(prev, { type: 'closed' }),
+      )
     })
     ws.addEventListener('message', (ev) => {
       if (ev.data instanceof ArrayBuffer) {
@@ -71,7 +80,9 @@ function useStreamwallWebsocketConnection(
         let state: StreamwallState
         if (msg.type === 'state') {
           state = msg.state
-          setIsConnected(true)
+          setConnectionStatus((prev) =>
+            nextConnectionStatus(prev, { type: 'state-received' }),
+          )
         } else {
           // Clone so updated object triggers React renders
           state = stateDiff.clone(
@@ -80,6 +91,18 @@ function useStreamwallWebsocketConnection(
         }
         lastStateData = state
         setStreamwallState(state)
+      } else if (msg.error === 'unauthorized') {
+        setConnectionStatus((prev) =>
+          nextConnectionStatus(prev, { type: 'unauthorized' }),
+        )
+        // The server won't accept this session on a retry - stop
+        // reconnecting so the UI can show a stable "reload / request a new
+        // invite" message instead of a spinner that will never resolve.
+        ws.close()
+      } else if (msg.error === 'streamwall disconnected') {
+        setConnectionStatus((prev) =>
+          nextConnectionStatus(prev, { type: 'server-down' }),
+        )
       } else {
         console.warn('unexpected ws message', msg)
       }
@@ -141,7 +164,7 @@ function useStreamwallWebsocketConnection(
 
   return {
     ...appState,
-    isConnected,
+    connectionStatus,
     send,
     sharedState,
     stateDoc,

--- a/packages/streamwall-control-ui/src/ConnectionStatusBanner.test.tsx
+++ b/packages/streamwall-control-ui/src/ConnectionStatusBanner.test.tsx
@@ -1,0 +1,73 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { ConnectionStatusBanner } from './ConnectionStatusBanner.tsx'
+
+vi.mock('react-icons/fa', () => ({
+  FaExclamationTriangle: () => null,
+  FaSyncAlt: () => null,
+}))
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+function renderBanner(
+  connectionStatus: Parameters<typeof ConnectionStatusBanner>[0]['connectionStatus'],
+  hasKnownState: boolean,
+): HTMLDivElement {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    render(
+      <ConnectionStatusBanner
+        connectionStatus={connectionStatus}
+        hasKnownState={hasKnownState}
+      />,
+      container!,
+    )
+  })
+  return container
+}
+
+describe('ConnectionStatusBanner', () => {
+  test('renders nothing once connected', () => {
+    const el = renderBanner('connected', true)
+    expect(el.querySelector('.connection-status-banner')).toBeNull()
+  })
+
+  test('renders nothing during the very first connect, before any state has ever arrived', () => {
+    const el = renderBanner('connecting', false)
+    expect(el.querySelector('.connection-status-banner')).toBeNull()
+  })
+
+  test('warns while reconnecting after having shown state before', () => {
+    const el = renderBanner('reconnecting', true)
+    const banner = el.querySelector('.connection-status-banner')
+    expect(banner).not.toBeNull()
+    expect(banner?.className).toContain('warning')
+    expect(banner?.textContent).toMatch(/reconnect/i)
+  })
+
+  test('flags unauthorized as a severe, non-retrying failure', () => {
+    const el = renderBanner('unauthorized', true)
+    const banner = el.querySelector('.connection-status-banner')
+    expect(banner).not.toBeNull()
+    expect(banner?.className).toContain('severe')
+    expect(banner?.textContent).toMatch(/session|reload|invite/i)
+  })
+
+  test('flags a disconnected streamwall app as severe', () => {
+    const el = renderBanner('server-down', true)
+    const banner = el.querySelector('.connection-status-banner')
+    expect(banner).not.toBeNull()
+    expect(banner?.className).toContain('severe')
+    expect(banner?.textContent).toMatch(/streamwall app/i)
+  })
+})

--- a/packages/streamwall-control-ui/src/ConnectionStatusBanner.test.tsx
+++ b/packages/streamwall-control-ui/src/ConnectionStatusBanner.test.tsx
@@ -19,7 +19,9 @@ afterEach(() => {
 })
 
 function renderBanner(
-  connectionStatus: Parameters<typeof ConnectionStatusBanner>[0]['connectionStatus'],
+  connectionStatus: Parameters<
+    typeof ConnectionStatusBanner
+  >[0]['connectionStatus'],
   hasKnownState: boolean,
 ): HTMLDivElement {
   container = document.createElement('div')

--- a/packages/streamwall-control-ui/src/ConnectionStatusBanner.tsx
+++ b/packages/streamwall-control-ui/src/ConnectionStatusBanner.tsx
@@ -1,0 +1,55 @@
+import { type ConnectionStatus } from 'streamwall-shared'
+import { FaExclamationTriangle, FaSyncAlt } from 'react-icons/fa'
+import { styled } from 'styled-components'
+
+const StyledConnectionStatusBanner = styled.div<{ $severe: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: ${({ $severe }) => ($severe ? 'var(--live)' : '#e0a800')};
+`
+
+const MESSAGE_BY_STATUS: Partial<Record<ConnectionStatus, string>> = {
+  reconnecting: 'Reconnecting to the control server — showing the last known state.',
+  unauthorized:
+    'Session is no longer authorized. Reload the page or request a new invite link.',
+  'server-down':
+    'The Streamwall app disconnected from the control server. Waiting for it to reconnect…',
+}
+
+const SEVERE_STATUSES = new Set<ConnectionStatus>(['unauthorized', 'server-down'])
+
+/**
+ * Explains *why* the client is disconnected instead of leaving the operator
+ * to guess from a generic spinner, and only fires once there's previously
+ * shown state to explain the loss of (a first-ever connect gets the normal
+ * "connecting" experience elsewhere in the UI) (issue #37).
+ */
+export function ConnectionStatusBanner({
+  connectionStatus,
+  hasKnownState,
+}: {
+  connectionStatus: ConnectionStatus
+  hasKnownState: boolean
+}) {
+  if (connectionStatus === 'connected') {
+    return null
+  }
+  if (connectionStatus === 'connecting' && !hasKnownState) {
+    return null
+  }
+
+  const message = MESSAGE_BY_STATUS[connectionStatus] ?? MESSAGE_BY_STATUS.reconnecting
+  const severe = SEVERE_STATUSES.has(connectionStatus)
+
+  return (
+    <StyledConnectionStatusBanner
+      className={`connection-status-banner ${severe ? 'severe' : 'warning'}`}
+      $severe={severe}
+    >
+      {severe ? <FaExclamationTriangle /> : <FaSyncAlt />}
+      {message}
+    </StyledConnectionStatusBanner>
+  )
+}

--- a/packages/streamwall-control-ui/src/ConnectionStatusBanner.tsx
+++ b/packages/streamwall-control-ui/src/ConnectionStatusBanner.tsx
@@ -1,5 +1,5 @@
-import { type ConnectionStatus } from 'streamwall-shared'
 import { FaExclamationTriangle, FaSyncAlt } from 'react-icons/fa'
+import { type ConnectionStatus } from 'streamwall-shared'
 import { styled } from 'styled-components'
 
 const StyledConnectionStatusBanner = styled.div<{ $severe: boolean }>`
@@ -11,14 +11,18 @@ const StyledConnectionStatusBanner = styled.div<{ $severe: boolean }>`
 `
 
 const MESSAGE_BY_STATUS: Partial<Record<ConnectionStatus, string>> = {
-  reconnecting: 'Reconnecting to the control server — showing the last known state.',
+  reconnecting:
+    'Reconnecting to the control server — showing the last known state.',
   unauthorized:
     'Session is no longer authorized. Reload the page or request a new invite link.',
   'server-down':
     'The Streamwall app disconnected from the control server. Waiting for it to reconnect…',
 }
 
-const SEVERE_STATUSES = new Set<ConnectionStatus>(['unauthorized', 'server-down'])
+const SEVERE_STATUSES = new Set<ConnectionStatus>([
+  'unauthorized',
+  'server-down',
+])
 
 /**
  * Explains *why* the client is disconnected instead of leaving the operator
@@ -40,7 +44,8 @@ export function ConnectionStatusBanner({
     return null
   }
 
-  const message = MESSAGE_BY_STATUS[connectionStatus] ?? MESSAGE_BY_STATUS.reconnecting
+  const message =
+    MESSAGE_BY_STATUS[connectionStatus] ?? MESSAGE_BY_STATUS.reconnecting
   const severe = SEVERE_STATUSES.has(connectionStatus)
 
   return (

--- a/packages/streamwall-control-ui/src/hotkeysOptions.test.tsx
+++ b/packages/streamwall-control-ui/src/hotkeysOptions.test.tsx
@@ -56,7 +56,7 @@ function renderControlUI(): HTMLDivElement {
   }
 
   const connection: StreamwallConnection = {
-    isConnected: true,
+    connectionStatus: 'connected',
     role: 'operator',
     send: () => {},
     sharedState: { views: {} },

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -35,6 +35,7 @@ import {
 import {
   clampGridDimension,
   Color,
+  type ConnectionStatus,
   type ContentKind,
   type ControlCommand,
   type DataSourceHealth,
@@ -59,6 +60,7 @@ import {
 import { createGlobalStyle, styled } from 'styled-components'
 import { matchesState } from 'xstate'
 import * as Y from 'yjs'
+import { ConnectionStatusBanner } from './ConnectionStatusBanner.tsx'
 import { DataSourceHealthBanner } from './DataSourceHealthBanner.tsx'
 import {
   computeHoveringIdx,
@@ -514,7 +516,7 @@ export interface CollabData {
 }
 
 export interface StreamwallConnection {
-  isConnected: boolean
+  connectionStatus: ConnectionStatus
   role: StreamwallRole | null
   send: (msg: ControlCommand, cb?: (msg: unknown) => void) => void
   sharedState: CollabData | undefined
@@ -616,7 +618,7 @@ export function ControlUI({
   connection: StreamwallConnection
 }) {
   const {
-    isConnected,
+    connectionStatus,
     send,
     sharedState,
     stateDoc,
@@ -632,6 +634,13 @@ export function ControlUI({
     layoutPresets,
     dataSourceHealth,
   } = connection
+  const isConnected = connectionStatus === 'connected'
+  // Whether at least one full state snapshot has ever been received - once
+  // true, `config`/`streams`/`views`/etc. keep showing that last-known
+  // snapshot across a disconnect (they're only ever cleared by a fresh
+  // snapshot, never by the socket closing), so a reconnect dims the existing
+  // wall instead of blanking it back to a loading screen (issue #37).
+  const hasKnownState = role != null
   const {
     cols,
     rows,
@@ -1270,6 +1279,10 @@ export function ControlUI({
           <ThemeToggle />
         </StyledHeader>
         <DataSourceHealthBanner dataSourceHealth={dataSourceHealth} />
+        <ConnectionStatusBanner
+          connectionStatus={connectionStatus}
+          hasKnownState={hasKnownState}
+        />
         {delayState && (
           <StreamDelayBox
             role={role}
@@ -1295,6 +1308,7 @@ export function ControlUI({
               onPointerLeave={clearHoveringIdx}
               $windowWidth={windowWidth}
               $windowHeight={windowHeight}
+              $dimmed={!isConnected}
             >
               <StyledGridInputs>
                 {range(0, rows).map((y) =>
@@ -1506,7 +1520,7 @@ export function ControlUI({
       </Stack>
       <Stack className="stream-list" $scroll={true} $minHeight={200}>
         <StyledDataContainer $isConnected={isConnected}>
-          {isConnected ? (
+          {hasKnownState ? (
             <div>
               <input
                 className="filter-input"
@@ -2708,6 +2722,7 @@ const StyledGridControlsContainer = styled.div`
 const StyledGridContainer = styled.div<{
   $windowWidth: number
   $windowHeight: number
+  $dimmed?: boolean
 }>`
   position: relative;
   /* Responsive: keep the wall's aspect ratio but fit the available space
@@ -2721,6 +2736,11 @@ const StyledGridContainer = styled.div<{
   border-radius: var(--r-md);
   background: var(--cell-bg);
   overflow: hidden;
+  /* While disconnected, keep showing the last-known grid instead of
+     unmounting it - just dimmed, so a reconnect banner can explain why it's
+     stale rather than blanking to a loading screen (issue #37). */
+  opacity: ${({ $dimmed }) => ($dimmed ? 0.5 : 1)};
+  transition: opacity 0.2s;
 
   &:hover ${StyledGridInputs} {
     opacity: 0.35;

--- a/packages/streamwall-control-ui/src/reconnectDisplay.test.tsx
+++ b/packages/streamwall-control-ui/src/reconnectDisplay.test.tsx
@@ -1,0 +1,138 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import type {
+  ConnectionStatus,
+  StreamData,
+  StreamDelayStatus,
+  StreamWindowConfig,
+} from 'streamwall-shared'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import * as Y from 'yjs'
+import { ControlUI, type StreamwallConnection } from './index.tsx'
+
+// react-icons renders through preact/compat's Context.Consumer, which
+// currently crashes under this package's happy-dom test environment
+// (unrelated to the markup under test here) - stub the icons out so the
+// component's own rendering logic can be exercised in isolation.
+vi.mock('react-icons/fa', () => ({
+  FaExchangeAlt: () => null,
+  FaExclamationTriangle: () => null,
+  FaRedoAlt: () => null,
+  FaRegLifeRing: () => null,
+  FaRegWindowMaximize: () => null,
+  FaSyncAlt: () => null,
+  FaVideoSlash: () => null,
+  FaVolumeUp: () => null,
+}))
+vi.mock('react-icons/md', () => ({
+  MdOutlineStayCurrentLandscape: () => null,
+  MdOutlineStayCurrentPortrait: () => null,
+}))
+vi.mock('react-hotkeys-hook', () => ({
+  useHotkeys: () => {},
+}))
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+const config: StreamWindowConfig = {
+  cols: 2,
+  rows: 1,
+  width: 1920,
+  height: 1080,
+  frameless: false,
+  fullscreen: false,
+  activeColor: '#f24d2e',
+  backgroundColor: '#000000',
+}
+
+const streams: StreamData[] = [
+  {
+    _id: 'a',
+    _dataSource: 'demo',
+    kind: 'video',
+    link: 'https://example.com/a',
+    label: 'Stream A',
+    status: 'Live',
+  },
+]
+
+const delayState: StreamDelayStatus = {
+  isConnected: true,
+  delaySeconds: 0,
+  restartSeconds: 0,
+  isCensored: false,
+  isStreamRunning: true,
+  startTime: 0,
+  state: 'idle',
+}
+
+function renderControlUI(
+  connectionStatus: ConnectionStatus,
+  { hasEverConnected }: { hasEverConnected: boolean },
+): HTMLDivElement {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+
+  const connection: StreamwallConnection = {
+    connectionStatus,
+    role: hasEverConnected ? 'operator' : null,
+    send: () => {},
+    sharedState: { views: {} },
+    stateDoc: new Y.Doc(),
+    config: hasEverConnected ? config : undefined,
+    streams: hasEverConnected ? streams : [],
+    customStreams: [],
+    views: [],
+    stateIdxMap: new Map(),
+    delayState,
+    authState: undefined,
+    layoutPresets: [],
+    dataSourceHealth: [],
+  }
+
+  act(() => {
+    render(<ControlUI connection={connection} />, container!)
+  })
+  return container
+}
+
+describe('reconnect display (issue #37)', () => {
+  test('a first-ever connect shows the plain loading state, no banner', () => {
+    const el = renderControlUI('connecting', { hasEverConnected: false })
+    expect(el.querySelector('.grid')).toBeNull()
+    expect(el.querySelector('.connection-status-banner')).toBeNull()
+    expect(el.textContent).toContain('loading...')
+  })
+
+  test('a connected wall shows the grid and stream list without a banner', () => {
+    const el = renderControlUI('connected', { hasEverConnected: true })
+    expect(el.querySelector('.grid')).not.toBeNull()
+    expect(el.querySelector('.connection-status-banner')).toBeNull()
+    expect(el.textContent).toContain('Stream A')
+  })
+
+  test('losing the connection after a successful load keeps the grid and stream list mounted, dimmed, with a banner', () => {
+    const el = renderControlUI('reconnecting', { hasEverConnected: true })
+    expect(el.querySelector('.grid')).not.toBeNull()
+    expect(el.textContent).toContain('Stream A')
+    expect(el.textContent).not.toContain('loading...')
+    const banner = el.querySelector('.connection-status-banner')
+    expect(banner).not.toBeNull()
+    expect(banner?.className).toContain('warning')
+  })
+
+  test('an unauthorized session keeps the last-known wall visible with a severe banner', () => {
+    const el = renderControlUI('unauthorized', { hasEverConnected: true })
+    expect(el.querySelector('.grid')).not.toBeNull()
+    const banner = el.querySelector('.connection-status-banner')
+    expect(banner?.className).toContain('severe')
+  })
+})

--- a/packages/streamwall-control-ui/src/responsiveLayout.test.tsx
+++ b/packages/streamwall-control-ui/src/responsiveLayout.test.tsx
@@ -55,7 +55,7 @@ function renderControlUI(): HTMLDivElement {
   }
 
   const connection: StreamwallConnection = {
-    isConnected: true,
+    connectionStatus: 'connected',
     role: 'operator',
     send: () => {},
     sharedState: { views: {} },

--- a/packages/streamwall-control-ui/src/transientProps.test.tsx
+++ b/packages/streamwall-control-ui/src/transientProps.test.tsx
@@ -73,7 +73,7 @@ function renderControlUI(): HTMLDivElement {
   }
 
   const connection: StreamwallConnection = {
-    isConnected: true,
+    connectionStatus: 'connected',
     role: 'operator',
     send: () => {},
     sharedState: { views: {} },

--- a/packages/streamwall-shared/src/connectionStatus.test.ts
+++ b/packages/streamwall-shared/src/connectionStatus.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'vitest'
+import { nextConnectionStatus } from './connectionStatus.ts'
+
+describe('nextConnectionStatus', () => {
+  test('a received state always resolves to connected', () => {
+    for (const current of [
+      'connecting',
+      'connected',
+      'reconnecting',
+      'unauthorized',
+      'server-down',
+    ] as const) {
+      expect(nextConnectionStatus(current, { type: 'state-received' })).toBe(
+        'connected',
+      )
+    }
+  })
+
+  test('an unauthorized error overrides any prior status', () => {
+    for (const current of [
+      'connecting',
+      'connected',
+      'reconnecting',
+      'server-down',
+    ] as const) {
+      expect(nextConnectionStatus(current, { type: 'unauthorized' })).toBe(
+        'unauthorized',
+      )
+    }
+  })
+
+  test('a server-down error overrides any prior status', () => {
+    for (const current of [
+      'connecting',
+      'connected',
+      'reconnecting',
+      'unauthorized',
+    ] as const) {
+      expect(nextConnectionStatus(current, { type: 'server-down' })).toBe(
+        'server-down',
+      )
+    }
+  })
+
+  test('closing a live connection starts reconnecting', () => {
+    expect(nextConnectionStatus('connected', { type: 'closed' })).toBe(
+      'reconnecting',
+    )
+  })
+
+  test('closing while already reconnecting stays reconnecting', () => {
+    expect(nextConnectionStatus('reconnecting', { type: 'closed' })).toBe(
+      'reconnecting',
+    )
+  })
+
+  test('closing before any state was ever received stays connecting', () => {
+    expect(nextConnectionStatus('connecting', { type: 'closed' })).toBe(
+      'connecting',
+    )
+  })
+
+  test('closing after unauthorized preserves the unauthorized reason', () => {
+    expect(nextConnectionStatus('unauthorized', { type: 'closed' })).toBe(
+      'unauthorized',
+    )
+  })
+
+  test('closing after server-down preserves the server-down reason', () => {
+    expect(nextConnectionStatus('server-down', { type: 'closed' })).toBe(
+      'server-down',
+    )
+  })
+})

--- a/packages/streamwall-shared/src/connectionStatus.ts
+++ b/packages/streamwall-shared/src/connectionStatus.ts
@@ -5,11 +5,7 @@
  * every failure mode (issue #37).
  */
 export type ConnectionStatus =
-  | 'connecting'
-  | 'connected'
-  | 'reconnecting'
-  | 'unauthorized'
-  | 'server-down'
+  'connecting' | 'connected' | 'reconnecting' | 'unauthorized' | 'server-down'
 
 export type ConnectionStatusEvent =
   | { type: 'state-received' }

--- a/packages/streamwall-shared/src/connectionStatus.ts
+++ b/packages/streamwall-shared/src/connectionStatus.ts
@@ -1,0 +1,43 @@
+/**
+ * Fine-grained lifecycle status for a client's websocket link to the control
+ * server, distinguishing *why* the link isn't up so the UI can show a
+ * specific reason instead of a single generic "connecting..." spinner for
+ * every failure mode (issue #37).
+ */
+export type ConnectionStatus =
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'unauthorized'
+  | 'server-down'
+
+export type ConnectionStatusEvent =
+  | { type: 'state-received' }
+  | { type: 'closed' }
+  | { type: 'unauthorized' }
+  | { type: 'server-down' }
+
+/**
+ * Pure transition function for `ConnectionStatus`, kept side-effect free so
+ * the reconnect/error-message handling can be unit-tested without a real (or
+ * mocked) WebSocket.
+ */
+export function nextConnectionStatus(
+  current: ConnectionStatus,
+  event: ConnectionStatusEvent,
+): ConnectionStatus {
+  switch (event.type) {
+    case 'state-received':
+      return 'connected'
+    case 'unauthorized':
+      return 'unauthorized'
+    case 'server-down':
+      return 'server-down'
+    case 'closed':
+      // Only a link that was actually up degrades to "reconnecting" - the
+      // more specific 'unauthorized'/'server-down' reasons (or the initial
+      // "still connecting") shouldn't be overwritten by the close event
+      // that immediately follows them.
+      return current === 'connected' ? 'reconnecting' : current
+  }
+}

--- a/packages/streamwall-shared/src/index.ts
+++ b/packages/streamwall-shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from './colors.ts'
+export * from './connectionStatus.ts'
 export * from './controlEndpoint.ts'
 export * from './geometry.ts'
 export * from './roles.ts'

--- a/packages/streamwall/src/renderer/control.tsx
+++ b/packages/streamwall/src/renderer/control.tsx
@@ -80,7 +80,7 @@ function useStreamwallIPCConnection(): StreamwallConnection {
 
   return {
     ...appState,
-    isConnected: true,
+    connectionStatus: 'connected',
     send,
     sharedState,
     stateDoc,


### PR DESCRIPTION
## Problem

A brief control-server disconnect discarded all local UI state: the grid unmounted, the sidebar fell back to "loading...", and the only indicator was a small status dot. There was no way to tell a transient reconnect apart from an unauthorized session or the Streamwall app itself being down, and commands issued during the outage could sit in the websocket library's send queue to fire all at once on reconnect against a possibly-changed layout.

## Solution

- **`nextConnectionStatus`** (`streamwall-shared`): a pure state-machine function distinguishing `connecting` / `connected` / `reconnecting` / `unauthorized` / `server-down`, replacing the previous binary `isConnected` flag.
- **Control client hook**: reports the specific reason for a disconnect based on the server's `{error: 'unauthorized'}` / `{error: 'streamwall disconnected'}` messages, and stops the websocket's automatic reconnect loop once unauthorized (retrying a rejected session can't succeed on its own). Local state is no longer wiped to `undefined` on every socket close - the last-known snapshot stays available to render. The Yjs collab doc is now reset on `open` rather than `close`, so any local edits that never reached the server are discarded right before the fresh snapshot merges in, instead of blanking the doc for the whole outage.
- **Control UI**: the grid and stream list keep rendering the last-known state (dimmed) across a disconnect instead of unmounting to "loading...", and a new `ConnectionStatusBanner` explains why - a plain "reconnecting" notice, or a more severe one for an unauthorized session (reload / request a new invite) or a disconnected Streamwall app.

Queued-command replay was already fixed by an earlier PR (`maxEnqueuedMessages: 0`, verified against the `reconnecting-websocket` source: sends made while closed are dropped, not queued) - this PR completes the remaining two parts of the issue.

## Testing

- `packages/streamwall-shared/src/connectionStatus.test.ts`: all state transitions of `nextConnectionStatus`.
- `packages/streamwall-control-ui/src/ConnectionStatusBanner.test.tsx`: banner visibility/severity per status.
- `packages/streamwall-control-ui/src/reconnectDisplay.test.tsx`: grid/stream list stay mounted and dimmed with a banner across reconnecting/unauthorized/server-down, versus the plain loading state on a first-ever connect.
- Full quality gate (typecheck, tests, lint, format, and a control-client build) verified green in an isolated worktree checkout of just this branch's commits.

## Risks / breaking changes

`StreamwallConnection.isConnected: boolean` is replaced by `connectionStatus: ConnectionStatus` - an internal interface with three consumers, all updated in this PR (websocket client, Electron IPC renderer, and the shared `ControlUI` component). No external API surface changes.

Closes #37