### PR TITLE
fix(streamwall): stop echoing control uplink Yjs updates back to the server

### DIFF
--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -61,6 +61,7 @@ import { flushStorage, loadStorage, safeUpdate } from './storage'
 import StreamdelayClient from './StreamdelayClient'
 import StreamWindow from './StreamWindow'
 import TwitchBot from './TwitchBot'
+import { UPLINK_ORIGIN, shouldForwardUpdateToUplink } from './uplinkEcho'
 import { initializeViewsState } from './viewsStateInit'
 import {
   shouldHideInsteadOfQuit,
@@ -839,7 +840,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     })
     ws.addEventListener('message', (ev) => {
       if (ev.data instanceof ArrayBuffer) {
-        Y.applyUpdate(stateDoc, new Uint8Array(ev.data))
+        Y.applyUpdate(stateDoc, new Uint8Array(ev.data), UPLINK_ORIGIN)
         return
       }
 
@@ -872,8 +873,8 @@ async function main(argv: ReturnType<typeof parseArgs>) {
       }
       ws.send(JSON.stringify({ type: 'state', state: clientState }))
     })
-    stateDoc.on('update', (update) => {
-      if (!isSocketOpen(ws)) {
+    stateDoc.on('update', (update, origin) => {
+      if (!shouldForwardUpdateToUplink(origin) || !isSocketOpen(ws)) {
         return
       }
       ws.send(update)

--- a/packages/streamwall/src/main/uplinkEcho.test.ts
+++ b/packages/streamwall/src/main/uplinkEcho.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { UPLINK_ORIGIN, shouldForwardUpdateToUplink } from './uplinkEcho'
+
+describe('shouldForwardUpdateToUplink', () => {
+  it('skips an update whose origin is the uplink itself', () => {
+    expect(shouldForwardUpdateToUplink(UPLINK_ORIGIN)).toBe(false)
+  })
+
+  it('forwards updates with no origin (e.g. local control window edits)', () => {
+    expect(shouldForwardUpdateToUplink(undefined)).toBe(true)
+    expect(shouldForwardUpdateToUplink(null)).toBe(true)
+  })
+
+  it('forwards updates tagged with an unrelated origin', () => {
+    expect(shouldForwardUpdateToUplink('app')).toBe(true)
+  })
+})

--- a/packages/streamwall/src/main/uplinkEcho.ts
+++ b/packages/streamwall/src/main/uplinkEcho.ts
@@ -1,0 +1,11 @@
+/**
+ * Yjs update origin tag applied to updates received over the control
+ * uplink WebSocket. Lets the uplink's own outgoing `stateDoc.on('update', ...)`
+ * listener recognize updates it just received and skip echoing them straight
+ * back to the same control server that sent them (issue #268).
+ */
+export const UPLINK_ORIGIN = 'uplink'
+
+export function shouldForwardUpdateToUplink(origin: unknown): boolean {
+  return origin !== UPLINK_ORIGIN
+}


### PR DESCRIPTION
## Problem

The Electron main process's control uplink WebSocket connection had a Yjs update echo bug:

- `ws.addEventListener('message', ...)` applied incoming binary Yjs updates via `Y.applyUpdate(stateDoc, ...)` with no `origin` argument.
- The outgoing `stateDoc.on('update', ...)` listener that relays doc changes to the control server sent every update, without filtering by origin.

So every Yjs update *received from* the control server (e.g. a browser client dragging a stream onto a grid cell, relayed by the control server) got applied locally, fired Yjs's `update` event, and was immediately sent right back to the same server that just sent it. This wastes bandwidth on every such change and, depending on how the control server's Yjs merge/broadcast logic handles receiving back an update it just sent, could also cause redundant broadcast fan-out to other connected clients.

`streamwall-control-client` (the browser control client) already gets this right via a `sendUpdate`/`receiveUpdate` pair tagged with a `'server'` origin. The Electron main process's uplink handling was missing the equivalent.

## Solution

Added `packages/streamwall/src/main/uplinkEcho.ts`, a small pure module (following the existing pattern of `windowCloseBehavior.ts`, `viewsStateInit.ts`, etc.) exporting:

- `UPLINK_ORIGIN` — the origin tag applied to updates received over the uplink.
- `shouldForwardUpdateToUplink(origin)` — returns `false` for updates tagged with `UPLINK_ORIGIN`.

Wired into `packages/streamwall/src/main/index.ts`:

- The uplink's `Y.applyUpdate` call now tags applied updates with `UPLINK_ORIGIN`.
- The uplink's outgoing `stateDoc.on('update', (update, origin) => ...)` listener now skips re-sending when `shouldForwardUpdateToUplink(origin)` is `false`.

## Testing

Added `packages/streamwall/src/main/uplinkEcho.test.ts` covering:
- an update tagged with `UPLINK_ORIGIN` is not forwarded
- an untagged update (local origin) is forwarded
- an update tagged with an unrelated origin is forwarded

Ran the full quality gate:
- `npx prettier --check` on changed files
- `npm run lint` (repo-wide, clean)
- `npm run typecheck` (all workspaces, clean)
- `npm run test` (repo-wide: 365 streamwall tests, 96 control-server tests, 206 control-ui tests, all passing)
- `electron-forge package` (app packages successfully)

## Risks / breaking changes

None. This only changes which Yjs updates get re-sent over the uplink WebSocket; it doesn't change any externally observable command/state protocol. The local control window's IPC channel (`controlWindow.on('ydoc', ...)` / `stateDoc.on('update', ...) -> controlWindow.onYDocUpdate`) is untouched — that's a separate code path with a similar-shaped but distinct issue, tracked separately (see linked follow-up issue below).

Closes #268