### PR TITLE
fix(control-ui): confirm before a tile resize overwrites another tile's cells

### DIFF
--- a/packages/streamwall-control-ui/src/gridInteractions.test.ts
+++ b/packages/streamwall-control-ui/src/gridInteractions.test.ts
@@ -5,6 +5,7 @@ import {
   computeResizeAssignments,
   computeSwap,
   isIdxInResizeBox,
+  resizeWouldOverwriteOtherStream,
   type SwapBox,
 } from './gridInteractions'
 
@@ -335,6 +336,106 @@ describe('computeKeyboardResizeHoverIdx', () => {
     expect(
       computeKeyboardResizeHoverIdx(cols, rows, 0, 'se', [0], 'Enter'),
     ).toBeUndefined()
+  })
+})
+
+describe('resizeWouldOverwriteOtherStream', () => {
+  it('reports true when the box spanned by the resize covers a cell held by a different stream', () => {
+    // 3-col grid; anchor at idx 0 (x0,y0), hover at idx 4 (x1,y1) spans the
+    // 2x2 box { 0, 1, 3, 4 }. Cell 4 already belongs to a different stream.
+    const currentAssignments = new Map([
+      [0, 'stream-a'],
+      [1, undefined],
+      [3, undefined],
+      [4, 'stream-b'],
+    ])
+    expect(
+      resizeWouldOverwriteOtherStream(
+        3,
+        0,
+        4,
+        'stream-a',
+        'se',
+        [0],
+        currentAssignments,
+      ),
+    ).toBe(true)
+  })
+
+  it('reports false when every spanned cell is already empty or already this stream', () => {
+    const currentAssignments = new Map([
+      [0, 'stream-a'],
+      [1, undefined],
+      [3, undefined],
+      [4, undefined],
+    ])
+    expect(
+      resizeWouldOverwriteOtherStream(
+        3,
+        0,
+        4,
+        'stream-a',
+        'se',
+        [0],
+        currentAssignments,
+      ),
+    ).toBe(false)
+  })
+
+  it('treats an empty-string streamId the same as undefined', () => {
+    const currentAssignments = new Map([
+      [0, 'stream-a'],
+      [1, ''],
+    ])
+    expect(
+      resizeWouldOverwriteOtherStream(
+        3,
+        0,
+        1,
+        'stream-a',
+        'e',
+        [0],
+        currentAssignments,
+      ),
+    ).toBe(false)
+  })
+
+  it('ignores cells outside the spanned box even if they belong to another stream', () => {
+    // Same grid as above but hover only reaches idx 1 (width 2, height 1) —
+    // cell 4's occupant is irrelevant since it falls outside the box.
+    const currentAssignments = new Map([
+      [0, 'stream-a'],
+      [1, undefined],
+      [4, 'stream-b'],
+    ])
+    expect(
+      resizeWouldOverwriteOtherStream(
+        3,
+        0,
+        1,
+        'stream-a',
+        'e',
+        [0],
+        currentAssignments,
+      ),
+    ).toBe(false)
+  })
+
+  it('does not flag a cell that is not present in the current assignments map', () => {
+    const currentAssignments = new Map<number, string | undefined>([
+      [0, 'stream-a'],
+    ])
+    expect(
+      resizeWouldOverwriteOtherStream(
+        3,
+        0,
+        1,
+        'stream-a',
+        'e',
+        [0],
+        currentAssignments,
+      ),
+    ).toBe(false)
   })
 })
 

--- a/packages/streamwall-control-ui/src/gridInteractions.ts
+++ b/packages/streamwall-control-ui/src/gridInteractions.ts
@@ -210,6 +210,41 @@ export function computeKeyboardResizeHoverIdx(
   return cols * newMaxY + newMaxX
 }
 
