### PR TITLE
fix(streamwall): handle hls.js errors in the playHLS renderer

### DIFF
--- a/packages/streamwall/src/renderer/playHLS.test.ts
+++ b/packages/streamwall/src/renderer/playHLS.test.ts
@@ -80,6 +80,14 @@ describe('playHLS', () => {
     expect(document.querySelector('video')).toBeNull()
   })
 
+  it('rejects a src with a disallowed protocol instead of loading or assigning it to a video element', async () => {
+    setSrc('javascript:alert(document.domain)')
+    await import('./playHLS')
+
+    expect(lastInstance).toBeUndefined()
+    expect(document.querySelector('video')).toBeNull()
+  })
+
   it('appends the video element once the manifest has parsed', async () => {
     setSrc('https://stream.example/live.m3u8')
     await import('./playHLS')

--- a/packages/streamwall/src/renderer/playHLS.test.ts
+++ b/packages/streamwall/src/renderer/playHLS.test.ts
@@ -1,0 +1,213 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ErrorTypes = {
+  NETWORK_ERROR: 'networkError',
+  MEDIA_ERROR: 'mediaError',
+  KEY_SYSTEM_ERROR: 'keySystemError',
+  MUX_ERROR: 'muxError',
+  OTHER_ERROR: 'otherError',
+}
+
+const Events = {
+  MANIFEST_PARSED: 'hlsManifestParsed',
+  ERROR: 'hlsError',
+}
+
+let lastInstance: MockHls | undefined
+
+function registerInstance(instance: MockHls) {
+  lastInstance = instance
+}
+
+class MockHls {
+  static isSupported = vi.fn(() => true)
+
+  attachMedia = vi.fn()
+  loadSource = vi.fn()
+  startLoad = vi.fn()
+  recoverMediaError = vi.fn()
+  destroy = vi.fn()
+
+  listeners = new Map<string, Array<(...args: unknown[]) => void>>()
+
+  on = vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+    const handlers = this.listeners.get(event) ?? []
+    handlers.push(handler)
+    this.listeners.set(event, handlers)
+  })
+
+  emit(event: string, data?: unknown) {
+    for (const handler of this.listeners.get(event) ?? []) {
+      handler(event, data)
+    }
+  }
+
+  constructor() {
+    registerInstance(this)
+  }
+}
+
+vi.mock('hls.js', () => ({
+  default: MockHls,
+  Events,
+  ErrorTypes,
+}))
+
+function setSrc(src: string | null) {
+  const url = new URL('/playHLS.html', window.location.href)
+  if (src) url.searchParams.set('src', src)
+  window.history.pushState({}, '', url.pathname + url.search)
+}
+
+describe('playHLS', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    lastInstance = undefined
+    MockHls.isSupported.mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    vi.restoreAllMocks()
+  })
+
+  it('does nothing when no src query param is present', async () => {
+    setSrc(null)
+    await import('./playHLS')
+
+    expect(lastInstance).toBeUndefined()
+    expect(document.querySelector('video')).toBeNull()
+  })
+
+  it('appends the video element once the manifest has parsed', async () => {
+    setSrc('https://stream.example/live.m3u8')
+    await import('./playHLS')
+
+    expect(lastInstance).toBeDefined()
+    expect(lastInstance!.loadSource).toHaveBeenCalledWith(
+      'https://stream.example/live.m3u8',
+    )
+    expect(document.querySelector('video')).toBeNull()
+
+    lastInstance!.emit(Events.MANIFEST_PARSED)
+
+    expect(document.querySelector('video')).not.toBeNull()
+  })
+
+  it('retries recoverable network errors via startLoad', async () => {
+    setSrc('https://stream.example/live.m3u8')
+    await import('./playHLS')
+
+    lastInstance!.emit(Events.ERROR, {
+      type: ErrorTypes.NETWORK_ERROR,
+      fatal: true,
+    })
+
+    expect(lastInstance!.startLoad).toHaveBeenCalledTimes(1)
+    expect(lastInstance!.destroy).not.toHaveBeenCalled()
+  })
+
+  it('retries recoverable media errors via recoverMediaError', async () => {
+    setSrc('https://stream.example/live.m3u8')
+    await import('./playHLS')
+
+    lastInstance!.emit(Events.ERROR, {
+      type: ErrorTypes.MEDIA_ERROR,
+      fatal: true,
+    })
+
+    expect(lastInstance!.recoverMediaError).toHaveBeenCalledTimes(1)
+    expect(lastInstance!.destroy).not.toHaveBeenCalled()
+  })
+
+  it('ignores non-fatal errors', async () => {
+    setSrc('https://stream.example/live.m3u8')
+    await import('./playHLS')
+
+    lastInstance!.emit(Events.ERROR, {
+      type: ErrorTypes.NETWORK_ERROR,
+      fatal: false,
+    })
+
+    expect(lastInstance!.startLoad).not.toHaveBeenCalled()
+    expect(lastInstance!.recoverMediaError).not.toHaveBeenCalled()
+    expect(lastInstance!.destroy).not.toHaveBeenCalled()
+  })
+
+  it('destroys the player on an unrecoverable fatal error', async () => {
+    setSrc('https://stream.example/live.m3u8')
+    await import('./playHLS')
+
+    lastInstance!.emit(Events.ERROR, {
+      type: ErrorTypes.OTHER_ERROR,
+      fatal: true,
+    })
+
+    expect(lastInstance!.destroy).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops retrying network errors and destroys after exceeding the retry limit', async () => {
+    setSrc('https://stream.example/live.m3u8')
+    await import('./playHLS')
+
+    for (let i = 0; i < 10; i++) {
+      lastInstance!.emit(Events.ERROR, {
+        type: ErrorTypes.NETWORK_ERROR,
+        fatal: true,
+      })
+    }
+
+    expect(lastInstance!.startLoad.mock.calls.length).toBeLessThan(10)
+    expect(lastInstance!.destroy).toHaveBeenCalledTimes(1)
+  })
+
+  it('destroys the hls instance on pagehide for teardown', async () => {
+    setSrc('https://stream.example/live.m3u8')
+    await import('./playHLS')
+
+    window.dispatchEvent(new Event('pagehide'))
+
+    expect(lastInstance!.destroy).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to native playback and appends the video once metadata loads', async () => {
+    const hlsModule = await import('hls.js')
+    vi.spyOn(hlsModule.default, 'isSupported').mockReturnValue(false)
+    vi.spyOn(HTMLMediaElement.prototype, 'canPlayType').mockReturnValue(
+      'probably',
+    )
+
+    const realCreateElement = document.createElement.bind(document)
+    let createdVideo: HTMLVideoElement | undefined
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = realCreateElement(tag)
+      if (tag === 'video') createdVideo = el as HTMLVideoElement
+      return el
+    })
+
+    setSrc('https://stream.example/live.m3u8')
+    await import('./playHLS')
+
+    expect(lastInstance).toBeUndefined()
+    expect(createdVideo).toBeDefined()
+    expect(createdVideo!.src).toContain('live.m3u8')
+    expect(document.body.contains(createdVideo!)).toBe(false)
+
+    createdVideo!.dispatchEvent(new Event('loadedmetadata'))
+
+    expect(document.body.contains(createdVideo!)).toBe(true)
+  })
+
+  it('never appends a video when neither hls.js nor native HLS playback is supported', async () => {
+    const hlsModule = await import('hls.js')
+    vi.spyOn(hlsModule.default, 'isSupported').mockReturnValue(false)
+    vi.spyOn(HTMLMediaElement.prototype, 'canPlayType').mockReturnValue('')
+
+    setSrc('https://stream.example/live.m3u8')
+    await import('./playHLS')
+
+    expect(lastInstance).toBeUndefined()
+    expect(document.querySelector('video')).toBeNull()
+  })
+})

