### PR TITLE
feat(streamwall): add log.level CLI flag to control electron-log verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ On first launch, if no user data `config.toml` exists yet, the control
 window shows a dismissible hint with the exact path above. Use **File →
 Open Config Folder** in the app menu at any time to open that directory.
 
+### Logging
+
+Streamwall writes logs to both the console and a file in Electron's userData
+log directory (its exact path is printed to the console on startup). File
+and console verbosity default to `debug`; set `log.level` in your config
+file (see `example.config.toml`) or pass `--log.level=<level>` on the
+command line to change it. Valid levels, from quietest to loudest: `error`,
+`warn`, `info`, `verbose`, `debug`, `silly`.
+
 ### Telemetry
 
 Streamwall reports uncaught errors to a Sentry project run by the maintainers

--- a/example.config.toml
+++ b/example.config.toml
@@ -1,3 +1,9 @@
+[log]
+# Verbosity of log output, written to both the console and the userData log
+# file (its path is printed to the console on startup; see README.md).
+# One of: error, warn, info, verbose, debug, silly.
+#level = "debug"
+
 [window]
 # Window dimensions
 #width = 1920

--- a/packages/streamwall/src/main/config.test.ts
+++ b/packages/streamwall/src/main/config.test.ts
@@ -256,6 +256,30 @@ describe('validateConfig', () => {
     }
     expect(() => validateConfig(config)).toThrow(ConfigError)
   })
