### PR TITLE
fix(control-ui): gate resize and drag-move handles behind mutate-state-doc role check

### DIFF
--- a/packages/streamwall-control-ui/src/ResizeHandles.test.tsx
+++ b/packages/streamwall-control-ui/src/ResizeHandles.test.tsx
@@ -1,0 +1,113 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { ResizeHandles } from './index.tsx'
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+function renderHandles(
+  props: Partial<Parameters<typeof ResizeHandles>[0]> = {},
+): HTMLDivElement {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    render(
+      <ResizeHandles
+        anchorIdx={0}
+        originalSpaces={[0]}
+        role="operator"
+        onResizeStart={() => {}}
+        onResizeKeyDown={() => {}}
+        {...props}
+      />,
+      container!,
+    )
+  })
+  return container
+}
+
+describe('ResizeHandles role gating', () => {
+  test('enables the resize handles for a role that can mutate the state doc', () => {
+    const box = renderHandles({ role: 'operator' })
+
+    const buttons = box.querySelectorAll('button')
+    expect(buttons.length).toBeGreaterThan(0)
+    for (const button of buttons) {
+      expect((button as HTMLButtonElement).disabled).toBe(false)
+    }
+  })
+
+  test('disables the resize handles for a monitor role', () => {
+    const box = renderHandles({ role: 'monitor' })
+
+    const buttons = box.querySelectorAll('button')
+    expect(buttons.length).toBeGreaterThan(0)
+    for (const button of buttons) {
+      expect((button as HTMLButtonElement).disabled).toBe(true)
+    }
+  })
+
+  test('does not invoke onResizeStart/onResizeKeyDown when disabled for a monitor role', () => {
+    const onResizeStart = vi.fn()
+    const onResizeKeyDown = vi.fn()
+    const box = renderHandles({
+      role: 'monitor',
+      onResizeStart,
+      onResizeKeyDown,
+    })
+    const handle = box.querySelector('button.handle.e') as HTMLButtonElement
+
+    handle.dispatchEvent(
+      new PointerEvent('pointerdown', { bubbles: true, pointerId: 1 }),
+    )
+    handle.dispatchEvent(
+      new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowRight' }),
+    )
+
+    expect(onResizeStart).not.toHaveBeenCalled()
+    expect(onResizeKeyDown).not.toHaveBeenCalled()
+  })
+
+  test('invokes onResizeStart/onResizeKeyDown when enabled for an operator role', () => {
+    const onResizeStart = vi.fn()
+    const onResizeKeyDown = vi.fn()
+    const box = renderHandles({
+      role: 'operator',
+      onResizeStart,
+      onResizeKeyDown,
+    })
+    const handle = box.querySelector('button.handle.e') as HTMLButtonElement
+
+    handle.dispatchEvent(
+      new PointerEvent('pointerdown', { bubbles: true, pointerId: 1 }),
+    )
+    handle.dispatchEvent(
+      new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowRight' }),
+    )
+
+    expect(onResizeStart).toHaveBeenCalledWith(0, 'e', [0], expect.anything())
+    expect(onResizeKeyDown).toHaveBeenCalledWith(0, 'e', [0], expect.anything())
+  })
+
+  test('gives every resize handle a descriptive aria-label', () => {
+    const box = renderHandles()
+
+    expect(
+      box.querySelector('button[aria-label="Resize right edge"]'),
+    ).not.toBeNull()
+    expect(
+      box.querySelector('button[aria-label="Resize bottom edge"]'),
+    ).not.toBeNull()
+    expect(
+      box.querySelector('button[aria-label="Resize bottom-right corner"]'),
+    ).not.toBeNull()
+  })
+})

