### PR TITLE
fix(streamwall): catch mediaPreload's emptied re-acquisition rejection

### DIFF
--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -168,3 +168,70 @@ describe('mediaPreload initial acquireMedia rejection', () => {
     expect(viewErrorCalls()).toHaveLength(1)
   })
 })
+
+describe("mediaPreload emptied handler's re-acquisition rejection", () => {
+  // Must match INITIAL_TIMEOUT in mediaPreload.ts; not exported since it's an
+  // implementation detail, not part of the module's public surface.
+  const INITIAL_TIMEOUT_MS = 10 * 1000
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.resetModules()
+    invoke.mockClear()
+    send.mockClear()
+    exposeInMainWorld.mockClear()
+    document.body.innerHTML = ''
+  })
+
+  function viewErrorCalls() {
+    return send.mock.calls.filter(([channel]) => channel === 'view-error')
+  }
+
+  it("reports the emptied handler's re-acquisition timeout instead of leaving it an unhandled rejection", async () => {
+    const video = document.createElement('video')
+    // happy-dom's HTMLVideoElement never implements videoWidth (always
+    // undefined), so give it a truthy value here to skip findMedia's "wait
+    // for playing" branch on the initial acquisition and let it resolve
+    // immediately once the element is found.
+    ;(video as unknown as { videoWidth: number }).videoWidth = 100
+    document.body.appendChild(video)
+
+    invoke.mockResolvedValueOnce({
+      content: { kind: 'video', link: 'https://example.com/stream' },
+      options: {},
+      volume: 1,
+    })
+
+    await import('./mediaPreload')
+    document.dispatchEvent(new Event('DOMContentLoaded'))
+    process.emit('loaded' as never)
+    await vi.advanceTimersByTimeAsync(0)
+
+    // Confirms the initial acquisition succeeded and attached the 'emptied'
+    // listener under test, rather than this test accidentally exercising
+    // the initial-acquisition rejection path covered above.
+    expect(send).toHaveBeenCalledWith('view-loaded')
+
+    // A real emptied element resets its own readiness; re-acquisition finds
+    // the same <video> again, but this time nothing ever fires 'playing',
+    // so findMedia's fixed-INITIAL_TIMEOUT wait rejects.
+    ;(video as unknown as { videoWidth: number }).videoWidth = 0
+    video.dispatchEvent(new Event('emptied'))
+    await vi.advanceTimersByTimeAsync(INITIAL_TIMEOUT_MS)
+
+    expect(viewErrorCalls()).toEqual([
+      [
+        'view-error',
+        {
+          error: expect.objectContaining({
+            message: 'timeout waiting for video to start',
+          }),
+        },
+      ],
+    ])
+  })
+})

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -376,9 +376,23 @@ async function main() {
         ipcRenderer.send('view-stalled')
         clearInterval(snapshotInterval)
 
-        const newMedia = await acquireMedia(Infinity)
-        if (newMedia !== media) {
-          media.remove()
+        // Unlike main()'s own top-level acquireMedia() call, this one is
+        // awaited within the handler itself, so a plain .catch() chained
+        // onto it wouldn't help: EventTarget.addEventListener discards
+        // whatever an async listener returns, so a rejection here becomes
+        // an unhandled rejection on the listener's own detached promise
+        // unless it's caught in place -- see #316 (same root cause as #309).
+        try {
+          const newMedia = await acquireMedia(Infinity)
+          if (newMedia !== media) {
+            media.remove()
+          }
+        } catch (error) {
+          if (hasReportedMediaError) {
+            return
+          }
+          hasReportedMediaError = true
+          ipcRenderer.send('view-error', { error })
         }
       },
       { once: true },


### PR DESCRIPTION
## Problem

The `emptied` re-acquisition path in `packages/streamwall/src/preload/mediaPreload.ts` has the same class of bug as #309 (fixed in #315), one level removed:

```ts
media.addEventListener(
  'emptied',
  async () => {
    console.warn('media emptied, re-acquiring', media)
    ipcRenderer.send('view-stalled')
    clearInterval(snapshotInterval)

    const newMedia = await acquireMedia(Infinity)   // <-- awaited within this handler...
    if (newMedia !== media) {
      media.remove()
    }
  },
  { once: true },
)
```

The `await` here only means a rejection propagates to the async arrow function's own returned promise — nothing catches *that* promise, since `EventTarget.addEventListener` discards whatever a listener returns. If `acquireMedia(Infinity)` rejects, this is an unhandled promise rejection.

This can happen despite the `Infinity` argument: `findMedia`'s second wait (for the video to actually start playing) always uses the fixed `INITIAL_TIMEOUT` (10s) regardless of the `elementTimeout` passed to `findMedia`/`acquireMedia`. So a media element that reappears after `emptied` but never starts playing within 10s still throws, and that throw goes unhandled — the specific error reason is lost and the view can be left silently stuck.

## Solution

Wrap the re-acquisition in a `try/catch` and forward the caught error via the same `view-error` channel used elsewhere, reusing the `hasReportedMediaError` double-report guard introduced in #315 so this doesn't race with (or override) a report already sent via the playHLS channel or the initial-acquisition path.

## Testing

Added a test (TDD: written first, confirmed it failed with the exact unhandled `'timeout waiting for video to start'` rejection against the unfixed code) that:
1. Lets the initial `acquireMedia` succeed by giving the `<video>` element a truthy `videoWidth` (happy-dom never implements this property natively, so it's always falsy by default).
2. Fires `emptied` on that element, resets `videoWidth` to simulate a real emptied element, and advances fake timers past `INITIAL_TIMEOUT`.
3. Asserts the specific `'timeout waiting for video to start'` error is now reported via `view-error` instead of being swallowed.

Full quality gate run locally: Prettier, ESLint, `tsc --noEmit`, and the full `streamwall` package test suite (363 tests) all pass.

## Risks / breaking changes

None — this only adds error reporting to a path that previously failed silently (or crashed the renderer process via an unhandled rejection).

Closes #316