### PR TITLE
feat(control-ui): extend blur hotkey past 20 cells for parity with audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,9 +204,14 @@ The following hotkeys are available with a "control" webpage focused, whether
 that's the Electron control UI or the standalone web control client:
 
 - **alt+[1...9,0,q,w,e,r,t,y,u,i,o,p]**: Listen to the corresponding stream
-  (20 grid positions, in that key order)
+  (grid positions 0-19, in that key order)
+- **alt+ctrl+[1...9,0,q,w,e,r,t,y,u,i,o,p]**: Listen to the corresponding
+  stream (grid positions 20-39, same key order, for grids larger than 20 cells)
 - **alt+shift+[1...9,0,q,w,e,r,t,y,u,i,o,p]**: Toggle blur on the
-  corresponding stream
+  corresponding stream (grid positions 0-19, in that key order)
+- **alt+ctrl+shift+[1...9,0,q,w,e,r,t,y,u,i,o,p]**: Toggle blur on the
+  corresponding stream (grid positions 20-39, same key order, for grids larger
+  than 20 cells)
 - **alt+s**: Select the currently focused stream box to be swapped
 - **alt+c**: Activate [Streamdelay](https://github.com/chromakode/streamdelay) censor mode
 - **alt+shift+c**: Deactivate [Streamdelay](https://github.com/chromakode/streamdelay) censor mode

--- a/packages/streamwall-control-ui/src/hotkeyLabel.test.ts
+++ b/packages/streamwall-control-ui/src/hotkeyLabel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { getHotkeyLabel } from './hotkeyLabel.ts'
+import { blurHotkeyLayerBindings, getHotkeyLabel } from './hotkeyLabel.ts'
 
 describe('getHotkeyLabel', () => {
   test('labels the first hotkey slot', () => {
@@ -40,5 +40,23 @@ describe('getHotkeyLabel', () => {
 
   test('returns undefined for a negative index', () => {
     expect(getHotkeyLabel(-1)).toBeUndefined()
+  })
+})
+
+describe('blurHotkeyLayerBindings', () => {
+  test('layer 0 chords the base 20 trigger keys with alt+shift', () => {
+    expect(blurHotkeyLayerBindings[0]).toBe(
+      'alt+shift+1,alt+shift+2,alt+shift+3,alt+shift+4,alt+shift+5,alt+shift+6,alt+shift+7,alt+shift+8,alt+shift+9,alt+shift+0,alt+shift+q,alt+shift+w,alt+shift+e,alt+shift+r,alt+shift+t,alt+shift+y,alt+shift+u,alt+shift+i,alt+shift+o,alt+shift+p',
+    )
+  })
+
+  test('layer 1 chords the same 20 trigger keys with alt+ctrl+shift, avoiding the audio layer 1 (alt+ctrl) collision', () => {
+    expect(blurHotkeyLayerBindings[1]).toBe(
+      'alt+ctrl+shift+1,alt+ctrl+shift+2,alt+ctrl+shift+3,alt+ctrl+shift+4,alt+ctrl+shift+5,alt+ctrl+shift+6,alt+ctrl+shift+7,alt+ctrl+shift+8,alt+ctrl+shift+9,alt+ctrl+shift+0,alt+ctrl+shift+q,alt+ctrl+shift+w,alt+ctrl+shift+e,alt+ctrl+shift+r,alt+ctrl+shift+t,alt+ctrl+shift+y,alt+ctrl+shift+u,alt+ctrl+shift+i,alt+ctrl+shift+o,alt+ctrl+shift+p',
+    )
+  })
+
+  test('only defines two layers, matching the 40-cell reach of the audio hotkeys', () => {
+    expect(blurHotkeyLayerBindings).toHaveLength(2)
   })
 })

--- a/packages/streamwall-control-ui/src/hotkeyLabel.ts
+++ b/packages/streamwall-control-ui/src/hotkeyLabel.ts
@@ -21,14 +21,24 @@ export const hotkeyTriggers = [
   'p',
 ]
 
+/** Builds the `alt+<...>+<key>` combos for each layer, e.g. `alt+1,alt+2,...`. */
+function hotkeyLayerBindingsFor(
+  layers: ReadonlyArray<{ readonly prefix: string }>,
+): string[] {
+  return layers.map((layer) =>
+    hotkeyTriggers.map((k) => `${layer.prefix}+${k}`).join(','),
+  )
+}
+
 /**
  * Audio-listen hotkeys are laid out in "layers": each layer maps the same 20
  * trigger keys to a block of grid cells, distinguished by an extra modifier.
  * Layer 0 (`alt+<key>`) covers cells 0-19; layer 1 (`alt+ctrl+<key>`) covers
- * cells 20-39. `alt+shift+<key>` is already taken by the blur toggle, so the
- * second audio layer stacks `ctrl` instead. (Caveat: on Windows international
- * layouts `Ctrl+Alt` acts as AltGr; acceptable since the control UI runs
- * primarily in the Electron control window and the handler preventDefault()s.)
+ * cells 20-39. `alt+shift+<key>` is already taken by the blur toggle's own
+ * base layer, so the second audio layer stacks `ctrl` instead. (Caveat: on
+ * Windows international layouts `Ctrl+Alt` acts as AltGr; acceptable since
+ * the control UI runs primarily in the Electron control window and the
+ * handler preventDefault()s.)
  *
  * Grids can have up to GRID_MAX * GRID_MAX = 64 cells, but cells 40-63 (only
  * reachable on 7x7/8x8 grids) are intentionally left without a hotkey rather
@@ -41,9 +51,23 @@ export const hotkeyLayers = [
 ] as const
 
 /** The `alt+<...>+<key>` combos each layer binds, e.g. `alt+1,alt+2,...`. */
-export const hotkeyLayerBindings = hotkeyLayers.map((layer) =>
-  hotkeyTriggers.map((k) => `${layer.prefix}+${k}`).join(','),
-)
+export const hotkeyLayerBindings = hotkeyLayerBindingsFor(hotkeyLayers)
+
+/**
+ * Blur-toggle hotkeys, laid out the same way as the audio-listen layers above
+ * for parity (see #294): layer 0 (`alt+shift+<key>`) covers cells 0-19, layer
+ * 1 covers cells 20-39. `alt+ctrl+<key>` is already taken by the audio-listen
+ * layer 1, so the second blur layer stacks `ctrl+shift` together instead of
+ * reusing either modifier alone. Same AltGr caveat as the audio layer above,
+ * plus the extra `shift` chord on top.
+ */
+export const blurHotkeyLayers = [
+  { prefix: 'alt+shift', label: 'Alt+Shift' },
+  { prefix: 'alt+ctrl+shift', label: 'Alt+Ctrl+Shift' },
+] as const
+
+/** The `alt+shift+...+<key>` combos each blur layer binds. */
+export const blurHotkeyLayerBindings = hotkeyLayerBindingsFor(blurHotkeyLayers)
 
 /**
  * Label for the audio-toggle hotkey assigned to grid cell `idx` (e.g. `Alt+1`

--- a/packages/streamwall-control-ui/src/hotkeysOptions.test.tsx
+++ b/packages/streamwall-control-ui/src/hotkeysOptions.test.tsx
@@ -119,3 +119,38 @@ describe('alt+ctrl+<n> second-layer listen-toggle hotkey (#240)', () => {
     expect(options).toEqual({ enableOnFormTags: true })
   })
 })
+
+describe('alt+shift+<n> blur-toggle hotkey', () => {
+  test('registers a base alt+shift chord layer covering 20 trigger keys', () => {
+    renderControlUI()
+
+    const baseLayerCall = useHotkeysMock.mock.calls.find(
+      ([keys]) =>
+        typeof keys === 'string' &&
+        keys
+          .split(',')
+          .every((k) => k.startsWith('alt+shift+') && !k.includes('ctrl')),
+    )
+
+    expect(baseLayerCall).toBeDefined()
+    const [keys] = baseLayerCall ?? []
+    expect((keys as string).split(',')).toHaveLength(20)
+  })
+})
+
+describe('alt+ctrl+shift+<n> second-layer blur-toggle hotkey (#294)', () => {
+  test('registers an alt+ctrl+shift chord layer covering the same 20 trigger keys', () => {
+    renderControlUI()
+
+    const secondLayerCall = useHotkeysMock.mock.calls.find(
+      ([keys]) =>
+        typeof keys === 'string' &&
+        keys.split(',').every((k) => k.startsWith('alt+ctrl+shift+')),
+    )
+
+    expect(secondLayerCall).toBeDefined()
+    const [keys] = secondLayerCall ?? []
+    // Same 20 trigger keys as the base blur layer, just chorded with ctrl too.
+    expect((keys as string).split(',')).toHaveLength(20)
+  })
+})

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -46,7 +46,11 @@ import { GridInput } from './GridInput.tsx'
 import { isIdxInResizeBox } from './gridInteractions'
 import { GridPreviewBox } from './GridPreviewBox.tsx'
 import { GridSizeControls } from './GridSizeControls.tsx'
-import { hotkeyLayerBindings, hotkeyTriggers } from './hotkeyLabel.ts'
+import {
+  blurHotkeyLayerBindings,
+  hotkeyLayerBindings,
+  hotkeyTriggers,
+} from './hotkeyLabel.ts'
 import './index.css'
 import { LayoutPresetControls } from './LayoutPresetControls.tsx'
 import { ResizeHandles } from './ResizeHandles.tsx'
@@ -602,15 +606,34 @@ export function ControlUI({
     { enableOnFormTags: true },
     [toggleListening],
   )
-  useHotkeys(
-    hotkeyTriggers.map((k) => `alt+shift+${k}`).join(','),
-    (ev, { hotkey }) => {
-      ev.preventDefault()
-      const idx = hotkeyTriggers.indexOf(hotkey[hotkey.length - 1])
+  const toggleBlurred = useCallback(
+    (idx: number) => {
       const isBlurred = stateIdxMap.get(idx)?.isBlurred ?? false
       handleSetBlurred(idx, !isBlurred)
     },
-    [stateIdxMap],
+    [stateIdxMap, handleSetBlurred],
+  )
+  // Blur toggle, layer 0: alt+shift+<key> -> cells 0-19.
+  useHotkeys(
+    blurHotkeyLayerBindings[0],
+    (ev, { hotkey }) => {
+      ev.preventDefault()
+      toggleBlurred(hotkeyTriggers.indexOf(hotkey[hotkey.length - 1]))
+    },
+    [toggleBlurred],
+  )
+  // Blur toggle, layer 1: alt+ctrl+shift+<key> -> cells 20-39 (see
+  // `blurHotkeyLayers`). Same trigger keys, offset by one layer of 20 cells.
+  useHotkeys(
+    blurHotkeyLayerBindings[1],
+    (ev, { hotkey }) => {
+      ev.preventDefault()
+      toggleBlurred(
+        hotkeyTriggers.length +
+          hotkeyTriggers.indexOf(hotkey[hotkey.length - 1]),
+      )
+    },
+    [toggleBlurred],
   )
   useHotkeys(
     `alt+c`,


### PR DESCRIPTION
## Problem

#240/#293 extended the audio-listen hotkey (`alt+<key>`) past the fixed 20-cell range by adding a second `alt+ctrl+<key>` layer for grid cells 20-39. The blur toggle (`alt+shift+<key>`) was intentionally left out of that PR, so the two toggles became asymmetric:

- Audio-listen: cells 0-39 (`alt+<key>` for 0-19, `alt+ctrl+<key>` for 20-39)
- Blur: cells 0-19 only (`alt+shift+<key>`)

## Solution

Add a second blur-toggle layer covering cells 20-39, mirroring the audio-layer approach:

- `alt+shift+<key>`: blur cells 0-19 (unchanged)
- `alt+ctrl+shift+<key>`: blur cells 20-39 (new)

`alt+ctrl` is already taken by the audio second layer and `alt+shift` by the blur base layer, so the new layer stacks `ctrl+shift` together, per the issue's suggestion.

`hotkeyLabel.ts` now generalizes the layer-binding builder (`hotkeyLayerBindingsFor`) so both the audio (`hotkeyLayers`/`hotkeyLayerBindings`) and blur (`blurHotkeyLayers`/`blurHotkeyLayerBindings`) hotkey layers share the same construction logic instead of duplicating the `.map(...).join(',')` pattern.

In `index.tsx`, the inline blur-toggle handler was extracted into a `toggleBlurred` callback (mirroring the existing `toggleListening` callback), and a second `useHotkeys` registration was added for the `alt+ctrl+shift` layer, offsetting the resolved index by `hotkeyTriggers.length` exactly like the audio layer 1 handler does.

README's Hotkeys section is updated to document both the audio and blur second layers (the audio layer added in #293 was never documented either).

## Testing

- `packages/streamwall-control-ui/src/hotkeyLabel.test.ts`: unit tests asserting the exact `alt+shift+...`/`alt+ctrl+shift+...` binding strings for both blur layers.
- `packages/streamwall-control-ui/src/hotkeysOptions.test.tsx`: component-level tests (mocking `useHotkeys`) asserting the base blur layer and the new second blur layer are each registered with the correct 20-key chord set, mirroring the existing audio-layer tests.
- Full quality gate run locally: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm run test` (all workspaces), and `npm -w streamwall-control-client run build` — all green.

## Risks / breaking changes

None. This only adds a new hotkey chord; existing bindings (`alt+shift+<key>` for cells 0-19, `alt+ctrl+<key>` for audio) are unchanged. As noted in #240, `alt+ctrl+shift` triggers AltGr-related behavior on some Windows international keyboard layouts — the same caveat already accepted for the audio layer, and only relevant to grids larger than 20 cells.

Closes #294