### PR TITLE
fix(streamwall): make markDataSource() a Repeater so combineDataSources() can return() cleanly

### DIFF
--- a/packages/streamwall/src/main/data.test.ts
+++ b/packages/streamwall/src/main/data.test.ts
@@ -633,12 +633,6 @@ describe('markDataSource', () => {
 })
 
 describe('combineDataSources', () => {
-  // combineDataSources() runs for the app's lifetime in production and is
-  // never torn down, so its generator's .return() path is untested upstream
-  // and currently never resolves (Repeater.latest appears not to propagate
-  // return() to contenders once multiple sources are involved). Reading a
-  // single value and letting the generator get garbage-collected avoids
-  // that hang; see the follow-up issue for the cleanup bug itself.
   test('keeps a stream kind when an overlay rotation patch is applied on top of it', async () => {
     const realData = new LocalStreamData([
       { link: 'https://a.example/s', kind: 'web' },
@@ -655,11 +649,15 @@ describe('combineDataSources', () => {
       ],
       new StreamIDGenerator(),
     )
-    const { value } = await gen.next()
-    expect(value?.byURL?.get('https://a.example/s')).toMatchObject({
-      kind: 'web',
-      rotation: 90,
-    })
+    try {
+      const { value } = await gen.next()
+      expect(value?.byURL?.get('https://a.example/s')).toMatchObject({
+        kind: 'web',
+        rotation: 90,
+      })
+    } finally {
+      await gen.return?.(undefined)
+    }
   })
 
   test('does not fabricate a stream from an overlay-only rotation patch', async () => {
@@ -674,8 +672,43 @@ describe('combineDataSources', () => {
       ],
       new StreamIDGenerator(),
     )
-    const { value } = await gen.next()
-    expect(value).toHaveLength(0)
-    expect(value?.byURL?.has('https://ghost.example/s')).toBe(false)
+    try {
+      const { value } = await gen.next()
+      expect(value).toHaveLength(0)
+      expect(value?.byURL?.has('https://ghost.example/s')).toBe(false)
+    } finally {
+      await gen.return?.(undefined)
+    }
+  })
+
+  // Regression test for #264: Repeater.latest() (used internally here) keeps
+  // one speculative .next() call in flight per source. Once two sources have
+  // each produced a value and a second combined value has been pulled, that
+  // speculative call sits pending on a source with no further data. Before
+  // markDataSource() was rewritten as a Repeater (see data.ts), it was a
+  // plain async generator, and native async generators queue .return() calls
+  // behind any in-flight .next() - so tearing down the combined generator at
+  // this point hung forever.
+  test('return() resolves after a second value has been pulled from multiple live sources', async () => {
+    const a = new LocalStreamData([
+      { kind: 'video', link: 'https://a.example/s' },
+    ])
+    const b = new LocalStreamData([
+      { kind: 'video', link: 'https://b.example/s' },
+    ])
+
+    const gen = combineDataSources(
+      [markDataSource(a.gen(), 'a'), markDataSource(b.gen(), 'b')],
+      new StreamIDGenerator(),
+    )
+
+    await gen.next()
+
+    const pending = gen.next()
+    await waitForListener(a, 'update')
+    a.update('https://a.example/s', { label: 'updated' })
+    await pending
+
+    await expect(gen.return(undefined)).resolves.toBeDefined()
   })
 })

--- a/packages/streamwall/src/main/data.ts
+++ b/packages/streamwall/src/main/data.ts
@@ -109,13 +109,36 @@ export async function* watchDataFile(
   }
 }
 
-export async function* markDataSource(dataSource: DataSource, name: string) {
-  for await (const streamList of dataSource) {
-    for (const s of streamList) {
-      s._dataSource = name
+// Built as a Repeater rather than a plain `async function*`: Repeater.latest()
+// (used by combineDataSources) always keeps one speculative `.next()` call
+// in flight per contender, which can be left permanently pending when a
+// source has no further data. A native async generator queues `.return()`
+// calls behind any in-flight `.next()` per the spec, so that dangling call
+// would block teardown forever; Repeater.return() instead settles pending
+// `.next()` calls immediately, which is what makes combineDataSources()'s
+// early return work (see #264).
+export function markDataSource(
+  dataSource: DataSource,
+  name: string,
+): DataSource {
+  return new Repeater(async (push, stop) => {
+    try {
+      while (true) {
+        const nextP = dataSource.next()
+        nextP.catch(() => {})
+        const iteration = await Promise.race([nextP, stop])
+        if (iteration === undefined || iteration.done) {
+          return iteration?.value
+        }
+        for (const s of iteration.value) {
+          s._dataSource = name
+        }
+        await push(iteration.value)
+      }
+    } finally {
+      await dataSource.return?.(undefined)
     }
-    yield streamList
-  }
+  })
 }
 
 /** Name passed to `markDataSource` for the overlay (rotate-stream) source. */


### PR DESCRIPTION
## Problem

`combineDataSources()`'s generator (in `packages/streamwall/src/main/data.ts`) can hang forever on `.return()` once at least two of its sources have each produced a value and a second combined value has been pulled from it. This has no impact on the running app today, since `packages/streamwall/src/main/index.ts`'s `main()` consumes `combineDataSources(...)` for the whole app lifetime and never tears it down — but it meant the generator's early-return path was untestable, and any future caller that does need to tear it down early (e.g. a config reload, a future test, or a refactor) would hang.

## Root cause

`combineDataSources()` iterates `Repeater.latest(dataSources)` (from `@repeaterjs/repeater`). `Repeater.latest()`'s internal implementation always keeps one speculative `.next()` call in flight per contender, prefetching ahead of consumer demand. Once a source has no further data to offer, that speculative call sits pending indefinitely.

Each data source passed into `Repeater.latest()` here is the result of `markDataSource(dataSource, name)`, which previously wrapped the underlying `Repeater`-based source (`LocalStreamData.gen()`, `watchDataFile()`, etc.) in a plain `async function*` using `for await`. Native async generators queue a `.return()` call behind any in-flight `.next()` call per the ECMAScript spec — they can't "jump the queue." So once `Repeater.latest()`'s internal per-contender loop leaves one of these dangling `.next()` calls in flight (which happens as soon as a second value has been pulled), `Repeater.latest()`'s own teardown logic tries to `.return()` the `markDataSource()`-wrapped generator, and that call gets queued behind the never-resolving `.next()` — hanging forever.

`Repeater.prototype.return()` is deliberately designed to sidestep this: it settles any pending `.next()` call immediately rather than queuing behind it. That safety property is lost as soon as a `Repeater` is wrapped in a plain async generator.

Confirmed with an isolated repro exercising `Repeater.latest()` directly (bypassing `markDataSource()`) against raw `Repeater`s from `LocalStreamData.gen()`: `.return()` resolves immediately. Re-adding a plain-`async function*` wrapper around the same sources reproduces the hang.

## Fix

Rewrite `markDataSource()` to return a `Repeater` instead of a plain async generator, using the same "race `.next()` against `stop`" pattern `Repeater.latest()` itself uses internally, and explicitly propagate teardown to the wrapped source via `dataSource.return()` in a `finally` block. This keeps `Repeater.return()`'s safe, non-queuing teardown semantics all the way through the `markDataSource()` → `combineDataSources()` → `Repeater.latest()` chain.

`LocalStreamData.gen()` and the `combineDataSources()`/`Repeater.latest()` call sites are unchanged — the fix is isolated to `markDataSource()`.

## Testing

- Added a regression test (`combineDataSources > return() resolves after a second value has been pulled from multiple live sources`) that pulls two values from a combined generator fed by two live `LocalStreamData` sources, then asserts `.return()` resolves. Verified TDD-red: reverting the fix causes this test to time out (5s) rather than pass.
- The two existing `combineDataSources` tests that previously relied on GC (with a comment explaining `.return()` "currently never resolves") now properly call `.return()` in a `finally` block, since it's safe again.
- Full quality gate green: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` (all workspaces), and `npm -w streamwall-control-client run build`.

## Risks / breaking changes

None expected. `markDataSource()`'s public behavior (tagging every yielded stream list with `_dataSource`) is unchanged; only its internal implementation and its early-return behavior changed (from "hangs" to "resolves"). The one production call site (`main()` in `index.ts`) never calls `.return()`, so this is purely an additive fix.

Closes #264

## Follow-ups

While investigating, I found a related but out-of-scope latent issue one layer deeper (`watchDataFile()`'s own plain-async-generator shape has the same unbounded early-return hang risk, independent of `markDataSource()`) and filed it separately: #339