### PR TITLE
feat(control-server): report caught internal WebSocket errors to Sentry

### DIFF
--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -23,7 +23,11 @@ import {
 } from 'streamwall-shared'
 import { Auth, StateWrapper, uniqueRand62 } from './auth.ts'
 import { TokenBucket } from './rateLimiter.ts'
-import { initSentry } from './sentry.ts'
+import {
+  captureException,
+  initSentry,
+  type SentryCaptureClient,
+} from './sentry.ts'
 import {
   applyValidatedDocUpdate,
   type DocUpdateLimits,
@@ -280,7 +284,15 @@ export async function initApp({
   baseURL,
   clientStaticPath,
   db: injectedDb,
-}: AppOptions & { db?: StorageDB }) {
+  sentryEnabled: injectedSentryEnabled,
+  sentryClient,
+}: AppOptions & {
+  db?: StorageDB
+  /** Test-only override so specs can exercise Sentry-enabled paths without a real DSN. */
+  sentryEnabled?: boolean
+  /** Test-only override for the client `captureException(...)` reports to. */
+  sentryClient?: SentryCaptureClient
+}) {
   const expectedOrigin = new URL(baseURL).origin
   const clients = new Map<string, Client>()
   const isSecure = baseURL.startsWith('https')
@@ -295,9 +307,21 @@ export async function initApp({
 
   // Opt-in crash reporting (see sentry.ts for why there is no default DSN).
   // Must be wired up before routes are registered so their errors are covered.
-  if (initSentry()) {
+  const sentryEnabled = injectedSentryEnabled ?? initSentry()
+  if (sentryEnabled) {
     Sentry.setupFastifyErrorHandler(app)
   }
+
+  // WebSocket message handling and doc-update delivery below run outside
+  // Fastify's request lifecycle, so `setupFastifyErrorHandler` never sees
+  // their errors — they are caught locally instead. All of those catch sites
+  // report here. This includes the ones that wrap a bare `ws.send()`: `ws`
+  // does not throw for the routine case of sending to an already-closing
+  // socket (it silently buffers via its internal `sendAfterClose` path), so a
+  // throw out of `send()` here signals a genuine anomaly (e.g. a payload
+  // serialization failure), not ordinary client churn.
+  const reportCaughtError = (err: unknown) =>
+    captureException(err, sentryEnabled, sentryClient)
 
   await app.register(fastifyCookie)
 
@@ -541,10 +565,12 @@ export async function initApp({
               client.lastStateSent = stateView
             } catch (err) {
               console.error('failed to send client state delta', client)
+              reportCaughtError(err)
             }
           }
         } catch (err) {
           console.error('Failed to handle ws message:', rawData, err)
+          reportCaughtError(err)
         }
       })
 
@@ -553,6 +579,7 @@ export async function initApp({
           ws.send(update)
         } catch (err) {
           console.error('Failed to send Streamwall doc update')
+          reportCaughtError(err)
         }
         for (const client of clients.values()) {
           if (client.clientId === origin) {
@@ -562,6 +589,7 @@ export async function initApp({
             client.ws.send(update)
           } catch (err) {
             console.error('Failed to send client doc update:', client)
+            reportCaughtError(err)
           }
         }
       })
@@ -757,6 +785,7 @@ export async function initApp({
           }
         } catch (err) {
           console.error('Failed to handle ws message:', rawData, err)
+          reportCaughtError(err)
         }
       })
 

--- a/packages/streamwall-control-server/src/sentry.test.ts
+++ b/packages/streamwall-control-server/src/sentry.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, test } from 'node:test'
 import {
   SENTRY_DSN_ENV,
   SENTRY_ENABLED_ENV,
+  captureException,
   getSentryConfig,
   initSentry,
 } from './sentry.ts'
@@ -108,5 +109,36 @@ describe('initSentry', () => {
     assert.equal(client.calls.length, 0)
     assert.equal(warnCalls.length, 1)
     assert.match(String(warnCalls[0][0]), new RegExp(SENTRY_DSN_ENV))
+  })
+})
+
+describe('captureException', () => {
+  function fakeCaptureClient() {
+    const calls: unknown[] = []
+    return {
+      calls,
+      captureException(err: unknown) {
+        calls.push(err)
+        return 'fake-event-id'
+      },
+    }
+  }
+
+  test('does nothing when crash reporting is disabled', () => {
+    const client = fakeCaptureClient()
+    const err = new Error('boom')
+
+    captureException(err, false, client)
+
+    assert.equal(client.calls.length, 0)
+  })
+
+  test('forwards the error to the client when crash reporting is enabled', () => {
+    const client = fakeCaptureClient()
+    const err = new Error('boom')
+
+    captureException(err, true, client)
+
+    assert.deepEqual(client.calls, [err])
   })
 })

