### PR TITLE
feat(control-ui): extend audio hotkeys past 20 cells via an alt+ctrl chord layer

### DIFF
--- a/packages/streamwall-control-ui/src/GridPreviewBox.test.tsx
+++ b/packages/streamwall-control-ui/src/GridPreviewBox.test.tsx
@@ -119,9 +119,19 @@ describe('GridPreviewBox', () => {
     )
   })
 
-  test('omits the hotkey tooltip for a cell beyond the fixed 20-slot hotkey range (#84)', () => {
+  test('surfaces the chorded hotkey for a cell in the second (alt+ctrl) layer (#240)', () => {
     const box = renderBox({
       pos: { x: 0, y: 0, width: 100, height: 100, spaces: [20] },
+    })
+
+    expect(box.firstElementChild?.getAttribute('title')).toBe(
+      'Alt+Ctrl+1 toggles audio',
+    )
+  })
+
+  test('omits the hotkey tooltip for a cell beyond both hotkey layers (#240)', () => {
+    const box = renderBox({
+      pos: { x: 0, y: 0, width: 100, height: 100, spaces: [40] },
     })
 
     expect(box.firstElementChild?.hasAttribute('title')).toBe(false)

--- a/packages/streamwall-control-ui/src/hotkeyLabel.test.ts
+++ b/packages/streamwall-control-ui/src/hotkeyLabel.test.ts
@@ -14,12 +14,28 @@ describe('getHotkeyLabel', () => {
     expect(getHotkeyLabel(10)).toBe('Alt+Q')
   })
 
-  test('labels the last of the fixed 20 slots', () => {
+  test('labels the last slot of the first (alt) layer', () => {
     expect(getHotkeyLabel(19)).toBe('Alt+P')
   })
 
-  test('returns undefined beyond the fixed 20-slot range', () => {
-    expect(getHotkeyLabel(20)).toBeUndefined()
+  test('labels the first slot of the second (alt+ctrl) layer', () => {
+    expect(getHotkeyLabel(20)).toBe('Alt+Ctrl+1')
+  })
+
+  test('labels the last digit slot of the second layer', () => {
+    expect(getHotkeyLabel(29)).toBe('Alt+Ctrl+0')
+  })
+
+  test('labels the first letter slot of the second layer', () => {
+    expect(getHotkeyLabel(30)).toBe('Alt+Ctrl+Q')
+  })
+
+  test('labels the last slot of the second layer', () => {
+    expect(getHotkeyLabel(39)).toBe('Alt+Ctrl+P')
+  })
+
+  test('returns undefined beyond the two 20-slot layers', () => {
+    expect(getHotkeyLabel(40)).toBeUndefined()
   })
 
   test('returns undefined for a negative index', () => {

--- a/packages/streamwall-control-ui/src/hotkeysOptions.test.tsx
+++ b/packages/streamwall-control-ui/src/hotkeysOptions.test.tsx
@@ -87,11 +87,35 @@ describe('alt+<n> listen-toggle hotkey', () => {
         typeof keys === 'string' &&
         keys
           .split(',')
-          .every((k) => k.startsWith('alt+') && !k.includes('shift')),
+          .every(
+            (k) =>
+              k.startsWith('alt+') &&
+              !k.includes('shift') &&
+              !k.includes('ctrl'),
+          ),
     )
 
     expect(listenToggleCall).toBeDefined()
     const options = listenToggleCall?.[2]
+    expect(options).toEqual({ enableOnFormTags: true })
+  })
+})
+
+describe('alt+ctrl+<n> second-layer listen-toggle hotkey (#240)', () => {
+  test('registers an alt+ctrl chord layer covering the same 20 trigger keys', () => {
+    renderControlUI()
+
+    const secondLayerCall = useHotkeysMock.mock.calls.find(
+      ([keys]) =>
+        typeof keys === 'string' &&
+        keys.split(',').every((k) => k.startsWith('alt+ctrl+')),
+    )
+
+    expect(secondLayerCall).toBeDefined()
+    const [keys, , options] = secondLayerCall ?? []
+    // Same 20 trigger keys as the base layer, just chorded with ctrl.
+    expect((keys as string).split(',')).toHaveLength(20)
+    // Must stay usable while a grid input is focused, like the base layer.
     expect(options).toEqual({ enableOnFormTags: true })
   })
 })

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -130,14 +130,43 @@ const hotkeyTriggers = [
 ]
 
 /**
- * Label for the `alt+<key>` hotkey that toggles audio on grid cell `idx`, or
- * `undefined` if `idx` falls outside hotkeyTriggers' fixed 20-slot range
- * (grids can have up to GRID_MAX * GRID_MAX = 64 cells, so not every cell has
- * an assigned hotkey).
+ * Audio-listen hotkeys are laid out in "layers": each layer maps the same 20
+ * trigger keys to a block of grid cells, distinguished by an extra modifier.
+ * Layer 0 (`alt+<key>`) covers cells 0-19; layer 1 (`alt+ctrl+<key>`) covers
+ * cells 20-39. `alt+shift+<key>` is already taken by the blur toggle, so the
+ * second audio layer stacks `ctrl` instead. (Caveat: on Windows international
+ * layouts `Ctrl+Alt` acts as AltGr; acceptable since the control UI runs
+ * primarily in the Electron control window and the handler preventDefault()s.)
+ *
+ * Grids can have up to GRID_MAX * GRID_MAX = 64 cells, but cells 40-63 (only
+ * reachable on 7x7/8x8 grids) are intentionally left without a hotkey rather
+ * than introducing a fragile triple-modifier layer that conflicts with OS
+ * shortcuts.
+ */
+const hotkeyLayers = [
+  { prefix: 'alt', label: 'Alt' },
+  { prefix: 'alt+ctrl', label: 'Alt+Ctrl' },
+] as const
+
+/** The `alt+<...>+<key>` combos each layer binds, e.g. `alt+1,alt+2,...`. */
+const hotkeyLayerBindings = hotkeyLayers.map((layer) =>
+  hotkeyTriggers.map((k) => `${layer.prefix}+${k}`).join(','),
+)
+
+/**
+ * Label for the audio-toggle hotkey assigned to grid cell `idx` (e.g. `Alt+1`
+ * or `Alt+Ctrl+1`), or `undefined` if `idx` falls outside every hotkey layer.
  */
 export function getHotkeyLabel(idx: number): string | undefined {
-  const key = hotkeyTriggers[idx]
-  return key === undefined ? undefined : `Alt+${key.toUpperCase()}`
+  if (idx < 0) {
+    return undefined
+  }
+  const layer = hotkeyLayers[Math.floor(idx / hotkeyTriggers.length)]
+  const key = hotkeyTriggers[idx % hotkeyTriggers.length]
+  if (layer === undefined || key === undefined) {
+    return undefined
+  }
+  return `${layer.label}+${key.toUpperCase()}`
 }
 
 /**
@@ -1176,17 +1205,37 @@ export function ControlUI({
   }, [])
 
   // Set up keyboard shortcuts.
-  useHotkeys(
-    hotkeyTriggers.map((k) => `alt+${k}`).join(','),
-    (ev, { hotkey }) => {
-      ev.preventDefault()
-      const idx = hotkeyTriggers.indexOf(hotkey[hotkey.length - 1])
+  const toggleListening = useCallback(
+    (idx: number) => {
       const isListening = stateIdxMap.get(idx)?.isListening ?? false
       handleSetListening(idx, !isListening)
     },
-    // This enables the hotkey while a grid input is focused.
+    [stateIdxMap, handleSetListening],
+  )
+  // Audio-listen toggle, layer 0: alt+<key> -> cells 0-19. `enableOnFormTags`
+  // keeps the hotkey live while a grid input is focused.
+  useHotkeys(
+    hotkeyLayerBindings[0],
+    (ev, { hotkey }) => {
+      ev.preventDefault()
+      toggleListening(hotkeyTriggers.indexOf(hotkey[hotkey.length - 1]))
+    },
     { enableOnFormTags: true },
-    [stateIdxMap],
+    [toggleListening],
+  )
+  // Audio-listen toggle, layer 1: alt+ctrl+<key> -> cells 20-39 (see
+  // `hotkeyLayers`). Same trigger keys, offset by one layer of 20 cells.
+  useHotkeys(
+    hotkeyLayerBindings[1],
+    (ev, { hotkey }) => {
+      ev.preventDefault()
+      toggleListening(
+        hotkeyTriggers.length +
+          hotkeyTriggers.indexOf(hotkey[hotkey.length - 1]),
+      )
+    },
+    { enableOnFormTags: true },
+    [toggleListening],
   )
   useHotkeys(
     hotkeyTriggers.map((k) => `alt+shift+${k}`).join(','),


### PR DESCRIPTION
## Problem

The `alt+<key>` audio-listen hotkey covered only the first 20 grid cells (`hotkeyTriggers` in `streamwall-control-ui/src/index.tsx`), while the grid can hold up to `GRID_MAX * GRID_MAX` = 64 cells (`streamwall-shared/src/geometry.ts`). Cells 20+ had no keyboard-accessible audio toggle at all. #237 shipped the "surface" half (tile-hover tooltip for cells 0-19); this PR ships the "extend" half that #237 deliberately deferred as a keybinding UX decision (#240).

## Solution

Add a second hotkey **layer** `alt+ctrl+<key>` covering cells 20-39, reusing the identical 20 trigger keys (`1234567890qwertyuiop`). Audio coverage goes from 20 → 40 cells.

- `hotkeyLayers` / `hotkeyLayerBindings` model the layers as data; `getHotkeyLabel` computes the label from `idx` (layer + within-layer key), returning `Alt+Ctrl+<KEY>` for cells 20-39 and `undefined` beyond.
- A shared `toggleListening` callback backs two `useHotkeys` registrations (one per layer), both with `enableOnFormTags: true` so they stay live while a grid input is focused.

## Architecture decisions

These were open UX/keybinding questions in #240; decisions and rationale are recorded [in the issue thread](https://github.com/NilsR0711/streamwall/issues/240#issuecomment-4974240210):

- **Chord scheme `alt+ctrl`** — mirrors the existing modifier-stacking design (`alt` audio, `alt+shift` blur). Since `alt+shift` is already taken by blur, the second audio layer stacks `ctrl`.
- **Discoverability is free** — the #237 tile-hover tooltip already renders `getHotkeyLabel(idx)`, so hovering cell 21 now shows `Alt+Ctrl+1 toggles audio`. No new UI.
- **Cross-platform** — `alt+ctrl` avoids the browser-reserved `ctrl+shift+*` family and the macOS `cmd+*` family. Known caveat: on Windows international layouts `Ctrl+Alt` acts as AltGr; acceptable since the control UI runs primarily in the Electron control window and the handler `preventDefault()`s. Documented in a code comment.
- **Scope stops at 40 cells** — cells 40-63 (only reachable on 7×7/8×8 grids with 40+ simultaneously-assigned streams) are left intentionally unassigned rather than adding a fragile triple-modifier (`alt+ctrl+shift`) layer that heavily conflicts with OS shortcuts. Audio only — the blur layer (`alt+shift`) stays at 20 cells (see follow-up below).

## Testing

- `hotkeyLabel.test.ts` — new cases for the second layer (idx 20 → `Alt+Ctrl+1`, 29 → `Alt+Ctrl+0`, 30 → `Alt+Ctrl+Q`, 39 → `Alt+Ctrl+P`, 40 → `undefined`).
- `GridPreviewBox.test.tsx` — cell 20 now surfaces `Alt+Ctrl+1 toggles audio`; the "beyond range" case moved to cell 40.
- `hotkeysOptions.test.tsx` — asserts the `alt+ctrl+<key>` layer is registered over 20 keys with `enableOnFormTags: true`.
- Full gate green locally: format:check, typecheck (all 4 packages), control-ui suite (152 tests), shared suite (243 tests), control-client build. Changed files lint clean.

## Risks / breaking changes

None. Purely additive — existing `alt+<key>` / `alt+shift+<key>` bindings are unchanged; react-hotkeys-hook does strict modifier matching, so `alt+ctrl+1` does not also trigger the `alt+1` handler.

## Follow-ups

- #294 — extend the blur toggle (`alt+shift+<key>`) to a second layer for parity with audio (out of scope here; #240 is audio-specific).

Closes #240