+
+  test('accepts each supported log level', () => {
+    for (const level of [
+      'error',
+      'warn',
+      'info',
+      'verbose',
+      'debug',
+      'silly',
+    ]) {
+      const config = { ...baseConfig(), log: { level } }
+      expect(() => validateConfig(config)).not.toThrow()
+    }
+  })
+
+  test('rejects an unsupported log level and names the key', () => {
+    const config = { ...baseConfig(), log: { level: 'chatty' } }
+    expect(() => validateConfig(config)).toThrow(ConfigError)
+    try {
+      validateConfig(config)
+    } catch (err) {
+      expect((err as Error).message).toContain('level')
+    }
+  })
 })
 
 describe('findUnknownConfigKeys', () => {

--- a/packages/streamwall/src/main/config.ts
+++ b/packages/streamwall/src/main/config.ts
@@ -1,6 +1,7 @@
 import TOML from '@iarna/toml'
 import { GRID_MAX, GRID_MIN, MAX_VIEW_IDX } from 'streamwall-shared'
 import { z } from 'zod'
+import { LOG_LEVELS } from './logger'
 
 /**
  * Raised for any invalid startup configuration — malformed TOML or a value that
@@ -42,6 +43,11 @@ const viewIdx = z.number().int().min(0).max(MAX_VIEW_IDX)
  */
 const streamwallConfigSchema = z.object({
   help: z.boolean().optional(),
+  log: z
+    .object({
+      level: z.enum(LOG_LEVELS),
+    })
+    .default({ level: 'debug' }),
   grid: z.object({
     cols: gridDimension,
     rows: gridDimension,

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -52,7 +52,12 @@ import {
   applyLayoutPreset,
   buildLayoutPreset,
 } from './layoutPresets'
-import log, { initLogger } from './logger'
+import log, {
+  LOG_LEVELS,
+  initLogger,
+  setLogLevel,
+  type LogLevel,
+} from './logger'
 import { installApplicationMenu } from './menu'
 import { denyWindowOpen } from './navigationSecurity'
 import { BROWSE_PARTITION, hardenSession } from './partitions'
@@ -108,6 +113,9 @@ function makeControlWebSocket(authorization: string | null) {
 
 export interface StreamwallConfig {
   help: boolean
+  log: {
+    level: LogLevel
+  }
   grid: {
     cols: number
     rows: number
@@ -205,6 +213,13 @@ function parseArgs(): StreamwallConfig {
       )
       warnUnknownConfigKeys(config, configFilePath)
       return config
+    })
+    .group(['log.level'], 'Logging')
+    .option('log.level', {
+      describe:
+        'Verbosity of log output, written to both the console and the log file',
+      choices: LOG_LEVELS,
+      default: 'debug',
     })
     .group(['grid.cols', 'grid.rows'], 'Grid dimensions')
     .option('grid.cols', {
@@ -965,6 +980,7 @@ function init() {
     }
     throw err
   }
+  setLogLevel(argv.log.level)
   if (argv.help) {
     return
   }

--- a/packages/streamwall/src/main/logger.test.ts
+++ b/packages/streamwall/src/main/logger.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest'
+import log, { LOG_LEVELS, setLogLevel } from './logger'
+
+describe('LOG_LEVELS', () => {
+  test('lists every level electron-log supports, quietest to loudest', () => {
+    expect(LOG_LEVELS).toEqual([
+      'error',
+      'warn',
+      'info',
+      'verbose',
+      'debug',
+      'silly',
+    ])
+  })
+})
+
+describe('setLogLevel', () => {
+  test('sets both the file and console transport to the given level', () => {
+    setLogLevel('warn')
+    expect(log.transports.file.level).toBe('warn')
+    expect(log.transports.console.level).toBe('warn')
+  })
+
+  test('supports the quietest level', () => {
+    setLogLevel('error')
+    expect(log.transports.file.level).toBe('error')
+    expect(log.transports.console.level).toBe('error')
+  })
+
+  test('supports the loudest level', () => {
+    setLogLevel('silly')
+    expect(log.transports.file.level).toBe('silly')
+    expect(log.transports.console.level).toBe('silly')
+  })
+})

--- a/packages/streamwall/src/main/logger.ts
+++ b/packages/streamwall/src/main/logger.ts
@@ -10,15 +10,34 @@ import log from 'electron-log/main'
 log.transports.file.level = false
 log.transports.console.level = 'debug'
 
+export const LOG_LEVELS = [
+  'error',
+  'warn',
+  'info',
+  'verbose',
+  'debug',
+  'silly',
+] as const
+
+export type LogLevel = (typeof LOG_LEVELS)[number]
+
 /**
  * Enables the userData log file. Call once from the app entrypoint after
- * Electron is ready to report a userData path.
+ * Electron is ready to report a userData path. Runs before the configured
+ * `log.level` is known (parsing the config itself logs), so it always starts
+ * at the most verbose level; `setLogLevel` narrows it down afterward.
  */
 export function initLogger() {
   log.initialize()
   log.transports.file.level = 'debug'
   log.info('Log file:', log.transports.file.getFile().path)
   return log
+}
+
+/** Sets both file and console verbosity, e.g. from the resolved `log.level` config. */
+export function setLogLevel(level: LogLevel) {
+  log.transports.file.level = level
+  log.transports.console.level = level
 }
 
 export default log


### PR DESCRIPTION
## Problem

`initLogger()` (added in #85) hardcodes the file transport level to `'debug'`, capturing everything from lifecycle tracing to errors with no way to reduce or increase verbosity at runtime.

## Solution

- Added a `log.level` config option, following the existing dotted `yargs` option pattern (`grid.cols`, `telemetry.sentry`, etc.): `--log.level=<level>` on the CLI, or `[log] level = "..."` in `config.toml`.
- `LOG_LEVELS` in `logger.ts` enumerates the six levels electron-log supports (`error`, `warn`, `info`, `verbose`, `debug`, `silly`), reused by both the CLI `choices` and the Zod schema so they can never drift apart.
- `setLogLevel()` applies the resolved level to both the file and console transports once `parseArgs()` has run. `initLogger()` still bootstraps the file transport at `'debug'` beforehand (unchanged), so no startup logging is lost before the configured level is known.
- Default remains `'debug'`, preserving current behavior for anyone who doesn't set the option.

## Architecture decisions

- Kept the two-phase logger init (`initLogger()` then `setLogLevel()`) rather than threading the level into a single call, since `initLogger()` runs before config parsing (whose own debug logging needs to reach the file too).
- Modeled `log` as a Zod object with a schema-level default (`{ level: 'debug' }`), mirroring the existing `playlist` field, so configs that omit `[log]` entirely keep validating without any test fixture changes.

## Testing

- `logger.test.ts` (new): verifies `LOG_LEVELS` and that `setLogLevel()` sets both transports correctly, including the quietest and loudest levels.
- `config.test.ts`: added cases accepting every supported level and rejecting an unsupported one with a message naming the key.
- Full workspace quality gate (Prettier, ESLint, tsc, `npm test` across all packages, control-client build) passes locally.

## Risks / breaking changes

None — the option is additive with a default matching current hardcoded behavior.

Closes #250