### PR TITLE
fix(control-ui): block keyboard tile resize that overwrites a neighbor

### DIFF
--- a/packages/streamwall-control-ui/src/ResizeHandles.tsx
+++ b/packages/streamwall-control-ui/src/ResizeHandles.tsx
@@ -62,6 +62,12 @@ const StyledResizeHandles = styled.div`
   }
 `
 
+// A keyboard resize step that would overwrite a neighbor's cells is blocked
+// (see handleResizeKeyDown); this hint surfaces the Shift-key override so
+// that block is discoverable rather than a silent no-op.
+const RESIZE_KEYBOARD_HINT =
+  'Arrow keys resize. Hold Shift to overwrite another tile.'
+
 const RESIZE_HANDLES: {
   handle: ResizeHandle
   className: string
@@ -108,6 +114,7 @@ export function ResizeHandles({
           type="button"
           className={className}
           aria-label={label}
+          title={RESIZE_KEYBOARD_HINT}
           disabled={disabled}
           onPointerDown={(ev) => {
             if (!disabled) {

--- a/packages/streamwall-control-ui/src/useTileResize.test.tsx
+++ b/packages/streamwall-control-ui/src/useTileResize.test.tsx
@@ -71,8 +71,15 @@ function fakePointerDown(button = 0): PointerEvent {
   } as unknown as PointerEvent
 }
 
-function fakeKeyDown(key: string): KeyboardEvent {
-  return { key, preventDefault: () => {} } as unknown as KeyboardEvent
+function fakeKeyDown(
+  key: string,
+  options: { shiftKey?: boolean } = {},
+): KeyboardEvent {
+  return {
+    key,
+    shiftKey: options.shiftKey ?? false,
+    preventDefault: () => {},
+  } as unknown as KeyboardEvent
 }
 
 // 2-column grid. sharedState views mirror the doc's seeded assignments.
@@ -122,6 +129,19 @@ function Harness({
         }
       >
         keyboard-resize-anchor-0-e-down
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          handleResizeKeyDown(
+            0,
+            'e',
+            [0],
+            fakeKeyDown('ArrowRight', { shiftKey: true }),
+          )
+        }
+      >
+        keyboard-resize-anchor-0-e-right-shift
       </button>
     </div>
   )
@@ -378,6 +398,51 @@ describe('useTileResize keyboard resize', () => {
     click('keyboard-resize-anchor-0-e-right')
 
     expect(readViews(doc).get(1)).toBeUndefined()
+  })
+
+  test('blocks an arrow-key step that would overwrite another stream, without confirming', () => {
+    const confirmSpy = vi.fn()
+    window.confirm = confirmSpy
+    const doc = new Y.Doc()
+    seedViews(
+      doc,
+      new Map([
+        [0, 'stream-a'],
+        [1, 'stream-b'],
+      ]),
+    )
+    const { click } = renderHarness(doc, {
+      views: {
+        '0': { streamId: 'stream-a' },
+        '1': { streamId: 'stream-b' },
+      },
+    })
+
+    click('keyboard-resize-anchor-0-e-right')
+
+    expect(readViews(doc).get(1)).toBe('stream-b')
+    expect(confirmSpy).not.toHaveBeenCalled()
+  })
+
+  test('commits the step when Shift explicitly overrides the overwrite block', () => {
+    const doc = new Y.Doc()
+    seedViews(
+      doc,
+      new Map([
+        [0, 'stream-a'],
+        [1, 'stream-b'],
+      ]),
+    )
+    const { click } = renderHarness(doc, {
+      views: {
+        '0': { streamId: 'stream-a' },
+        '1': { streamId: 'stream-b' },
+      },
+    })
+
+    click('keyboard-resize-anchor-0-e-right-shift')
+
+    expect(readViews(doc).get(1)).toBe('stream-a')
   })
 })
 

--- a/packages/streamwall-control-ui/src/useTileResize.ts
+++ b/packages/streamwall-control-ui/src/useTileResize.ts
@@ -14,6 +14,17 @@ interface CollabViews {
   views: { [viewIdx: string]: { streamId: string | undefined } }
 }
 
+/** Snapshots a `CollabViews.views` map into the `Map<idx, streamId>` shape `resizeWouldOverwriteOtherStream` expects. */
+function collectCurrentAssignments(
+  views: CollabViews['views'] | undefined,
+): Map<number, string | undefined> {
+  const currentAssignments = new Map<number, string | undefined>()
+  for (const [idx, view] of Object.entries(views ?? {})) {
+    currentAssignments.set(Number(idx), view.streamId)
+  }
+  return currentAssignments
+}
+
 /**
  * Manages the grid wall's tile-resize gesture: which tile (if any) is being
  * resized from which handle, and committing the resulting stream-id
@@ -70,6 +81,10 @@ export function useTileResize({
   // Keyboard equivalent of the pointer-drag resize above: each arrow-key
   // press commits a one-cell step immediately (there's no keyboard hover
   // state to preview), rather than opening an in-progress `resize` gesture.
+  // A step that would overwrite a neighbor's cells can't be gated behind the
+  // pointer path's window.confirm (a dialog per keystroke would break the
+  // interaction — see #327), so it's blocked as a no-op instead; holding
+  // Shift explicitly overrides the block and commits the step anyway.
   const handleResizeKeyDown = useCallback(
     (
       anchorIdx: number,
@@ -94,6 +109,20 @@ export function useTileResize({
       ev.preventDefault()
       const streamId = sharedState?.views?.[anchorIdx]?.streamId ?? undefined
       if (streamId == null || streamId === '') {
+        return
+      }
+      if (
+        !ev.shiftKey &&
+        resizeWouldOverwriteOtherStream(
+          cols,
+          anchorIdx,
+          hoverIdx,
+          streamId,
+          handle,
+          originalSpaces,
+          collectCurrentAssignments(sharedState?.views),
+        )
+      ) {
         return
       }
       stateDoc.transact(() => {
@@ -132,10 +161,6 @@ export function useTileResize({
       // Growing a tile over part of a neighbor silently claims those cells
       // and fragments the rest of the neighbor into smaller boxes — warn
       // before that happens, mirroring handleSetGridSize's confirm.
-      const currentAssignments = new Map<number, string | undefined>()
-      for (const [idx, view] of Object.entries(sharedState?.views ?? {})) {
-        currentAssignments.set(Number(idx), view.streamId)
-      }
       if (
         resizeWouldOverwriteOtherStream(
           cols,
@@ -144,7 +169,7 @@ export function useTileResize({
           resize.streamId,
           resize.handle,
           resize.originalSpaces,
-          currentAssignments,
+          collectCurrentAssignments(sharedState?.views),
         ) &&
         !window.confirm(
           'Resizing this tile will overwrite part of another tile. Continue?',


### PR DESCRIPTION
## Problem

`useTileResize`'s `handleResizeKeyDown` (arrow-key tile resize) commits every step immediately with no guard against overwriting a neighboring tile's cells. Growing a tile over part of a neighbor via the keyboard silently claims those cells and fragments the rest of the neighbor — the same UX gap #267 fixed for pointer-drag resizes in #326.

#326 intentionally left the keyboard path unguarded, since gating every keystroke behind a `window.confirm(...)` would require a mouse click to dismiss on every press, defeating the purpose of keyboard-driven resizing.

## Solution

Followed the issue's first suggested approach: block (no-op) an arrow-key step that would overwrite another stream's cells, and require an explicit modifier-key override (Shift) to proceed.

- `handleResizeKeyDown` now checks `resizeWouldOverwriteOtherStream` (already added in #326) before committing a step. If the step would overwrite another stream's cells and Shift isn't held, it's a no-op.
- Holding Shift while pressing the arrow key explicitly overrides the block and commits the step, claiming the neighbor's cells as before.
- Extracted `collectCurrentAssignments` out of `endResize` so both the pointer-drag confirm path and the new keyboard block path share the same "current views → assignments map" setup instead of duplicating it.
- Added a `title` hint ("Arrow keys resize. Hold Shift to overwrite another tile.") on the resize handles so the Shift override is discoverable instead of a silent no-op.

## Architecture decisions

- Chose the modifier-key override over a transient/dismissible warning UI (the issue's second suggestion) — it needed no new UI component and matches the existing `shiftKey`-as-modifier pattern already used elsewhere in this file (`GridControls`'s listen/background-listen click).
- `resizeWouldOverwriteOtherStream` and `computeResizeAssignments` are reused as-is; no changes to `gridInteractions.ts` were needed.

## Testing

TDD: added failing tests first (`test(control-ui): cover keyboard resize overwrite blocking`), then implemented the guard (`fix(control-ui): ...`).

New coverage in `useTileResize.test.tsx`:
- Blocks a keyboard resize step that would overwrite another stream's cells, without calling `window.confirm`.
- Commits the step when Shift is held, overriding the block.

Full quality gate run locally: Prettier, ESLint, `tsc --noEmit` (all packages), full test suite (`npm test` — 99 control-server node:test cases + 227 vitest cases, all passing), and the control-client production build.

## Risks / breaking changes

None. Existing pointer-drag resize confirmation behavior is unchanged (just refactored to share the assignments helper). Keyboard resizes that don't overwrite another stream behave exactly as before.

Closes #327