### PR TITLE
fix(control-ui): surface inbound-message rate-limit disconnects to the operator

### DIFF
--- a/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.test.tsx
+++ b/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.test.tsx
@@ -303,6 +303,19 @@ describe('useStreamwallWebsocketConnection', () => {
       expect(getConnection().disconnectReason).toBeNull()
     })
 
+    it('is set from a rate-limited error message instead of being dropped as unexpected', () => {
+      const { getConnection } = mount()
+      const socket = instances[0]!
+
+      act(() => {
+        socket.dispatch('message', {
+          data: JSON.stringify({ error: 'rate limit exceeded' }),
+        })
+      })
+
+      expect(getConnection().disconnectReason).toBe('rate-limited')
+    })
+
     it('clears once a full state message confirms a successful reconnect', () => {
       const { getConnection } = mount()
       const socket = instances[0]!

--- a/packages/streamwall-control-ui/src/ConnectionStatusBanner.test.tsx
+++ b/packages/streamwall-control-ui/src/ConnectionStatusBanner.test.tsx
@@ -61,4 +61,11 @@ describe('ConnectionStatusBanner', () => {
     const banner = el.querySelector('[role="status"]')
     expect(banner?.textContent).toContain('Streamwall app disconnected')
   })
+
+  test('distinguishes a rate-limited connection from a generic disconnect', () => {
+    const el = renderBanner({ isConnected: false, reason: 'rate-limited' })
+    const banner = el.querySelector('[role="status"]')
+    expect(banner?.textContent).toContain('Too many messages')
+    expect(banner?.className).toContain('rate-limited')
+  })
 })

--- a/packages/streamwall-control-ui/src/ConnectionStatusBanner.tsx
+++ b/packages/streamwall-control-ui/src/ConnectionStatusBanner.tsx
@@ -17,6 +17,7 @@ const StyledConnectionStatusBanner = styled.div`
 const MESSAGE_BY_REASON: Record<DisconnectReason, string> = {
   unauthorized: 'Session invalid - please sign in again.',
   'streamwall-disconnected': 'Streamwall app disconnected - reconnecting...',
+  'rate-limited': 'Too many messages sent - reconnecting...',
 }
 
 const GENERIC_MESSAGE = 'Connection lost - reconnecting...'

--- a/packages/streamwall-shared/src/connectionStatus.test.ts
+++ b/packages/streamwall-shared/src/connectionStatus.test.ts
@@ -14,6 +14,12 @@ describe('parseDisconnectReason', () => {
     )
   })
 
+  test('recognizes an inbound message rate limit', () => {
+    expect(parseDisconnectReason({ error: 'rate limit exceeded' })).toBe(
+      'rate-limited',
+    )
+  })
+
   test('returns null for an unrelated server error', () => {
     expect(
       parseDisconnectReason({ error: 'streamwall already connected' }),

--- a/packages/streamwall-shared/src/connectionStatus.ts
+++ b/packages/streamwall-shared/src/connectionStatus.ts
@@ -5,11 +5,13 @@
  * treat "no reason" (a `null` return from `parseDisconnectReason`) as a
  * generic, still-retrying disconnect (most likely a transient network blip).
  */
-export type DisconnectReason = 'unauthorized' | 'streamwall-disconnected'
+export type DisconnectReason =
+  'unauthorized' | 'streamwall-disconnected' | 'rate-limited'
 
 const REASON_BY_SERVER_ERROR: Record<string, DisconnectReason> = {
   unauthorized: 'unauthorized',
   'streamwall disconnected': 'streamwall-disconnected',
+  'rate limit exceeded': 'rate-limited',
 }
 
 /**


### PR DESCRIPTION
## Problem

#35/#287 fixed command-response errors (`{ response: true, id, error }`) being silently dropped by the client. Issue #288 flagged a related but distinct class of server error that is still only logged to the browser console, never shown to the user: connection-level rejections sent as a raw `ws.send(JSON.stringify({ error: ... }))` before a client session is established.

## Investigation

`packages/streamwall-shared/src/connectionStatus.ts` already maps two of the four raw errors named in the issue (`unauthorized`, `streamwall disconnected`) to a `DisconnectReason`, rendered by `ConnectionStatusBanner` - that mechanism landed after the issue's evidence was gathered. Of the remaining two:

- `'streamwall already connected'` is sent only on `/streamwall/:id/ws` - the Streamwall **desktop app's** uplink connection, not the browser control-ui/control-client. It never reaches the code path this issue is about.
- `'rate limit exceeded'` is sent by `createWsMessageGuard`, which **is** shared by both the uplink and the browser `/client/ws` route. When a browser client trips the per-connection message-rate limit, it gets this error then a socket close - and since `parseDisconnectReason` had no mapping for it, it fell through to `console.warn('unexpected ws message', msg)` instead of surfacing anything to the operator.

That's the one real, reachable gap for the control UI.

## Fix

Add a `'rate-limited'` `DisconnectReason` alongside the existing `'unauthorized'` and `'streamwall-disconnected'` cases, with its own `ConnectionStatusBanner` message, so a rate-limited browser client sees "Too many messages sent - reconnecting..." instead of the connection silently going quiet.

## Testing

- `packages/streamwall-shared/src/connectionStatus.test.ts`: `parseDisconnectReason` recognizes `'rate limit exceeded'`.
- `packages/streamwall-control-ui/src/ConnectionStatusBanner.test.tsx`: banner renders the rate-limited message/class.
- `packages/streamwall-control-client/src/useStreamwallWebsocketConnection.test.tsx`: `disconnectReason` is set from a rate-limit error message instead of being dropped.
- Full quality gate run locally: `format:check`, `lint`, `typecheck`, `test` (all workspaces), and `streamwall-control-client`'s `build` - all green.

## Risks / breaking changes

None. Purely additive: one new `DisconnectReason` variant and its banner copy.

Closes #288