### PR TITLE
fix(streamwall): preserve the new link on LocalStreamData entries after rekeying

### DIFF
--- a/packages/streamwall/src/main/data.test.ts
+++ b/packages/streamwall/src/main/data.test.ts
@@ -486,6 +486,16 @@ describe('LocalStreamData', () => {
     expect(data.dataByURL.has('https://b.example/s')).toBe(true)
   })
 
+  test('update() stores the new link on the entry itself after rekeying', () => {
+    const data = new LocalStreamData([
+      { kind: 'video', link: 'https://a.example/s' },
+    ])
+    data.update('https://a.example/s', { link: 'https://b.example/s' })
+    expect(data.dataByURL.get('https://b.example/s')?.link).toBe(
+      'https://b.example/s',
+    )
+  })
+
   test('update() emits the full entry list on the "update" event', () => {
     const data = new LocalStreamData()
     const onUpdate = vi.fn()

--- a/packages/streamwall/src/main/data.ts
+++ b/packages/streamwall/src/main/data.ts
@@ -177,7 +177,12 @@ export class LocalStreamData extends EventEmitter<LocalStreamDataEvents> {
   update(url: string, data: Partial<StreamDataContent>) {
     const existing = this.dataByURL.get(url)
     const kind = data.kind ?? existing?.kind ?? 'video'
-    const updated: StreamDataContent = { ...existing, ...data, kind, link: url }
+    const updated: StreamDataContent = {
+      ...existing,
+      ...data,
+      kind,
+      link: data.link ?? url,
+    }
     this.dataByURL.set(data.link ?? url, updated)
     if (data.link != null && url !== data.link) {
       this.dataByURL.delete(url)


### PR DESCRIPTION
## Problem

`LocalStreamData.update()` in `packages/streamwall/src/main/data.ts` supports "rekeying" an entry to a new URL by passing a `data.link` that differs from the `url` argument (the map lookup key). The `Map` key was correctly moved to the new link, but the stored entry object's own `link` field was forced back to the *old* `url`:

```ts
const updated: StreamDataContent = { ...existing, ...data, kind, link: url }
```

`link: url` always won over any `link` present in `data`, so the entry stored under the new map key still reported the old link via its own `.link` property.

## Impact

Any downstream consumer that keys off the entry's own `.link` field (rather than the `Map` key) after a rekey sees the stale, pre-rename URL. For example, `combineDataSources()` rebuilds its own lookup map keyed by `data.link`, so a renamed custom stream re-entering that merge would be indexed under the old URL again, effectively undoing the rekey for anything downstream.

No code path in `packages/streamwall-control-ui` currently exercises this (the UI always calls `update(props.link, { ...props, ... })` with an unchanged link), so the bug was latent rather than user-visible today.

## Solution

Use `data.link ?? url` for the `link` field instead of unconditionally `url`, so a rekeyed entry reports its new URL both as the `Map` key and on the entry itself.

## Testing

- Added a test asserting the stored entry's own `.link` field reflects the new URL after a rekey (`update() stores the new link on the entry itself after rekeying`), which fails against the old implementation and passes against the fix.
- Full `packages/streamwall` suite: 326/326 passing.
- `tsc --noEmit`, `eslint`, and `prettier --check` all clean on the changed files.

## Risks / breaking changes

None. The change only affects the rekey path, which no current caller exercises with an actual link change.

Closes #274