### PR TITLE
fix(streamwall): install Electron binary before tests run to avoid Windows race

### DIFF
--- a/packages/streamwall/package.json
+++ b/packages/streamwall/package.json
@@ -11,6 +11,7 @@
     "make": "electron-forge make",
     "publish": "electron-forge publish",
     "lint": "eslint .",
+    "pretest": "install-electron",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit -p tsconfig.json"


### PR DESCRIPTION
## Problem

`Test (windows-latest)` intermittently fails with:

```
Error: failed to create '...\node_modules\electron\dist\locales\en-US.pak': The file exists. (os error 80)
...
FAIL src/main/data.test.ts [ src/main/data.test.ts ]
Error: Electron failed to install correctly. Please delete `node_modules/electron` and run "npx install-electron --no" manually.
```

A rerun with no code changes passes, confirming it's a transient race, not a product bug (noticed while babysitting #330 / #258).

## Root cause

`electron@43`'s `package.json` no longer declares a `postinstall` script. Instead, `node_modules/electron/index.js` downloads and unzips the Electron binary **lazily**, the first time something does `require('electron')`, guarded by a `path.txt` file that's only written *after* extraction finishes successfully (`node_modules/electron/install.js`).

Vitest runs test files across parallel workers. Several files in `packages/streamwall` (`menu.test.ts`, `navigationSecurity.test.ts`, and others via imports) call `require('electron')`. When `node_modules/electron/dist` doesn't exist yet, every worker that hits its first `require('electron')` sees no `path.txt` and independently starts extracting the same zip into `node_modules/electron/dist` at the same time. On `windows-latest`, two workers racing to create the same extracted file (e.g. `locales/en-US.pak`) trips `ERROR_FILE_EXISTS` (os error 80); POSIX runners tolerate the same race silently, which is why this only ever surfaces on Windows.

## Fix

Add a `pretest` script to `packages/streamwall/package.json` that runs `install-electron` (the bin electron ships for exactly this purpose) before `vitest run`. npm always runs `pretest` before `test`, serially, so the binary is downloaded and extracted exactly once before any parallel Vitest worker can race the extraction. `install-electron` is idempotent — it checks the cached version/path and exits immediately if the binary is already present — so this adds no meaningful cost on repeat runs (verified locally: no-op after first install).

## Testing performed

- `npm test -w packages/streamwall` — confirmed `pretest` runs `install-electron` before `vitest run`, 380/380 tests pass.
- `npm run format:check`, `npm run lint`, `npm run typecheck` — all clean.
- `npm test` (full workspace suite) — all packages pass (streamwall, streamwall-shared, streamwall-control-client, streamwall-control-server, streamwall-control-ui).
- `npm -w streamwall-control-client run build` — succeeds.
- No TDD tests added: this is a CI/tooling reliability fix with no product-code behavior change: the race is between OS-level file-extraction processes on a Windows CI runner and can't be reproduced or asserted against in this repo's unit test suites.

## Risks / breaking changes

None. The change only adds a synchronous pre-step to the `test` script; it doesn't alter runtime or build behavior. Local `npm test` runs on any platform get the same protection.

Closes #333