### PR TITLE
feat(streamwall): preload next view for seamless content swap on running cells

### DIFF
--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -162,23 +162,31 @@ function makeFakeViewActorWithSnapshot(snapshot: {
 
 /**
  * A stand-in for a ViewActor with enough of the `setViews()` teardown surface
- * (`stop()`, `context.view`/`context.offscreenWin`) to verify a skipped view
- * is torn down rather than leaked.
+ * (`stop()`, `context.view`/`context.offscreenWin`/`context.disposeView`) to
+ * verify a skipped view is torn down rather than leaked. `next`, when passed,
+ * exercises the branch that also disposes an in-flight preload.
  */
-function makeTeardownTrackingViewActor(id: number) {
-  const contentView = { webContents: { close: vi.fn() } }
-  const offscreenWin = {
-    contentView: { removeChildView: vi.fn() },
-    destroy: vi.fn(),
-  }
+function makeTeardownTrackingViewActor(
+  id: number,
+  next: { view: unknown; offscreenWin: unknown } | null = null,
+) {
+  const contentView = {}
+  const offscreenWin = {}
+  const disposeView = vi.fn()
   const stop = vi.fn()
   return {
     stop,
-    contentView,
-    offscreenWin,
+    disposeView,
     actor: {
       getSnapshot: () => ({
-        context: { id, view: contentView, offscreenWin, pos: null },
+        context: {
+          id,
+          view: contentView,
+          offscreenWin,
+          pos: null,
+          next,
+          disposeView,
+        },
         matches: () => false,
       }),
       matches: () => false,
@@ -209,8 +217,188 @@ describe('StreamWindow.setViews', () => {
     sw.setViews(viewContentMap, streams)
 
     expect(tracked.stop).toHaveBeenCalled()
-    expect(tracked.contentView.webContents.close).toHaveBeenCalled()
-    expect(tracked.offscreenWin.destroy).toHaveBeenCalled()
+    expect(tracked.disposeView).toHaveBeenCalledTimes(1)
     expect(sw.views.size).toBe(0)
+  })
+
+  it('also disposes an in-flight preload when tearing down a view that had one', () => {
+    const sw = makeStreamWindow(makeConfig({ cols: 1, rows: 1 }))
+    sw.win = {
+      contentView: { removeChildView: vi.fn() },
+    } as unknown as InstanceType<typeof StreamWindow>['win']
+    sw.views = new Map()
+
+    const next = { view: {}, offscreenWin: {} }
+    const tracked = makeTeardownTrackingViewActor(99, next)
+    sw.createView = vi.fn(() => tracked.actor)
+
+    const viewContentMap: ViewContentMap = new Map([
+      ['0', { url: 'https://example.com/missing', kind: 'video' }],
+    ])
+    const streams = { byURL: new Map() }
+
+    sw.setViews(viewContentMap, streams)
+
+    expect(tracked.disposeView).toHaveBeenCalledTimes(2)
+    expect(tracked.disposeView).toHaveBeenCalledWith(
+      next.view,
+      next.offscreenWin,
+    )
+  })
+})
+
+/**
+ * A minimal fake WebContentsView whose `webContents.on('did-fail-load', ...)`
+ * registration is captured, so a test can trigger it directly instead of
+ * needing a real Electron webContents.
+ */
+function makeFakeView(id: number) {
+  const handlers: Record<string, (...args: never[]) => void> = {}
+  const view = {
+    webContents: {
+      id,
+      on: (event: string, cb: (...args: never[]) => void) => {
+        handlers[event] = cb
+      },
+    },
+  }
+  return { view, handlers }
+}
+
+function fireDidFailLoad(
+  handlers: Record<string, (...args: never[]) => void>,
+  errorCode: number,
+  isMainFrame: boolean,
+) {
+  handlers['did-fail-load']?.(
+    ...([
+      null,
+      errorCode,
+      'ERR_SOMETHING',
+      'https://example.com',
+      isMainFrame,
+    ] as never[]),
+  )
+}
+
+describe('StreamWindow view registration and disposal', () => {
+  it('disposeRawView closes the webContents, destroys the offscreen window, and deregisters routing', () => {
+    const sw = makeStreamWindow(makeConfig())
+    const removeChildViewOnWin = vi.fn()
+    sw.win = {
+      contentView: { removeChildView: removeChildViewOnWin },
+    } as unknown as InstanceType<typeof StreamWindow>['win']
+    sw.viewsByWebContentsId = new Map([[7, {} as never]])
+    const close = vi.fn()
+    const view = { webContents: { id: 7, close } }
+    const removeChildViewOnOffscreen = vi.fn()
+    const destroy = vi.fn()
+    const offscreenWin = {
+      contentView: { removeChildView: removeChildViewOnOffscreen },
+      destroy,
+    }
+
+    ;(
+      sw as unknown as {
+        disposeRawView: (v: unknown, w: unknown) => void
+      }
+    ).disposeRawView(view, offscreenWin)
+
+    expect(removeChildViewOnOffscreen).toHaveBeenCalledWith(view)
+    expect(removeChildViewOnWin).toHaveBeenCalledWith(view)
+    expect(close).toHaveBeenCalledTimes(1)
+    expect(destroy).toHaveBeenCalledTimes(1)
+    expect(sw.viewsByWebContentsId.has(7)).toBe(false)
+  })
+
+  function registerView(
+    sw: InstanceType<typeof StreamWindow>,
+    view: unknown,
+    actor: unknown,
+  ) {
+    ;(
+      sw as unknown as {
+        registerView: (v: unknown, a: unknown) => void
+      }
+    ).registerView(view, actor)
+  }
+
+  it('routes a load failure on the currently displayed view to VIEW_ERROR', () => {
+    const sw = makeStreamWindow(makeConfig())
+    sw.viewsByWebContentsId = new Map()
+    const { view, handlers } = makeFakeView(7)
+    const send = vi.fn()
+    const actor = {
+      getSnapshot: () => ({ context: { view, next: null } }),
+      send,
+    }
+
+    registerView(sw, view, actor)
+    expect(sw.viewsByWebContentsId.get(7)).toBe(actor)
+    fireDidFailLoad(handlers, -105, true)
+
+    expect(send).toHaveBeenCalledWith({
+      type: 'VIEW_ERROR',
+      error: expect.any(Error),
+    })
+  })
+
+  it('routes a load failure on the preloading next view to NEXT_VIEW_ERROR', () => {
+    const sw = makeStreamWindow(makeConfig())
+    sw.viewsByWebContentsId = new Map()
+    const { view: currentView } = makeFakeView(7)
+    const { view: nextView, handlers } = makeFakeView(8)
+    const send = vi.fn()
+    const actor = {
+      getSnapshot: () => ({
+        context: { view: currentView, next: { view: nextView } },
+      }),
+      send,
+    }
+
+    registerView(sw, nextView, actor)
+    fireDidFailLoad(handlers, -105, true)
+
+    expect(send).toHaveBeenCalledWith({
+      type: 'NEXT_VIEW_ERROR',
+      error: expect.any(Error),
+    })
+  })
+
+  it('ignores a stale load failure from a view that is no longer current or next', () => {
+    const sw = makeStreamWindow(makeConfig())
+    sw.viewsByWebContentsId = new Map()
+    const { view: currentView } = makeFakeView(7)
+    const { view: staleView, handlers } = makeFakeView(9)
+    const send = vi.fn()
+    const actor = {
+      getSnapshot: () => ({ context: { view: currentView, next: null } }),
+      send,
+    }
+
+    // A view that was superseded (e.g. a completed swap, or an abandoned
+    // preload) is never registered again for this actor, but its
+    // webContents could still fire a straggling did-fail-load.
+    registerView(sw, staleView, actor)
+    fireDidFailLoad(handlers, -105, true)
+
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('ignores ERR_ABORTED and non-main-frame failures', () => {
+    const sw = makeStreamWindow(makeConfig())
+    sw.viewsByWebContentsId = new Map()
+    const { view, handlers } = makeFakeView(7)
+    const send = vi.fn()
+    const actor = {
+      getSnapshot: () => ({ context: { view, next: null } }),
+      send,
+    }
+
+    registerView(sw, view, actor)
+    fireDidFailLoad(handlers, -3, true) // ERR_ABORTED
+    fireDidFailLoad(handlers, -105, false) // not the main frame
+
+    expect(send).not.toHaveBeenCalled()
   })
 })

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -56,6 +56,13 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
   backgroundView: WebContentsView
   overlayView: WebContentsView
   views: Map<number, ViewActor>
+  // Routes IPC messages from a specific WebContentsView back to whichever
+  // actor owns it. Keyed by live `webContents.id`, unlike `views` (keyed by
+  // each actor's stable `context.id`, fixed at creation): once a content swap
+  // (see viewStateMachine's `running.swap`) promotes a preloaded view to be
+  // an actor's current one, that view's webContents.id generally differs
+  // from the actor's original `context.id`, so routing needs its own map.
+  viewsByWebContentsId: Map<number, ViewActor>
 
   constructor(
     config: StreamWindowConfig,
@@ -65,6 +72,7 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
     this.config = config
     this.retryConfig = retryConfig
     this.views = new Map()
+    this.viewsByWebContentsId = new Map()
 
     const {
       width,
@@ -155,29 +163,59 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
       this.emit('load')
     })
 
+    // Whether this IPC message came from the view an actor is currently
+    // preloading in the background (see viewStateMachine's `running.swap`),
+    // as opposed to the one it's actively displaying -- so the two can be
+    // routed to distinct events instead of being conflated.
+    const isFromNextView = (actor: ViewActor, senderId: number) =>
+      actor.getSnapshot().context.next?.view.webContents.id === senderId
+
     ipcMain.handle('view-init', async (ev) => {
-      const view = this.views.get(ev.sender.id)
-      if (view) {
-        view.send({ type: 'VIEW_INIT' })
-        const { content, options, volume } = view.getSnapshot().context
-        return {
-          content,
-          options,
-          volume,
-        }
+      const view = this.viewsByWebContentsId.get(ev.sender.id)
+      if (!view) {
+        return
       }
+      const { content, options, volume } = view.getSnapshot().context
+      view.send({
+        type: isFromNextView(view, ev.sender.id)
+          ? 'NEXT_VIEW_INIT'
+          : 'VIEW_INIT',
+      })
+      return { content, options, volume }
     })
     ipcMain.on('view-loaded', (ev) => {
-      this.views.get(ev.sender.id)?.send?.({ type: 'VIEW_LOADED' })
+      const view = this.viewsByWebContentsId.get(ev.sender.id)
+      if (!view) {
+        return
+      }
+      view.send({
+        type: isFromNextView(view, ev.sender.id)
+          ? 'NEXT_VIEW_LOADED'
+          : 'VIEW_LOADED',
+      })
     })
     ipcMain.on('view-stalled', (ev) => {
-      this.views.get(ev.sender.id)?.send?.({ type: 'VIEW_STALLED' })
+      this.viewsByWebContentsId.get(ev.sender.id)?.send({
+        type: 'VIEW_STALLED',
+      })
     })
     ipcMain.on('view-info', (ev, { info }) => {
-      this.views.get(ev.sender.id)?.send?.({ type: 'VIEW_INFO', info })
+      this.viewsByWebContentsId.get(ev.sender.id)?.send({
+        type: 'VIEW_INFO',
+        info,
+      })
     })
     ipcMain.on('view-error', (ev, { error }) => {
-      this.views.get(ev.sender.id)?.send?.({ type: 'VIEW_ERROR', error })
+      const view = this.viewsByWebContentsId.get(ev.sender.id)
+      if (!view) {
+        return
+      }
+      view.send({
+        type: isFromNextView(view, ev.sender.id)
+          ? 'NEXT_VIEW_ERROR'
+          : 'VIEW_ERROR',
+        error,
+      })
     })
     ipcMain.on('devtools-overlay', () => {
       overlayView.webContents.openDevTools()
@@ -198,13 +236,20 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
     this.emit('resize')
   }
 
-  createView() {
+  /**
+   * Creates a bare WebContentsView + its dedicated hidden host window (used
+   * while the view is loading, before it's positioned in the wall), with no
+   * actor/routing attached yet. Shared by `createView()` (the initial view
+   * for a new cell) and `createNextView` (a preloaded view for a content swap
+   * on an already-running cell -- see viewStateMachine's `running.swap`).
+   */
+  private createRawView(): {
+    view: WebContentsView
+    offscreenWin: BrowserWindow
+  } {
     const {
-      win,
-      config: { width, height },
+      config: { width, height, backgroundColor },
     } = this
-    assert(win != null, 'Window must be initialized')
-    const { backgroundColor } = this.config
     // Give every view its own unique, ephemeral partition so that streams can
     // not share cookies/localStorage/cache with each other, the browse window,
     // or anything persisted to disk.
@@ -225,28 +270,98 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
     })
     view.setBackgroundColor(backgroundColor)
 
-    const viewId = view.webContents.id
-
     // Lock the view to its stream URL: deny popups and block navigation/redirect
     // escapes while still allowing the page to reload itself.
     secureStreamView(view.webContents)
 
-    // Hidden window used for loading the BrowserView before it's positioned in the wall
+    // Hidden window used for loading the view before it's positioned in the wall.
     const offscreenWin = new BrowserWindow({
       width,
       height,
       show: false,
     })
 
-    const actor = createActor(viewStateMachine, {
+    return { view, offscreenWin }
+  }
+
+  /**
+   * Wires up routing/failure-reporting for a view created by
+   * `createRawView()` so it's addressable by `viewsByWebContentsId` and its
+   * load failures reach the given actor as the right event. Split out from
+   * `createRawView()` because it needs the actor, which doesn't exist yet
+   * when the very first view for a new cell is created.
+   */
+  private registerView(view: WebContentsView, actor: ViewActor) {
+    const viewId = view.webContents.id
+    this.viewsByWebContentsId.set(viewId, actor)
+
+    // Surface main-frame load failures (e.g. ERR_NAME_NOT_RESOLVED) as view
+    // errors so the state machine leaves the loading state instead of hanging.
+    // loadPage intentionally does not await loadURL — awaiting would delay the
+    // navigate->waitForInit transition past the preload's early VIEW_INIT and
+    // hang every view — so failures are reported here instead.
+    view.webContents.on(
+      'did-fail-load',
+      (_event, errorCode, errorDescription, _validatedURL, isMainFrame) => {
+        // -3 is ERR_ABORTED: superseded navigation or self-reload, not a failure.
+        if (!isMainFrame || errorCode === -3) {
+          return
+        }
+        const error = new Error(
+          `Failed to load (${errorCode}): ${errorDescription}`,
+        )
+        const { context } = actor.getSnapshot()
+        if (context.next?.view.webContents.id === viewId) {
+          actor.send({ type: 'NEXT_VIEW_ERROR', error })
+        } else if (context.view.webContents.id === viewId) {
+          // Otherwise this view has since been retired (e.g. a swap promoted
+          // a different one to current) -- ignore the stale event.
+          actor.send({ type: 'VIEW_ERROR', error })
+        }
+      },
+    )
+  }
+
+  /** Tears down a view + host window created by `createRawView()`. */
+  private disposeRawView(view: WebContentsView, offscreenWin: BrowserWindow) {
+    this.viewsByWebContentsId.delete(view.webContents.id)
+    offscreenWin.contentView.removeChildView(view)
+    this.win.contentView.removeChildView(view)
+    view.webContents.close()
+    offscreenWin.destroy()
+  }
+
+  createView() {
+    const { win } = this
+    assert(win != null, 'Window must be initialized')
+
+    const { view, offscreenWin } = this.createRawView()
+    const viewId = view.webContents.id
+
+    // Forward-declared: `createNextView` closes over `actor` but must be
+    // built before `createActor()` returns it, since it's part of that same
+    // call's `input`. Assigned exactly once, right below.
+    // eslint-disable-next-line prefer-const
+    let actor!: ViewActor
+    const createNextView = () => {
+      const next = this.createRawView()
+      this.registerView(next.view, actor)
+      return next
+    }
+
+    actor = createActor(viewStateMachine, {
       input: {
         id: viewId,
         view,
         win,
         offscreenWin,
         retry: this.retryConfig,
+        createNextView,
+        disposeView: (v: WebContentsView, w: BrowserWindow) =>
+          this.disposeRawView(v, w),
       },
     })
+    this.registerView(view, actor)
 
     let lastSnapshot: SnapshotFrom<typeof viewStateMachine> | undefined
     actor.subscribe((snapshot) => {
@@ -258,26 +373,6 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
     })
 
     actor.start()
-
-    // Surface main-frame load failures (e.g. ERR_NAME_NOT_RESOLVED) as view
-    // errors so the state machine leaves the loading state instead of hanging.
-    // loadPage intentionally does not await loadURL — awaiting would delay the
-    // navigate->waitForInit transition past the preload's early VIEW_INIT and
-    // hang every view — so failures are reported here instead.
-    view.webContents.on(
-      'did-fail-load',
-      (_event, errorCode, errorDescription, _validatedURL, isMainFrame) => {
-        // -3 is ERR_ABORTED: superseded navigation or self-reload, not a failure.
-        if (isMainFrame && errorCode !== -3) {
-          actor.send({
-            type: 'VIEW_ERROR',
-            error: new Error(
-              `Failed to load (${errorCode}): ${errorDescription}`,
-            ),
-          })
-        }
-      },
-    )
 
     return actor
   }
@@ -319,7 +414,7 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
 
   setViews(viewContentMap: ViewContentMap, streams: StreamList) {
     const { width, height, cols, rows } = this.config
-    const { win, views } = this
+    const { views } = this
     const boxes = boxesFromViewContentMap(cols, rows, viewContentMap)
     const remainingBoxes = new Set(boxes)
     const unusedViews = new Set(views.values())
@@ -399,11 +494,20 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
     }
     for (const view of unusedViews) {
       view.stop()
-      const { view: contentView, offscreenWin } = view.getSnapshot().context
-      offscreenWin.contentView.removeChildView(contentView)
-      win.contentView.removeChildView(contentView)
-      contentView.webContents.close()
-      offscreenWin.destroy()
+      const {
+        view: contentView,
+        offscreenWin,
+        next,
+        disposeView,
+      } = view.getSnapshot().context
+      disposeView(contentView, offscreenWin)
+      // A preload can still be in flight for a cell being torn down entirely
+      // (as opposed to just interrupted -- see viewStateMachine's `running.
+      // exit` -- this covers the case where the whole actor is discarded);
+      // dispose it too so its WebContentsView/offscreen window don't leak.
+      if (next) {
+        disposeView(next.view, next.offscreenWin)
+      }
     }
     this.views = newViews
     this.emitState()

--- a/packages/streamwall/src/main/viewStateMachine.test.ts
+++ b/packages/streamwall/src/main/viewStateMachine.test.ts
@@ -29,6 +29,14 @@ function makeRetry(overrides: Partial<RetryConfig> = {}): RetryConfig {
   }
 }
 
+// Every actor needs a next-view factory + disposer even in tests that never
+// exercise the preload path, since they're required `input` fields.
+const noopCreateNextView = () => ({
+  view: {} as never,
+  offscreenWin: {} as never,
+})
+const noopDisposeView = noop
+
 // Replace every electron-touching action and the loadPage actor so only the
 // pure state/context logic under test runs. loadPage resolves immediately,
 // moving loading.navigate -> loading.waitForInit.
@@ -37,6 +45,9 @@ function makeActor(retry: RetryConfig, loadPageImpl?: () => Promise<void>) {
     actions: {
       offscreenView: noop,
       positionView: noop,
+      offscreenNextView: noop,
+      performSwap: noop,
+      resyncSwappedView: noop,
       muteAudio: noop,
       unmuteAudio: noop,
       openDevTools: noop,
@@ -55,6 +66,8 @@ function makeActor(retry: RetryConfig, loadPageImpl?: () => Promise<void>) {
       win: {} as never,
       offscreenWin: {} as never,
       retry,
+      createNextView: noopCreateNextView,
+      disposeView: noopDisposeView,
     },
   })
 }
@@ -320,6 +333,9 @@ describe('viewStateMachine volume control', () => {
       actions: {
         offscreenView: noop,
         positionView: noop,
+        offscreenNextView: noop,
+        performSwap: noop,
+        resyncSwappedView: noop,
         muteAudio: noop,
         unmuteAudio: noop,
         openDevTools: noop,
@@ -338,6 +354,8 @@ describe('viewStateMachine volume control', () => {
         win: {} as never,
         offscreenWin: {} as never,
         retry,
+        createNextView: noopCreateNextView,
+        disposeView: noopDisposeView,
       },
     })
     return { actor, sendViewVolume }
@@ -387,7 +405,7 @@ describe('viewStateMachine volume control', () => {
   })
 })
 
-describe('viewStateMachine content swap while running', () => {
+describe('viewStateMachine content swap while running (seamless preload)', () => {
   beforeEach(() => {
     vi.useFakeTimers()
   })
@@ -400,16 +418,33 @@ describe('viewStateMachine content swap while running', () => {
     kind: 'video' as const,
   }
   const OTHER_POS = { x: 10, y: 10, width: 50, height: 50, spaces: [1] }
+  const THIRD_CONTENT = {
+    url: 'https://example.com/third-stream',
+    kind: 'video' as const,
+  }
+  const THIRD_POS = { x: 20, y: 20, width: 30, height: 30, spaces: [2] }
 
-  // Same setup as makeActor, but with spies on offscreenView/positionView so
-  // tests can assert whether the view was shuffled offscreen and repositioned.
-  function makeActorWithPlacementSpies(retry: RetryConfig) {
+  // Same setup as makeActor, but with spies on the placement/swap actions and
+  // a fake createNextView/disposeView pair so tests can assert exactly when a
+  // second view is created, attached, swapped in, or discarded.
+  function makeActorWithSwapSpies(retry: RetryConfig) {
     const offscreenView = vi.fn()
     const positionView = vi.fn()
+    const offscreenNextView = vi.fn()
+    const performSwap = vi.fn()
+    const resyncSwappedView = vi.fn()
+    const disposeView = vi.fn()
+    const createNextView = vi.fn(() => ({
+      view: {} as never,
+      offscreenWin: {} as never,
+    }))
     const machine = viewStateMachine.provide({
       actions: {
         offscreenView,
         positionView,
+        offscreenNextView,
+        performSwap,
+        resyncSwappedView,
         muteAudio: noop,
         unmuteAudio: noop,
         openDevTools: noop,
@@ -428,77 +463,166 @@ describe('viewStateMachine content swap while running', () => {
         win: {} as never,
         offscreenWin: {} as never,
         retry,
+        createNextView,
+        disposeView,
       },
     })
-    return { actor, offscreenView, positionView }
+    return {
+      actor,
+      offscreenView,
+      positionView,
+      offscreenNextView,
+      performSwap,
+      resyncSwappedView,
+      disposeView,
+      createNextView,
+    }
   }
 
-  it('reloads directly into loading without re-shuffling the view offscreen', async () => {
-    const { actor, offscreenView } = makeActorWithPlacementSpies(makeRetry())
+  it('preloads a second view for changed content instead of reloading the current one', async () => {
+    const { actor, offscreenView, offscreenNextView, createNextView } =
+      makeActorWithSwapSpies(makeRetry())
     actor.start()
     await reachRunning(actor)
     expect(offscreenView).toHaveBeenCalledTimes(1)
 
-    actor.send({
-      type: 'DISPLAY',
-      pos: OTHER_POS,
-      content: OTHER_CONTENT,
-    })
+    actor.send({ type: 'DISPLAY', pos: OTHER_POS, content: OTHER_CONTENT })
 
     const snapshot = actor.getSnapshot()
-    expect(matchesState('displaying.loading', snapshot.value)).toBe(true)
+    // The cell never leaves `running`: the currently displayed view keeps
+    // playing, undisturbed, while the new content loads in the background.
+    expect(matchesState('displaying.running', snapshot.value)).toBe(true)
+    expect(
+      matchesState('displaying.running.swap.preloading', snapshot.value),
+    ).toBe(true)
     expect(snapshot.context.content).toEqual(OTHER_CONTENT)
     expect(snapshot.context.pos).toEqual(OTHER_POS)
-    // The view is already live in the main window; swapping content must not
-    // repeat the "move offscreen while it (re)loads" shuffle that a fresh
-    // display does.
+    expect(snapshot.context.next).not.toBeNull()
+    expect(createNextView).toHaveBeenCalledTimes(1)
+    expect(offscreenNextView).toHaveBeenCalledTimes(1)
+    // No offscreen shuffle of the still-displayed current view.
     expect(offscreenView).toHaveBeenCalledTimes(1)
   })
 
-  it('returns to running with the new content and repositions the view', async () => {
-    const { actor, offscreenView, positionView } =
-      makeActorWithPlacementSpies(makeRetry())
+  it('swaps in the preloaded view once it reports ready, without leaving running', async () => {
+    const { actor, performSwap, resyncSwappedView, positionView } =
+      makeActorWithSwapSpies(makeRetry())
     actor.start()
     await reachRunning(actor)
     positionView.mockClear()
 
-    actor.send({
-      type: 'DISPLAY',
-      pos: OTHER_POS,
-      content: OTHER_CONTENT,
-    })
+    actor.send({ type: 'DISPLAY', pos: OTHER_POS, content: OTHER_CONTENT })
     await vi.advanceTimersByTimeAsync(0)
-    actor.send({ type: 'VIEW_INIT' })
-    actor.send({ type: 'VIEW_LOADED' })
+    actor.send({ type: 'NEXT_VIEW_INIT' })
+    actor.send({ type: 'NEXT_VIEW_LOADED' })
 
     const snapshot = actor.getSnapshot()
-    expect(matchesState('displaying.running', snapshot.value)).toBe(true)
+    expect(matchesState('displaying.running.swap.idle', snapshot.value)).toBe(
+      true,
+    )
     expect(snapshot.context.content).toEqual(OTHER_CONTENT)
-    expect(snapshot.context.pos).toEqual(OTHER_POS)
-    expect(offscreenView).toHaveBeenCalledTimes(1)
-    expect(positionView).toHaveBeenCalledTimes(1)
+    expect(snapshot.context.next).toBeNull()
+    expect(performSwap).toHaveBeenCalledTimes(1)
+    expect(resyncSwappedView).toHaveBeenCalledTimes(1)
+    // running's own entry (positionView) never re-fires: the swap is handled
+    // entirely by performSwap, not by re-entering running.
+    expect(positionView).not.toHaveBeenCalled()
   })
 
-  it('still performs a fresh load for the new content (retry budget included)', async () => {
-    const { actor } = makeActorWithPlacementSpies(makeRetry({ maxRetries: 1 }))
+  it('abandons a stale preload and starts a fresh one when content changes again mid-preload', async () => {
+    const { actor, disposeView, createNextView } =
+      makeActorWithSwapSpies(makeRetry())
     actor.start()
     await reachRunning(actor)
 
-    actor.send({
-      type: 'DISPLAY',
-      pos: OTHER_POS,
-      content: OTHER_CONTENT,
-    })
-    actor.send({ type: 'VIEW_ERROR', error: new Error('boom') })
+    actor.send({ type: 'DISPLAY', pos: OTHER_POS, content: OTHER_CONTENT })
+    expect(disposeView).not.toHaveBeenCalled()
 
-    // A fresh content swap should get its own retry budget rather than
-    // inheriting exhaustion from whatever the previous content did.
-    expect(actor.getSnapshot().context.retryCount).toBe(0)
+    actor.send({ type: 'DISPLAY', pos: THIRD_POS, content: THIRD_CONTENT })
+
+    expect(disposeView).toHaveBeenCalledTimes(1)
+    expect(createNextView).toHaveBeenCalledTimes(2)
+    const snapshot = actor.getSnapshot()
+    expect(snapshot.context.content).toEqual(THIRD_CONTENT)
+    expect(snapshot.context.pos).toEqual(THIRD_POS)
+    expect(
+      matchesState('displaying.running.swap.preloading', snapshot.value),
+    ).toBe(true)
+  })
+
+  it('does not restart an in-flight preload for a duplicate DISPLAY of the same pending target', async () => {
+    const { actor, createNextView } = makeActorWithSwapSpies(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+
+    actor.send({ type: 'DISPLAY', pos: OTHER_POS, content: OTHER_CONTENT })
+    actor.send({ type: 'DISPLAY', pos: OTHER_POS, content: OTHER_CONTENT })
+
+    expect(createNextView).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to a full reload of the current view if the preload errors', async () => {
+    const { actor, disposeView } = makeActorWithSwapSpies(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+
+    actor.send({ type: 'DISPLAY', pos: OTHER_POS, content: OTHER_CONTENT })
+    actor.send({ type: 'NEXT_VIEW_ERROR', error: new Error('boom') })
+
+    const snapshot = actor.getSnapshot()
+    expect(matchesState('displaying.loading', snapshot.value)).toBe(true)
+    expect(snapshot.context.next).toBeNull()
+    expect(disposeView).toHaveBeenCalledTimes(1)
+    // The content stays the intended target: the fallback reload retries
+    // loading it on the existing (still-live) current view.
+    expect(snapshot.context.content).toEqual(OTHER_CONTENT)
+  })
+
+  it('falls back to a full reload if the preload never finishes within the loading timeout', async () => {
+    const { actor, disposeView } = makeActorWithSwapSpies(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+
+    actor.send({ type: 'DISPLAY', pos: OTHER_POS, content: OTHER_CONTENT })
+    await vi.advanceTimersByTimeAsync(45 * 1000) // LOADING_TIMEOUT
+
+    const snapshot = actor.getSnapshot()
+    expect(matchesState('displaying.loading', snapshot.value)).toBe(true)
+    expect(snapshot.context.next).toBeNull()
+    expect(disposeView).toHaveBeenCalledTimes(1)
+  })
+
+  it('discards an in-flight preload when a manual RELOAD interrupts it', async () => {
+    const { actor, disposeView } = makeActorWithSwapSpies(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'DISPLAY', pos: OTHER_POS, content: OTHER_CONTENT })
+
+    actor.send({ type: 'RELOAD' })
+
+    const snapshot = actor.getSnapshot()
+    expect(matchesState('displaying.loading', snapshot.value)).toBe(true)
+    expect(snapshot.context.next).toBeNull()
+    expect(disposeView).toHaveBeenCalledTimes(1)
+  })
+
+  it('discards an in-flight preload when the current view errors out', async () => {
+    const { actor, disposeView } = makeActorWithSwapSpies(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'DISPLAY', pos: OTHER_POS, content: OTHER_CONTENT })
+
+    actor.send({ type: 'VIEW_ERROR', error: new Error('current view crashed') })
+
+    const snapshot = actor.getSnapshot()
+    expect(matchesState('displaying.error', snapshot.value)).toBe(true)
+    expect(snapshot.context.next).toBeNull()
+    expect(disposeView).toHaveBeenCalledTimes(1)
   })
 
   it('ignores a DISPLAY with unchanged content and position while running', async () => {
-    const { actor, offscreenView, positionView } =
-      makeActorWithPlacementSpies(makeRetry())
+    const { actor, offscreenView, positionView, createNextView } =
+      makeActorWithSwapSpies(makeRetry())
     actor.start()
     await reachRunning(actor)
     positionView.mockClear()
@@ -510,13 +634,30 @@ describe('viewStateMachine content swap while running', () => {
     expect(snapshot.context.content).toEqual(CONTENT)
     expect(snapshot.context.pos).toEqual(POS)
     // contentPosUnchanged guard: nothing actually changed, so the view must
-    // not be re-shuffled offscreen or repositioned.
+    // not be re-shuffled offscreen or repositioned, and no preload starts.
     expect(offscreenView).toHaveBeenCalledTimes(1)
     expect(positionView).not.toHaveBeenCalled()
+    expect(createNextView).not.toHaveBeenCalled()
+  })
+
+  it('repositions the current view for a position-only change while running', async () => {
+    const { actor, positionView, createNextView } =
+      makeActorWithSwapSpies(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    positionView.mockClear()
+
+    actor.send({ type: 'DISPLAY', pos: OTHER_POS, content: CONTENT })
+
+    const snapshot = actor.getSnapshot()
+    expect(matchesState('displaying.running', snapshot.value)).toBe(true)
+    expect(snapshot.context.pos).toEqual(OTHER_POS)
+    expect(positionView).toHaveBeenCalledTimes(1)
+    expect(createNextView).not.toHaveBeenCalled()
   })
 
   it('reloads via a manual RELOAD from running without moving the view offscreen again', async () => {
-    const { actor, offscreenView } = makeActorWithPlacementSpies(makeRetry())
+    const { actor, offscreenView } = makeActorWithSwapSpies(makeRetry())
     actor.start()
     await reachRunning(actor)
     expect(offscreenView).toHaveBeenCalledTimes(1)
@@ -559,6 +700,9 @@ describe('viewStateMachine loadPage navigation', () => {
       actions: {
         offscreenView: noop,
         positionView: noop,
+        offscreenNextView: noop,
+        performSwap: noop,
+        resyncSwappedView: noop,
         muteAudio: noop,
         unmuteAudio: noop,
         openDevTools: noop,
@@ -574,6 +718,8 @@ describe('viewStateMachine loadPage navigation', () => {
         win: {} as never,
         offscreenWin: {} as never,
         retry,
+        createNextView: noopCreateNextView,
+        disposeView: noopDisposeView,
       },
     })
     return { actor, view, executeJavaScript, loadURL }
@@ -902,15 +1048,21 @@ describe('viewStateMachine deferred MUTE/BLUR/BACKGROUND requests', () => {
     await reachRunning(actor)
     actor.send({ type: 'UNMUTE' })
 
-    // A playlist advance / drag-to-place reassignment: same cell, new content.
+    // A playlist advance / drag-to-place reassignment: same cell, new
+    // content. It preloads a second view (see the "seamless preload" describe
+    // block above) rather than reloading in place, so the completion events
+    // are NEXT_VIEW_INIT/NEXT_VIEW_LOADED and the cell never leaves running.
     actor.send({ type: 'DISPLAY', pos: POS, content: OTHER_CONTENT })
-    expect(matchesState('displaying.loading', actor.getSnapshot().value)).toBe(
-      true,
-    )
+    expect(
+      matchesState(
+        'displaying.running.swap.preloading',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
 
     await vi.advanceTimersByTimeAsync(0)
-    actor.send({ type: 'VIEW_INIT' })
-    actor.send({ type: 'VIEW_LOADED' })
+    actor.send({ type: 'NEXT_VIEW_INIT' })
+    actor.send({ type: 'NEXT_VIEW_LOADED' })
 
     expect(
       matchesState(
@@ -928,8 +1080,8 @@ describe('viewStateMachine deferred MUTE/BLUR/BACKGROUND requests', () => {
 
     actor.send({ type: 'DISPLAY', pos: POS, content: OTHER_CONTENT })
     await vi.advanceTimersByTimeAsync(0)
-    actor.send({ type: 'VIEW_INIT' })
-    actor.send({ type: 'VIEW_LOADED' })
+    actor.send({ type: 'NEXT_VIEW_INIT' })
+    actor.send({ type: 'NEXT_VIEW_LOADED' })
 
     expect(
       matchesState(
@@ -947,8 +1099,8 @@ describe('viewStateMachine deferred MUTE/BLUR/BACKGROUND requests', () => {
 
     actor.send({ type: 'DISPLAY', pos: POS, content: OTHER_CONTENT })
     await vi.advanceTimersByTimeAsync(0)
-    actor.send({ type: 'VIEW_INIT' })
-    actor.send({ type: 'VIEW_LOADED' })
+    actor.send({ type: 'NEXT_VIEW_INIT' })
+    actor.send({ type: 'NEXT_VIEW_LOADED' })
 
     expect(
       matchesState(

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -70,6 +70,17 @@ const viewStateMachine = setup({
       win: BrowserWindow
       offscreenWin: BrowserWindow
       retry: RetryConfig
+      // Creates and registers a second, hidden WebContentsView (plus its own
+      // offscreen host window) that a content swap can preload in the
+      // background while the current one keeps displaying. See `next` below.
+      createNextView: () => {
+        view: WebContentsView
+        offscreenWin: BrowserWindow
+      }
+      // Tears down a view + its offscreen host window created by
+      // `createNextView` (or the initial one from input), detaching it from
+      // whichever contentView currently holds it.
+      disposeView: (view: WebContentsView, offscreenWin: BrowserWindow) => void
     },
 
     context: {} as {
@@ -82,6 +93,17 @@ const viewStateMachine = setup({
       options: ContentDisplayOptions | null
       info: ContentViewInfo | null
       retry: RetryConfig
+      createNextView: () => {
+        view: WebContentsView
+        offscreenWin: BrowserWindow
+      }
+      disposeView: (view: WebContentsView, offscreenWin: BrowserWindow) => void
+      // The second WebContentsView being preloaded in the background for a
+      // content swap while `running`, or null when there is none in flight.
+      // Its `content`/`pos` are whatever `context.content`/`context.pos`
+      // already hold (those are assigned as soon as the swap starts), so
+      // this only needs to carry the view/window pair itself.
+      next: { view: WebContentsView; offscreenWin: BrowserWindow } | null
       // Per-tile playback volume, from 0 (silent) to 1 (full). Independent of
       // the mute/listening state: it is the level applied once the tile is
       // unmuted.
@@ -112,6 +134,12 @@ const viewStateMachine = setup({
       | { type: 'VIEW_STALLED' }
       | { type: 'VIEW_INFO'; info: ContentViewInfo }
       | { type: 'VIEW_ERROR'; error: unknown }
+      // The preloading second view's counterparts of VIEW_INIT/VIEW_LOADED/
+      // VIEW_ERROR, routed separately so they can never be confused with an
+      // event about the currently-displayed view.
+      | { type: 'NEXT_VIEW_INIT' }
+      | { type: 'NEXT_VIEW_LOADED' }
+      | { type: 'NEXT_VIEW_ERROR'; error: unknown }
       | { type: 'MUTE' }
       | { type: 'UNMUTE' }
       | { type: 'BACKGROUND' }
@@ -203,6 +231,75 @@ const viewStateMachine = setup({
 
       view.setBounds(pos)
     },
+
+    // Attaches the freshly-created preload view to its own hidden offscreen
+    // window while it loads, mirroring `offscreenView` for the current view.
+    offscreenNextView: ({ context }) => {
+      const { next } = context
+      assert(next)
+      next.offscreenWin.contentView.addChildView(next.view)
+      const { width, height } = next.offscreenWin.getBounds()
+      next.view.setBounds({ x: 0, y: 0, width, height })
+    },
+
+    // Discards a preload in flight (if any): tears down its view/offscreen
+    // window and clears the slot. Safe to call when there is no preload.
+    disposeStaleNextView: assign(({ context }) => {
+      if (context.next) {
+        context.disposeView(context.next.view, context.next.offscreenWin)
+      }
+      return { next: null }
+    }),
+
+    // Moves the preloaded view into the wall at the current view's z-index
+    // and bounds, then retires the current view. Must run before
+    // `promoteNextView` reassigns `context.view`/`context.next`.
+    performSwap: ({ context }) => {
+      const {
+        win,
+        view: oldView,
+        offscreenWin: oldOffscreenWin,
+        next,
+        pos,
+      } = context
+      assert(next)
+
+      const existingIdx = win.contentView.children.indexOf(oldView)
+      next.offscreenWin.contentView.removeChildView(next.view)
+      win.contentView.addChildView(
+        next.view,
+        existingIdx !== -1 ? existingIdx : win.contentView.children.length - 1,
+      )
+      if (pos) {
+        next.view.setBounds(pos)
+      }
+
+      win.contentView.removeChildView(oldView)
+      context.disposeView(oldView, oldOffscreenWin)
+    },
+
+    // Promotes the preloaded view to be the view for this cell now that
+    // `performSwap` has placed it in the wall and retired the old one.
+    promoteNextView: assign(({ context }) => {
+      assert(context.next)
+      return {
+        view: context.next.view,
+        offscreenWin: context.next.offscreenWin,
+        next: null,
+      }
+    }),
+
+    // The newly-promoted view is a fresh WebContentsView: reapply the
+    // options/volume/mute state that the retired view already had, since
+    // none of `running`'s own entry actions re-fire for an in-place swap.
+    resyncSwappedView: ({ context }) => {
+      const { view, options, volume, desiredAudio } = context
+      view.webContents.audioMuted = desiredAudio === 'muted'
+      if (options) {
+        view.webContents.send('options', options)
+      }
+      view.webContents.send('volume', volume)
+    },
   },
 
   guards: {
@@ -283,11 +380,16 @@ const viewStateMachine = setup({
 }).createMachine({
   id: 'view',
   initial: 'empty',
-  context: ({ input: { id, view, win, offscreenWin, retry } }) => ({
+  context: ({
+    input: { id, view, win, offscreenWin, retry, createNextView, disposeView },
+  }) => ({
     id,
     view,
     win,
     offscreenWin,
+    createNextView,
+    disposeView,
+    next: null,
     pos: null,
     content: null,
     options: null,
@@ -458,6 +560,11 @@ const viewStateMachine = setup({
           // Reaching running means the view recovered: clear any error streak so
           // the next failure starts its backoff from scratch.
           entry: ['positionView', 'resetRetryState'],
+          // Leaving `running` for any reason (manual RELOAD, a renderer-
+          // reported VIEW_ERROR, or a stalled-view auto-reload) abandons any
+          // preload that was in flight for this cell, so its WebContentsView
+          // and offscreen window don't leak.
+          exit: 'disposeStaleNextView',
           on: {
             DISPLAY: [
               // Noop if nothing changed.
@@ -480,22 +587,27 @@ const viewStateMachine = setup({
                 },
               },
               // Content actually changed (e.g. a playlist advance or manual
-              // reassignment) while this cell was already running: reload
-              // straight into `loading` as a sibling transition instead of
-              // going through the root DISPLAY handler, which would re-enter
-              // `displaying` and repeat its entry actions -- most visibly
-              // `offscreenView`, which briefly pulls the view out of the wall
-              // even though it's already live and positioned there. This
-              // still fully reloads the WebContentsView (see `loadPage`);
-              // there is no crossfade or seamless handoff. Removing that
-              // reload cost would require preloading the next view in
-              // parallel before swapping it in.
+              // reassignment) while this cell was already running and there
+              // is no preload already in flight (that case is instead handled
+              // by `swap.preloading`'s own DISPLAY handler below, so its
+              // `reenter` only restarts `preloading` instead of `running`):
+              // preload a second WebContentsView for the new content in the
+              // background -- via the `swap` region below -- while the
+              // currently displayed view keeps playing undisturbed, instead
+              // of reloading it in place.
               {
-                target: '#view.displaying.loading',
-                actions: assign({
-                  pos: ({ event }) => event.pos,
-                  content: ({ event }) => event.content,
-                }),
+                target: '#view.displaying.running.swap.preloading',
+                actions: [
+                  'disposeStaleNextView',
+                  assign({
+                    pos: ({ event }) => event.pos,
+                    content: ({ event }) => event.content,
+                  }),
+                  assign({
+                    next: ({ context }) => context.createNextView(),
+                  }),
+                  'offscreenNextView',
+                ],
               },
             ],
           },
@@ -593,6 +705,127 @@ const viewStateMachine = setup({
                   },
                 },
                 blurred: {},
+              },
+            },
+            // Preloads the next WebContentsView for a content swap in the
+            // background, independent of playback/audio/video above, so the
+            // currently displayed view is never disturbed until the new one
+            // is actually ready to take its place (see the `running.on.
+            // DISPLAY` handler that enters `preloading`).
+            swap: {
+              initial: 'idle',
+              states: {
+                idle: {},
+                preloading: {
+                  initial: 'navigate',
+                  // Safety net mirroring the top-level LOADING_TIMEOUT: if the
+                  // preloaded view never finishes initializing, abandon it
+                  // and fall back to a normal reload of the current view
+                  // instead of preloading forever.
+                  after: {
+                    [LOADING_TIMEOUT]: {
+                      target: '#view.displaying.loading',
+                      actions: {
+                        type: 'logError',
+                        params: {
+                          error: 'Timed out waiting for preloaded view to load',
+                        },
+                      },
+                    },
+                  },
+                  on: {
+                    NEXT_VIEW_ERROR: {
+                      target: '#view.displaying.loading',
+                      actions: {
+                        type: 'logError',
+                        params: ({ event: { error } }) => ({ error }),
+                      },
+                    },
+                    // Content changed again while a preload was already in
+                    // flight for a since-superseded target (rapid successive
+                    // changes): abandon it and restart preloading for the
+                    // newest content. `reenter: true` is scoped to this
+                    // handler's own state (`preloading`, defined right here),
+                    // so only it and its navigate/waitForInit/waitForVideo
+                    // descendants re-enter -- `running` itself, and the
+                    // currently displayed view, are untouched.
+                    DISPLAY: [
+                      {
+                        guard: {
+                          type: 'contentPosUnchanged',
+                          params: ({ event: { content, pos } }) => ({
+                            content,
+                            pos,
+                          }),
+                        },
+                      },
+                      {
+                        actions: assign({ pos: ({ event }) => event.pos }),
+                        guard: {
+                          type: 'contentUnchanged',
+                          params: ({ event: { content } }) => ({ content }),
+                        },
+                      },
+                      {
+                        target: '#view.displaying.running.swap.preloading',
+                        reenter: true,
+                        actions: [
+                          'disposeStaleNextView',
+                          assign({
+                            pos: ({ event }) => event.pos,
+                            content: ({ event }) => event.content,
+                          }),
+                          assign({
+                            next: ({ context }) => context.createNextView(),
+                          }),
+                          'offscreenNextView',
+                        ],
+                      },
+                    ],
+                  },
+                  states: {
+                    navigate: {
+                      invoke: {
+                        src: 'loadPage',
+                        input: ({ context }) => {
+                          assert(context.next)
+                          return {
+                            content: context.content,
+                            view: context.next.view,
+                          }
+                        },
+                        onDone: {
+                          target: 'waitForInit',
+                        },
+                        onError: {
+                          target: '#view.displaying.loading',
+                          actions: {
+                            type: 'logError',
+                            params: ({ event: { error } }) => ({ error }),
+                          },
+                        },
+                      },
+                    },
+                    waitForInit: {
+                      on: {
+                        NEXT_VIEW_INIT: 'waitForVideo',
+                      },
+                    },
+                    waitForVideo: {
+                      on: {
+                        NEXT_VIEW_LOADED: {
+                          target: '#view.displaying.running.swap.idle',
+                          actions: [
+                            'performSwap',
+                            'promoteNextView',
+                            'resyncSwappedView',
+                            'resetRetryState',
+                          ],
+                        },
+                      },
+                    },
+                  },
+                },
               },
             },
           },


### PR DESCRIPTION
## Summary

#198 removed the extra offscreen shuffle that happened when a running grid cell's content changed (playlist advance, drag-to-place reassignment), but a content swap still fully reloaded the cell's `WebContentsView` for the new URL (`loadPage` -> `wc.loadURL`), going through a `loading` -> `waitForInit` -> `waitForVideo` round trip with a visible blank/loading period. That reload cost was explicitly left out of scope for #198 as follow-up work.

## Technical solution

- `viewStateMachine`'s `running` state gains a new parallel region, `swap`, with states `idle`/`preloading`. When content changes while a cell is already `running`, instead of reloading the current view in place, the machine now creates a second, hidden `WebContentsView` (via a `createNextView` factory supplied through actor `input`) and loads the new content on it in the background, through the same `navigate` -> `waitForInit` -> `waitForVideo` progression as a normal load (reusing the existing `loadPage` actor), routed via new `NEXT_VIEW_INIT`/`NEXT_VIEW_LOADED`/`NEXT_VIEW_ERROR` events so they can never be confused with events about the currently-displayed view.
- Once the preloaded view reports ready (`NEXT_VIEW_LOADED`), `performSwap` moves it into the wall at the retiring view's z-index/bounds and tears the old view down; `promoteNextView` makes it the cell's current view; `resyncSwappedView` reapplies the mute/options/volume state the retired view already had (none of `running`'s own entry actions re-fire, since the cell never leaves `running`).
- If content changes again before a preload finishes, the stale in-flight preload is abandoned and a fresh one starts for the newest target (`swap.preloading`'s own `DISPLAY` handler, with `reenter: true` scoped to `preloading` itself -- not `running` -- so the currently displayed view is never disturbed by this).
- If a preload errors (`NEXT_VIEW_ERROR`) or never finishes within the existing `LOADING_TIMEOUT`, it falls back to the pre-existing full-reload behavior on the current view -- no new terminal failure mode.
- Leaving `running` for any other reason (manual `RELOAD`, a `VIEW_ERROR` on the *currently displayed* view, or a stalled-view auto-reload) disposes any in-flight preload via `running`'s own `exit` action, so it can't leak a `WebContentsView`/offscreen `BrowserWindow`.
- `StreamWindow` gains a `viewsByWebContentsId` routing map, keyed by live `webContents.id`, used for `view-init`/`view-loaded`/`view-info`/`view-error` IPC routing. This replaces the old `views` map (keyed by an actor's original, immutable `context.id`) for that purpose, since a swap changes which `WebContentsView` is an actor's *current* one -- an event from the promoted view's `webContents.id` would no longer resolve against the old id-based lookup.
- `createRawView`/`registerView`/`disposeRawView` are new private helpers factored out of the old `createView()` body, shared between creating a cell's initial view and creating/tearing down a preloaded one, so both go through the same partition/session-hardening/navigation-security/routing/failure-reporting setup and the same teardown path.

## Testing performed

- `viewStateMachine.test.ts`: rewrote the `content swap while running` describe block for the new preload/swap behavior -- preloading starts without disturbing the current view or re-shuffling it offscreen, the swap completes and resyncs state without re-entering `running`, a stale in-flight preload is abandoned and replaced when content changes again, duplicate `DISPLAY`s for the same pending target don't restart a preload, preload errors/timeouts fall back to a full reload, and an in-flight preload is discarded when `RELOAD`/`VIEW_ERROR` interrupt it.
- `StreamWindow.test.ts`: extended the `setViews` teardown test to also assert an in-flight preload is disposed, and added coverage for `disposeRawView` (teardown + routing deregistration) and `registerView`'s load-failure routing (current view -> `VIEW_ERROR`, preloading view -> `NEXT_VIEW_ERROR`, a stale/already-retired view's failure is ignored, `ERR_ABORTED`/non-main-frame failures are ignored).
- Full quality gate run against all 5 workspaces: format (Prettier), lint (ESLint), typecheck (tsc), and test (`streamwall` 327, `streamwall-shared` 243, `streamwall-control-server` 90 (node:test), `streamwall-control-ui` 146) -- all green.
- Packaged the Electron app (`electron-forge package`) to confirm the Vite bundle for the main process builds cleanly, and launched the packaged app to confirm `StreamWindow` constructs and loads a stream data source without crashing.

## Risks / breaking changes

- For any cell using this path, a content swap now briefly holds two live `WebContentsView`s (and their own hidden host `BrowserWindow`s/renderer processes) at once instead of one, as called out as a tradeoff in the issue -- this only affects a cell mid-swap, not the wall's steady-state resource usage.
- No changes to any external API, IPC contract from the renderer side, or config format.

Closes #238