+/**
+ * Reports whether committing a resize gesture would overwrite any cell that
+ * currently belongs to a stream other than the one being resized. Growing a
+ * tile over part of a neighbor silently claims those cells (see
+ * {@link computeResizeAssignments}) and fragments the remainder of the
+ * neighbor into smaller boxes — callers use this to gate the commit behind a
+ * confirmation, mirroring the grid-shrink confirm in `handleSetGridSize`.
+ */
+export function resizeWouldOverwriteOtherStream(
+  cols: number,
+  anchorIdx: number,
+  hoverIdx: number,
+  streamId: string,
+  handle: ResizeHandle,
+  originalSpaces: number[],
+  currentAssignments: Map<number, string | undefined>,
+): boolean {
+  const { minX, maxX, minY, maxY } = computeResizeBox(
+    cols,
+    anchorIdx,
+    hoverIdx,
+    handle,
+    originalSpaces,
+  )
+  for (let y = minY; y <= maxY; y++) {
+    for (let x = minX; x <= maxX; x++) {
+      const existing = currentAssignments.get(cols * y + x)
+      if (existing !== undefined && existing !== '' && existing !== streamId) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
 export function computeResizeAssignments(
   cols: number,
   anchorIdx: number,

--- a/packages/streamwall-control-ui/src/useTileResize.test.tsx
+++ b/packages/streamwall-control-ui/src/useTileResize.test.tsx
@@ -32,6 +32,12 @@ afterEach(() => {
     container.remove()
     container = undefined
   }
+  vi.restoreAllMocks()
+  // happy-dom doesn't implement window.confirm; tests that stub it assign it
+  // directly, so undo that here rather than leaving a stale mock behind for
+  // later tests.
+  // @ts-expect-error -- resetting a test-only stub, not a real property
+  delete window.confirm
 })
 
 function seedViews(
@@ -206,6 +212,82 @@ describe('useTileResize', () => {
     // Resizing 'e' (east) from anchor 0 out to cell 1 spans both top cells.
     expect(readViews(doc).get(0)).toBe('stream-a')
     expect(readViews(doc).get(1)).toBe('stream-a')
+    expect(resizing()).toBe('')
+  })
+
+  test('commits without confirming when the resize does not overwrite another stream', () => {
+    // happy-dom does not implement window.confirm, so it's stubbed directly
+    // rather than spied on.
+    const confirmSpy = vi.fn()
+    window.confirm = confirmSpy
+    const doc = new Y.Doc()
+    seedViews(
+      doc,
+      new Map([
+        [0, 'stream-a'],
+        [1, undefined],
+      ]),
+    )
+    const { click } = renderHarness(doc, {
+      views: { '0': { streamId: 'stream-a' } },
+    })
+
+    click('start-resize-anchor-0-e')
+    click('hover-1')
+    windowPointerUp()
+
+    expect(confirmSpy).not.toHaveBeenCalled()
+    expect(readViews(doc).get(1)).toBe('stream-a')
+  })
+
+  test('asks for confirmation before a resize would overwrite another stream, and commits when confirmed', () => {
+    const confirmSpy = vi.fn().mockReturnValue(true)
+    window.confirm = confirmSpy
+    const doc = new Y.Doc()
+    seedViews(
+      doc,
+      new Map([
+        [0, 'stream-a'],
+        [1, 'stream-b'],
+      ]),
+    )
+    const { click } = renderHarness(doc, {
+      views: {
+        '0': { streamId: 'stream-a' },
+        '1': { streamId: 'stream-b' },
+      },
+    })
+
+    click('start-resize-anchor-0-e')
+    click('hover-1')
+    windowPointerUp()
+
+    expect(confirmSpy).toHaveBeenCalledOnce()
+    expect(readViews(doc).get(1)).toBe('stream-a')
+  })
+
+  test('does not commit a resize that would overwrite another stream when the user cancels', () => {
+    window.confirm = vi.fn().mockReturnValue(false)
+    const doc = new Y.Doc()
+    seedViews(
+      doc,
+      new Map([
+        [0, 'stream-a'],
+        [1, 'stream-b'],
+      ]),
+    )
+    const { click, resizing } = renderHarness(doc, {
+      views: {
+        '0': { streamId: 'stream-a' },
+        '1': { streamId: 'stream-b' },
+      },
+    })
+
+    click('start-resize-anchor-0-e')
+    click('hover-1')
+    windowPointerUp()
+
+    expect(readViews(doc).get(1)).toBe('stream-b')
     expect(resizing()).toBe('')
   })
 

--- a/packages/streamwall-control-ui/src/useTileResize.ts
+++ b/packages/streamwall-control-ui/src/useTileResize.ts
@@ -6,6 +6,7 @@ import { isPrimaryButton } from './gestures'
 import {
   computeKeyboardResizeHoverIdx,
   computeResizeAssignments,
+  resizeWouldOverwriteOtherStream,
   type ResizeHandle,
 } from './gridInteractions'
 
@@ -128,6 +129,30 @@ export function useTileResize({
         setResize(undefined)
         return
       }
+      // Growing a tile over part of a neighbor silently claims those cells
+      // and fragments the rest of the neighbor into smaller boxes — warn
+      // before that happens, mirroring handleSetGridSize's confirm.
+      const currentAssignments = new Map<number, string | undefined>()
+      for (const [idx, view] of Object.entries(sharedState?.views ?? {})) {
+        currentAssignments.set(Number(idx), view.streamId)
+      }
+      if (
+        resizeWouldOverwriteOtherStream(
+          cols,
+          resize.anchorIdx,
+          hoveringIdx,
+          resize.streamId,
+          resize.handle,
+          resize.originalSpaces,
+          currentAssignments,
+        ) &&
+        !window.confirm(
+          'Resizing this tile will overwrite part of another tile. Continue?',
+        )
+      ) {
+        setResize(undefined)
+        return
+      }
       stateDoc.transact(() => {
         const viewsMap = stateDoc.getMap<Y.Map<string | undefined>>('views')
         const assignments = computeResizeAssignments(
@@ -150,7 +175,7 @@ export function useTileResize({
       window.removeEventListener('pointerup', endResize)
       window.removeEventListener('pointercancel', endResize)
     }
-  }, [resize, cols, rows, hoveringIdx, stateDoc])
+  }, [resize, cols, rows, hoveringIdx, stateDoc, sharedState])
 
   // Escape cancels an in-progress resize without committing. The window
   // pointerup/pointercancel listener above is a no-op once resize is


### PR DESCRIPTION
## Problem

`computeResizeAssignments` intentionally overwrites any other tile's cells that fall inside a resized box — existing, tested behavior that #262 correctly did not change. The in-progress resize highlight (`isIdxInResizeBox`) accurately previews which cells a commit would overwrite, but nothing stopped the commit itself.

Growing a tile over part of a neighbor (e.g. covering 2 of a 2x2 neighbor's 4 cells) silently overwrote those cells and fragmented the remainder of the neighbor into separate 1x1 boxes, with no confirmation — unlike the existing grid-resize-shrink flow (`handleSetGridSize`), which asks for confirmation before a smaller grid would drop assignments.

## Solution

- Added `resizeWouldOverwriteOtherStream` to `gridInteractions.ts`: a pure predicate that reuses the same box-spanning math as `computeResizeAssignments`/`isIdxInResizeBox` to report whether any cell inside the resize box currently belongs to a *different* stream than the one being resized.
- Wired it into `useTileResize`'s `endResize` (the pointer-drag resize commit): when the predicate is true, `window.confirm(...)` gates the commit, mirroring the existing grid-shrink confirmation in `handleSetGridSize`.
- The keyboard resize path (arrow keys) is intentionally left unguarded. It commits one grid cell at a time on every key press with no hover preview to batch against — a confirm dialog per keystroke would break the interaction rather than protect it, and unlike the pointer-drag gesture there's no single "commit" moment to gate.

## Testing

- `gridInteractions.test.ts`: new `resizeWouldOverwriteOtherStream` describe block covering overwrite detection, the empty/self-stream no-op cases, empty-string-as-empty handling, out-of-box cells, and missing map entries.
- `useTileResize.test.tsx`: new tests exercising the real `endResize` pointer-event path — commits silently when nothing would be overwritten, prompts and commits on confirm, and aborts (leaving the doc untouched) on cancel.
- Full local quality gate green: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` (all 5 workspaces), `npm -w streamwall-control-client run build`.

**UI verification note:** this fix lives in `useTileResize`'s pointer-event handling and a pure grid-math predicate; there's no rendering/layout change. Manually driving it end-to-end would require the full multi-process stack (a connected Electron Streamwall uplink providing live grid state + a running control-server), which isn't practical to stand up in this environment. The `useTileResize.test.tsx` coverage renders the real Preact hook, dispatches real `PointerEvent`s, mutates a real `Y.Doc`, and stubs `window.confirm` to assert the exact gating behavior a user would see — the closest practical substitute for a live browser session.

## Risk

Low. Purely additive UX safety net (per the issue: "not a correctness bug"); no changes to the underlying assignment math (`computeResizeAssignments` unchanged) or to any other commit path (drag-move/swap, grid resize, layout presets).

Closes #267