### PR TITLE
chore(control-ui): remove dead, fully-commented-out main() function

### DIFF
--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -1393,26 +1393,3 @@ const StyledStatusBar = styled.div`
     accent-color: var(--accent);
   }
 `
-
-// TODO: reuse for server
-/*
-export function main() {
-  const script = document.getElementById('main-script')
-  const wsEndpoint =
-    typeof script?.dataset?.wsEndpoint === 'string'
-      ? script.dataset.wsEndpoint
-      : 'defaultWsEndpoint'
-  const role =
-    typeof script?.dataset?.role === 'string'
-      ? (script.dataset.role as StreamwallRole)
-      : null
-
-  render(
-    <>
-      <GlobalStyle />
-      <App wsEndpoint={wsEndpoint} role={role} />
-    </>,
-    document.body,
-  )
-}
-*/


### PR DESCRIPTION
## Problem

\`packages/streamwall-control-ui/src/index.tsx\` had a \`main()\` function whose entire body was commented out (wrapped in \`/* ... */\`), including its own \`<GlobalStyle />\` + \`<App />\` render call. It predates the recent \`index.tsx\` module split (#302) and was left untouched there since it was out of scope for that pure code-organization change.

## Solution

Verified nothing depends on this export before deleting it:
- Nothing in the codebase calls \`main()\` — it was a no-op export since the whole body was a comment.
- No other package imports a \`main\` export from \`streamwall-control-ui\`; consumers (\`streamwall-control-client\`, \`streamwall\`'s renderer) only import \`ControlUI\`, \`GlobalStyle\`, and various types.
- Grepping for \`App\` (the component the dead code referenced) and \`main-script\` (the DOM id it read) turns up no matching component or usage elsewhere in the repo — confirming this was leftover scaffolding from an earlier architecture, not a live "reuse for server" plan.

Removed the block entirely (23 lines deleted, no other changes).

## Testing performed

Pure dead-code deletion with no behavior change (the removed code was 100% inside a comment, so it never executed) — no new tests needed per the TDD exception for changes with no testable behavior. Ran the full quality gate to confirm no regressions:
- \`npm run format:check\` — clean
- \`npm run lint\` — clean
- \`npm run typecheck\` (all workspaces) — clean
- \`npm test\` (all workspaces) — 302 tests passing (206 control-ui + 96 control-server)
- \`npm -w streamwall-control-client run build\` — succeeds (mirrors the CI "Build (web control client)" job)

## Risks / breaking changes

None. The removed code was inert (fully commented out, unreachable) and not part of any package's public surface.

Closes #312