### PR TITLE
fix(streamwall): catch mediaPreload's initial acquireMedia() rejection

### DIFF
--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const executeJavaScript = vi.fn()
 // Never resolves, so the assertions below can prove the visibility spoof
@@ -92,5 +92,79 @@ describe('mediaPreload error channel', () => {
     importedMediaApi().reportError('<img src=x onerror=alert(1)>')
 
     expect(send).not.toHaveBeenCalledWith('view-error', expect.anything())
+  })
+})
+
+describe('mediaPreload initial acquireMedia rejection', () => {
+  // Must match INITIAL_TIMEOUT in mediaPreload.ts; not exported since it's an
+  // implementation detail, not part of the module's public surface.
+  const INITIAL_TIMEOUT_MS = 10 * 1000
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.resetModules()
+    invoke.mockClear()
+    send.mockClear()
+    exposeInMainWorld.mockClear()
+  })
+
+  function viewErrorCalls() {
+    return send.mock.calls.filter(([channel]) => channel === 'view-error')
+  }
+
+  // Resolves view-init with 'video' content (so main() reaches the
+  // acquireMedia() call) and fires process's 'loaded' event (so main()'s own
+  // pageReady wait resolves). The module-scope DOMContentLoaded-gated
+  // pageReady used by waitForQuery is deliberately left unresolved, so no
+  // <video> element is ever "found" and the INITIAL_TIMEOUT sleep always
+  // wins the race in findMedia().
+  async function loadWithVideoContent() {
+    invoke.mockResolvedValueOnce({
+      content: { kind: 'video', link: 'https://example.com/stream' },
+      options: {},
+      volume: 1,
+    })
+    await import('./mediaPreload')
+    process.emit('loaded' as never)
+    await vi.advanceTimersByTimeAsync(0)
+  }
+
+  it("reports findMedia's specific timeout instead of leaving it an unhandled rejection", async () => {
+    await loadWithVideoContent()
+
+    await vi.advanceTimersByTimeAsync(INITIAL_TIMEOUT_MS)
+
+    expect(viewErrorCalls()).toEqual([
+      [
+        'view-error',
+        { error: expect.objectContaining({ message: 'could not find video' }) },
+      ],
+    ])
+  })
+
+  it('does not let a late generic timeout override an already-reported playHLS error', async () => {
+    await loadWithVideoContent()
+
+    importedMediaApi().reportError('hls-unsupported')
+    expect(viewErrorCalls()).toHaveLength(1)
+
+    await vi.advanceTimersByTimeAsync(INITIAL_TIMEOUT_MS)
+
+    expect(viewErrorCalls()).toHaveLength(1)
+  })
+
+  it('does not let a late playHLS report override an already-reported generic timeout', async () => {
+    await loadWithVideoContent()
+
+    await vi.advanceTimersByTimeAsync(INITIAL_TIMEOUT_MS)
+    expect(viewErrorCalls()).toHaveLength(1)
+
+    importedMediaApi().reportError('hls-unsupported')
+
+    expect(viewErrorCalls()).toHaveLength(1)
   })
 })

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -319,12 +319,19 @@ const MEDIA_ERROR_MESSAGES: Record<string, string> = {
   'src-rejected': 'Stream source rejected (disallowed URL scheme)',
 }
 
+// Guards against reporting more than one view-error per preload load: the
+// playHLS reportError() channel and findMedia's own timeout race each other
+// for the same view, and only the first (more specific, where applicable)
+// cause should reach the operator.
+let hasReportedMediaError = false
+
 const mediaApi = {
   reportError(reason: string) {
     const message = MEDIA_ERROR_MESSAGES[reason]
-    if (message === undefined) {
+    if (message === undefined || hasReportedMediaError) {
       return
     }
+    hasReportedMediaError = true
     ipcRenderer.send('view-error', { error: message })
   },
 }
@@ -381,7 +388,19 @@ async function main() {
 
   if (content.kind === 'video' || content.kind === 'audio') {
     webFrame.insertCSS(VIDEO_OVERRIDE_STYLE, { cssOrigin: 'user' })
-    acquireMedia(INITIAL_TIMEOUT)
+    // Unlike the re-acquisition triggered by the 'emptied' listener inside
+    // acquireMedia (which is awaited within that async handler), this first
+    // call is fire-and-forget from main()'s perspective, so its rejection
+    // must be caught here or it becomes an unhandled rejection and
+    // findMedia's specific reason (e.g. "could not find video") never
+    // reaches the operator -- see #309.
+    acquireMedia(INITIAL_TIMEOUT).catch((error) => {
+      if (hasReportedMediaError) {
+        return
+      }
+      hasReportedMediaError = true
+      ipcRenderer.send('view-error', { error })
+    })
     ipcRenderer.send('view-info', {
       info: {
         title: document.title,


### PR DESCRIPTION
## Problem

In `mediaPreload.ts`, `main()` kicks off the first media acquisition fire-and-forget:

```ts
if (content.kind === 'video' || content.kind === 'audio') {
  webFrame.insertCSS(VIDEO_OVERRIDE_STYLE, { cssOrigin: 'user' })
  acquireMedia(INITIAL_TIMEOUT)      // not awaited, no .catch
  ipcRenderer.send('view-info', { ... })
}
```

`acquireMedia()` → `findMedia()` throws (`'could not find video'` / `'timeout waiting for video to start'`) when no `<video>`/`<audio>` element appears within `INITIAL_TIMEOUT` (10s). Because this call is neither awaited nor `.catch`-ed, the rejection becomes an **unhandled promise rejection** in the renderer — `main().catch(...)` only wraps `main()`'s synchronous body, not the detached `acquireMedia` promise.

Impact:
1. `findMedia`'s specific error reasons never reached the operator.
2. A view that will never produce a `<video>` showed a black tile for ~45s (the state machine's generic `LOADING_TIMEOUT`) instead of ~10s, with a less informative message.
3. An unhandled-rejection console warning fired on every such view.

## Solution

Attach a `.catch()` to the initial `acquireMedia(INITIAL_TIMEOUT)` call that forwards the error via the same `ipcRenderer.send('view-error', { error })` path `main().catch` already uses, so `findMedia`'s specific reasons surface promptly (~10s instead of ~45s).

Since PR #308 added a separate `playHLS` → `reportError()` channel for the "can never play" case (which also targets the same view via `view-error`), both paths can now race to report the same failure. Added a module-scoped `hasReportedMediaError` guard, checked/set symmetrically in both `mediaApi.reportError` and the new `.catch` handler, so only the first cause reaches the operator regardless of which fires first.

## Testing

Added three tests to `mediaPreload.test.ts` driving `main()`'s real `acquireMedia` flow with fake timers (video content that never appears in the DOM, so the `INITIAL_TIMEOUT` sleep always wins the race):
- the initial timeout is now reported via `view-error` instead of becoming an unhandled rejection
- a `playHLS`-reported error is not overridden by a later generic timeout
- a generic timeout that already fired is not overridden by a later `playHLS` report

Full quality gate run locally: `format:check`, `lint`, `typecheck` (all workspaces), `test` (all workspaces — 302 tests), and the control-client `build` — all green.

## Risks / breaking changes

None. Purely additive error handling on an existing IPC channel; no public API changes.

Closes #309