--- a/packages/streamwall-control-server/src/sentry.ts
+++ b/packages/streamwall-control-server/src/sentry.ts
@@ -48,3 +48,25 @@ export function initSentry(
   client.init({ dsn: config.dsn })
   return true
 }
+
+/** The subset of the Sentry client this module depends on to report caught errors, for injection in tests. */
+export interface SentryCaptureClient {
+  captureException(err: unknown): unknown
+}
+
+/**
+ * Reports an already-caught error to Sentry when crash reporting is enabled.
+ * Takes `enabled` explicitly (the value `initSentry()` returned) rather than
+ * tracking module-level state, so this stays a pure function callers can
+ * unit test without depending on a prior `initSentry()` call.
+ */
+export function captureException(
+  err: unknown,
+  enabled: boolean,
+  client: SentryCaptureClient = Sentry,
+): void {
+  if (!enabled) {
+    return
+  }
+  client.captureException(err)
+}

--- a/packages/streamwall-control-server/src/sentryReporting.test.ts
+++ b/packages/streamwall-control-server/src/sentryReporting.test.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import { test } from 'node:test'
+import { setTimeout as delay } from 'node:timers/promises'
+import type WebSocket from 'ws'
+
+import type { SentryCaptureClient } from './sentry.ts'
+import {
+  buildTestApp,
+  connectStreamwallUplink,
+  listenTestApp,
+  redeemInviteAndConnectClient,
+  VALID_STATE,
+} from './testHelpers.ts'
+
+const BASE_URL = 'http://localhost:3000'
+
+/**
+ * `@fastify/websocket` bundles its own nested `ws` install
+ * (`@fastify/websocket/node_modules/ws`), separate from the copy this
+ * package imports directly. Every server-side socket in `initApp` is an
+ * instance of *that* nested copy's `WebSocket` class, so mocking the
+ * `WebSocket` this file imports would never intercept a server-side send.
+ * Resolve the exact copy `@fastify/websocket` requires so the mock below
+ * lands on the right prototype.
+ */
+const localRequire = createRequire(import.meta.url)
+const requireFromFastifyWebsocket = createRequire(
+  localRequire.resolve('@fastify/websocket'),
+)
+const wsModule = requireFromFastifyWebsocket('ws')
+const ServerWebSocket: typeof WebSocket = wsModule.WebSocket ?? wsModule
+
+/** Records every error passed to `captureException`. */
+function fakeSentryClient(): SentryCaptureClient & { calls: unknown[] } {
+  const calls: unknown[] = []
+  return {
+    calls,
+    captureException(err: unknown) {
+      calls.push(err)
+      return 'fake-event-id'
+    },
+  }
+}
+
+test('a synchronous ws.send() failure while broadcasting a state delta is reported to Sentry', async (t) => {
+  process.env.STREAMWALL_RATE_LIMIT_MAX = '10000'
+  process.env.STREAMWALL_AUTH_RATE_LIMIT_MAX = '10000'
+
+  const sentryClient = fakeSentryClient()
+  const { app, auth } = await buildTestApp({
+    baseURL: BASE_URL,
+    sentryEnabled: true,
+    sentryClient,
+  })
+  t.after(() => app.close())
+  const port = await listenTestApp(app)
+
+  const { ws: streamwallWs } = await connectStreamwallUplink(auth, port)
+  streamwallWs.send(JSON.stringify({ type: 'state', state: VALID_STATE }))
+  await delay(150)
+
+  await redeemInviteAndConnectClient(app, auth, port, BASE_URL, 'admin')
+  await delay(50)
+
+  // Force the next `ws.send()` carrying a state-delta payload to throw
+  // synchronously, simulating the kind of internal `ws` send failure the
+  // `failed to send client state delta` catch block guards against. Every
+  // other `send()` call (initial handshake frames, Yjs doc updates, the
+  // test's own client sockets, which use a different `ws` copy entirely)
+  // passes through to the real implementation.
+  const originalSend: typeof WebSocket.prototype.send =
+    ServerWebSocket.prototype.send
+  const sendError = new Error('boom - forced send failure')
+  t.mock.method(
+    ServerWebSocket.prototype,
+    'send',
+    function (
+      this: WebSocket,
+      ...args: Parameters<typeof WebSocket.prototype.send>
+    ) {
+      const [data] = args
+      if (typeof data === 'string' && data.includes('"state-delta"')) {
+        throw sendError
+      }
+      return originalSend.apply(this, args)
+    },
+  )
+
+  streamwallWs.send(
+    JSON.stringify({
+      type: 'state',
+      state: { ...VALID_STATE, config: { ...VALID_STATE.config, cols: 4 } },
+    }),
+  )
+  await delay(150)
+
+  assert.equal(sentryClient.calls.length, 1)
+  assert.equal(sentryClient.calls[0], sendError)
+})

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -13,7 +13,8 @@ import type {
 } from 'streamwall-shared'
 import WebSocket from 'ws'
 import { type AppOptions, initApp } from './index.ts'
