### PR TITLE
fix(streamwall): reuse a running actor's view across a genuine content change

### DIFF
--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -1,4 +1,8 @@
-import type { StreamWindowConfig, ViewContentMap } from 'streamwall-shared'
+import type {
+  StreamWindowConfig,
+  ViewContent,
+  ViewContentMap,
+} from 'streamwall-shared'
 import { describe, expect, it, vi } from 'vitest'
 
 // StreamWindow pulls in Electron (directly and via ./loadHTML and
@@ -244,6 +248,217 @@ describe('StreamWindow.setViews', () => {
       next.view,
       next.offscreenWin,
     )
+  })
+})
+
+/**
+ * A stand-in for a ViewActor whose `getSnapshot().matches({ displaying:
+ * 'running' })` responds according to `running`, for exercising setViews'
+ * space-overlap-only matcher (issue #311): it must only reuse an actor that
+ * is actually in the `running` state, since neither `loading` nor `error`
+ * have a DISPLAY handler of their own for changed content -- the event would
+ * bubble to `displaying`'s handler, whose `contentUnchanged` guard would then
+ * silently swallow it, stranding the actor on its old content forever.
+ */
+function makeReuseTestActor(opts: {
+  id: number
+  content: ViewContent | null
+  spaces: number[]
+  running: boolean
+}) {
+  const send = vi.fn()
+  const stop = vi.fn()
+  const disposeView = vi.fn()
+  const actor = {
+    getSnapshot: () => ({
+      context: {
+        id: opts.id,
+        content: opts.content,
+        pos: { spaces: opts.spaces },
+        view: {},
+        offscreenWin: {},
+        next: null,
+        disposeView,
+      },
+      matches: (query: { displaying: string }) =>
+        opts.running && query.displaying === 'running',
+    }),
+    send,
+    stop,
+  } as unknown as ReturnType<typeof StreamWindow.prototype.createView>
+  return { actor, send, stop, disposeView }
+}
+
+describe('StreamWindow.setViews reusing an actor across a genuine content change', () => {
+  it('sends DISPLAY to the running actor already occupying a box space instead of tearing it down and creating a new view (issue #311)', () => {
+    const sw = makeStreamWindow(makeConfig({ cols: 1, rows: 1 }))
+    sw.win = {
+      contentView: { removeChildView: vi.fn() },
+    } as unknown as InstanceType<typeof StreamWindow>['win']
+
+    const streamA: ViewContent = {
+      url: 'https://example.com/a',
+      kind: 'video',
+    }
+    const streamB: ViewContent = {
+      url: 'https://example.com/b',
+      kind: 'video',
+    }
+    const { actor, send, stop } = makeReuseTestActor({
+      id: 1,
+      content: streamA,
+      spaces: [0],
+      running: true,
+    })
+    sw.views = new Map([[1, actor]])
+    sw.createView = vi.fn()
+
+    // Space 0 now requests streamB instead of the streamA the actor there is
+    // currently displaying -- a genuine content change, e.g. a playlist
+    // advance or a drag-to-place reassignment.
+    const viewContentMap: ViewContentMap = new Map([['0', streamB]])
+    const streams = { byURL: new Map([[streamB.url, {}]]) }
+
+    sw.setViews(viewContentMap, streams)
+
+    expect(sw.createView).not.toHaveBeenCalled()
+    expect(stop).not.toHaveBeenCalled()
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'DISPLAY', content: streamB }),
+    )
+    expect(sw.views.get(1)).toBe(actor)
+  })
+
+  it('does not reuse a still-loading actor across a content change, since the state machine has no handler that would apply it', () => {
+    const sw = makeStreamWindow(makeConfig({ cols: 1, rows: 1 }))
+    sw.win = {
+      contentView: { removeChildView: vi.fn() },
+    } as unknown as InstanceType<typeof StreamWindow>['win']
+
+    const streamA: ViewContent = {
+      url: 'https://example.com/a',
+      kind: 'video',
+    }
+    const streamB: ViewContent = {
+      url: 'https://example.com/b',
+      kind: 'video',
+    }
+    const { actor, send, stop, disposeView } = makeReuseTestActor({
+      id: 1,
+      content: streamA,
+      spaces: [0],
+      running: false,
+    })
+    sw.views = new Map([[1, actor]])
+    const { actor: newActor, send: newSend } = makeReuseTestActor({
+      id: 2,
+      content: null,
+      spaces: [],
+      running: false,
+    })
+    sw.createView = vi.fn(() => newActor)
+
+    const viewContentMap: ViewContentMap = new Map([['0', streamB]])
+    const streams = { byURL: new Map([[streamB.url, {}]]) }
+
+    sw.setViews(viewContentMap, streams)
+
+    expect(sw.createView).toHaveBeenCalledTimes(1)
+    expect(send).not.toHaveBeenCalled()
+    expect(stop).toHaveBeenCalled()
+    expect(disposeView).toHaveBeenCalled()
+    expect(newSend).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'DISPLAY', content: streamB }),
+    )
+  })
+
+  it('still prefers an exact same-content match over the space-overlap fallback when both apply to different boxes', () => {
+    const sw = makeStreamWindow(makeConfig({ cols: 3, rows: 1 }))
+    sw.win = {
+      contentView: { removeChildView: vi.fn() },
+    } as unknown as InstanceType<typeof StreamWindow>['win']
+
+    const streamA: ViewContent = {
+      url: 'https://example.com/a',
+      kind: 'video',
+    }
+    const streamB: ViewContent = {
+      url: 'https://example.com/b',
+      kind: 'video',
+    }
+    const streamC: ViewContent = {
+      url: 'https://example.com/c',
+      kind: 'video',
+    }
+    const streamE: ViewContent = {
+      url: 'https://example.com/e',
+      kind: 'video',
+    }
+    // Occupies space 0, showing stale content A that nothing wants anymore --
+    // a candidate for the space-overlap fallback once space 0 asks for
+    // something new.
+    const spaceOnly = makeReuseTestActor({
+      id: 1,
+      content: streamA,
+      spaces: [0],
+      running: true,
+    })
+    // Occupies space 1, but its content B is requested by a different box
+    // (space 2) -- a candidate for the exact-content matcher, which must
+    // claim it (and reposition it there) before the fallback matcher ever
+    // runs, regardless of which space it currently sits in.
+    const moved = makeReuseTestActor({
+      id: 2,
+      content: streamB,
+      spaces: [1],
+      running: true,
+    })
+    sw.views = new Map([
+      [1, spaceOnly.actor],
+      [2, moved.actor],
+    ])
+    const { actor: newActor, send: newSend } = makeReuseTestActor({
+      id: 3,
+      content: null,
+      spaces: [],
+      running: false,
+    })
+    sw.createView = vi.fn(() => newActor)
+
+    const viewContentMap: ViewContentMap = new Map([
+      ['0', streamC], // genuine content change -> should reuse spaceOnly
+      ['1', streamE], // unrelated new content -> no existing actor fits
+      ['2', streamB], // same content as `moved`, elsewhere -> should reuse moved
+    ])
+    const streams = {
+      byURL: new Map([
+        [streamB.url, {}],
+        [streamC.url, {}],
+        [streamE.url, {}],
+      ]),
+    }
+
+    sw.setViews(viewContentMap, streams)
+
+    // Only the unrelated box (space 1) needed a brand-new view.
+    expect(sw.createView).toHaveBeenCalledTimes(1)
+    expect(newSend).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'DISPLAY', content: streamE }),
+    )
+
+    // The exact-content match reused `moved` for its new space instead of
+    // being pre-empted by the space-overlap fallback.
+    expect(moved.send).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'DISPLAY', content: streamB }),
+    )
+    expect(moved.stop).not.toHaveBeenCalled()
+
+    // The space-overlap fallback reused `spaceOnly` for its box's genuinely
+    // new content instead of tearing it down.
+    expect(spaceOnly.send).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'DISPLAY', content: streamC }),
+    )
+    expect(spaceOnly.stop).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -439,6 +439,19 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
         v.matches({ displaying: 'running' }),
       // Then try view with the same URL that is still loading...
       (v, content) => isEqual(v.context.content, content),