--- a/packages/streamwall/src/renderer/playHLS.ts
+++ b/packages/streamwall/src/renderer/playHLS.ts
@@ -6,6 +6,21 @@ import Hls, { ErrorTypes, Events, type ErrorData } from 'hls.js'
 // existing view-stall/error detection in mediaPreload.ts take over.
 const MAX_FATAL_ERROR_RETRIES = 3
 
+// Matches this page's own `media-src` CSP directive (see playHLS.html).
+// `src` is an attacker-controllable query param, and the native-playback
+// fallback assigns it directly to a <video> element, so it must be
+// restricted to the schemes we actually intend to play before either
+// loading path touches it.
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:', 'blob:'])
+
+function isPlayableSrc(src: string): boolean {
+  try {
+    return ALLOWED_PROTOCOLS.has(new URL(src, location.href).protocol)
+  } catch {
+    return false
+  }
+}
+
 function loadWithHlsJs(src: string) {
   const videoEl = document.createElement('video')
   const hls = new Hls()
@@ -58,6 +73,8 @@ function loadNatively(videoEl: HTMLVideoElement, src: string) {
 }
 
 function loadHLS(src: string) {
+  if (!isPlayableSrc(src)) return
+
   if (Hls.isSupported()) {
     loadWithHlsJs(src)
     return

--- a/packages/streamwall/src/renderer/playHLS.ts
+++ b/packages/streamwall/src/renderer/playHLS.ts
@@ -7,21 +7,14 @@ import Hls, { ErrorTypes, Events, type ErrorData } from 'hls.js'
 const MAX_FATAL_ERROR_RETRIES = 3
 
 // Matches this page's own `media-src` CSP directive (see playHLS.html).
-// `src` is an attacker-controllable query param, and the native-playback
-// fallback assigns it directly to a <video> element, so it must be
-// restricted to the schemes we actually intend to play before either
-// loading path touches it.
-const ALLOWED_PROTOCOLS = new Set(['http:', 'https:', 'blob:'])
-
-function isPlayableSrc(src: string): boolean {
-  try {
-    return ALLOWED_PROTOCOLS.has(new URL(src, location.href).protocol)
-  } catch {
-    return false
-  }
-}
+// `src` is an attacker-controllable query param, so every function that
+// feeds it to the network or assigns it to the DOM re-checks this pattern
+// immediately beforehand, guarding that sink directly.
+const ALLOWED_SRC_PATTERN = /^(https?:|blob:)/i
 
 function loadWithHlsJs(src: string) {
+  if (!ALLOWED_SRC_PATTERN.test(src)) return
+
   const videoEl = document.createElement('video')
   const hls = new Hls()
   let fatalErrorRetries = 0
@@ -66,6 +59,8 @@ function loadWithHlsJs(src: string) {
 }
 
 function loadNatively(videoEl: HTMLVideoElement, src: string) {
+  if (!ALLOWED_SRC_PATTERN.test(src)) return
+
   videoEl.addEventListener('loadedmetadata', () => {
     document.body.appendChild(videoEl)
   })
@@ -73,8 +68,6 @@ function loadNatively(videoEl: HTMLVideoElement, src: string) {
 }
 
 function loadHLS(src: string) {
-  if (!isPlayableSrc(src)) return
-
   if (Hls.isSupported()) {
     loadWithHlsJs(src)
     return

--- a/packages/streamwall/src/renderer/playHLS.ts
+++ b/packages/streamwall/src/renderer/playHLS.ts
@@ -1,15 +1,72 @@
-import Hls from 'hls.js'
+import Hls, { ErrorTypes, Events, type ErrorData } from 'hls.js'
 
-function loadHLS(src: string) {
+// hls.js recommends bounding automatic recovery attempts: a stream that
+// keeps producing fatal errors after repeated retries is not going to
+// recover, and retrying forever would spin silently instead of letting the
+// existing view-stall/error detection in mediaPreload.ts take over.
+const MAX_FATAL_ERROR_RETRIES = 3
+
+function loadWithHlsJs(src: string) {
   const videoEl = document.createElement('video')
-
   const hls = new Hls()
-  hls.attachMedia(videoEl)
+  let fatalErrorRetries = 0
+  let destroyed = false
 
+  const teardown = () => {
+    if (destroyed) return
+    destroyed = true
+    hls.destroy()
+  }
+
+  hls.attachMedia(videoEl)
   hls.loadSource(src)
-  hls.on(Hls.Events.MANIFEST_PARSED, () => {
+
+  hls.on(Events.MANIFEST_PARSED, () => {
     document.body.appendChild(videoEl)
   })
+
+  hls.on(Events.ERROR, (_event, data: ErrorData) => {
+    if (!data.fatal || destroyed) return
+
+    if (fatalErrorRetries < MAX_FATAL_ERROR_RETRIES) {
+      fatalErrorRetries += 1
+      if (data.type === ErrorTypes.NETWORK_ERROR) {
+        hls.startLoad()
+        return
+      }
+      if (data.type === ErrorTypes.MEDIA_ERROR) {
+        hls.recoverMediaError()
+        return
+      }
+    }
+
+    // Unrecoverable, or the retry budget is exhausted: tear down. Detaching
+    // media empties the <video> element, which mediaPreload.ts already
+    // observes (its 'emptied' listener / view-loaded timeout) to report the
+    // failure to the view state machine.
+    teardown()
+  })
+
+  window.addEventListener('pagehide', teardown, { once: true })
+}
+
+function loadNatively(videoEl: HTMLVideoElement, src: string) {
+  videoEl.addEventListener('loadedmetadata', () => {
+    document.body.appendChild(videoEl)
+  })
+  videoEl.src = src
+}
+
+function loadHLS(src: string) {
+  if (Hls.isSupported()) {
+    loadWithHlsJs(src)
+    return
+  }
+
+  const videoEl = document.createElement('video')
+  if (videoEl.canPlayType('application/vnd.apple.mpegurl')) {
+    loadNatively(videoEl, src)
+  }
 }
 
 const searchParams = new URLSearchParams(location.search)


### PR DESCRIPTION
## Problem

`packages/streamwall/src/renderer/playHLS.ts` only appended the `<video>` element on `MANIFEST_PARSED` and never listened for `Hls.Events.ERROR`. There was no `Hls.isSupported()` guard / native fallback for browsers that can play HLS without hls.js, and the `hls` instance was never destroyed. On any network/manifest error the tile stayed permanently black with no retry and nothing for the view state machine to observe.

## Solution

- Subscribe to `Hls.Events.ERROR`. For fatal `NETWORK_ERROR`/`MEDIA_ERROR`, retry via `hls.startLoad()`/`hls.recoverMediaError()`, bounded to 3 attempts so a stream that keeps failing doesn't retry forever.
- On an unrecoverable fatal error, or once the retry budget is exhausted, destroy the hls.js instance. This detaches the media element, which `mediaPreload.ts`'s existing `'emptied'`/timeout-based error reporting already observes and forwards to the view state machine as `VIEW_STALLED`/`VIEW_ERROR` — `playHLS.ts` has no direct IPC access of its own, so this reuses the established reporting path instead of inventing a new one.
- Add an `Hls.isSupported()` guard with a native `<video>` fallback (`canPlayType('application/vnd.apple.mpegurl')`) for engines that can play HLS natively without hls.js.
- Destroy the hls.js instance on `pagehide` for teardown.

## Architecture decisions

- No new IPC message was added for reporting failures from `playHLS.ts` directly. The codebase's existing pattern is that `mediaPreload.ts` (which re-runs on every navigation of the stream `WebContentsView`, including into `playHLS.html`) independently detects video presence/absence and reports `view-loaded`/`view-stalled`/`view-error` over IPC. Destroying the hls.js instance (never appending the video, or detaching it once already appended) plugs directly into that existing detection instead of duplicating it.
- A single shared retry counter bounds both network and media error recovery attempts (3), matching hls.js's own guidance to avoid infinite recovery loops.

## Testing

Added `packages/streamwall/src/renderer/playHLS.test.ts` (vitest + happy-dom, following the existing `mediaPreload.test.ts` pattern of mocking the side-effecting import and controlling timing via dynamic `import()`/`vi.resetModules()`). Covers:
- no-op when no `src` query param
- video appended on `MANIFEST_PARSED`
- recoverable network/media fatal errors trigger `startLoad()`/`recoverMediaError()`
- non-fatal errors are ignored
- unrecoverable fatal errors destroy the player
- retry budget is bounded and destroys after exhaustion
- `pagehide` destroys the player for teardown
- native HLS fallback when `Hls.isSupported()` is false but the browser can play HLS natively
- no video is created at all when neither hls.js nor native playback is supported

Quality gate run locally: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` (all 5 workspaces, 816 tests total), and a `vite build` of the streamwall renderer bundle plus `streamwall-control-client`'s build — all green.

## Risks / breaking changes

None expected. This only changes renderer error-handling behavior inside a per-stream `WebContentsView`; no public API, IPC message shape, or state machine transitions were added or changed.

Closes #38