-import type { StoredData } from './storage.ts'
+import type { SentryCaptureClient } from './sentry.ts'
+import type { StorageDB, StoredData } from './storage.ts'
 
 /**
  * Creates a throwaway directory containing a minimal index.html so that
@@ -40,7 +41,13 @@ export function inMemoryDb(): Low<StoredData> {
  * Builds a fully-wired app instance backed by in-memory storage and throwaway
  * static assets, ready for `app.inject()` or `app.listen()` in tests.
  */
-export function buildTestApp(overrides: Partial<AppOptions> = {}) {
+export function buildTestApp(
+  overrides: Partial<AppOptions> & {
+    db?: StorageDB
+    sentryEnabled?: boolean
+    sentryClient?: SentryCaptureClient
+  } = {},
+) {
   return initApp({
     baseURL: 'http://localhost:3000',
     clientStaticPath: makeStaticDir(),


### PR DESCRIPTION
## Problem

`packages/streamwall-control-server` has opt-in Sentry crash reporting (`src/sentry.ts`, added in #292), but it only covers process-level `uncaughtException`/`unhandledRejection` and Fastify request errors via `setupFastifyErrorHandler`. `src/index.ts` has five `catch` blocks around WebSocket message handling and doc-update delivery that were only ever logged locally via `console.error`:

- `failed to send client state delta`
- `Failed to handle ws message:` (two call sites)
- `Failed to send Streamwall doc update`
- `Failed to send client doc update:`

None of these reach Sentry even with crash reporting enabled, since they never throw past their local `try`/`catch` and never go through a Fastify route handler.

## Solution

Added a small `captureException(err, enabled, client)` helper to `sentry.ts`, mirroring the existing `initSentry()` dependency-injection pattern (`enabled` is the flag `initSentry()` already returns; `client` defaults to the real `Sentry` module, injectable in tests). Wired it into all five catch sites in `index.ts` via a `reportCaughtError` closure created once per `initApp()` call.

**Why all five, not a subset:** I initially assumed the three `ws.send()`-wrapping catches were noise (routine disconnect races) and only the two message-handling catches were worth reporting. Checking `ws`'s actual `send()` implementation disproved that: without a callback, `send()` on a non-`OPEN` socket silently buffers via its internal `sendAfterClose` path instead of throwing — it only throws synchronously for a `CONNECTING`-state socket or a genuine internal error (e.g. payload serialization). None of these five catches guard an expected/routine condition, so all five report.

## Testing

- `sentry.test.ts`: unit tests for `captureException` (both branches — disabled no-ops, enabled forwards to the injected client).
- `sentryReporting.test.ts`: end-to-end test that forces a synchronous `ws.send()` failure on a real state-delta broadcast and asserts it reaches the injected Sentry client. Notably, `@fastify/websocket` bundles its own nested `ws` install separate from the one this package imports directly, so every server-side socket is an instance of *that* nested copy's `WebSocket` class — the test resolves and mocks that exact copy (documented inline) rather than the top-level import, which would never intercept a server-side send.
- `initApp()` gained test-only `sentryEnabled`/`sentryClient` overrides (mirroring the existing `db` injection pattern) so specs can exercise the Sentry-enabled path without a real DSN or mutating `process.env`.
- Full workspace quality gate green locally: `format:check`, `lint`, `typecheck`, `test` (all 5 packages, including the new server tests — 99/99 passing).

## Risk / breaking changes

None. This only adds error-reporting side effects that are inert unless an operator has already opted into `STREAMWALL_SENTRY_ENABLED` + `STREAMWALL_SENTRY_DSN`. No public API changes; the new `sentryEnabled`/`sentryClient` parameters are additive and test-only.

Closes #298
