### PR TITLE
fix(control-ui): translate stray German placeholder to English

### DIFF
--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -954,7 +954,7 @@ export function ControlUI({
                 className="filter-input"
                 onChange={handleStreamFilterChange}
                 value={streamFilter}
-                placeholder="Quellen filtern…"
+                placeholder="Filter streams…"
               />
               <h3>
                 Viewing <span className="ct">{wallStreams.length}</span>


### PR DESCRIPTION
## Summary
- The stream filter input in the control UI had a German placeholder (`"Quellen filtern…"`) while the rest of the codebase's UI copy is English-only.
- Replaced it with `"Filter streams…"` to match project convention.
- Swept `streamwall-control-ui`, `streamwall-control-client`, `streamwall/src/renderer`, and `overlay` for other stray non-English strings — none found.

## Test plan
- [x] Verified no remaining non-English UI strings via grep across the checked packages