### PR TITLE
fix(streamwall): surface uplink connection rejections instead of logging them as disallowed commands

### DIFF
--- a/packages/streamwall-shared/src/connectionStatus.test.ts
+++ b/packages/streamwall-shared/src/connectionStatus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { parseDisconnectReason } from './connectionStatus.ts'
+import { parseDisconnectReason, parseUplinkError } from './connectionStatus.ts'
 
 describe('parseDisconnectReason', () => {
   test('recognizes an unauthorized session', () => {
@@ -49,5 +49,45 @@ describe('parseDisconnectReason', () => {
 
   test('returns null when the error field is not a string', () => {
     expect(parseDisconnectReason({ error: 42 })).toBeNull()
+  })
+})
+
+describe('parseUplinkError', () => {
+  test('recognizes a rejected uplink token', () => {
+    expect(parseUplinkError({ error: 'unauthorized' })).toBe('unauthorized')
+  })
+
+  test('recognizes a conflicting Streamwall connection', () => {
+    expect(parseUplinkError({ error: 'streamwall already connected' })).toBe(
+      'already-connected',
+    )
+  })
+
+  test('returns null for a client-only disconnect reason', () => {
+    // 'streamwall disconnected' and 'rate limit exceeded' are only ever sent
+    // on the browser client socket, never on the desktop uplink.
+    expect(parseUplinkError({ error: 'streamwall disconnected' })).toBeNull()
+    expect(parseUplinkError({ error: 'rate limit exceeded' })).toBeNull()
+  })
+
+  test('returns null for a state push', () => {
+    expect(parseUplinkError({ type: 'state', state: {} })).toBeNull()
+  })
+
+  test('returns null for a command message', () => {
+    expect(
+      parseUplinkError({ type: 'set-view-blurred', viewIdx: 0, blurred: true }),
+    ).toBeNull()
+  })
+
+  test.each([null, undefined, 'unauthorized', 42, ['unauthorized'], true])(
+    'returns null for non-object input %p',
+    (input) => {
+      expect(parseUplinkError(input)).toBeNull()
+    },
+  )
+
+  test('returns null when the error field is not a string', () => {
+    expect(parseUplinkError({ error: 42 })).toBeNull()
   })
 })

--- a/packages/streamwall-shared/src/connectionStatus.ts
+++ b/packages/streamwall-shared/src/connectionStatus.ts
@@ -15,6 +15,38 @@ const REASON_BY_SERVER_ERROR: Record<string, DisconnectReason> = {
 }
 
 /**
+ * Reason the control server refused the Streamwall desktop app's own uplink
+ * connection (`/streamwall/:id/ws` in streamwall-control-server). Like the
+ * browser client, the server sends `{error: '...'}` immediately before closing
+ * the socket - but the uplink only ever sees these two rejections, distinct
+ * from the browser client's reason set above.
+ */
+export type UplinkErrorReason = 'unauthorized' | 'already-connected'
+
+const UPLINK_REASON_BY_SERVER_ERROR: Record<string, UplinkErrorReason> = {
+  unauthorized: 'unauthorized',
+  'streamwall already connected': 'already-connected',
+}
+
+/**
+ * Extracts a `{error: '<string>'}` payload from a parsed control-server
+ * message, returning the raw error string or `null` if the message isn't a
+ * server error at all (a state push, a command, or malformed input). Shared by
+ * the reason parsers below so both apply the same untrusted-input guard.
+ */
+function readServerError(message: unknown): string | null {
+  if (
+    typeof message !== 'object' ||
+    message === null ||
+    !('error' in message)
+  ) {
+    return null
+  }
+  const { error } = message as { error: unknown }
+  return typeof error === 'string' ? error : null
+}
+
+/**
  * Reads the disconnect reason out of a parsed control-server websocket
  * message. The server sends `{error: '...'}` immediately before closing the
  * socket when the session is invalid or the Streamwall app itself isn't
@@ -24,16 +56,17 @@ const REASON_BY_SERVER_ERROR: Record<string, DisconnectReason> = {
 export function parseDisconnectReason(
   message: unknown,
 ): DisconnectReason | null {
-  if (
-    typeof message !== 'object' ||
-    message === null ||
-    !('error' in message)
-  ) {
-    return null
-  }
-  const { error } = message as { error: unknown }
-  if (typeof error !== 'string') {
-    return null
-  }
-  return REASON_BY_SERVER_ERROR[error] ?? null
+  const error = readServerError(message)
+  return error === null ? null : (REASON_BY_SERVER_ERROR[error] ?? null)
+}
+
+/**
+ * Reads the connection-refused reason out of a parsed control-server uplink
+ * message. Returns `null` for anything that isn't a recognized `{error: '...'}`
+ * rejection (a real command or a state push), so the desktop can forward those
+ * onward unchanged instead of mistaking them for disallowed commands.
+ */
+export function parseUplinkError(message: unknown): UplinkErrorReason | null {
+  const error = readServerError(message)
+  return error === null ? null : (UPLINK_REASON_BY_SERVER_ERROR[error] ?? null)
 }

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -12,10 +12,12 @@ import {
   ControlCommand,
   DataSourceType,
   StreamwallState,
+  UplinkErrorReason,
   isCommandAllowedFromUplink,
   isSecureControlEndpoint,
   isSocketOpen,
   parseControlEndpoint,
+  parseUplinkError,
 } from 'streamwall-shared'
 import { updateElectronApp } from 'update-electron-app'
 import WebSocket from 'ws'
@@ -64,6 +66,19 @@ import {
   shouldHideInsteadOfQuit,
   shouldQuitOnAllWindowsClosed,
 } from './windowCloseBehavior'
+
+/**
+ * Human-readable explanation logged when the control server refuses the uplink
+ * connection. These `{error: '...'}` messages carry no command `type`, so
+ * without this they would otherwise be logged by `onCommand` as a misleading
+ * "disallowed command: undefined" (issue #300).
+ */
+const UPLINK_ERROR_MESSAGE: Record<UplinkErrorReason, string> = {
+  unauthorized:
+    'the control server rejected the uplink token (invalid or expired)',
+  'already-connected':
+    'another Streamwall instance is already connected to the control server',
+}
 
 /**
  * Builds a WebSocket subclass for the control uplink.
@@ -833,6 +848,19 @@ async function main(argv: ReturnType<typeof parseArgs>) {
         msg = JSON.parse(ev.data)
       } catch (err) {
         log.warn('Failed to parse control WebSocket message:', err)
+        return
+      }
+
+      // The server sends `{error: '...'}` right before closing the uplink when
+      // it refuses the connection. These carry no command `type`, so surface
+      // the real reason here instead of letting onCommand's uplink allowlist
+      // reject them as a "disallowed command: undefined" (issue #300).
+      const uplinkError = parseUplinkError(msg)
+      if (uplinkError) {
+        log.warn(
+          'Control server refused the uplink connection:',
+          UPLINK_ERROR_MESSAGE[uplinkError],
+        )
         return
       }
 


### PR DESCRIPTION
## Problem

When the control server refuses the Streamwall **desktop app's** own uplink connection (`/streamwall/:id/ws`), it sends an error frame right before closing the socket:

- `{ error: 'unauthorized' }` — bad or expired uplink token
- `{ error: 'streamwall already connected' }` — a second desktop instance tried to connect while one is already connected

On the receiving end, the uplink `message` handler in `packages/streamwall/src/main/index.ts` forwarded every parsed JSON message straight into `onCommand(msg, 'uplink')`. Since these error frames carry no command `type`, they hit the untrusted-uplink allowlist guard and were logged as:

```
Rejecting disallowed command from control uplink: undefined
```

That gave the operator no indication of *why* the uplink was actually rejected. It was never a crash (the allowlist safely no-ops), just a misleading log line where a clear one is trivial.

## Solution

- Add `parseUplinkError()` to `streamwall-shared` (`connectionStatus.ts`), mirroring the existing `parseDisconnectReason()` used by the browser client. It recognizes the two `{ error: ... }` rejections the server sends on the uplink and returns a typed `UplinkErrorReason` (`'unauthorized' | 'already-connected'`), or `null` for anything else (state pushes, real commands, malformed input) so they forward on unchanged.
- Refactor the shared, identical `{error: string}` extraction guard into a private `readServerError()` helper used by both parsers — no behavior change to `parseDisconnectReason`.
- Wire it into the desktop uplink handler: check `parseUplinkError(msg)` before `onCommand`, and log the real reason via a human-readable `UPLINK_ERROR_MESSAGE` map instead of routing the frame through the "disallowed command" path.

## Architecture decisions

- Placed the recognizer in `streamwall-shared` next to `parseDisconnectReason`, keeping the browser-client and desktop-uplink error handling parallel and pure/testable. The uplink error set is deliberately distinct from the browser client's (`streamwall disconnected` / `rate limit exceeded` are never sent on the uplink), so it gets its own typed reason and mapping rather than overloading `DisconnectReason`.
- The log-message map lives in the desktop main, mirroring how `ConnectionStatusBanner`'s `MESSAGE_BY_REASON` maps `DisconnectReason` to operator-facing text in the UI.

## Testing

- New unit tests for `parseUplinkError` in `connectionStatus.test.ts`: recognizes both uplink rejections, returns `null` for client-only reasons, state pushes, commands, non-object input, and non-string `error` fields.
- Full quality gate green locally: `format:check`, `lint`, `typecheck`, `test` (858 tests across all packages), and the control-client build.

## Risks / breaking changes

None. The shared refactor is a pure extraction covered by the existing `parseDisconnectReason` tests; the new behavior only replaces a misleading log line with a clear one on the desktop uplink.

Closes #300