### PR TITLE
feat(streamwall): offer a Create Example Config action on first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,11 @@ Configuration precedence is:
 See `example.config.toml` for an example.
 
 On first launch, if no user data `config.toml` exists yet, the control
-window shows a dismissible hint with the exact path above. Use **File →
-Open Config Folder** in the app menu at any time to open that directory.
+window shows a dismissible hint with the exact path above, offering a
+**Create Example Config** action that writes `example.config.toml` there as
+a working starting point (restart Streamwall afterward to load it). The
+same action is available as **File → Create Example Config** in the app
+menu, alongside **File → Open Config Folder**, until a config file exists.
 
 ### Telemetry
 

--- a/packages/streamwall/src/assets.d.ts
+++ b/packages/streamwall/src/assets.d.ts
@@ -2,3 +2,9 @@
 // but opaque to tsc: stylesheet imports and @fontsource font packages.
 declare module '*.css'
 declare module '@fontsource/*'
+
+// Vite's `?raw` suffix inlines a file's contents as a string at build time.
+declare module '*.toml?raw' {
+  const content: string
+  export default content
+}

--- a/packages/streamwall/src/main/ControlWindow.test.ts
+++ b/packages/streamwall/src/main/ControlWindow.test.ts
@@ -32,6 +32,9 @@ vi.mock('electron', () => ({
 
 vi.mock('./loadHTML', () => ({ loadHTML: vi.fn() }))
 
+const createExampleConfig = vi.fn()
+vi.mock('./exampleConfig', () => ({ createExampleConfig }))
+
 const { default: ControlWindow } = await import('./ControlWindow')
 
 const configInfo = {
@@ -88,6 +91,44 @@ describe('ControlWindow first-run info', () => {
     })
 
     expect(result).toBeUndefined()
+  })
+})
+
+describe('ControlWindow create-example-config', () => {
+  it('delegates to createExampleConfig with the configured path', () => {
+    const controlWindow = new ControlWindow(configInfo)
+    const sender = (controlWindow.win as unknown as FakeBrowserWindow)
+      .webContents
+
+    ipcHandlers.get('control:create-example-config')!({ sender })
+
+    expect(createExampleConfig).toHaveBeenCalledWith(configInfo.configPath)
+  })
+
+  it('propagates errors (e.g. a file already existing) to the caller instead of swallowing them', () => {
+    const controlWindow = new ControlWindow(configInfo)
+    const sender = (controlWindow.win as unknown as FakeBrowserWindow)
+      .webContents
+    const err = new Error('EEXIST: file already exists')
+    createExampleConfig.mockImplementationOnce(() => {
+      throw err
+    })
+
+    expect(() =>
+      ipcHandlers.get('control:create-example-config')!({ sender }),
+    ).toThrow(err)
+  })
+
+  it('ignores requests from a sender other than its own window', () => {
+    const controlWindow = new ControlWindow(configInfo)
+    void controlWindow
+    createExampleConfig.mockClear()
+
+    ipcHandlers.get('control:create-example-config')!({
+      sender: { send: vi.fn() },
+    })
+
+    expect(createExampleConfig).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/streamwall/src/main/ControlWindow.ts
+++ b/packages/streamwall/src/main/ControlWindow.ts
@@ -3,6 +3,7 @@ import EventEmitter from 'events'
 import { dirname } from 'node:path'
 import path from 'path'
 import { ControlCommand, StreamwallState } from 'streamwall-shared'
+import { createExampleConfig } from './exampleConfig'
 import { loadHTML } from './loadHTML'
 
 export interface ControlWindowEventMap {
@@ -77,6 +78,16 @@ export default class ControlWindow extends EventEmitter<ControlWindowEventMap> {
         return
       }
       shell.openPath(dirname(configInfo.configPath))
+    })
+
+    ipcMain.handle('control:create-example-config', (ev) => {
+      if (ev.sender !== this.win.webContents) {
+        return
+      }
+      // Lets a write failure (e.g. a file that raced into existence since
+      // hasUserConfig was checked) reject the renderer's invoke() call
+      // rather than being swallowed (#246).
+      createExampleConfig(configInfo.configPath)
     })
   }
 

--- a/packages/streamwall/src/main/exampleConfig.test.ts
+++ b/packages/streamwall/src/main/exampleConfig.test.ts
@@ -1,0 +1,36 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import exampleConfigToml from '../../../../example.config.toml?raw'
+import { createExampleConfig } from './exampleConfig'
+
+let dir: string | undefined
+
+afterEach(() => {
+  if (dir) {
+    rmSync(dir, { recursive: true, force: true })
+    dir = undefined
+  }
+})
+
+describe('createExampleConfig', () => {
+  it('writes the bundled example.config.toml verbatim to the given path', () => {
+    dir = mkdtempSync(path.join(tmpdir(), 'sw-example-config-'))
+    const configPath = path.join(dir, 'config.toml')
+
+    createExampleConfig(configPath)
+
+    expect(readFileSync(configPath, 'utf-8')).toBe(exampleConfigToml)
+  })
+
+  it('fails loud instead of overwriting a file that already exists at that path', () => {
+    dir = mkdtempSync(path.join(tmpdir(), 'sw-example-config-'))
+    const configPath = path.join(dir, 'config.toml')
+    writeFileSync(configPath, 'existing user config')
+
+    expect(() => createExampleConfig(configPath)).toThrow()
+
+    expect(readFileSync(configPath, 'utf-8')).toBe('existing user config')
+  })
+})

--- a/packages/streamwall/src/main/exampleConfig.ts
+++ b/packages/streamwall/src/main/exampleConfig.ts
@@ -1,0 +1,12 @@
+import fs from 'node:fs'
+import exampleConfigToml from '../../../../example.config.toml?raw'
+
+/**
+ * Writes the bundled example.config.toml verbatim to `configPath`. Uses the
+ * 'wx' flag so this atomically fails instead of silently overwriting a file
+ * that raced into existence between a hasUserConfig check and this write
+ * (#246).
+ */
+export function createExampleConfig(configPath: string): void {
+  fs.writeFileSync(configPath, exampleConfigToml, { flag: 'wx' })
+}

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -420,7 +420,11 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   // and the control UI's first-run hint (#86).
   const userConfigPath = join(app.getPath('userData'), 'config.toml')
   const hasUserConfig = fs.existsSync(userConfigPath)
-  installApplicationMenu(userConfigPath, log.transports.file.getFile().path)
+  installApplicationMenu(
+    userConfigPath,
+    log.transports.file.getFile().path,
+    hasUserConfig,
+  )
 
   log.debug('Creating StreamWindow...')
   const idGen = new StreamIDGenerator()

--- a/packages/streamwall/src/main/menu.test.ts
+++ b/packages/streamwall/src/main/menu.test.ts
@@ -1,17 +1,24 @@
 import type { MenuItemConstructorOptions } from 'electron'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import log from './logger'
 
 const setApplicationMenu = vi.fn()
 const buildFromTemplate = vi.fn((template: MenuItemConstructorOptions[]) => ({
   __template: template,
 }))
 const openPath = vi.fn()
+const showMessageBoxSync = vi.fn()
+const showErrorBox = vi.fn()
 
 vi.mock('electron', () => ({
   Menu: { setApplicationMenu, buildFromTemplate },
   shell: { openPath },
+  dialog: { showMessageBoxSync, showErrorBox },
   app: { name: 'Streamwall' },
 }))
+
+const createExampleConfig = vi.fn()
+vi.mock('./exampleConfig', () => ({ createExampleConfig }))
 
 const { buildApplicationMenuTemplate, installApplicationMenu } =
   await import('./menu')
@@ -58,7 +65,7 @@ describe('buildApplicationMenuTemplate', () => {
   })
 
   it('includes an "Open Config Folder" item that opens the directory containing the config path', () => {
-    const template = buildApplicationMenuTemplate(CONFIG_PATH, LOG_PATH)
+    const template = buildApplicationMenuTemplate(CONFIG_PATH, LOG_PATH, true)
 
     const item = findMenuItem(template, 'Open Config Folder')
     expect(typeof item.click).toBe('function')
@@ -74,6 +81,7 @@ describe('buildApplicationMenuTemplate', () => {
     const template = buildApplicationMenuTemplate(
       '/home/test/.config/Streamwall/config.toml',
       '/home/test/.config/Streamwall/logs/main.log',
+      false,
     )
 
     const item = findMenuItem(template, 'Open Config Folder')
@@ -86,7 +94,7 @@ describe('buildApplicationMenuTemplate', () => {
   })
 
   it('includes an "Open Logs Folder" item that opens the directory containing the log file', () => {
-    const template = buildApplicationMenuTemplate(CONFIG_PATH, LOG_PATH)
+    const template = buildApplicationMenuTemplate(CONFIG_PATH, LOG_PATH, true)
 
     const item = findMenuItem(template, 'Open Logs Folder')
     expect(typeof item.click).toBe('function')
@@ -97,6 +105,57 @@ describe('buildApplicationMenuTemplate', () => {
   })
 })
 
+describe('buildApplicationMenuTemplate "Create Example Config" item', () => {
+  afterEach(() => {
+    createExampleConfig.mockReset()
+    showMessageBoxSync.mockClear()
+    showErrorBox.mockClear()
+    vi.restoreAllMocks()
+  })
+
+  it('is offered when no config.toml exists yet', () => {
+    const template = buildApplicationMenuTemplate(CONFIG_PATH, LOG_PATH, false)
+
+    expect(searchForMenuItem(template, 'Create Example Config')).toBeDefined()
+  })
+
+  it('is not offered once a user config already exists, matching the hasUserConfig gating used elsewhere (#246)', () => {
+    const template = buildApplicationMenuTemplate(CONFIG_PATH, LOG_PATH, true)
+
+    expect(searchForMenuItem(template, 'Create Example Config')).toBeUndefined()
+  })
+
+  it('writes the example config to the config path and confirms success', () => {
+    const template = buildApplicationMenuTemplate(CONFIG_PATH, LOG_PATH, false)
+
+    const item = findMenuItem(template, 'Create Example Config')
+    ;(item.click as () => void)()
+
+    expect(createExampleConfig).toHaveBeenCalledWith(CONFIG_PATH)
+    expect(showMessageBoxSync).toHaveBeenCalledTimes(1)
+    expect(showErrorBox).not.toHaveBeenCalled()
+  })
+
+  it('fails loud with an error dialog instead of silently ignoring a write failure (e.g. a race left a file there)', () => {
+    const err = new Error('EEXIST: file already exists')
+    createExampleConfig.mockImplementationOnce(() => {
+      throw err
+    })
+    const errorSpy = vi.spyOn(log, 'error').mockImplementation(() => log)
+    const template = buildApplicationMenuTemplate(CONFIG_PATH, LOG_PATH, false)
+
+    const item = findMenuItem(template, 'Create Example Config')
+    ;(item.click as () => void)()
+
+    expect(showErrorBox).toHaveBeenCalledTimes(1)
+    expect(showMessageBoxSync).not.toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Failed to create example config',
+      err,
+    )
+  })
+})
+
 describe('installApplicationMenu', () => {
   afterEach(() => {
     setApplicationMenu.mockClear()
@@ -104,7 +163,7 @@ describe('installApplicationMenu', () => {
   })
 
   it('builds a menu from the template and installs it as the application menu', () => {
-    installApplicationMenu(CONFIG_PATH, LOG_PATH)
+    installApplicationMenu(CONFIG_PATH, LOG_PATH, true)
 
     expect(buildFromTemplate).toHaveBeenCalledTimes(1)
     expect(setApplicationMenu).toHaveBeenCalledTimes(1)

--- a/packages/streamwall/src/main/menu.ts
+++ b/packages/streamwall/src/main/menu.ts
@@ -1,5 +1,7 @@
-import { Menu, MenuItemConstructorOptions, app, shell } from 'electron'
+import { Menu, MenuItemConstructorOptions, app, dialog, shell } from 'electron'
 import { dirname } from 'node:path'
+import { createExampleConfig } from './exampleConfig'
+import log from './logger'
 
 /**
  * Builds the application menu template. Its main purpose is the "Open Config
@@ -7,10 +9,13 @@ import { dirname } from 'node:path'
  * `console.debug`, which is invisible to anyone running the packaged app
  * outside a terminal (#86). "Open Logs Folder" serves the same purpose for
  * the electron-log file written to the OS-standard log directory (#85).
+ * "Create Example Config" gives a first-time user a working starting point
+ * instead of an empty file they have to author from scratch (#246).
  */
 export function buildApplicationMenuTemplate(
   configPath: string,
   logPath: string,
+  hasUserConfig: boolean,
 ): MenuItemConstructorOptions[] {
   const openConfigFolder = () => {
     // Targets the userData directory itself (not the config file), since
@@ -20,6 +25,25 @@ export function buildApplicationMenuTemplate(
   }
   const openLogsFolder = () => {
     shell.openPath(dirname(logPath))
+  }
+  const createExampleConfigAction = () => {
+    try {
+      createExampleConfig(configPath)
+      dialog.showMessageBoxSync({
+        type: 'info',
+        message: 'Example config created',
+        detail: `Wrote an example config to ${configPath}. Restart Streamwall to use it.`,
+      })
+    } catch (err) {
+      // Write failures (e.g. a file that raced into existence since
+      // hasUserConfig was checked) fail loud rather than being silently
+      // ignored or clobbering what's there (#246).
+      log.error('Failed to create example config', err)
+      dialog.showErrorBox(
+        'Could not create example config',
+        err instanceof Error ? err.message : String(err),
+      )
+    }
   }
 
   const template: MenuItemConstructorOptions[] = []
@@ -36,6 +60,14 @@ export function buildApplicationMenuTemplate(
     submenu: [
       { label: 'Open Config Folder', click: openConfigFolder },
       { label: 'Open Logs Folder', click: openLogsFolder },
+      ...(hasUserConfig
+        ? []
+        : ([
+            {
+              label: 'Create Example Config',
+              click: createExampleConfigAction,
+            },
+          ] as MenuItemConstructorOptions[])),
       ...(process.platform === 'darwin'
         ? []
         : ([
@@ -51,8 +83,11 @@ export function buildApplicationMenuTemplate(
 export function installApplicationMenu(
   configPath: string,
   logPath: string,
+  hasUserConfig: boolean,
 ): void {
   Menu.setApplicationMenu(
-    Menu.buildFromTemplate(buildApplicationMenuTemplate(configPath, logPath)),
+    Menu.buildFromTemplate(
+      buildApplicationMenuTemplate(configPath, logPath, hasUserConfig),
+    ),
   )
 }

--- a/packages/streamwall/src/preload/controlPreload.ts
+++ b/packages/streamwall/src/preload/controlPreload.ts
@@ -16,6 +16,8 @@ const api = {
   getFirstRunInfo: (): Promise<FirstRunInfo> =>
     ipcRenderer.invoke('control:first-run-info'),
   openConfigFolder: () => ipcRenderer.invoke('control:open-config-folder'),
+  createExampleConfig: (): Promise<void> =>
+    ipcRenderer.invoke('control:create-example-config'),
   onState: (handleState: (state: StreamwallState) => void) => {
     const internalHandler = (_ev: IpcRendererEvent, state: StreamwallState) =>
       handleState(state)

--- a/packages/streamwall/src/renderer/FirstRunHint.test.tsx
+++ b/packages/streamwall/src/renderer/FirstRunHint.test.tsx
@@ -18,19 +18,29 @@ function renderHint(props: Partial<Parameters<typeof FirstRunHint>[0]> = {}) {
   container = document.createElement('div')
   document.body.appendChild(container)
   const onOpenConfigFolder = vi.fn()
+  const onCreateExampleConfig = vi.fn().mockResolvedValue(undefined)
   const onDismiss = vi.fn()
+  const mergedProps = {
+    configPath: '/home/test/.config/Streamwall/config.toml',
+    onOpenConfigFolder,
+    onCreateExampleConfig,
+    onDismiss,
+    ...props,
+  }
   act(() => {
-    render(
-      <FirstRunHint
-        configPath="/home/test/.config/Streamwall/config.toml"
-        onOpenConfigFolder={onOpenConfigFolder}
-        onDismiss={onDismiss}
-        {...props}
-      />,
-      container!,
-    )
+    render(<FirstRunHint {...mergedProps} />, container!)
   })
-  return { onOpenConfigFolder, onDismiss }
+  return {
+    onOpenConfigFolder: mergedProps.onOpenConfigFolder,
+    onCreateExampleConfig: mergedProps.onCreateExampleConfig,
+    onDismiss: mergedProps.onDismiss,
+  }
+}
+
+async function flushMicrotasks() {
+  await act(async () => {
+    await Promise.resolve()
+  })
 }
 
 describe('FirstRunHint', () => {
@@ -64,5 +74,40 @@ describe('FirstRunHint', () => {
     act(() => button.click())
 
     expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  test('creates the example config when its action button is clicked, then confirms success', async () => {
+    const { onCreateExampleConfig } = renderHint()
+
+    const button = container!.querySelector(
+      'button[data-testid="create-example-config"]',
+    ) as HTMLButtonElement
+    act(() => button.click())
+    await flushMicrotasks()
+
+    expect(onCreateExampleConfig).toHaveBeenCalledTimes(1)
+    expect(container!.textContent).toContain('restart Streamwall')
+    expect(
+      container!.querySelector('button[data-testid="create-example-config"]'),
+    ).toBeNull()
+  })
+
+  test('shows an inline error instead of dismissing when creating the example config fails', async () => {
+    const { onCreateExampleConfig } = renderHint({
+      onCreateExampleConfig: vi.fn().mockRejectedValue(new Error('EEXIST')),
+    })
+
+    const button = container!.querySelector(
+      'button[data-testid="create-example-config"]',
+    ) as HTMLButtonElement
+    act(() => button.click())
+    await flushMicrotasks()
+
+    expect(onCreateExampleConfig).toHaveBeenCalledTimes(1)
+    expect(container!.textContent).toContain("Couldn't create")
+    // The banner stays up so the user can still open the folder or dismiss.
+    expect(
+      container!.querySelector('button[data-testid="open-config-folder"]'),
+    ).not.toBeNull()
   })
 })

--- a/packages/streamwall/src/renderer/FirstRunHint.tsx
+++ b/packages/streamwall/src/renderer/FirstRunHint.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'preact/hooks'
 import { styled } from 'styled-components'
 
 const Banner = styled.div`
@@ -23,6 +24,11 @@ const ConfigPath = styled.code`
   border-radius: var(--r-sm);
   padding: 1px 5px;
   word-break: break-all;
+`
+
+const ErrorText = styled.div`
+  color: #e05252;
+  margin-top: 4px;
 `
 
 const ActionButton = styled.button`
@@ -52,8 +58,11 @@ const DismissButton = styled.button`
 export interface FirstRunHintProps {
   configPath: string
   onOpenConfigFolder: () => void
+  onCreateExampleConfig: () => Promise<void>
   onDismiss: () => void
 }
+
+type CreateExampleConfigStatus = 'idle' | 'pending' | 'done' | 'error'
 
 /**
  * Shown when the app started with no userData config.toml (#86): the wall
@@ -63,22 +72,63 @@ export interface FirstRunHintProps {
 export function FirstRunHint({
   configPath,
   onOpenConfigFolder,
+  onCreateExampleConfig,
   onDismiss,
 }: FirstRunHintProps) {
+  const [createStatus, setCreateStatus] =
+    useState<CreateExampleConfigStatus>('idle')
+
+  async function handleCreateExampleConfig() {
+    setCreateStatus('pending')
+    try {
+      await onCreateExampleConfig()
+      setCreateStatus('done')
+    } catch {
+      setCreateStatus('error')
+    }
+  }
+
   return (
     <Banner>
       <Message>
-        No <ConfigPath>config.toml</ConfigPath> found yet, so the wall has no
-        streams configured. Add one at <ConfigPath>{configPath}</ConfigPath>, or
-        pass <ConfigPath>--config</ConfigPath> / data source flags on the
-        command line.
+        {createStatus === 'done' ? (
+          <>
+            Wrote an example config to <ConfigPath>{configPath}</ConfigPath>.
+            Please restart Streamwall to use it.
+          </>
+        ) : (
+          <>
+            No <ConfigPath>config.toml</ConfigPath> found yet, so the wall has
+            no streams configured. Add one at{' '}
+            <ConfigPath>{configPath}</ConfigPath>, or pass{' '}
+            <ConfigPath>--config</ConfigPath> / data source flags on the command
+            line.
+          </>
+        )}
+        {createStatus === 'error' && (
+          <ErrorText>
+            Couldn't create the example config - a file may already exist at
+            that path. Check the logs for details.
+          </ErrorText>
+        )}
       </Message>
-      <ActionButton
-        data-testid="open-config-folder"
-        onClick={onOpenConfigFolder}
-      >
-        Open Config Folder
-      </ActionButton>
+      {createStatus !== 'done' && (
+        <ActionButton
+          data-testid="create-example-config"
+          disabled={createStatus === 'pending'}
+          onClick={handleCreateExampleConfig}
+        >
+          Create Example Config
+        </ActionButton>
+      )}
+      {createStatus !== 'done' && (
+        <ActionButton
+          data-testid="open-config-folder"
+          onClick={onOpenConfigFolder}
+        >
+          Open Config Folder
+        </ActionButton>
+      )}
       <DismissButton
         data-testid="dismiss-first-run-hint"
         aria-label="Dismiss"

--- a/packages/streamwall/src/renderer/control.tsx
+++ b/packages/streamwall/src/renderer/control.tsx
@@ -133,6 +133,9 @@ function App() {
         <FirstRunHint
           configPath={firstRunHint.configPath!}
           onOpenConfigFolder={() => window.streamwallControl.openConfigFolder()}
+          onCreateExampleConfig={() =>
+            window.streamwallControl.createExampleConfig()
+          }
           onDismiss={firstRunHint.dismiss}
         />
       )}


### PR DESCRIPTION
## Problem

#86 asked for three first-run affordances: a hint showing the config path,
an "Open Config Folder" menu item, and (implicitly) a "create example
config" affordance. #244 shipped the first two and left the third out,
which was split into this issue. A first-time user with no `config.toml`
still has to author one from scratch by hand-copying `example.config.toml`.

## Solution

- **`exampleConfig.ts`** (new): `createExampleConfig(configPath)` writes
  `example.config.toml`'s contents (inlined at build time via Vite's `?raw`
  import, so it's part of the bundle in both dev and packaged builds - no
  `extraResource` packaging config needed) to `configPath` using the `'wx'`
  flag, so the write atomically fails instead of overwriting a file that
  raced into existence since a `hasUserConfig` check.
- **`ControlWindow`**: a new `control:create-example-config` IPC handler
  delegates to `createExampleConfig()`; a write failure rejects the
  renderer's `invoke()` call rather than being swallowed. Exposed on
  `controlPreload` as `streamwallControl.createExampleConfig()` (untested
  by design, matching the package's other thin IPC passthroughs, per #244).
- **App menu** (`menu.ts`): a `File > Create Example Config` item, shown
  only while `hasUserConfig` is false (the same gating used elsewhere).
  Confirms success with a message box; a failure is logged via
  `electron-log` and shown in an error dialog.
- **`FirstRunHint`**: a new "Create Example Config" button next to "Open
  Config Folder". On success the banner switches to a confirmation message
  telling the user to restart Streamwall; on failure it shows an inline
  error without dismissing, so "Open Config Folder" and dismiss stay
  reachable.
- **README**: documents both entry points.

## Architecture decisions

- Chose Vite's `?raw` import over `packagerConfig.extraResource` +
  `process.resourcesPath`: it works identically in dev and packaged builds
  with no forge.config changes, avoids a dev/packaged code-path split, and
  keeps `example.config.toml` as the single source of truth at the repo
  root (no duplicate copy inside the package).
- The write uses the `'wx'` flag rather than `existsSync` + `writeFileSync`,
  so the "don't clobber a raced-in file" requirement is enforced atomically
  instead of leaving a TOCTOU window.
- `hasUserConfig` is only computed once at boot (matching the existing
  `ControlWindow`/menu pattern from #244), so the offered actions reflect
  the state at launch; the UI's success message tells the user to restart
  to pick up the new file, consistent with how config is otherwise only
  read at startup.

## Testing

- TDD throughout: `exampleConfig.test.ts`, `ControlWindow.test.ts`
  (extended), `menu.test.ts` (extended), `FirstRunHint.test.tsx` (extended)
  all written before their implementations, covering the happy path, the
  no-clobber/fail-loud path, sender validation, and the `hasUserConfig`
  gating.
- Full quality gate green: `format:check`, `lint`, `typecheck` (all
  workspaces), `test` (all workspaces), and `electron-forge package`
  (production Vite build) succeed. Verified the built main-process bundle
  actually contains the inlined example config content and new UI strings.
- Not verified: a live GUI run of the packaged app (no display in this
  environment) - build success plus full unit coverage of the IPC handler,
  menu template, and hint component's rendering/interactions is the
  available signal.

## Risks / breaking changes

None expected. `buildApplicationMenuTemplate`/`installApplicationMenu` gain
a required `hasUserConfig` parameter; the sole caller (`index.ts`) is
updated.

Closes #246