### PR TITLE
fix(control-server): include the caught error in ws-relay console.error logs

### DIFF
--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -564,7 +564,7 @@ export async function initApp({
               client.ws.send(JSON.stringify({ type: 'state-delta', delta }))
               client.lastStateSent = stateView
             } catch (err) {
-              console.error('failed to send client state delta', client)
+              console.error('failed to send client state delta', client, err)
               reportCaughtError(err)
             }
           }
@@ -578,7 +578,7 @@ export async function initApp({
         try {
           ws.send(update)
         } catch (err) {
-          console.error('Failed to send Streamwall doc update')
+          console.error('Failed to send Streamwall doc update', err)
           reportCaughtError(err)
         }
         for (const client of clients.values()) {
@@ -588,7 +588,7 @@ export async function initApp({
           try {
             client.ws.send(update)
           } catch (err) {
-            console.error('Failed to send client doc update:', client)
+            console.error('Failed to send client doc update:', client, err)
             reportCaughtError(err)
           }
         }

--- a/packages/streamwall-control-server/src/sentryReporting.test.ts
+++ b/packages/streamwall-control-server/src/sentryReporting.test.ts
@@ -3,6 +3,7 @@ import { createRequire } from 'node:module'
 import { test } from 'node:test'
 import { setTimeout as delay } from 'node:timers/promises'
 import type WebSocket from 'ws'
+import * as Y from 'yjs'
 
 import type { SentryCaptureClient } from './sentry.ts'
 import {
@@ -12,6 +13,13 @@ import {
   redeemInviteAndConnectClient,
   VALID_STATE,
 } from './testHelpers.ts'
+
+/** Encodes a full-state update from a fresh doc mutated by `mutate`. */
+function updateFrom(mutate: (doc: Y.Doc) => void): Uint8Array {
+  const doc = new Y.Doc()
+  doc.transact(() => mutate(doc))
+  return Y.encodeStateAsUpdate(doc)
+}
 
 const BASE_URL = 'http://localhost:3000'
 
@@ -87,6 +95,8 @@ test('a synchronous ws.send() failure while broadcasting a state delta is report
     },
   )
 
+  const errorMock = t.mock.method(console, 'error')
+
   streamwallWs.send(
     JSON.stringify({
       type: 'state',
@@ -97,4 +107,86 @@ test('a synchronous ws.send() failure while broadcasting a state delta is report
 
   assert.equal(sentryClient.calls.length, 1)
   assert.equal(sentryClient.calls[0], sendError)
+
+  const loggedCall = errorMock.mock.calls.find(
+    (call) => call.arguments[0] === 'failed to send client state delta',
+  )
+  assert.ok(loggedCall, 'expected the send failure to be logged locally too')
+  assert.equal(
+    loggedCall?.arguments.at(-1),
+    sendError,
+    'the local log should include the caught error, not just the client',
+  )
+})
+
+test('a synchronous ws.send() failure while relaying a doc update is reported to Sentry and logged locally for both the uplink and connected clients', async (t) => {
+  process.env.STREAMWALL_RATE_LIMIT_MAX = '10000'
+  process.env.STREAMWALL_AUTH_RATE_LIMIT_MAX = '10000'
+
+  const sentryClient = fakeSentryClient()
+  const { app, auth } = await buildTestApp({
+    baseURL: BASE_URL,
+    sentryEnabled: true,
+    sentryClient,
+  })
+  t.after(() => app.close())
+  const port = await listenTestApp(app)
+
+  const { ws: streamwallWs } = await connectStreamwallUplink(auth, port)
+  streamwallWs.send(JSON.stringify({ type: 'state', state: VALID_STATE }))
+  await delay(150)
+
+  await redeemInviteAndConnectClient(app, auth, port, BASE_URL, 'admin')
+  await delay(50)
+
+  // Force every subsequent binary (Yjs doc-update) send to throw, simulating
+  // the kind of internal `ws` send failure the `Failed to send Streamwall doc
+  // update` and `Failed to send client doc update:` catch blocks guard
+  // against. JSON (text) frames pass through untouched.
+  const originalSend: typeof WebSocket.prototype.send =
+    ServerWebSocket.prototype.send
+  const sendError = new Error('boom - forced doc update send failure')
+  t.mock.method(
+    ServerWebSocket.prototype,
+    'send',
+    function (
+      this: WebSocket,
+      ...args: Parameters<typeof WebSocket.prototype.send>
+    ) {
+      const [data] = args
+      if (typeof data !== 'string') {
+        throw sendError
+      }
+      return originalSend.apply(this, args)
+    },
+  )
+
+  const errorMock = t.mock.method(console, 'error')
+
+  streamwallWs.send(updateFrom((d) => d.getMap('test').set('a', 'b')))
+  await delay(150)
+
+  assert.equal(sentryClient.calls.length, 2)
+  assert.equal(sentryClient.calls[0], sendError)
+  assert.equal(sentryClient.calls[1], sendError)
+
+  const uplinkCall = errorMock.mock.calls.find(
+    (call) => call.arguments[0] === 'Failed to send Streamwall doc update',
+  )
+  assert.ok(uplinkCall, 'expected the uplink send failure to be logged')
+  assert.equal(
+    uplinkCall?.arguments.at(-1),
+    sendError,
+    'the local log should include the caught error',
+  )
+
+  const clientCall = errorMock.mock.calls.find(
+    (call) => call.arguments[0] === 'Failed to send client doc update:',
+  )
+  assert.ok(clientCall, 'expected the client send failure to be logged')
+  assert.equal(
+    clientCall?.arguments.at(-1),
+    sendError,
+    'the local log should include the caught error, not just the client',
+  )
 })


### PR DESCRIPTION
## Problem

Follow-up from #298 (PR #328). While wiring `captureException` into `packages/streamwall-control-server/src/index.ts`'s WebSocket catch blocks, three of them were found to log a message but never include the caught `err`, even though it's bound by the `catch` clause:

- `console.error('failed to send client state delta', client)`
- `console.error('Failed to send Streamwall doc update')` (logs nothing about the failure at all)
- `console.error('Failed to send client doc update:', client)`

The two `'Failed to handle ws message:'` sites already logged `err` correctly and were left alone. Since #328, all five catches also forward to Sentry, but an operator reading local logs couldn't tell what actually went wrong — only which client was affected.

## Solution

Added `err` as the final `console.error` argument at all three sites, e.g. `console.error('failed to send client state delta', client, err)`. Purely additive logging change — no control flow, error handling, or Sentry reporting behavior changed.

## Testing

- Extended the existing `sentryReporting.test.ts` state-delta send-failure test to also assert the local `console.error` call now includes `err`, not just `client`.
- Added a new test that forces a doc-update relay failure (both the uplink's own `ws.send()` and a connected client's `ws.send()`) and asserts both of the other two log sites now include `err`.
- Full quality gate green locally: `format:check`, `lint`, `typecheck`, `test` (all 5 workspaces).

## Risk / breaking changes

None. Logging-only change; no public API or behavior changes.

Closes #329