--- a/packages/streamwall-control-ui/src/gridDragMoveRoleGating.test.tsx
+++ b/packages/streamwall-control-ui/src/gridDragMoveRoleGating.test.tsx
@@ -1,0 +1,221 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import type {
+  StreamData,
+  StreamDelayStatus,
+  StreamWindowConfig,
+  StreamwallRole,
+} from 'streamwall-shared'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import * as Y from 'yjs'
+import {
+  ControlUI,
+  type StreamwallConnection,
+  type ViewInfo,
+} from './index.tsx'
+
+// react-icons renders through preact/compat's Context.Consumer, which
+// currently crashes under this package's happy-dom test environment
+// (unrelated to the drag-move gating under test here) - stub the icons out
+// so ControlUI's own rendering can be exercised in isolation.
+vi.mock('react-icons/fa', () => ({
+  FaExchangeAlt: () => null,
+  FaExclamationTriangle: () => null,
+  FaRedoAlt: () => null,
+  FaRegLifeRing: () => null,
+  FaRegWindowMaximize: () => null,
+  FaSyncAlt: () => null,
+  FaVideoSlash: () => null,
+  FaVolumeUp: () => null,
+}))
+vi.mock('react-icons/md', () => ({
+  MdOutlineStayCurrentLandscape: () => null,
+  MdOutlineStayCurrentPortrait: () => null,
+}))
+vi.mock('react-hotkeys-hook', () => ({
+  useHotkeys: () => {},
+}))
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+const config: StreamWindowConfig = {
+  cols: 2,
+  rows: 1,
+  width: 800,
+  height: 400,
+  frameless: false,
+  fullscreen: false,
+  activeColor: '#fff',
+  backgroundColor: '#000',
+}
+
+function makeStream(id: string, label: string): StreamData {
+  return {
+    _id: id,
+    _dataSource: 'custom',
+    kind: 'video',
+    link: `https://example.com/${id}`,
+    label,
+  }
+}
+
+function renderControlUI(role: StreamwallRole | null): {
+  root: HTMLDivElement
+  stateDoc: Y.Doc
+} {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+
+  const stateDoc = new Y.Doc()
+  stateDoc.transact(() => {
+    const viewsMap = stateDoc.getMap<Y.Map<string | undefined>>('views')
+    const box0 = new Y.Map<string | undefined>()
+    box0.set('streamId', 'stream-a')
+    viewsMap.set('0', box0)
+    const box1 = new Y.Map<string | undefined>()
+    box1.set('streamId', 'stream-b')
+    viewsMap.set('1', box1)
+  })
+
+  const delayState: StreamDelayStatus = {
+    isConnected: true,
+    delaySeconds: 0,
+    restartSeconds: 0,
+    isCensored: false,
+    isStreamRunning: true,
+    startTime: 0,
+    state: 'idle',
+  }
+
+  const stateIdxMap = new Map<number, ViewInfo>([
+    [0, { spaces: [0] } as ViewInfo],
+    [1, { spaces: [1] } as ViewInfo],
+  ])
+
+  const connection: StreamwallConnection = {
+    isConnected: true,
+    role,
+    send: () => {},
+    sharedState: {
+      views: {
+        '0': { streamId: 'stream-a' },
+        '1': { streamId: 'stream-b' },
+      },
+    },
+    stateDoc,
+    config,
+    streams: [
+      makeStream('stream-a', 'Stream A'),
+      makeStream('stream-b', 'Stream B'),
+    ],
+    customStreams: [],
+    views: [],
+    stateIdxMap,
+    delayState,
+    authState: undefined,
+    layoutPresets: [],
+    dataSourceHealth: [],
+  }
+
+  act(() => {
+    render(<ControlUI connection={connection} />, container!)
+  })
+  return { root: container, stateDoc }
+}
+
+function getStreamId(stateDoc: Y.Doc, idx: number): string | undefined {
+  return stateDoc
+    .getMap<Y.Map<string | undefined>>('views')
+    .get(String(idx))
+    ?.get('streamId')
+}
+
+// Drags cell 0 onto cell 1. happy-dom doesn't compute real layout geometry, so
+// `getBoundingClientRect` is stubbed to a fixed 800x400 box matching `config`
+// above, making `computeHoveringIdx`'s cell math deterministic (cell 0 spans
+// x:[0,400), cell 1 spans x:[400,800)).
+function dragCell0OntoCell1(root: HTMLDivElement) {
+  const grid = root.querySelector('.grid') as HTMLElement
+  grid.getBoundingClientRect = () =>
+    ({
+      width: 800,
+      height: 400,
+      left: 0,
+      top: 0,
+      right: 800,
+      bottom: 400,
+      x: 0,
+      y: 0,
+      toJSON() {},
+    }) as DOMRect
+
+  const cell0Input = grid.querySelectorAll('input')[0]
+
+  act(() => {
+    grid.dispatchEvent(
+      new PointerEvent('pointermove', {
+        bubbles: true,
+        clientX: 100,
+        clientY: 100,
+      }),
+    )
+  })
+  act(() => {
+    cell0Input.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        button: 0,
+        pointerId: 1,
+        clientX: 100,
+        clientY: 100,
+      }),
+    )
+  })
+  act(() => {
+    grid.dispatchEvent(
+      new PointerEvent('pointermove', {
+        bubbles: true,
+        clientX: 500,
+        clientY: 100,
+      }),
+    )
+  })
+  act(() => {
+    window.dispatchEvent(
+      new PointerEvent('pointerup', { clientX: 500, clientY: 100 }),
+    )
+  })
+}
+
+// Locks in the fix for issue #286: the drag-move gesture (`handleGridPointerDown`
+// / `swapBoxes`) had no `roleCan(role, 'mutate-state-doc')` gate, unlike
+// `GridInput`'s own `disabled` attribute. A `monitor`-role client could start a
+// drag-move gesture, see it apply to their own local Y.Doc, then watch it
+// silently roll back once the control-server rejected the update server-side.
+describe('grid drag-move role gating', () => {
+  test('commits a drag-move swap for a role that can mutate the state doc', () => {
+    const { root, stateDoc } = renderControlUI('operator')
+
+    dragCell0OntoCell1(root)
+
+    expect(getStreamId(stateDoc, 0)).toBe('stream-b')
+    expect(getStreamId(stateDoc, 1)).toBe('stream-a')
+  })
+
+  test('does not mutate the state doc when dragged by a monitor role', () => {
+    const { root, stateDoc } = renderControlUI('monitor')
+
+    dragCell0OntoCell1(root)
+
+    expect(getStreamId(stateDoc, 0)).toBe('stream-a')
+    expect(getStreamId(stateDoc, 1)).toBe('stream-b')
+  })
+})

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -653,7 +653,7 @@ export function ControlUI({
   // since concurrent operators rarely target the same cells simultaneously.
   const swapBoxes = useCallback(
     (fromIdx: number, toIdx: number) => {
-      if (cols == null || rows == null) {
+      if (cols == null || rows == null || !roleCan(role, 'mutate-state-doc')) {
         return
       }
       stateDoc.transact(() => {
@@ -679,7 +679,7 @@ export function ControlUI({
         }
       })
     },
-    [stateDoc, stateIdxMap, cols, rows],
+    [stateDoc, stateIdxMap, cols, rows, role],
   )
 
   const handleSwap = useCallback(
@@ -731,7 +731,11 @@ export function ControlUI({
 
   const handleGridPointerDown = useCallback(
     (ev: PointerEvent) => {
-      if (!isPrimaryButton(ev.button) || hoveringIdx == null) {
+      if (
+        !isPrimaryButton(ev.button) ||
+        hoveringIdx == null ||
+        !roleCan(role, 'mutate-state-doc')
+      ) {
         return
       }
       if (swapStartIdx !== undefined) {
@@ -740,7 +744,7 @@ export function ControlUI({
       }
       setMoveStart({ idx: hoveringIdx, x: ev.clientX, y: ev.clientY })
     },
-    [hoveringIdx, swapStartIdx, handleSwap],
+    [hoveringIdx, swapStartIdx, handleSwap, role],
   )
 
   useLayoutEffect(() => {
@@ -796,7 +800,7 @@ export function ControlUI({
       originalSpaces: number[],
       ev: PointerEvent,
     ) => {
-      if (!isPrimaryButton(ev.button)) {
+      if (!isPrimaryButton(ev.button) || !roleCan(role, 'mutate-state-doc')) {
         return
       }
       ev.preventDefault()
@@ -807,7 +811,7 @@ export function ControlUI({
       }
       setResize({ anchorIdx, streamId, handle, originalSpaces })
     },
-    [sharedState],
+    [sharedState, role],
   )
 
   // Keyboard equivalent of the pointer-drag resize above: each arrow-key
@@ -820,7 +824,7 @@ export function ControlUI({
       originalSpaces: number[],
       ev: KeyboardEvent,
     ) => {
-      if (cols == null || rows == null) {
+      if (cols == null || rows == null || !roleCan(role, 'mutate-state-doc')) {
         return
       }
       const hoverIdx = computeKeyboardResizeHoverIdx(
@@ -854,7 +858,7 @@ export function ControlUI({
         }
       })
     },
-    [cols, rows, sharedState, stateDoc],
+    [cols, rows, sharedState, stateDoc, role],
   )
 
   useLayoutEffect(() => {
@@ -1412,41 +1416,13 @@ export function ControlUI({
                         pointerEvents: 'none',
                       }}
                     >
-                      <StyledResizeHandles>
-                        <button
-                          type="button"
-                          className="handle e"
-                          aria-label="Resize right edge"
-                          onPointerDown={(ev) =>
-                            handleResizeStart(anchorIdx, 'e', pos.spaces, ev)
-                          }
-                          onKeyDown={(ev) =>
-                            handleResizeKeyDown(anchorIdx, 'e', pos.spaces, ev)
-                          }
-                        />
-                        <button
-                          type="button"
-                          className="handle s"
-                          aria-label="Resize bottom edge"
-                          onPointerDown={(ev) =>
-                            handleResizeStart(anchorIdx, 's', pos.spaces, ev)
-                          }
-                          onKeyDown={(ev) =>
-                            handleResizeKeyDown(anchorIdx, 's', pos.spaces, ev)
-                          }
-                        />
-                        <button
-                          type="button"
-                          className="handle se"
-                          aria-label="Resize bottom-right corner"
-                          onPointerDown={(ev) =>
-                            handleResizeStart(anchorIdx, 'se', pos.spaces, ev)
-                          }
-                          onKeyDown={(ev) =>
-                            handleResizeKeyDown(anchorIdx, 'se', pos.spaces, ev)
-                          }
-                        />
-                      </StyledResizeHandles>
+                      <ResizeHandles
+                        anchorIdx={anchorIdx}
+                        originalSpaces={pos.spaces}
+                        role={role}
+                        onResizeStart={handleResizeStart}
+                        onResizeKeyDown={handleResizeKeyDown}
+                      />
                     </div>
                   )
                 })}
@@ -2044,6 +2020,69 @@ const StyledResizeHandles = styled.div`
     border-radius: 2px;
   }
 `
+
+const RESIZE_HANDLES: {
+  handle: ResizeHandle
+  className: string
+  label: string
+}[] = [
+  { handle: 'e', className: 'handle e', label: 'Resize right edge' },
+  { handle: 's', className: 'handle s', label: 'Resize bottom edge' },
+  { handle: 'se', className: 'handle se', label: 'Resize bottom-right corner' },
+]
+
+export function ResizeHandles({
+  anchorIdx,
+  originalSpaces,
+  role,
+  onResizeStart,
+  onResizeKeyDown,
+}: {
+  anchorIdx: number
+  originalSpaces: number[]
+  role: StreamwallRole | null
+  onResizeStart: (
+    anchorIdx: number,
+    handle: ResizeHandle,
+    originalSpaces: number[],
+    ev: PointerEvent,
+  ) => void
+  onResizeKeyDown: (
+    anchorIdx: number,
+    handle: ResizeHandle,
+    originalSpaces: number[],
+    ev: KeyboardEvent,
+  ) => void
+}) {
+  // Gated the same way `GridInput` already is (issue #286): unlike a plain
+  // `disabled` attribute, this also short-circuits the callbacks themselves,
+  // so a monitor-role client can't start a resize gesture even if a
+  // pointerdown/keydown somehow still reached a disabled button.
+  const disabled = !roleCan(role, 'mutate-state-doc')
+  return (
+    <StyledResizeHandles>
+      {RESIZE_HANDLES.map(({ handle, className, label }) => (
+        <button
+          key={handle}
+          type="button"
+          className={className}
+          aria-label={label}
+          disabled={disabled}
+          onPointerDown={(ev) => {
+            if (!disabled) {
+              onResizeStart(anchorIdx, handle, originalSpaces, ev)
+            }
+          }}
+          onKeyDown={(ev) => {
+            if (!disabled) {
+              onResizeKeyDown(anchorIdx, handle, originalSpaces, ev)
+            }
+          }}
+        />
+      ))}
+    </StyledResizeHandles>
+  )
+}
 
 const StyledGridSizeControls = styled.div`
   display: flex;


### PR DESCRIPTION
## Problem

While fixing accessibility issues in the control UI grid controls (#40, PR #285), a review noticed that `GridInput` (the text input used to assign a stream to a cell) is correctly gated behind `disabled={!roleCan(role, 'mutate-state-doc')}`, but the resize-handle buttons (`handleResizeStart`/`handleResizeKeyDown`) and the drag-move/swap pointer handlers (`handleGridPointerDown` / `swapBoxes`) have no equivalent role check.

This is not an authorization bypass: the control-server independently enforces `roleCan(identity.role, 'mutate-state-doc')` before applying or rebroadcasting any Yjs doc update, so a `monitor`-role client's resize/drag mutations are rejected server-side and never reach the authoritative doc or other peers.

However, the UI gap causes a confusing UX for a `monitor`-role client: they can start a resize or drag-move, see it apply locally (the mutation lands in their own local Y.Doc first), and then watch it silently roll back once the server rejects the update and the next resync arrives — with no explanation of why.

## Solution

Gated the resize handles and drag-move/swap interactions the same way `GridInput` already is:

- `swapBoxes`, `handleGridPointerDown`, `handleResizeStart`, and `handleResizeKeyDown` now bail out early when `!roleCan(role, 'mutate-state-doc')`.
- Extracted the previously-inline resize-handle `<button>`s into a `ResizeHandles` component, gated by both a `disabled` attribute (visual + native keyboard-focus prevention, mirroring `GridInput`) and short-circuited `onPointerDown`/`onKeyDown` callbacks (defense in depth, independent of whatever a disabled button does at the DOM-dispatch level).

## Testing

- `ResizeHandles.test.tsx` (new): verifies the resize handles are `disabled` for a `monitor` role and enabled for `operator`, and that `onResizeStart`/`onResizeKeyDown` are not invoked when disabled.
- `gridDragMoveRoleGating.test.tsx` (new): renders the full `ControlUI` component and simulates a real drag-move gesture (pointerdown → pointermove → pointerup) across two grid cells. Confirms an `operator`-role client's drag commits a swap in the Y.Doc, while a `monitor`-role client's identical gesture leaves the Y.Doc untouched — locking in the fix for the actual reported gap.
- Full workspace quality gate (format, lint, typecheck, tests, control-client build) passes locally.

No breaking changes; this only tightens client-side UI gating to match server-side enforcement that was already in place.

Closes #286