### PR TITLE
fix(control-ui): validate create-invite response against Invite shape

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15296,7 +15296,8 @@
         "streamwall-shared": "*",
         "styled-components": "^6.4.3",
         "xstate": "^5.32.5",
-        "yjs": "^13.6.31"
+        "yjs": "^13.6.31",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@preact/preset-vite": "^2.10.5",

--- a/packages/streamwall-control-ui/package.json
+++ b/packages/streamwall-control-ui/package.json
@@ -20,7 +20,8 @@
     "streamwall-shared": "*",
     "styled-components": "^6.4.3",
     "xstate": "^5.32.5",
-    "yjs": "^13.6.31"
+    "yjs": "^13.6.31",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.10.5",

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -48,6 +48,7 @@ import { GridPreviewBox } from './GridPreviewBox.tsx'
 import { GridSizeControls } from './GridSizeControls.tsx'
 import { hotkeyLayerBindings, hotkeyTriggers } from './hotkeyLabel.ts'
 import './index.css'
+import { type Invite, parseInviteResponse } from './invite.ts'
 import { LayoutPresetControls } from './LayoutPresetControls.tsx'
 import { ResizeHandles } from './ResizeHandles.tsx'
 import {
@@ -75,12 +76,6 @@ export interface ViewInfo {
   isBlurred: boolean
   volume: number
   spaces: number[]
-}
-
-interface Invite {
-  tokenId: string
-  name: string
-  secret: string
 }
 
 const normalStreamKinds = new Set(['video', 'audio', 'web'])
@@ -502,11 +497,18 @@ export function ControlUI({
           role,
         },
         (msg) => {
-          setNewInvite(msg as Invite) // TODO: validate w/ Zod
+          const invite = parseInviteResponse(msg)
+          if (!invite) {
+            setCommandError(
+              'Received a malformed invite response from the server',
+            )
+            return
+          }
+          setNewInvite(invite)
         },
       )
     },
-    [send],
+    [send, setCommandError],
   )
 
   const handleDeleteToken = useCallback(

--- a/packages/streamwall-control-ui/src/invite.test.ts
+++ b/packages/streamwall-control-ui/src/invite.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'vitest'
+import { parseInviteResponse } from './invite.ts'
+
+describe('parseInviteResponse', () => {
+  test('accepts a well-formed invite response', () => {
+    expect(
+      parseInviteResponse({
+        tokenId: 'tok-1',
+        name: 'Alex',
+        secret: 's3cret',
+      }),
+    ).toEqual({
+      tokenId: 'tok-1',
+      name: 'Alex',
+      secret: 's3cret',
+    })
+  })
+
+  test('strips unrelated fields alongside a valid invite', () => {
+    expect(
+      parseInviteResponse({
+        response: true,
+        id: 0,
+        tokenId: 'tok-1',
+        name: 'Alex',
+        secret: 's3cret',
+      }),
+    ).toEqual({
+      tokenId: 'tok-1',
+      name: 'Alex',
+      secret: 's3cret',
+    })
+  })
+
+  test('rejects a response missing the secret', () => {
+    expect(parseInviteResponse({ tokenId: 'tok-1', name: 'Alex' })).toBeNull()
+  })
+
+  test('rejects a response with a non-string tokenId', () => {
+    expect(
+      parseInviteResponse({ tokenId: 42, name: 'Alex', secret: 's3cret' }),
+    ).toBeNull()
+  })
+
+  test('rejects an empty object', () => {
+    expect(parseInviteResponse({})).toBeNull()
+  })
+
+  test('rejects non-object responses', () => {
+    expect(parseInviteResponse(undefined)).toBeNull()
+    expect(parseInviteResponse(null)).toBeNull()
+    expect(parseInviteResponse('tok-1')).toBeNull()
+    expect(parseInviteResponse(42)).toBeNull()
+  })
+})

--- a/packages/streamwall-control-ui/src/invite.ts
+++ b/packages/streamwall-control-ui/src/invite.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod'
+
+/**
+ * Runtime shape of a successful `create-invite` response. The control server
+ * only sends this once the response has already been checked for an
+ * `{ error }` shape (see `commandError.ts`), but a server-side bug, future
+ * field rename, or client/server version skew could still send a "success"
+ * payload that doesn't actually match — so this is validated rather than
+ * cast (issue #296).
+ */
+export const inviteResponseSchema = z.object({
+  tokenId: z.string(),
+  name: z.string(),
+  secret: z.string(),
+})
+
+export type Invite = z.infer<typeof inviteResponseSchema>
+
+/** Validates an untrusted `create-invite` response, returning `null` instead of throwing or silently accepting malformed data. */
+export function parseInviteResponse(response: unknown): Invite | null {
+  const result = inviteResponseSchema.safeParse(response)
+  return result.success ? result.data : null
+}


### PR DESCRIPTION
## Problem

`handleCreateInvite` blindly cast a successful `create-invite` response to `Invite`:

```ts
(msg) => {
  setNewInvite(msg as Invite) // TODO: validate w/ Zod
},
```

`createErrorSurfacingSend` (from #287) already routes `{ error }`-shaped responses to the shared `CommandErrorBanner`, so a dropped/rejected request is handled. But a *successful* response that doesn't actually match `{ tokenId, name, secret }` — a server-side bug, a future field rename, a client/server version skew — was accepted silently, and the UI would render a broken invite panel (`undefined` tokenId/secret/name) with no error surfaced.

## Solution

- Added `packages/streamwall-control-ui/src/invite.ts` with a Zod schema (`inviteResponseSchema`) describing the expected `create-invite` response shape, and `parseInviteResponse()`, which validates and returns `null` on a mismatch instead of throwing or silently accepting bad data.
- `handleCreateInvite` now calls `parseInviteResponse`; on `null` it reports the malformed response through the existing `setCommandError`/`CommandErrorBanner` path (the same UI path errors already use), instead of setting broken invite state.
- Removed the local `interface Invite` in favor of the type inferred from the Zod schema (`z.infer<typeof inviteResponseSchema>`), matching the pattern already used in `streamwall-shared/src/schemas.ts` for other command payloads.
- Added `zod` as a direct dependency of `streamwall-control-ui` (previously only pulled in transitively via `streamwall-shared`).

## Architecture decisions

- Kept the schema/validator in a small, focused, independently testable module (`invite.ts`) rather than inlining it in the already-large `index.tsx`, consistent with the module split from #302.
- Reused the existing `setCommandError` banner instead of introducing a new error-display mechanism, so malformed responses and server-reported errors look the same to the operator.

## Testing performed

- New `invite.test.ts`: valid response, extra/unrelated fields stripped, missing field, wrong field type, empty object, non-object inputs (`undefined`/`null`/string/number) — all rejected as `null`.
- Full workspace quality gate: `npm run format:check`, `npm run lint`, `npm run typecheck` (all 5 packages), `npm test` (all 5 packages, 212 control-ui tests + 96 control-server tests + others), and `streamwall-control-client`'s `vite build` — all green.

## Risks / breaking changes

None. Purely additive runtime validation on an already-narrow response path; the happy path (well-formed server response) is unchanged.

## Follow-ups

Two related, out-of-scope unchecked casts were found nearby and filed separately rather than folded into this change:
- #321 — `AccessPanel.tsx`'s role `<select>` value is cast to `StreamwallRole` instead of validated against `validRoles`.
- #322 — `useYDoc.ts` casts the Yjs doc snapshot to the generic `T` with no runtime validation.

Closes #296