### PR TITLE
test(electron): cover MUTE/BLUR/BACKGROUND surviving every reload path

### DIFF
--- a/packages/streamwall/src/main/viewStateMachine.test.ts
+++ b/packages/streamwall/src/main/viewStateMachine.test.ts
@@ -60,6 +60,12 @@ function makeActor(retry: RetryConfig, loadPageImpl?: () => Promise<void>) {
 }
 
 const CONTENT = { url: 'https://example.com/stream', kind: 'video' as const }
+// Distinct from CONTENT so DISPLAY-while-running is recognized as a content
+// swap (playlist advance / drag-to-place reassignment) rather than a noop.
+const OTHER_CONTENT = {
+  url: 'https://example.com/other-stream',
+  kind: 'video' as const,
+}
 const POS = { x: 0, y: 0, width: 100, height: 100, spaces: [0] }
 
 function display(actor: ReturnType<typeof makeActor>) {
@@ -712,6 +718,234 @@ describe('viewStateMachine deferred MUTE/BLUR/BACKGROUND requests', () => {
       true,
     )
 
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'VIEW_INIT' })
+    actor.send({ type: 'VIEW_LOADED' })
+
+    expect(
+      matchesState(
+        'displaying.running.audio.background',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+  })
+
+  it('keeps a listening view listening across an automatic stalled reload', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'UNMUTE' })
+    expect(
+      matchesState(
+        'displaying.running.audio.listening',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+
+    actor.send({ type: 'VIEW_STALLED' })
+    await vi.advanceTimersByTimeAsync(2000) // stalledTimeout -> reload
+    expect(matchesState('displaying.loading', actor.getSnapshot().value)).toBe(
+      true,
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'VIEW_INIT' })
+    actor.send({ type: 'VIEW_LOADED' })
+
+    expect(
+      matchesState(
+        'displaying.running.audio.listening',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+  })
+
+  it('keeps a blurred view blurred across an automatic stalled reload', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'BLUR' })
+    expect(
+      matchesState(
+        'displaying.running.video.blurred',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+
+    actor.send({ type: 'VIEW_STALLED' })
+    await vi.advanceTimersByTimeAsync(2000) // stalledTimeout -> reload
+    expect(matchesState('displaying.loading', actor.getSnapshot().value)).toBe(
+      true,
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'VIEW_INIT' })
+    actor.send({ type: 'VIEW_LOADED' })
+
+    expect(
+      matchesState(
+        'displaying.running.video.blurred',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+  })
+
+  it('keeps a listening view listening across an automatic error-retry reload', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'UNMUTE' })
+
+    actor.send({ type: 'VIEW_ERROR', error: new Error('boom') })
+    expect(matchesState('displaying.error', actor.getSnapshot().value)).toBe(
+      true,
+    )
+
+    await vi.advanceTimersByTimeAsync(1000) // delay * 2^0 -> back to loading
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'VIEW_INIT' })
+    actor.send({ type: 'VIEW_LOADED' })
+
+    expect(
+      matchesState(
+        'displaying.running.audio.listening',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+  })
+
+  it('keeps a blurred view blurred across an automatic error-retry reload', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'BLUR' })
+
+    actor.send({ type: 'VIEW_ERROR', error: new Error('boom') })
+    await vi.advanceTimersByTimeAsync(1000) // delay * 2^0 -> back to loading
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'VIEW_INIT' })
+    actor.send({ type: 'VIEW_LOADED' })
+
+    expect(
+      matchesState(
+        'displaying.running.video.blurred',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+  })
+
+  it('keeps a backgrounded view backgrounded across an automatic error-retry reload', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'BACKGROUND' })
+
+    actor.send({ type: 'VIEW_ERROR', error: new Error('boom') })
+    await vi.advanceTimersByTimeAsync(1000) // delay * 2^0 -> back to loading
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'VIEW_INIT' })
+    actor.send({ type: 'VIEW_LOADED' })
+
+    expect(
+      matchesState(
+        'displaying.running.audio.background',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+  })
+
+  it('keeps a listening view listening across a manual RELOAD', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'UNMUTE' })
+
+    actor.send({ type: 'RELOAD' })
+    expect(matchesState('displaying.loading', actor.getSnapshot().value)).toBe(
+      true,
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'VIEW_INIT' })
+    actor.send({ type: 'VIEW_LOADED' })
+
+    expect(
+      matchesState(
+        'displaying.running.audio.listening',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+  })
+
+  it('keeps a blurred view blurred across a manual RELOAD', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'BLUR' })
+
+    actor.send({ type: 'RELOAD' })
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'VIEW_INIT' })
+    actor.send({ type: 'VIEW_LOADED' })
+
+    expect(
+      matchesState(
+        'displaying.running.video.blurred',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+  })
+
+  it('keeps a listening view listening across a content swap while running', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'UNMUTE' })
+
+    // A playlist advance / drag-to-place reassignment: same cell, new content.
+    actor.send({ type: 'DISPLAY', pos: POS, content: OTHER_CONTENT })
+    expect(matchesState('displaying.loading', actor.getSnapshot().value)).toBe(
+      true,
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'VIEW_INIT' })
+    actor.send({ type: 'VIEW_LOADED' })
+
+    expect(
+      matchesState(
+        'displaying.running.audio.listening',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+  })
+
+  it('keeps a blurred view blurred across a content swap while running', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'BLUR' })
+
+    actor.send({ type: 'DISPLAY', pos: POS, content: OTHER_CONTENT })
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'VIEW_INIT' })
+    actor.send({ type: 'VIEW_LOADED' })
+
+    expect(
+      matchesState(
+        'displaying.running.video.blurred',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+  })
+
+  it('keeps a backgrounded view backgrounded across a content swap while running', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'BACKGROUND' })
+
+    actor.send({ type: 'DISPLAY', pos: POS, content: OTHER_CONTENT })
     await vi.advanceTimersByTimeAsync(0)
     actor.send({ type: 'VIEW_INIT' })
     actor.send({ type: 'VIEW_LOADED' })