+      // Finally, if no view already shows this content, reuse whichever
+      // running view already occupies the box's space regardless of its
+      // content, so a genuine content change (a playlist advance, a
+      // drag-to-place reassignment) reuses the actor already there via a
+      // DISPLAY event -- letting `running`'s own swap handling take over --
+      // instead of always tearing it down and creating a brand-new one.
+      // Scoped to `running` only: `loading`/`error` have no DISPLAY handler
+      // of their own for changed content, so the event would bubble up to
+      // `displaying`'s handler, whose `contentUnchanged` guard would then
+      // silently drop it and strand the actor on its old content.
+      (v, _content, spaces) =>
+        v.matches({ displaying: 'running' }) &&
+        intersection(v.context.pos?.spaces, spaces).length > 0,
     ]
 
     for (const matcher of matchers) {


### PR DESCRIPTION
## Problem

`StreamWindow.setViews()` reconciles the current grid against a freshly-rebuilt `viewContentMap` using three matchers, all of which require the candidate view's *current* content to already equal the box's requested content:

```js
const matchers = [
  (v, content, spaces) => isEqual(v.context.content, content) && v.matches({ displaying: 'running' }) && intersection(...).length > 0,
  (v, content) => isEqual(v.context.content, content) && v.matches({ displaying: 'running' }),
  (v, content) => isEqual(v.context.content, content),
]
```

When a cell's content genuinely changes (e.g. a playlist advances from stream A to stream B, or a drag-to-place reassignment), no existing view already shows B, so none of the matchers select the actor currently showing A for that space. That actor lands in `unusedViews` and is torn down; a brand-new actor is created via `createView()` instead — meaning the actor showing A never receives a `DISPLAY` event with content B at all.

As a result, the offscreen-shuffle fix from #198/#234 and the preload/seamless-swap work from #238/#306 (both implemented at the `viewStateMachine` level in `running.on.DISPLAY`) were effectively dead code from the real application's perspective: a genuine playlist advance or reassignment went through full actor teardown + fresh `createView()` every time, which is *more* expensive than either the pre-#234 full-reload-in-place or the #306 preload/swap it was meant to replace.

## Solution

Add a fourth, lowest-priority matcher to `setViews()` that reuses a `running` actor purely by space overlap when no content match exists, so the new content reaches it via a `DISPLAY` event and takes the `running.on.DISPLAY` content-changed path (preload + swap) instead of a full teardown/recreate.

Scoped to `displaying: 'running'` only: `loading`/`error` have no `DISPLAY` handler of their own for changed content, so the event would bubble up to `displaying`'s own handler, whose `contentUnchanged` guard would then silently drop it — reusing a non-running actor this way would strand it on its stale content forever instead of applying the new one. Only actors already fully `running` are safe to reuse this way.

Matcher priority is otherwise unchanged: an exact content match (moved to a new position) still wins over the space-overlap fallback, since matchers run in priority order across all boxes before the next matcher is tried.

## Testing

Added `packages/streamwall/src/main/StreamWindow.test.ts` coverage (TDD — written first, confirmed failing against the old matcher set, then made to pass):

- A genuine content change on a space occupied by a `running` actor now sends it `DISPLAY` and reuses it, instead of tearing it down and calling `createView()`.
- A still-`loading` actor is *not* reused across a content change (would silently strand it, per the guard reasoning above) — the box still falls through to `createView()`.
- An exact same-content match (a moved stream) still takes priority over the space-overlap fallback when both could apply, across separate boxes in the same `setViews()` call.

Full quality gate run locally: `format:check`, `lint`, `typecheck`, `test` (all workspaces) and the control-client `build` — all green.

## Risk / breaking changes

None expected for existing behavior: the new matcher only activates when none of the three existing (higher-priority) matchers found a match, so same-content moves and same-content-in-place cases are unaffected. The only behavior change is that a genuine content change on an already-running cell now goes through the existing preload/swap machinery instead of full actor teardown — which is exactly the intended effect of #234/#306, now actually reachable.

Closes #311