### PR TITLE
fix(control-client): keep last-known grid cell assignments during a disconnect

### DIFF
--- a/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.test.tsx
+++ b/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.test.tsx
@@ -3,6 +3,7 @@ import { act } from 'preact/test-utils'
 import type { StreamwallConnection } from 'streamwall-control-ui'
 import type { ControlCommand, StreamwallState } from 'streamwall-shared'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as Y from 'yjs'
 
 const { FakeSocket, instances } = vi.hoisted(() => {
   type Listener = (ev: unknown) => void
@@ -250,6 +251,78 @@ describe('useStreamwallWebsocketConnection', () => {
       })
 
       expect(getConnection().stateDoc).not.toBe(docBeforeClose)
+    })
+  })
+
+  // The Yjs doc still gets reset on close (see the test above), which would
+  // otherwise blank the grid's cell assignments (`sharedState.views`) for the
+  // duration of a blip even though the rest of the state keeps rendering its
+  // last-known content. `sharedState` should keep serving the pre-disconnect
+  // snapshot until the server's resync repopulates the fresh doc (issue #283).
+  describe('sharedState across a disconnect (issue #283)', () => {
+    function setCellAssignment(doc: Y.Doc, idx: string, streamId: string) {
+      const viewsMap = doc.getMap<Y.Map<string | undefined>>('views')
+      const cellMap = new Y.Map<string | undefined>()
+      cellMap.set('streamId', streamId)
+      viewsMap.set(idx, cellMap)
+    }
+
+    it('keeps the last-known cell assignments instead of blanking them on close', () => {
+      const { getConnection } = mount()
+
+      act(() => {
+        setCellAssignment(getConnection().stateDoc, '0', 'abc')
+      })
+      expect(getConnection().sharedState?.views['0']?.streamId).toBe('abc')
+
+      const socket = instances[0]!
+      act(() => {
+        socket.dispatch('close')
+      })
+
+      expect(getConnection().isConnected).toBe(false)
+      expect(getConnection().sharedState?.views['0']?.streamId).toBe('abc')
+    })
+
+    it('does not mutate the fresh post-close doc with the frozen snapshot', () => {
+      const { getConnection } = mount()
+
+      act(() => {
+        setCellAssignment(getConnection().stateDoc, '0', 'abc')
+      })
+
+      const socket = instances[0]!
+      act(() => {
+        socket.dispatch('close')
+      })
+
+      const freshDoc = getConnection().stateDoc
+      const viewsMap = freshDoc.getMap<Y.Map<string | undefined>>('views')
+      expect(viewsMap.size).toBe(0)
+    })
+
+    it('switches back to the live sharedState once reconnected', () => {
+      const { getConnection } = mount()
+
+      act(() => {
+        setCellAssignment(getConnection().stateDoc, '0', 'abc')
+      })
+
+      const socket = instances[0]!
+      act(() => {
+        socket.dispatch('close')
+      })
+      expect(getConnection().sharedState?.views['0']?.streamId).toBe('abc')
+
+      act(() => {
+        setCellAssignment(getConnection().stateDoc, '0', 'fresh')
+      })
+      act(() => {
+        socket.dispatch('message', stateMessage())
+      })
+
+      expect(getConnection().isConnected).toBe(true)
+      expect(getConnection().sharedState?.views['0']?.streamId).toBe('fresh')
     })
   })
 

--- a/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.ts
+++ b/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.ts
@@ -36,6 +36,19 @@ export function useStreamwallWebsocketConnection(
   const [streamwallState, setStreamwallState] = useState<StreamwallState>()
   const appState = useStreamwallState(streamwallState)
 
+  // Kept in sync with `sharedState` on every render so `handleClose` (which
+  // runs outside React's render cycle) can always read the value from just
+  // before the disconnect - see `lastKnownSharedStateRef` below.
+  const sharedStateRef = useRef(sharedState)
+  sharedStateRef.current = sharedState
+  // `stateDoc` gets swapped for a fresh, empty doc on every disconnect (see
+  // the comment on `handleClose`), which would otherwise blank the grid's
+  // cell assignments (`sharedState.views`) for the duration of a blip. This
+  // snapshot lets the connection keep serving the pre-disconnect data for
+  // rendering while offline; it's never written back into `stateDoc`, so it
+  // can't reintroduce the divergence risk the reset avoids (issue #283).
+  const lastKnownSharedStateRef = useRef<CollabData | undefined>(undefined)
+
   useEffect(() => {
     let lastStateData: StreamwallState | undefined
     const ws = new ReconnectingWebSocket(wsEndpoint, [], {
@@ -62,6 +75,7 @@ export function useStreamwallWebsocketConnection(
     // silently diverge from what the server (and every other client)
     // actually has.
     function handleClose() {
+      lastKnownSharedStateRef.current = sharedStateRef.current
       setStateDoc(new Y.Doc())
       setIsConnected(false)
       // Any command awaiting a response will never hear back from this
@@ -192,7 +206,9 @@ export function useStreamwallWebsocketConnection(
     isConnected,
     disconnectReason,
     send,
-    sharedState,
+    sharedState: isConnected
+      ? sharedState
+      : (lastKnownSharedStateRef.current ?? sharedState),
     stateDoc,
     undoManager,
   }


### PR DESCRIPTION
## Problem

Follow-up from #37 / PR #282. A brief websocket disconnect (blip) intentionally leaves `streamwallState` untouched so the grid container, sizing, stream counts, and sidebar keep rendering their last-known content (dimmed via `isConnected`). However, `stateDoc` — the Yjs CRDT doc that grid cell assignments (`sharedState.views`, i.e. which stream is placed in which cell) are written into — is deliberately reset to a fresh, empty `Y.Doc()` on every `close`. That reset is what prevents a worse divergence bug: an offline-made local edit could otherwise survive a Yjs merge into the server's post-reconnect resync and silently diverge from what the server/other clients have (see PR #282's description).

The side effect: during a blip, the grid *cell assignments* briefly render as empty/unassigned (since they're derived straight from the reset `stateDoc`), then repopulate once the server's full resync arrives. Purely a visible flash, not a data-integrity issue — but distracting.

## Solution

`useStreamwallWebsocketConnection` now keeps a read-only snapshot of `sharedState` from just before the doc reset:

- A ref (`sharedStateRef`) is kept in sync with the current `sharedState` on every render.
- `handleClose` copies that ref's value into `lastKnownSharedStateRef` right before swapping in the fresh `Y.Doc()`.
- The hook's returned `sharedState` serves the frozen snapshot while `!isConnected`, and switches back to the live, editable `sharedState` once reconnected (`isConnected` becomes `true` again on the next full `state` message).

The snapshot is never written back into `stateDoc` — it only affects what's returned for rendering — so it can't reintroduce the divergence risk the reset avoids today.

## Testing

Added a new `describe('sharedState across a disconnect (issue #283)')` block to `useStreamwallWebsocketConnection.test.tsx` (TDD: written first, confirmed failing, then implemented until green):

- keeps the last-known cell assignments instead of blanking them on close
- does not mutate the fresh post-close doc with the frozen snapshot (guards against reintroducing the divergence bug)
- switches back to the live `sharedState` once reconnected

Full quality gate run locally: `format:check`, `lint`, `typecheck` (all 5 workspaces), `test` (all workspaces — 325 + 243 + 15 + 90 + 146 tests, all green), and `vite build` for `streamwall-control-client`.

## Risks / breaking changes

None. The change is scoped to `useStreamwallWebsocketConnection`'s return value during the disconnected window; connected-state behavior is unchanged.

Closes #283