### PR TITLE
fix(streamwall): stop echoing control window IPC Yjs updates back to itself

### DIFF
--- a/packages/streamwall/src/main/controlWindowEcho.test.ts
+++ b/packages/streamwall/src/main/controlWindowEcho.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CONTROL_WINDOW_ORIGIN,
+  shouldForwardUpdateToControlWindow,
+} from './controlWindowEcho'
+
+describe('shouldForwardUpdateToControlWindow', () => {
+  it('skips an update whose origin is the control window itself', () => {
+    expect(shouldForwardUpdateToControlWindow(CONTROL_WINDOW_ORIGIN)).toBe(
+      false,
+    )
+  })
+
+  it('forwards updates with no origin (e.g. persisted storage load)', () => {
+    expect(shouldForwardUpdateToControlWindow(undefined)).toBe(true)
+    expect(shouldForwardUpdateToControlWindow(null)).toBe(true)
+  })
+
+  it('forwards updates tagged with an unrelated origin (e.g. the uplink)', () => {
+    expect(shouldForwardUpdateToControlWindow('uplink')).toBe(true)
+  })
+})

--- a/packages/streamwall/src/main/controlWindowEcho.ts
+++ b/packages/streamwall/src/main/controlWindowEcho.ts
@@ -1,0 +1,12 @@
+/**
+ * Yjs update origin tag applied to updates received over the local Electron
+ * IPC channel from the control window. Lets the control window's own
+ * outgoing `stateDoc.on('update', ...)` listener recognize updates it just
+ * received and skip echoing them straight back down to the same control
+ * window that sent them (issue #323).
+ */
+export const CONTROL_WINDOW_ORIGIN = 'controlWindow'
+
+export function shouldForwardUpdateToControlWindow(origin: unknown): boolean {
+  return origin !== CONTROL_WINDOW_ORIGIN
+}

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -38,6 +38,10 @@ import {
 } from './config'
 import ControlWindow from './ControlWindow'
 import {
+  CONTROL_WINDOW_ORIGIN,
+  shouldForwardUpdateToControlWindow,
+} from './controlWindowEcho'
+import {
   LocalStreamData,
   OVERLAY_DATA_SOURCE_NAME,
   StreamIDGenerator,
@@ -732,7 +736,10 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   })
 
   // Control <- main collab updates
-  stateDoc.on('update', (update) => {
+  stateDoc.on('update', (update, origin) => {
+    if (!shouldForwardUpdateToControlWindow(origin)) {
+      return
+    }
     controlWindow.onYDocUpdate(update)
   })
 
@@ -743,7 +750,9 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   })
 
   // Control -> main
-  controlWindow.on('ydoc', (update) => Y.applyUpdate(stateDoc, update))
+  controlWindow.on('ydoc', (update) =>
+    Y.applyUpdate(stateDoc, update, CONTROL_WINDOW_ORIGIN),
+  )
   controlWindow.on('command', (command) =>
     dispatchCommand(onCommand, command, 'local'),
   )


### PR DESCRIPTION
## Problem

The Electron main process's local IPC channel between the main process and the control window had the same class of Yjs update echo bug fixed for the separate control uplink WebSocket in #320:

- `controlWindow.on('ydoc', (update) => Y.applyUpdate(stateDoc, update))` applied incoming updates from the control window with no `origin` argument.
- The outgoing `stateDoc.on('update', (update) => controlWindow.onYDocUpdate(update))` listener that relays doc changes down to the control window sent every update, without filtering by origin.

So every Yjs edit made in the control window (e.g. dragging a stream onto a grid cell) got sent to main, applied, and then immediately relayed straight back down to the same control window over IPC that already had that state locally. This wastes an IPC message and triggers redundant `update` event processing in the renderer (recomputing `docValue`, potentially pushing an extra entry through the undo manager) for state the renderer already has.

Unlike the uplink case, this doesn't cause an infinite loop — the renderer's `sendUpdate` callback already guards against echoing updates tagged with its own `'app'` origin back *up* to main — but main's echo happens on the way *down*, before that guard has a chance to apply.

## Solution

Added `packages/streamwall/src/main/controlWindowEcho.ts`, mirroring the existing `uplinkEcho.ts` pattern, exporting:

- `CONTROL_WINDOW_ORIGIN` — the origin tag applied to updates received over the control window IPC channel.
- `shouldForwardUpdateToControlWindow(origin)` — returns `false` for updates tagged with `CONTROL_WINDOW_ORIGIN`.

Wired into `packages/streamwall/src/main/index.ts`:

- `controlWindow.on('ydoc', ...)` now tags applied updates with `CONTROL_WINDOW_ORIGIN`.
- The `stateDoc.on('update', (update, origin) => ...)` listener that forwards to `controlWindow.onYDocUpdate` now skips re-sending when `shouldForwardUpdateToControlWindow(origin)` is `false`.

Kept as its own dedicated module rather than merging with `uplinkEcho.ts`, matching the existing pattern of small single-purpose modules (`windowCloseBehavior.ts`, `viewsStateInit.ts`, `uplinkEcho.ts`, etc.) in this directory.

## Testing

Added `packages/streamwall/src/main/controlWindowEcho.test.ts` covering:
- an update tagged with `CONTROL_WINDOW_ORIGIN` is not forwarded
- an untagged update (e.g. loaded from persisted storage) is forwarded
- an update tagged with an unrelated origin (e.g. the uplink) is forwarded

Ran the full quality gate:
- `npm run format:check` (clean)
- `npm run lint` (repo-wide, clean)
- `npm run typecheck` (all workspaces, clean)
- `npm run test` (repo-wide: streamwall, streamwall-shared, streamwall-control-client, streamwall-control-server, streamwall-control-ui — all passing)

## Risks / breaking changes

None. This only changes which Yjs updates get re-sent over the local control window IPC channel; it doesn't change any externally observable command/state protocol. The separate control uplink WebSocket path (fixed in #320) is untouched.

Closes #323