### PR DESCRIPTION
## Problem

Issue #236 describes `displaying.running`'s `audio`/`video` parallel regions resetting to their initial substates (`muted`/`normal`) every time `running` is re-entered — via a stalled-view auto-reload, an error auto-retry, a manual `RELOAD`, or a content swap (playlist advance / drag-to-place reassignment) while already running. Since nothing re-applied the operator's last `MUTE`/`UNMUTE`/`BLUR`/`UNBLUR`/`BACKGROUND` choice, a cell being listened to or blurred would silently revert whenever the underlying stream reloaded for any reason.

## Investigation

`viewStateMachine.ts` already stores the operator's last request in `context.desiredAudio`/`context.desiredBlurred`, applied via guarded eventless (`always`) transitions as soon as `running`'s `audio`/`video` regions are (re-)entered. This mechanism was added by #261 (closing #24), which focused on requests made *while still loading/recovering from an error* (i.e. before `running`'s regions exist at all).

Because `context` is not reset on re-entry into `running` (only `retryCount`/`error` are, via `resetRetryState`), the same mechanism generically covers the broader "re-entering `running` resets state" problem described in #236 — it isn't specific to how `running` is reached. Existing tests only exercised this for the `background` case across a stalled reload, though, leaving the other three reload paths and the `listening`/`blurred` states unverified.

## Solution

No production code changes. Added 10 test cases to `viewStateMachine.test.ts` exercising `listening`, `blurred`, and `background` across all four reload paths named in #236 (stalled auto-reload, error auto-retry, manual `RELOAD`, content swap). All pass against the existing implementation, confirming #261 already resolved #236 as a side effect — this PR closes the verification gap and adds a regression net around it.

## Testing

- `npm run format:check` — clean
- `npm run lint` — clean
- `npm run typecheck` — clean across all workspaces
- `npm test` — clean across all workspaces (816 tests total, including the 10 new cases)
- `npm -w streamwall-control-client run build` — succeeds

## Risks / breaking changes

None. Test-only change; no behavior changes.

Closes #236