### PR TITLE
feat(control-server): add opt-in Sentry crash reporting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3469,9 +3469,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
-      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -3501,12 +3501,29 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
-      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -3517,13 +3534,14 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
-      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
+      "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -4357,6 +4375,27 @@
         "node": ">=14"
       }
     },
+    "node_modules/@sentry/core": {
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.65.0.tgz",
+      "integrity": "sha512-3aqtmM5NgNGo45BNaaBzi0LPQZAw//NEL4HKS5fXm12pJMa4KEkze8DEKnkTEIrGnWaOJKamecHKlnNg/Mqf/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.15.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core/node_modules/@sentry/conventions": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.15.1.tgz",
+      "integrity": "sha512-ZLP8bRdMON3prWE2tJyImuYscCxdcJeIPIhrOs/rgyFm3C1nCh1B6gdvPj3AZ5zW08oSFFCsq7T+tYEW3h8MNA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@sentry/feedback": {
       "version": "10.62.0",
       "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.62.0.tgz",
@@ -4376,6 +4415,156 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.65.0.tgz",
+      "integrity": "sha512-t35dcdyksysVch/m/XdLgGJqGKJhr9eMD30Ctn3TeQ8yMB0wNXySfjPR5Yg93fpjmfaHtzc6iYIXRAvgNVfrvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/sdk-trace-base": "^2.9.0",
+        "@sentry/conventions": "^0.15.1",
+        "@sentry/core": "10.65.0",
+        "@sentry/node-core": "10.65.0",
+        "@sentry/opentelemetry": "10.65.0",
+        "@sentry/server-utils": "10.65.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.65.0.tgz",
+      "integrity": "sha512-U01X9mPT+jZnsLPmPWfBU67Ka+t/Sdd9RGAuvGoKdrI6N47a/9PDkM9oCW+kj0fmZwogZHTgSnzJU5oi3pImgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.15.1",
+        "@sentry/core": "10.65.0",
+        "@sentry/opentelemetry": "10.65.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/node-core/node_modules/@sentry/conventions": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.15.1.tgz",
+      "integrity": "sha512-ZLP8bRdMON3prWE2tJyImuYscCxdcJeIPIhrOs/rgyFm3C1nCh1B6gdvPj3AZ5zW08oSFFCsq7T+tYEW3h8MNA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/conventions": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.15.1.tgz",
+      "integrity": "sha512-ZLP8bRdMON3prWE2tJyImuYscCxdcJeIPIhrOs/rgyFm3C1nCh1B6gdvPj3AZ5zW08oSFFCsq7T+tYEW3h8MNA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/server-utils": {
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.65.0.tgz",
+      "integrity": "sha512-80toEFD6s+0Le7jrYB6pHWLF703WSg0WyavAWqrBGWG8JkREHgedAxzFYgoY5GlMI756qk6Ea7UzhJTHd2zAXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.15.0",
+        "@apm-js-collab/code-transformer-bundler-plugins": "^0.5.0",
+        "@apm-js-collab/tracing-hooks": "^0.10.1",
+        "@sentry/conventions": "^0.15.1",
+        "@sentry/core": "10.65.0",
+        "magic-string": "~0.30.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.65.0.tgz",
+      "integrity": "sha512-8C6FPvm3XBvUrkM52dX3Gz0p2H0Ij8t4sahUA+GTiCz0WM0fnyPeQPGC/b6I4jamV9UXyCZRnE1UEEGCoD+c7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.15.1",
+        "@sentry/core": "10.65.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      }
+    },
+    "node_modules/@sentry/opentelemetry/node_modules/@sentry/conventions": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.15.1.tgz",
+      "integrity": "sha512-ZLP8bRdMON3prWE2tJyImuYscCxdcJeIPIhrOs/rgyFm3C1nCh1B6gdvPj3AZ5zW08oSFFCsq7T+tYEW3h8MNA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@sentry/replay": {
@@ -15051,6 +15240,7 @@
         "@fastify/rate-limit": "^11.1.0",
         "@fastify/static": "^10.1.0",
         "@fastify/websocket": "^11.3.0",
+        "@sentry/node": "^10.65.0",
         "base-x": "^5.0.1",
         "fastify": "^5.10.0",
         "jsondiffpatch": "^0.7.6",

--- a/packages/streamwall-control-server/README.md
+++ b/packages/streamwall-control-server/README.md
@@ -60,6 +60,24 @@ The Content-Security-Policy is kept compatible with the served control client.
 `upgrade-insecure-requests` is only emitted when `STREAMWALL_CONTROL_URL` uses
 `https`, so the plain-`http` local setup keeps working over `ws://`.
 
+### Telemetry
+
+Crash reporting to [Sentry](https://sentry.io) (via `@sentry/node`) is
+opt-in and off by default:
+
+| Variable                    | Default | Description                                       |
+| --------------------------- | ------- | ------------------------------------------------- |
+| `STREAMWALL_SENTRY_ENABLED` | `false` | Set to `true` to enable crash reporting.          |
+| `STREAMWALL_SENTRY_DSN`     | none    | Your Sentry project's DSN. Required when enabled. |
+
+Unlike the Electron app (`packages/streamwall`), which reports to a DSN the
+maintainer bundles for their own official builds, this server is meant to be
+self-hosted by independent operators. There is no default DSN to ship — set
+`STREAMWALL_SENTRY_ENABLED=true` together with your own project's
+`STREAMWALL_SENTRY_DSN` to send this server's uncaught exceptions and 5xx
+request errors there. If enabled without a DSN, the server logs a warning at
+startup and continues running with reporting disabled.
+
 ## Deployment
 
 There is no separate compile step: the source targets Node 22's native

--- a/packages/streamwall-control-server/package.json
+++ b/packages/streamwall-control-server/package.json
@@ -18,6 +18,7 @@
     "@fastify/rate-limit": "^11.1.0",
     "@fastify/static": "^10.1.0",
     "@fastify/websocket": "^11.3.0",
+    "@sentry/node": "^10.65.0",
     "base-x": "^5.0.1",
     "fastify": "^5.10.0",
     "jsondiffpatch": "^0.7.6",

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -3,6 +3,7 @@ import fastifyHelmet from '@fastify/helmet'
 import fastifyRateLimit from '@fastify/rate-limit'
 import fastifyStatic from '@fastify/static'
 import fastifyWebsocket from '@fastify/websocket'
+import * as Sentry from '@sentry/node'
 import Fastify from 'fastify'
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
@@ -22,6 +23,7 @@ import {
 } from 'streamwall-shared'
 import { Auth, StateWrapper, uniqueRand62 } from './auth.ts'
 import { TokenBucket } from './rateLimiter.ts'
+import { initSentry } from './sentry.ts'
 import {
   applyValidatedDocUpdate,
   type DocUpdateLimits,
@@ -290,6 +292,12 @@ export async function initApp({
   const auth = new Auth(db.data.auth)
 
   const app = Fastify()
+
+  // Opt-in crash reporting (see sentry.ts for why there is no default DSN).
+  // Must be wired up before routes are registered so their errors are covered.
+  if (initSentry()) {
+    Sentry.setupFastifyErrorHandler(app)
+  }
 
   await app.register(fastifyCookie)
 

--- a/packages/streamwall-control-server/src/sentry.test.ts
+++ b/packages/streamwall-control-server/src/sentry.test.ts
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict'
+import { afterEach, beforeEach, describe, test } from 'node:test'
+
+import {
+  SENTRY_DSN_ENV,
+  SENTRY_ENABLED_ENV,
+  getSentryConfig,
+  initSentry,
+} from './sentry.ts'
+
+describe('getSentryConfig', () => {
+  const originalEnabled = process.env[SENTRY_ENABLED_ENV]
+  const originalDsn = process.env[SENTRY_DSN_ENV]
+
+  afterEach(() => {
+    if (originalEnabled === undefined) {
+      delete process.env[SENTRY_ENABLED_ENV]
+    } else {
+      process.env[SENTRY_ENABLED_ENV] = originalEnabled
+    }
+    if (originalDsn === undefined) {
+      delete process.env[SENTRY_DSN_ENV]
+    } else {
+      process.env[SENTRY_DSN_ENV] = originalDsn
+    }
+  })
+
+  test('defaults to disabled with no DSN when unset', () => {
+    delete process.env[SENTRY_ENABLED_ENV]
+    delete process.env[SENTRY_DSN_ENV]
+
+    assert.deepEqual(getSentryConfig(), { enabled: false, dsn: undefined })
+  })
+
+  test('enables only on the exact string "true"', () => {
+    process.env[SENTRY_ENABLED_ENV] = 'true'
+    assert.equal(getSentryConfig().enabled, true)
+
+    process.env[SENTRY_ENABLED_ENV] = '1'
+    assert.equal(getSentryConfig().enabled, false)
+
+    process.env[SENTRY_ENABLED_ENV] = 'TRUE'
+    assert.equal(getSentryConfig().enabled, false)
+  })
+
+  test('reads the DSN from the environment', () => {
+    process.env[SENTRY_DSN_ENV] = 'https://example@o0.ingest.sentry.io/1'
+    assert.equal(getSentryConfig().dsn, 'https://example@o0.ingest.sentry.io/1')
+  })
+})
+
+describe('initSentry', () => {
+  function fakeClient() {
+    const calls: Array<{ dsn: string }> = []
+    return {
+      calls,
+      init(options: { dsn: string }) {
+        calls.push(options)
+      },
+    }
+  }
+
+  let warnCalls: unknown[][]
+  let originalWarn: typeof console.warn
+
+  beforeEach(() => {
+    warnCalls = []
+    originalWarn = console.warn
+    console.warn = (...args: unknown[]) => {
+      warnCalls.push(args)
+    }
+  })
+
+  afterEach(() => {
+    console.warn = originalWarn
+  })
+
+  test('does nothing when disabled', () => {
+    const client = fakeClient()
+
+    const result = initSentry({ enabled: false, dsn: undefined }, client)
+
+    assert.equal(result, false)
+    assert.equal(client.calls.length, 0)
+    assert.equal(warnCalls.length, 0)
+  })
+
+  test('initializes the client with the configured DSN when enabled', () => {
+    const client = fakeClient()
+
+    const result = initSentry(
+      { enabled: true, dsn: 'https://example@o0.ingest.sentry.io/1' },
+      client,
+    )
+
+    assert.equal(result, true)
+    assert.deepEqual(client.calls, [
+      { dsn: 'https://example@o0.ingest.sentry.io/1' },
+    ])
+  })
+
+  test('warns and skips initialization when enabled without a DSN', () => {
+    const client = fakeClient()
+
+    const result = initSentry({ enabled: true, dsn: undefined }, client)
+
+    assert.equal(result, false)
+    assert.equal(client.calls.length, 0)
+    assert.equal(warnCalls.length, 1)
+    assert.match(String(warnCalls[0][0]), new RegExp(SENTRY_DSN_ENV))
+  })
+})

--- a/packages/streamwall-control-server/src/sentry.ts
+++ b/packages/streamwall-control-server/src/sentry.ts
@@ -1,0 +1,50 @@
+import * as Sentry from '@sentry/node'
+
+/**
+ * Unlike the Electron app (which ships a DSN for the maintainer's own Sentry
+ * project), this server is self-hosted by independent operators. There is no
+ * sensible default DSN to bundle, so crash reporting stays off unless an
+ * operator both opts in and supplies their own project's DSN.
+ */
+export const SENTRY_ENABLED_ENV = 'STREAMWALL_SENTRY_ENABLED'
+export const SENTRY_DSN_ENV = 'STREAMWALL_SENTRY_DSN'
+
+export interface SentryConfig {
+  enabled: boolean
+  dsn: string | undefined
+}
+
+/** Reads the crash-reporting configuration from the environment. */
+export function getSentryConfig(): SentryConfig {
+  return {
+    enabled: process.env[SENTRY_ENABLED_ENV] === 'true',
+    dsn: process.env[SENTRY_DSN_ENV],
+  }
+}
+
+/** The subset of the Sentry client this module depends on, for injection in tests. */
+export interface SentryClient {
+  init(options: { dsn: string }): void
+}
+
+/**
+ * Initializes Sentry crash reporting if enabled and configured. Returns
+ * whether initialization happened, so callers can decide whether to also wire
+ * up framework-specific error capture (e.g. Fastify's error handler).
+ */
+export function initSentry(
+  config: SentryConfig = getSentryConfig(),
+  client: SentryClient = Sentry,
+): boolean {
+  if (!config.enabled) {
+    return false
+  }
+  if (!config.dsn) {
+    console.warn(
+      `${SENTRY_ENABLED_ENV} is set but ${SENTRY_DSN_ENV} is missing; skipping Sentry initialization.`,
+    )
+    return false
+  }
+  client.init({ dsn: config.dsn })
+  return true
+}


### PR DESCRIPTION
## Problem

`packages/streamwall` (the Electron app) reports uncaught errors to Sentry
in the main process and every renderer it fully authors, gated by
`telemetry.sentry` (#87 / #243). `packages/streamwall-control-server` — a
separate, standalone Fastify/Node.js process used for multi-operator
remote-control setups — was explicitly out of scope for that work and had
no crash reporting at all.

## Solution

Added opt-in Sentry crash reporting to the control server via `@sentry/node`:

- `src/sentry.ts`: reads `STREAMWALL_SENTRY_ENABLED` (must be exactly
  `"true"`) and `STREAMWALL_SENTRY_DSN` from the environment, matching the
  existing `STREAMWALL_*` env-var config convention used throughout this
  package (see README). `initSentry()` calls `Sentry.init({ dsn })` only
  when both are set; if enabled without a DSN it logs a warning and leaves
  reporting off rather than throwing.
- `src/index.ts`: calls `initSentry()` when building the Fastify app, and
  when it returns `true`, wires `Sentry.setupFastifyErrorHandler(app)`
  before routes are registered, so both the SDK's default
  `uncaughtException`/`unhandledRejection` capture and Fastify request
  errors (5xx and uncaught) are reported.
- README: new "Telemetry" section documenting the two env vars and why,
  unlike the Electron app, there's no bundled default DSN.

### Why no default DSN (architecture decision)

The Electron app ships a DSN for the maintainer's own Sentry project — that
project is a single artifact the maintainer builds and distributes. The
control server is explicitly designed to be **self-hosted by independent
operators** running their own multi-operator setups. Bundling the
maintainer's DSN would silently send every self-hosted deployment's crash
data to the maintainer's Sentry project without operator consent or
ownership. Instead, operators opt in and point the server at their own
project.

## Testing performed

- New unit tests (`src/sentry.test.ts`) cover `getSentryConfig()` (default
  disabled, exact-string `"true"` matching, DSN passthrough) and
  `initSentry()` (no-op when disabled, initializes with injected fake
  client when enabled+configured, warns and skips when enabled without a
  DSN) — 6 tests, all passing.
- Full `streamwall-control-server` suite (96 tests) passes unchanged.
- Full monorepo suite (`npm test` across all workspaces) passes.
- `npm run typecheck` and `npm run lint` clean across all workspaces.
- Manually booted the server with `STREAMWALL_SENTRY_ENABLED=true` and a
  dummy DSN: server starts cleanly, logs bootstrap info, and serves
  requests normally (verified via `curl` against `/` and `/invite/:id`).

## Risks / breaking changes

None. The feature is off by default (existing deployments are unaffected)
and adds one new dependency (`@sentry/node`).

Closes #245