### PR TITLE
refactor(streamwall): drop dead try/catch around Number() in TwitchBot.onMsg

### DIFF
--- a/packages/streamwall/src/main/TwitchBot.test.ts
+++ b/packages/streamwall/src/main/TwitchBot.test.ts
@@ -1,3 +1,4 @@
+import type { PrivmsgMessage } from 'dank-twitch-irc'
 import { EventEmitter } from 'events'
 import type { StreamData } from 'streamwall-shared'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -120,6 +121,22 @@ describe('TwitchBot', () => {
       expect.stringContaining('announce'),
       expect.any(Error),
     )
+  })
+
+  it('tallies a vote when a chat message matches the vote pattern', () => {
+    const bot = new TwitchBot(CONFIG)
+
+    bot.onMsg({ messageText: '!2' } as PrivmsgMessage)
+
+    expect(bot.votes.get(2)).toBe(1)
+  })
+
+  it('ignores chat messages that do not match the vote pattern', () => {
+    const bot = new TwitchBot(CONFIG)
+
+    bot.onMsg({ messageText: 'hello there' } as PrivmsgMessage)
+
+    expect(bot.votes.size).toBe(0)
   })
 
   it('does not crash the process when the repeat-announce timeout rejects', async () => {

--- a/packages/streamwall/src/main/TwitchBot.ts
+++ b/packages/streamwall/src/main/TwitchBot.ts
@@ -199,12 +199,7 @@ export default class TwitchBot extends EventEmitter {
       return
     }
 
-    let idx
-    try {
-      idx = Number(match[1])
-    } catch (err) {
-      return
-    }
+    const idx = Number(match[1])
 
     this.votes.set(idx, (this.votes.get(idx) || 0) + 1)
   }


### PR DESCRIPTION
## Summary
- `TwitchBot.onMsg` wrapped `Number(match[1])` in a `try`/`catch`, but `Number()` never throws — it returns `NaN` for unparseable input — and `match[1]` is already guaranteed to be one-or-more digits by the preceding `VOTE_RE = /^!(\d+)$/` match. The `catch` branch was unreachable dead code.
- Removed the `try`/`catch` and assign `idx` directly.

## Technical solution
No behavior change: `idx` was always a valid finite number before and after this change, since `Number()` cannot throw and the regex match guarantees digit input.

## Testing performed
- Added regression tests for `TwitchBot.onMsg` covering vote tallying on a matching message and no-op on a non-matching message, added *before* the refactor to confirm they pass against the pre-existing behavior.
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test` (all workspaces)
- `npm -w streamwall-control-client run build`

## Risks / breaking changes
None — pure dead-code removal, no behavior change.

Closes #258