### PR TITLE
fix(streamwall): catch async rejections when dispatching onCommand from event handlers

### DIFF
--- a/packages/streamwall/src/main/commandDispatch.test.ts
+++ b/packages/streamwall/src/main/commandDispatch.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import { afterEach, beforeEach, test, vi } from 'vitest'
+
+import { dispatchCommand } from './commandDispatch'
+import log from './logger'
+
+let unhandledRejections: unknown[] = []
+const onUnhandledRejection = (reason: unknown) => {
+  unhandledRejections.push(reason)
+}
+
+beforeEach(() => {
+  unhandledRejections = []
+  process.on('unhandledRejection', onUnhandledRejection)
+})
+
+afterEach(() => {
+  process.off('unhandledRejection', onUnhandledRejection)
+  vi.restoreAllMocks()
+})
+
+test('dispatchCommand invokes onCommand with the message and source', () => {
+  const onCommand = vi.fn().mockResolvedValue(undefined)
+
+  dispatchCommand(onCommand, { type: 'ping' }, 'local')
+
+  assert.deepEqual(onCommand.mock.calls, [[{ type: 'ping' }, 'local']])
+})
+
+test('dispatchCommand logs and swallows a rejection instead of leaking an unhandled rejection', async () => {
+  const err = new Error('downstream failure')
+  const onCommand = vi.fn().mockRejectedValue(err)
+  vi.spyOn(log, 'error').mockImplementation(() => undefined)
+
+  dispatchCommand(onCommand, { type: 'ping' }, 'uplink')
+
+  // Let the rejected promise's microtask queue (including any unhandled
+  // rejection detection) settle before asserting.
+  await new Promise((resolve) => setImmediate(resolve))
+
+  assert.equal(unhandledRejections.length, 0)
+  assert.equal(log.error.mock.calls.length, 1)
+  const [message, loggedErr] = log.error.mock.calls[0]
+  assert.match(message, /uplink/)
+  assert.equal(loggedErr, err)
+})
+
+test('dispatchCommand tags the logged error with the local source', async () => {
+  const err = new Error('boom')
+  const onCommand = vi.fn().mockRejectedValue(err)
+  vi.spyOn(log, 'error').mockImplementation(() => undefined)
+
+  dispatchCommand(onCommand, { type: 'ping' }, 'local')
+  await new Promise((resolve) => setImmediate(resolve))
+
+  const [message] = log.error.mock.calls[0]
+  assert.match(message, /local/)
+})

--- a/packages/streamwall/src/main/commandDispatch.ts
+++ b/packages/streamwall/src/main/commandDispatch.ts
@@ -1,0 +1,19 @@
+import log from './logger'
+
+export type CommandSource = 'local' | 'uplink'
+
+// onCommand is async and is invoked fire-and-forget from two event handlers:
+// the control window's 'command' event and the uplink WebSocket's 'message'
+// event. Neither awaits or catches it, so a rejecting downstream `await`
+// inside onCommand would otherwise escape as an unhandled promise rejection
+// for every dispatched command (issue #256). Routing both call sites through
+// here logs the failure instead.
+export function dispatchCommand<Msg>(
+  onCommand: (msg: Msg, source: CommandSource) => Promise<void>,
+  msg: Msg,
+  source: CommandSource,
+): void {
+  onCommand(msg, source).catch((err) => {
+    log.error(`Unhandled error while processing a ${source} command:`, err)
+  })
+}

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -29,6 +29,7 @@ import {
   sentryEnabledSwitchValue,
 } from '../sentryConfig'
 import { createSessionHostResolver, ensureValidURL } from '../util'
+import { dispatchCommand } from './commandDispatch'
 import {
   ConfigError,
   findUnknownConfigKeys,
@@ -743,7 +744,9 @@ async function main(argv: ReturnType<typeof parseArgs>) {
 
   // Control -> main
   controlWindow.on('ydoc', (update) => Y.applyUpdate(stateDoc, update))
-  controlWindow.on('command', (command) => onCommand(command, 'local'))
+  controlWindow.on('command', (command) =>
+    dispatchCommand(onCommand, command, 'local'),
+  )
 
   // Closing either top-level window quits the app, except on macOS where the
   // convention is to hide the window and keep the app (and its dock icon)
@@ -865,7 +868,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
         return
       }
 
-      onCommand(msg, 'uplink')
+      dispatchCommand(onCommand, msg, 'uplink')
     })
     stateEmitter.on('state', () => {
       if (!isSocketOpen(ws)) {


### PR DESCRIPTION
## Problem

`onCommand` in `packages/streamwall/src/main/index.ts` is `async` and is invoked fire-and-forget from two event handlers, neither of which awaits it or attaches a `.catch()`:

- the control window's `'command'` event: `controlWindow.on('command', (command) => onCommand(command, 'local'))`
- the uplink WebSocket's `'message'` handler: `onCommand(msg, 'uplink')`

A rejecting `await` inside `onCommand` (or one added later) — a downstream call on window/session state, IPC, or storage — would escape as an unhandled promise rejection instead of being logged, for every command dispatched from either the local control window or the remote uplink.

Same class of issue as #19, already fixed for `TwitchBot` in #254.

## Solution

Extracted a `dispatchCommand` helper into a new `commandDispatch.ts`, following the same pattern already used for `uplinkEcho.ts`: pull a small, pure piece out of the otherwise Electron-entangled `index.ts` entrypoint so it can be unit tested without mocking the whole app.

`dispatchCommand(onCommand, msg, source)` calls `onCommand(msg, source)` and attaches `.catch((err) => log.error(...))`, logging the source (`local`/`uplink`) and the error instead of letting the rejection escape. Both call sites in `index.ts` now go through it.

## Testing

Added `commandDispatch.test.ts`:

- happy path: `dispatchCommand` invokes `onCommand` with the message and source unchanged.
- a rejecting `onCommand` is caught and logged with the `uplink` source, and — proven via a temporary `process.on('unhandledRejection', ...)` listener, the same technique used in `TwitchBot.test.ts` — no unhandled rejection escapes.
- the `local` source is tagged correctly in the logged message.

Full quality gate run locally: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm run test` (all workspaces green, including the new tests), and `npm -w streamwall-control-client run build`.

## Risks / breaking changes

None. This only adds error handling around an existing fire-and-forget call; no behavioral change on the success path.

Closes #256