### PR TITLE
fix(streamwall): report unplayable HLS tiles promptly instead of via the load timeout

### DIFF
--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -5,17 +5,32 @@ const executeJavaScript = vi.fn()
 // Never resolves, so the assertions below can prove the visibility spoof
 // does not wait on the view-init round trip before running.
 const invoke = vi.fn(() => new Promise(() => {}))
+const send = vi.fn()
+const exposeInMainWorld = vi.fn()
 
 vi.mock('electron', () => ({
-  ipcRenderer: { invoke, send: vi.fn(), on: vi.fn() },
+  contextBridge: { exposeInMainWorld },
+  ipcRenderer: { invoke, send, on: vi.fn() },
   webFrame: { executeJavaScript, insertCSS: vi.fn() },
 }))
+
+type MediaApi = { reportError: (reason: string) => void }
+
+function importedMediaApi(): MediaApi {
+  const call = exposeInMainWorld.mock.calls.find(
+    ([name]) => name === 'streamwallMedia',
+  )
+  if (!call) throw new Error('streamwallMedia was not exposed')
+  return call[1] as MediaApi
+}
 
 describe('mediaPreload visibility spoofing', () => {
   afterEach(() => {
     vi.resetModules()
     executeJavaScript.mockClear()
     invoke.mockClear()
+    send.mockClear()
+    exposeInMainWorld.mockClear()
   })
 
   it('overrides document.visibilityState/hidden in the page world as soon as the preload script runs', async () => {
@@ -32,5 +47,50 @@ describe('mediaPreload visibility spoofing', () => {
     // the spoof isn't gated on it -- it must apply before the page's own
     // scripts run, not after this preload script finishes its own setup.
     expect(invoke).toHaveBeenCalledWith('view-init')
+  })
+})
+
+describe('mediaPreload error channel', () => {
+  afterEach(() => {
+    vi.resetModules()
+    send.mockClear()
+    exposeInMainWorld.mockClear()
+  })
+
+  it('exposes a streamwallMedia bridge to the page world', async () => {
+    await import('./mediaPreload')
+
+    expect(exposeInMainWorld).toHaveBeenCalledWith(
+      'streamwallMedia',
+      expect.objectContaining({ reportError: expect.any(Function) }),
+    )
+  })
+
+  it('maps a known reason to a fixed message and sends it as a view-error', async () => {
+    await import('./mediaPreload')
+
+    importedMediaApi().reportError('hls-unsupported')
+
+    expect(send).toHaveBeenCalledWith('view-error', {
+      error: 'HLS playback is not supported',
+    })
+  })
+
+  it('maps the src-rejected reason to its own fixed message', async () => {
+    await import('./mediaPreload')
+
+    importedMediaApi().reportError('src-rejected')
+
+    expect(send).toHaveBeenCalledWith('view-error', {
+      error: 'Stream source rejected (disallowed URL scheme)',
+    })
+  })
+
+  it('ignores an unknown reason so an untrusted page cannot inject arbitrary error text', async () => {
+    await import('./mediaPreload')
+
+    importedMediaApi().reportError('<img src=x onerror=alert(1)>')
+
+    expect(send).not.toHaveBeenCalledWith('view-error', expect.anything())
   })
 })

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -1,4 +1,4 @@
-import { ipcRenderer, webFrame } from 'electron'
+import { contextBridge, ipcRenderer, webFrame } from 'electron'
 import throttle from 'lodash/throttle'
 import { ContentDisplayOptions } from 'streamwall-shared'
 import { VolumeController } from './volumeController'
@@ -300,6 +300,38 @@ async function findMedia(
 
   return video
 }
+
+// The locally-bundled HLS player page (renderer/playHLS.ts) loads under this
+// preload but, being page script under contextIsolation, has no direct
+// ipcRenderer access. When it decides up front that a stream can never play --
+// the engine supports neither hls.js nor native HLS, or a src is rejected by
+// its scheme allowlist -- it never creates a <video>, so findMedia() above sits
+// until the state machine's much longer load timeout fires a generic error.
+// Expose a minimal channel so the page can surface the specific cause at once.
+//
+// The reason is looked up in a closed vocabulary and only the mapped, fixed
+// message is ever sent -- never free-form text from the page. This preload is
+// also attached to untrusted remote stream views, so the strict mapping ensures
+// the worst a page can do here is put its own tile into an error state it could
+// already reach by simply failing to play.
+const MEDIA_ERROR_MESSAGES: Record<string, string> = {
+  'hls-unsupported': 'HLS playback is not supported',
+  'src-rejected': 'Stream source rejected (disallowed URL scheme)',
+}
+
+const mediaApi = {
+  reportError(reason: string) {
+    const message = MEDIA_ERROR_MESSAGES[reason]
+    if (message === undefined) {
+      return
+    }
+    ipcRenderer.send('view-error', { error: message })
+  },
+}
+
+export type StreamwallMediaGlobal = typeof mediaApi
+
+contextBridge.exposeInMainWorld('streamwallMedia', mediaApi)
 
 async function main() {
   const viewInit = ipcRenderer.invoke('view-init')

--- a/packages/streamwall/src/renderer/playHLS.test.ts
+++ b/packages/streamwall/src/renderer/playHLS.test.ts
@@ -60,16 +60,23 @@ function setSrc(src: string | null) {
   window.history.pushState({}, '', url.pathname + url.search)
 }
 
+const reportError = vi.fn()
+
 describe('playHLS', () => {
   beforeEach(() => {
     document.body.innerHTML = ''
     lastInstance = undefined
     MockHls.isSupported.mockReturnValue(true)
+    reportError.mockClear()
+    ;(window as unknown as { streamwallMedia: unknown }).streamwallMedia = {
+      reportError,
+    }
   })
 
   afterEach(() => {
     vi.resetModules()
     vi.restoreAllMocks()
+    delete (window as unknown as { streamwallMedia?: unknown }).streamwallMedia
   })
 
   it('does nothing when no src query param is present', async () => {
@@ -86,6 +93,20 @@ describe('playHLS', () => {
 
     expect(lastInstance).toBeUndefined()
     expect(document.querySelector('video')).toBeNull()
+  })
+
+  it('reports a rejected src promptly instead of leaving the tile black', async () => {
+    setSrc('javascript:alert(document.domain)')
+    await import('./playHLS')
+
+    expect(reportError).toHaveBeenCalledWith('src-rejected')
+  })
+
+  it('does not report an error when playback proceeds normally', async () => {
+    setSrc('https://stream.example/live.m3u8')
+    await import('./playHLS')
+
+    expect(reportError).not.toHaveBeenCalled()
   })
 
   it('appends the video element once the manifest has parsed', async () => {
@@ -217,5 +238,16 @@ describe('playHLS', () => {
 
     expect(lastInstance).toBeUndefined()
     expect(document.querySelector('video')).toBeNull()
+  })
+
+  it('reports HLS as unsupported instead of relying on the load timeout', async () => {
+    const hlsModule = await import('hls.js')
+    vi.spyOn(hlsModule.default, 'isSupported').mockReturnValue(false)
+    vi.spyOn(HTMLMediaElement.prototype, 'canPlayType').mockReturnValue('')
+
+    setSrc('https://stream.example/live.m3u8')
+    await import('./playHLS')
+
+    expect(reportError).toHaveBeenCalledWith('hls-unsupported')
   })
 })

--- a/packages/streamwall/src/renderer/playHLS.ts
+++ b/packages/streamwall/src/renderer/playHLS.ts
@@ -1,4 +1,13 @@
 import Hls, { ErrorTypes, Events, type ErrorData } from 'hls.js'
+import type { StreamwallMediaGlobal } from '../preload/mediaPreload'
+
+declare global {
+  interface Window {
+    // Exposed by mediaPreload.ts, this page's preload. Optional because the
+    // page can be rendered without the bridge (e.g. in unit tests).
+    streamwallMedia?: StreamwallMediaGlobal
+  }
+}
 
 // hls.js recommends bounding automatic recovery attempts: a stream that
 // keeps producing fatal errors after repeated retries is not going to
@@ -68,6 +77,14 @@ function loadNatively(videoEl: HTMLVideoElement, src: string) {
 }
 
 function loadHLS(src: string) {
+  // A rejected src never reaches a playback path (the sink guards in
+  // loadWithHlsJs/loadNatively would drop it), so report it here rather than
+  // letting the tile sit black until the load timeout.
+  if (!ALLOWED_SRC_PATTERN.test(src)) {
+    window.streamwallMedia?.reportError('src-rejected')
+    return
+  }
+
   if (Hls.isSupported()) {
     loadWithHlsJs(src)
     return
@@ -76,7 +93,12 @@ function loadHLS(src: string) {
   const videoEl = document.createElement('video')
   if (videoEl.canPlayType('application/vnd.apple.mpegurl')) {
     loadNatively(videoEl, src)
+    return
   }
+
+  // Neither hls.js nor native HLS is available: no <video> will ever be
+  // created, so surface the specific cause immediately.
+  window.streamwallMedia?.reportError('hls-unsupported')
 }
 
 const searchParams = new URLSearchParams(location.search)


### PR DESCRIPTION
## Problem

After #291, `playHLS.ts`'s `loadHLS()` creates **no** `<video>` element when the engine supports neither hls.js (`Hls.isSupported()` is false) nor native HLS (`canPlayType('application/vnd.apple.mpegurl')` is falsy). The same happens if a malformed/rejected `src` reaches `loadHLS()` and is dropped by the scheme allowlist added in #291.

Because `playHLS.ts` is page script under `contextIsolation`, it has no direct IPC access, so this case is invisible to it. `mediaPreload.ts`'s `findMedia()` then just waits — the view never sends `view-loaded`, so it hangs in `loading` until the state machine's `LOADING_TIMEOUT` fires a generic *"Timed out waiting for view to load"*, leaving the tile black for up to that full timeout instead of reporting the actual cause (HLS unsupported / rejected src) promptly.

Fixes #304.

## Solution

Expose a minimal error channel from `mediaPreload.ts` (this page's preload) via `contextBridge` — `window.streamwallMedia.reportError(reason)` — mirroring `mediaPreload.ts`'s existing `ipcRenderer.send('view-error', ...)` pattern. `playHLS.ts` calls it in the two dead-end cases:

- **`hls-unsupported`** — neither hls.js nor native HLS playback is available.
- **`src-rejected`** — the `src` fails the `ALLOWED_SRC_PATTERN` scheme allowlist.

Reporting the error transitions the view to `displaying.error` immediately; leaving the `loading` state cancels the long load-timeout timer, so the specific message is what the operator sees (no generic-timeout clobber).

## Architecture / security decisions

- **Why `mediaPreload.ts` and not a new preload:** the playHLS view uses `mediaPreload.js` as its preload for the existing media-detection lifecycle (`findMedia`, `VolumeController`, snapshots, `view-loaded`/`view-stalled`). The player still relies on all of that, so the channel belongs there.
- **Closed vocabulary, not free-form text:** `reportError` looks the reason up in a fixed `MEDIA_ERROR_MESSAGES` map and only ever sends the mapped message — never caller-supplied text. `mediaPreload.ts` is also attached to **untrusted remote stream views**, so the strict mapping ensures the worst a page can do through this bridge is put its *own* tile into an error state it could already reach by simply failing to play; it cannot inject arbitrary error text into the operator UI. Unknown reasons are ignored.
- The `ALLOWED_SRC_PATTERN` sink guards inside `loadWithHlsJs`/`loadNatively` are left untouched (defense-in-depth, guarding each DOM/network sink directly); the new `loadHLS` check is purely for prompt error reporting + early return.

## Testing

- `packages/streamwall/src/preload/mediaPreload.test.ts` — the bridge is exposed; known reasons map to their fixed `view-error` messages; unknown reasons are ignored (injection attempt sends nothing).
- `packages/streamwall/src/renderer/playHLS.test.ts` — reports `hls-unsupported` when both playback paths are unavailable, reports `src-rejected` for a disallowed scheme, and does **not** report on the normal playback path.
- Full local quality gate green: `format:check`, `lint`, `typecheck`, full test suite (all workspaces).

An end-to-end drive in the packaged app isn't practical here: the trigger is an engine that can play HLS *neither* via hls.js *nor* natively (Chromium/Electron's bundled engine always can today). The unit tests exercise the exact branches by mocking `Hls.isSupported`/`canPlayType` and the `contextBridge`, consistent with how #291 was covered.

## Risks / breaking changes

None. Purely additive: a new optional `window.streamwallMedia` bridge and two early-return error reports on paths that previously fell through silently. Behavior on all playing/erroring paths that already produced a `<video>` is unchanged.