### PR TITLE
feat: add stream presets and favorites

### DIFF
--- a/packages/streamwall-control-client/src/dev.tsx
+++ b/packages/streamwall-control-client/src/dev.tsx
@@ -165,6 +165,7 @@ const demoState: StreamwallState = {
   views: demoViews as unknown as StreamwallState['views'],
   streamdelay: null,
   layoutPresets: [],
+  favorites: ['https://twitch.tv/woke'],
   dataSourceHealth: [],
 }
 

--- a/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.test.tsx
+++ b/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.test.tsx
@@ -70,6 +70,7 @@ const minimalState: StreamwallState = {
   views: [],
   streamdelay: null,
   layoutPresets: [],
+  favorites: [],
   dataSourceHealth: [],
 }
 

--- a/packages/streamwall-control-server/src/auth.test.ts
+++ b/packages/streamwall-control-server/src/auth.test.ts
@@ -315,6 +315,7 @@ function makeState(): StreamwallState {
     layoutPresets: [
       { id: 'p1', name: 'My Layout', cols: 2, rows: 2, views: {} },
     ],
+    favorites: ['https://example.com/stream'],
     dataSourceHealth: [],
   }
 }
@@ -368,6 +369,7 @@ test('StateWrapper.view passes non-sensitive fields through unchanged', () => {
   assert.equal(view.views, state.views)
   assert.equal(view.streamdelay, state.streamdelay)
   assert.equal(view.layoutPresets, state.layoutPresets)
+  assert.equal(view.favorites, state.favorites)
 })
 
 test('StateWrapper.info returns an unprivileged (monitor) view with no auth', () => {

--- a/packages/streamwall-control-server/src/auth.ts
+++ b/packages/streamwall-control-server/src/auth.ts
@@ -95,6 +95,7 @@ export class StateWrapper extends EventEmitter {
       views,
       streamdelay,
       layoutPresets,
+      favorites,
       dataSourceHealth,
     } = this._value
 
@@ -108,6 +109,7 @@ export class StateWrapper extends EventEmitter {
       views,
       streamdelay,
       layoutPresets,
+      favorites,
       dataSourceHealth,
     }
     if (role === 'admin') {

--- a/packages/streamwall-control-ui/src/CustomStreamInput.test.tsx
+++ b/packages/streamwall-control-ui/src/CustomStreamInput.test.tsx
@@ -68,6 +68,7 @@ function makeConnection(customStreams: StreamData[]): StreamwallConnection {
     delayState,
     authState: undefined,
     layoutPresets: [],
+    favorites: [],
     dataSourceHealth: [],
   }
 }

--- a/packages/streamwall-control-ui/src/GridViewIdentity.test.tsx
+++ b/packages/streamwall-control-ui/src/GridViewIdentity.test.tsx
@@ -121,6 +121,7 @@ function makeConnection(viewCount: number): StreamwallConnection {
     delayState,
     authState: undefined,
     layoutPresets: [],
+    favorites: [],
     dataSourceHealth: [],
   }
 }

--- a/packages/streamwall-control-ui/src/Sidebar.test.tsx
+++ b/packages/streamwall-control-ui/src/Sidebar.test.tsx
@@ -38,6 +38,7 @@ describe('StreamList', () => {
           rows={[baseRow({ _id: 'a' }), baseRow({ _id: 'b' })]}
           disabled={false}
           onClickId={() => {}}
+          favorites={new Set()}
         />,
         container!,
       )
@@ -60,6 +61,7 @@ describe('StreamList', () => {
           rows={[baseRow({ _id: 'xyz' })]}
           disabled={false}
           onClickId={onClickId}
+          favorites={new Set()}
         />,
         container!,
       )
@@ -85,6 +87,7 @@ describe('StreamList', () => {
           rows={[baseRow({ _id: 'xyz' })]}
           disabled={true}
           onClickId={onClickId}
+          favorites={new Set()}
         />,
         container!,
       )
@@ -114,6 +117,7 @@ describe('StreamList', () => {
           ]}
           disabled={false}
           onClickId={() => {}}
+          favorites={new Set()}
         />,
         container!,
       )
@@ -132,6 +136,7 @@ describe('StreamList', () => {
           rows={[baseRow({ source: 'Some Source', city: 'Springfield' })]}
           disabled={false}
           onClickId={() => {}}
+          favorites={new Set()}
         />,
         container!,
       )
@@ -139,6 +144,78 @@ describe('StreamList', () => {
 
     expect(container.textContent).toContain('Some Source')
     expect(container.textContent).toContain('Springfield')
+  })
+})
+
+describe('StreamList favorites', () => {
+  test('renders a filled star for a favorited row and an empty star for a non-favorited one', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      render(
+        <StreamList
+          rows={[
+            baseRow({ _id: 'a', link: 'https://example.com/a' }),
+            baseRow({ _id: 'b', link: 'https://example.com/b' }),
+          ]}
+          disabled={false}
+          onClickId={() => {}}
+          favorites={new Set(['https://example.com/a'])}
+          onToggleFavorite={() => {}}
+        />,
+        container!,
+      )
+    })
+
+    const buttons = container.querySelectorAll('button')
+    expect(buttons).toHaveLength(2)
+    expect(buttons[0].textContent).toBe('★')
+    expect(buttons[1].textContent).toBe('☆')
+  })
+
+  test('invokes onToggleFavorite with the row link when the star is clicked, without triggering onClickId', () => {
+    const onToggleFavorite = vi.fn()
+    const onClickId = vi.fn()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      render(
+        <StreamList
+          rows={[baseRow({ _id: 'a', link: 'https://example.com/a' })]}
+          disabled={false}
+          onClickId={onClickId}
+          favorites={new Set()}
+          onToggleFavorite={onToggleFavorite}
+        />,
+        container!,
+      )
+    })
+
+    const button = container.querySelector('button') as HTMLButtonElement
+    act(() => {
+      button.click()
+    })
+
+    expect(onToggleFavorite).toHaveBeenCalledWith('https://example.com/a')
+    expect(onClickId).not.toHaveBeenCalled()
+  })
+
+  test('hides the favorite star entirely when onToggleFavorite is not provided', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      render(
+        <StreamList
+          rows={[baseRow({ _id: 'a' })]}
+          disabled={false}
+          onClickId={() => {}}
+          favorites={new Set()}
+        />,
+        container!,
+      )
+    })
+
+    expect(container.querySelector('button')).toBeNull()
   })
 })
 

--- a/packages/streamwall-control-ui/src/Sidebar.tsx
+++ b/packages/streamwall-control-ui/src/Sidebar.tsx
@@ -57,21 +57,45 @@ const StyledStreamLine = styled.div`
   }
 `
 
+const StyledFavoriteButton = styled.button<{ $active: boolean }>`
+  flex-shrink: 0;
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  color: ${({ $active }) => ($active ? '#f5c518' : 'var(--text-dim, #888)')};
+`
+
 function StreamLine({
   id,
   row: { label, source, link, notes, city, state, orientation },
   disabled,
   onClickId,
+  isFavorite,
+  onToggleFavorite,
 }: {
   id: string
   row: StreamData
   disabled: boolean
   onClickId: (id: string) => void
+  isFavorite: boolean
+  onToggleFavorite?: (link: string) => void
 }) {
   // Use mousedown instead of click event so a potential destination grid input stays focused.
   const handleMouseDownId = useCallback(() => {
     onClickId(id)
   }, [onClickId, id])
+  const handleToggleFavoriteClick = useCallback<
+    JSX.MouseEventHandler<HTMLButtonElement>
+  >(
+    (ev) => {
+      ev.stopPropagation()
+      onToggleFavorite?.(link)
+    },
+    [onToggleFavorite, link],
+  )
   return (
     <StyledStreamLine>
       <StyledId
@@ -81,6 +105,18 @@ function StreamLine({
       >
         {id}
       </StyledId>
+      {onToggleFavorite && (
+        <StyledFavoriteButton
+          type="button"
+          className="favorite-star"
+          $active={isFavorite}
+          onClick={handleToggleFavoriteClick}
+          aria-label={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+          title={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+        >
+          {isFavorite ? '★' : '☆'}
+        </StyledFavoriteButton>
+      )}
       <div>
         {label ? (
           label
@@ -104,10 +140,14 @@ export function StreamList({
   rows,
   disabled,
   onClickId,
+  favorites,
+  onToggleFavorite,
 }: {
   rows: StreamData[]
   disabled: boolean
   onClickId: (id: string) => void
+  favorites: ReadonlySet<string>
+  onToggleFavorite?: (link: string) => void
 }) {
   return rows.map((row) => (
     <StreamLine
@@ -116,6 +156,8 @@ export function StreamList({
       row={row}
       disabled={disabled}
       onClickId={onClickId}
+      isFavorite={favorites.has(row.link)}
+      onToggleFavorite={onToggleFavorite}
     />
   ))
 }

--- a/packages/streamwall-control-ui/src/StreamList.test.tsx
+++ b/packages/streamwall-control-ui/src/StreamList.test.tsx
@@ -49,7 +49,10 @@ function makeStream(id: string): StreamData {
   }
 }
 
-function makeConnection(streams: StreamData[]): StreamwallConnection {
+function makeConnection(
+  streams: StreamData[],
+  favorites: string[] = [],
+): StreamwallConnection {
   const delayState: StreamDelayStatus = {
     isConnected: true,
     delaySeconds: 0,
@@ -74,6 +77,7 @@ function makeConnection(streams: StreamData[]): StreamwallConnection {
     delayState,
     authState: undefined,
     layoutPresets: [],
+    favorites,
     dataSourceHealth: [],
   }
 }
@@ -129,5 +133,77 @@ describe('stream list identity across ControlUI re-renders', () => {
       'expected to still find a rendered row for stream-a',
     ).not.toBeUndefined()
     expect(after).toBe(before)
+  })
+})
+
+describe('favorites', () => {
+  test('surfaces a favorited stream under a Favorites heading with the correct count', () => {
+    const stream = makeStream('stream-a')
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      render(
+        <ControlUI
+          connection={makeConnection([stream], [stream.link])}
+        />,
+        container!,
+      )
+    })
+
+    const heading = [...container.querySelectorAll('h3')].find((h) =>
+      h.textContent?.startsWith('Favorites'),
+    )
+    expect(heading).not.toBeUndefined()
+    expect(heading?.textContent).toContain('1')
+  })
+
+  test('sends add-favorite when starring a stream that is not yet a favorite', () => {
+    const stream = makeStream('stream-a')
+    const connection = makeConnection([stream])
+    const send = vi.fn()
+    connection.send = send
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      render(<ControlUI connection={connection} />, container!)
+    })
+
+    const button = container.querySelector(
+      '.favorite-star',
+    ) as HTMLButtonElement
+    act(() => {
+      button.click()
+    })
+
+    const lastCall = send.mock.calls.at(-1)
+    expect(lastCall?.[0]).toEqual({
+      type: 'add-favorite',
+      url: stream.link,
+    })
+  })
+
+  test('sends remove-favorite when un-starring an already-favorited stream', () => {
+    const stream = makeStream('stream-a')
+    const connection = makeConnection([stream], [stream.link])
+    const send = vi.fn()
+    connection.send = send
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      render(<ControlUI connection={connection} />, container!)
+    })
+
+    const button = container.querySelector(
+      '.favorite-star',
+    ) as HTMLButtonElement
+    act(() => {
+      button.click()
+    })
+
+    const lastCall = send.mock.calls.at(-1)
+    expect(lastCall?.[0]).toEqual({
+      type: 'remove-favorite',
+      url: stream.link,
+    })
   })
 })

--- a/packages/streamwall-control-ui/src/StreamList.test.tsx
+++ b/packages/streamwall-control-ui/src/StreamList.test.tsx
@@ -143,9 +143,7 @@ describe('favorites', () => {
     document.body.appendChild(container)
     act(() => {
       render(
-        <ControlUI
-          connection={makeConnection([stream], [stream.link])}
-        />,
+        <ControlUI connection={makeConnection([stream], [stream.link])} />,
         container!,
       )
     })

--- a/packages/streamwall-control-ui/src/connectionStatus.test.tsx
+++ b/packages/streamwall-control-ui/src/connectionStatus.test.tsx
@@ -70,6 +70,7 @@ function renderControlUI(isConnected: boolean): HTMLDivElement {
     delayState,
     authState: undefined,
     layoutPresets: [],
+    favorites: [],
     dataSourceHealth: [],
   }
 

--- a/packages/streamwall-control-ui/src/disconnectRendering.test.tsx
+++ b/packages/streamwall-control-ui/src/disconnectRendering.test.tsx
@@ -72,6 +72,7 @@ function renderControlUI(
     delayState,
     authState: undefined,
     layoutPresets: [],
+    favorites: [],
     dataSourceHealth: [],
     ...connectionOverrides,
   }

--- a/packages/streamwall-control-ui/src/gridDragMoveRoleGating.test.tsx
+++ b/packages/streamwall-control-ui/src/gridDragMoveRoleGating.test.tsx
@@ -122,6 +122,7 @@ function renderControlUI(role: StreamwallRole | null): {
     delayState,
     authState: undefined,
     layoutPresets: [],
+    favorites: [],
     dataSourceHealth: [],
   }
 

--- a/packages/streamwall-control-ui/src/hotkeysOptions.test.tsx
+++ b/packages/streamwall-control-ui/src/hotkeysOptions.test.tsx
@@ -69,6 +69,7 @@ function renderControlUI(): HTMLDivElement {
     delayState,
     authState: undefined,
     layoutPresets: [],
+    favorites: [],
     dataSourceHealth: [],
   }
 

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -87,13 +87,15 @@ const normalStreamKinds = new Set(['video', 'audio', 'web'])
 function filterStreams(
   streams: StreamData[],
   wallStreamIds: Set<string>,
+  favoriteLinks: ReadonlySet<string>,
   filter: string,
 ) {
   const wallStreams = []
   const liveStreams = []
   const otherStreams = []
+  const favoriteStreams = []
   for (const stream of streams) {
-    const { _id, kind, status, label, source, state, city } = stream
+    const { _id, kind, status, label, source, state, city, link } = stream
     if (kind && !normalStreamKinds.has(kind)) {
       continue
     }
@@ -105,6 +107,9 @@ function filterStreams(
     ) {
       continue
     }
+    if (favoriteLinks.has(link)) {
+      favoriteStreams.push(stream)
+    }
     if (wallStreamIds.has(_id)) {
       wallStreams.push(stream)
     } else if ((kind && kind !== 'video') || status === 'Live') {
@@ -113,7 +118,7 @@ function filterStreams(
       otherStreams.push(stream)
     }
   }
-  return [wallStreams, liveStreams, otherStreams]
+  return [wallStreams, liveStreams, otherStreams, favoriteStreams]
 }
 
 export { useYDoc } from './useYDoc.ts'
@@ -143,6 +148,7 @@ export interface StreamwallConnection {
   delayState: StreamDelayStatus | null | undefined
   authState?: StreamwallState['auth']
   layoutPresets: LayoutPreset[]
+  favorites: string[]
   dataSourceHealth: DataSourceHealth[]
 }
 
@@ -159,6 +165,7 @@ export function useStreamwallState(state: StreamwallState | undefined) {
         delayState: undefined,
         authState: undefined,
         layoutPresets: [],
+        favorites: [],
         dataSourceHealth: [],
       }
     }
@@ -171,6 +178,7 @@ export function useStreamwallState(state: StreamwallState | undefined) {
       views: stateViews,
       streamdelay,
       layoutPresets,
+      favorites,
       dataSourceHealth,
     } = state
     const stateIdxMap = new Map()
@@ -220,6 +228,7 @@ export function useStreamwallState(state: StreamwallState | undefined) {
       customStreams,
       stateIdxMap,
       layoutPresets,
+      favorites,
       dataSourceHealth,
     }
   }, [state])
@@ -246,6 +255,7 @@ export function ControlUI({
     authState,
     role,
     layoutPresets,
+    favorites,
     dataSourceHealth,
   } = connection
   const {
@@ -558,6 +568,19 @@ export function ControlUI({
     [send],
   )
 
+  const favoritesSet = useMemo(() => new Set(favorites), [favorites])
+
+  const handleToggleFavorite = useCallback(
+    (url: string) => {
+      if (favoritesSet.has(url)) {
+        send({ type: 'remove-favorite', url })
+      } else {
+        send({ type: 'add-favorite', url })
+      }
+    },
+    [send, favoritesSet],
+  )
+
   const preventLinkClick = useCallback((ev: Event) => {
     ev.preventDefault()
   }, [])
@@ -665,10 +688,13 @@ export function ControlUI({
       ),
     [sharedState],
   )
-  const [wallStreams, liveStreams, otherStreams] = useMemo(
-    () => filterStreams(streams, wallStreamIds, streamFilter),
-    [streams, wallStreamIds, streamFilter],
+  const [wallStreams, liveStreams, otherStreams, favoriteStreams] = useMemo(
+    () => filterStreams(streams, wallStreamIds, favoritesSet, streamFilter),
+    [streams, wallStreamIds, favoritesSet, streamFilter],
   )
+  const toggleFavoriteHandler = roleCan(role, 'add-favorite')
+    ? handleToggleFavorite
+    : undefined
   return (
     <AppShell className="app-shell">
       <Stack className="grid-container">
@@ -957,12 +983,24 @@ export function ControlUI({
                 placeholder="Quellen filtern…"
               />
               <h3>
+                Favorites <span className="ct">{favoriteStreams.length}</span>
+              </h3>
+              <StreamList
+                rows={favoriteStreams}
+                disabled={!roleCan(role, 'mutate-state-doc')}
+                onClickId={handleClickId}
+                favorites={favoritesSet}
+                onToggleFavorite={toggleFavoriteHandler}
+              />
+              <h3>
                 Viewing <span className="ct">{wallStreams.length}</span>
               </h3>
               <StreamList
                 rows={wallStreams}
                 disabled={!roleCan(role, 'mutate-state-doc')}
                 onClickId={handleClickId}
+                favorites={favoritesSet}
+                onToggleFavorite={toggleFavoriteHandler}
               />
               <h3>
                 Live <span className="ct">{liveStreams.length}</span>
@@ -971,6 +1009,8 @@ export function ControlUI({
                 rows={liveStreams}
                 disabled={!roleCan(role, 'mutate-state-doc')}
                 onClickId={handleClickId}
+                favorites={favoritesSet}
+                onToggleFavorite={toggleFavoriteHandler}
               />
               <h3>
                 Offline / Unknown{' '}
@@ -980,6 +1020,8 @@ export function ControlUI({
                 rows={otherStreams}
                 disabled={!roleCan(role, 'mutate-state-doc')}
                 onClickId={handleClickId}
+                favorites={favoritesSet}
+                onToggleFavorite={toggleFavoriteHandler}
               />
             </div>
           ) : (

--- a/packages/streamwall-control-ui/src/responsiveLayout.test.tsx
+++ b/packages/streamwall-control-ui/src/responsiveLayout.test.tsx
@@ -68,6 +68,7 @@ function renderControlUI(): HTMLDivElement {
     delayState,
     authState: undefined,
     layoutPresets: [],
+    favorites: [],
     dataSourceHealth: [],
   }
 

--- a/packages/streamwall-control-ui/src/swapHotkeyRoleGating.test.tsx
+++ b/packages/streamwall-control-ui/src/swapHotkeyRoleGating.test.tsx
@@ -122,6 +122,7 @@ function renderControlUI(role: StreamwallRole | null): HTMLDivElement {
     delayState,
     authState: undefined,
     layoutPresets: [],
+    favorites: [],
     dataSourceHealth: [],
   }
 

--- a/packages/streamwall-control-ui/src/transientProps.test.tsx
+++ b/packages/streamwall-control-ui/src/transientProps.test.tsx
@@ -86,6 +86,7 @@ function renderControlUI(): HTMLDivElement {
     delayState,
     authState: undefined,
     layoutPresets: [],
+    favorites: [],
     dataSourceHealth: [],
   }
 

--- a/packages/streamwall-shared/src/roles.test.ts
+++ b/packages/streamwall-shared/src/roles.test.ts
@@ -35,6 +35,8 @@ const operatorOnlyActions = [
   'load-layout-preset',
   'delete-layout-preset',
   'set-view-volume',
+  'add-favorite',
+  'remove-favorite',
 ] as const satisfies readonly StreamwallAction[]
 
 // Available to every authenticated role down to monitor.

--- a/packages/streamwall-shared/src/roles.ts
+++ b/packages/streamwall-shared/src/roles.ts
@@ -19,6 +19,8 @@ const operatorActions = [
   'load-layout-preset',
   'delete-layout-preset',
   'set-view-volume',
+  'add-favorite',
+  'remove-favorite',
 ] as const
 
 const monitorActions = ['set-view-blurred', 'set-stream-censored'] as const

--- a/packages/streamwall-shared/src/schemas.test.ts
+++ b/packages/streamwall-shared/src/schemas.test.ts
@@ -387,6 +387,46 @@ describe('controlCommandMessageSchema', () => {
     ).toBe(false)
   })
 
+  test('accepts a valid add-favorite command', () => {
+    expect(
+      controlCommandMessageSchema.safeParse({
+        id: 1,
+        type: 'add-favorite',
+        url: 'https://example.com/stream',
+      }).success,
+    ).toBe(true)
+  })
+
+  test('rejects add-favorite with an empty url', () => {
+    expect(
+      controlCommandMessageSchema.safeParse({
+        id: 1,
+        type: 'add-favorite',
+        url: '',
+      }).success,
+    ).toBe(false)
+  })
+
+  test('accepts a valid remove-favorite command', () => {
+    expect(
+      controlCommandMessageSchema.safeParse({
+        id: 1,
+        type: 'remove-favorite',
+        url: 'https://example.com/stream',
+      }).success,
+    ).toBe(true)
+  })
+
+  test('rejects remove-favorite with an empty url', () => {
+    expect(
+      controlCommandMessageSchema.safeParse({
+        id: 1,
+        type: 'remove-favorite',
+        url: '',
+      }).success,
+    ).toBe(false)
+  })
+
   test('parsed commands remain assignable to the ControlCommand type', () => {
     const result = controlCommandMessageSchema.safeParse({
       id: 7,

--- a/packages/streamwall-shared/src/schemas.ts
+++ b/packages/streamwall-shared/src/schemas.ts
@@ -206,6 +206,14 @@ export const controlCommandSchema = z.discriminatedUnion('type', [
     type: z.literal('delete-layout-preset'),
     presetId: layoutPresetIdSchema,
   }),
+  z.object({
+    type: z.literal('add-favorite'),
+    url: z.string().min(1),
+  }),
+  z.object({
+    type: z.literal('remove-favorite'),
+    url: z.string().min(1),
+  }),
 ])
 
 /**

--- a/packages/streamwall-shared/src/stateDiff.test.ts
+++ b/packages/streamwall-shared/src/stateDiff.test.ts
@@ -49,6 +49,7 @@ function makeState(overrides: Partial<StreamwallState> = {}): StreamwallState {
     views: [makeView(0), makeView(1)],
     streamdelay: null,
     layoutPresets: [],
+    favorites: [],
     dataSourceHealth: [],
     ...overrides,
   }

--- a/packages/streamwall-shared/src/types.ts
+++ b/packages/streamwall-shared/src/types.ts
@@ -150,6 +150,8 @@ export interface StreamwallState {
   views: ViewState[]
   streamdelay: StreamDelayStatus | null
   layoutPresets: LayoutPreset[]
+  /** Stream URLs (`StreamDataContent.link`) a user has starred for quick access. */
+  favorites: string[]
   dataSourceHealth: DataSourceHealth[]
 }
 
@@ -181,6 +183,8 @@ export type ControlCommand =
   | { type: 'save-layout-preset'; name: string }
   | { type: 'load-layout-preset'; presetId: string }
   | { type: 'delete-layout-preset'; presetId: string }
+  | { type: 'add-favorite'; url: string }
+  | { type: 'remove-favorite'; url: string }
 
 export type ControlUpdate = {
   type: 'state'

--- a/packages/streamwall/src/main/config.test.ts
+++ b/packages/streamwall/src/main/config.test.ts
@@ -118,6 +118,26 @@ describe('validateConfig', () => {
     expect(() => validateConfig(config)).not.toThrow()
   })
 
+  test('accepts a config with a presets list', () => {
+    const config = { ...baseConfig(), presets: ['de-tv'] }
+    expect(() => validateConfig(config)).not.toThrow()
+  })
+
+  test('accepts a config that omits presets, relying on the default', () => {
+    const config = baseConfig()
+    expect(() => validateConfig(config)).not.toThrow()
+  })
+
+  test('rejects a non-array presets value', () => {
+    const config = { ...baseConfig(), presets: 'de-tv' }
+    expect(() => validateConfig(config)).toThrow(ConfigError)
+  })
+
+  test('rejects a presets list containing a non-string entry', () => {
+    const config = { ...baseConfig(), presets: [123] }
+    expect(() => validateConfig(config)).toThrow(ConfigError)
+  })
+
   test('rejects a non-numeric grid dimension and names the key', () => {
     const config = baseConfig()
     config.grid.cols = Number.NaN

--- a/packages/streamwall/src/main/config.ts
+++ b/packages/streamwall/src/main/config.ts
@@ -65,6 +65,7 @@ const streamwallConfigSchema = z.object({
     'json-url': z.array(z.string()),
     'toml-file': z.array(z.string()),
   }),
+  presets: z.array(z.string()).default(['de-tv']),
   streamdelay: z.object({
     endpoint: z.string(),
     key: z.string().nullable(),

--- a/packages/streamwall/src/main/data.test.ts
+++ b/packages/streamwall/src/main/data.test.ts
@@ -11,9 +11,11 @@ import {
   LocalStreamData,
   markDataSource,
   pollDataURL,
+  presetDataSource,
   StreamIDGenerator,
   watchDataFile,
 } from './data'
+import type { PresetPack } from './presets'
 
 class FakeWatcher extends EventEmitter {
   close = vi.fn(async () => {})
@@ -677,5 +679,49 @@ describe('combineDataSources', () => {
     const { value } = await gen.next()
     expect(value).toHaveLength(0)
     expect(value?.byURL?.has('https://ghost.example/s')).toBe(false)
+  })
+})
+
+describe('presetDataSource', () => {
+  test('yields the pack entries once and stays open', async () => {
+    const pack: PresetPack = {
+      id: 'test-pack',
+      name: 'Test Pack',
+      entries: [{ link: 'https://a.example/s', kind: 'video', label: 'A' }],
+    }
+    const gen = presetDataSource(pack)
+    try {
+      const { value } = await gen.next()
+      expect(value).toEqual([
+        { link: 'https://a.example/s', kind: 'video', label: 'A' },
+      ])
+    } finally {
+      await gen.return?.(undefined)
+    }
+  })
+
+  test('combines with other sources via combineDataSources, tagged with the given source name', async () => {
+    const pack: PresetPack = {
+      id: 'de-tv',
+      name: 'German Free-TV',
+      entries: [
+        { link: 'https://ard.example/s', kind: 'video', label: 'ARD' },
+      ],
+    }
+    const idGen = new StreamIDGenerator()
+    // combineDataSources()'s .return() never resolves (Repeater.latest does
+    // not propagate return() to its contenders), so - matching the existing
+    // combineDataSources tests above - read a single value and let the
+    // generator get garbage-collected rather than tearing it down.
+    const iterator = combineDataSources(
+      [markDataSource(presetDataSource(pack), 'preset:de-tv')],
+      idGen,
+    )
+    const { value } = await iterator.next()
+    expect(value).toHaveLength(1)
+    expect(value?.[0]).toMatchObject({
+      link: 'https://ard.example/s',
+      _dataSource: 'preset:de-tv',
+    })
   })
 })

--- a/packages/streamwall/src/main/data.test.ts
+++ b/packages/streamwall/src/main/data.test.ts
@@ -704,9 +704,7 @@ describe('presetDataSource', () => {
     const pack: PresetPack = {
       id: 'de-tv',
       name: 'German Free-TV',
-      entries: [
-        { link: 'https://ard.example/s', kind: 'video', label: 'ARD' },
-      ],
+      entries: [{ link: 'https://ard.example/s', kind: 'video', label: 'ARD' }],
     }
     const idGen = new StreamIDGenerator()
     // combineDataSources()'s .return() never resolves (Repeater.latest does

--- a/packages/streamwall/src/main/data.ts
+++ b/packages/streamwall/src/main/data.ts
@@ -12,6 +12,7 @@ import {
   StreamList,
 } from '../../../streamwall-shared/src/types'
 import log from './logger'
+import type { PresetPack } from './presets'
 
 const sleep = promisify(setTimeout)
 
@@ -107,6 +108,21 @@ export async function* watchDataFile(
   } finally {
     await watcher.close()
   }
+}
+
+/**
+ * Emits a preset pack's entries once. Presets are static, bundled data -
+ * there is nothing to poll or watch - so this pushes its one value and then
+ * stays open, mirroring how `LocalStreamData.gen()` behaves after its
+ * initial push.
+ */
+export function presetDataSource(
+  pack: PresetPack,
+): AsyncIterableIterator<StreamDataContent[]> {
+  return new Repeater(async (push, stop) => {
+    await push(pack.entries as StreamDataContent[])
+    await stop
+  })
 }
 
 export async function* markDataSource(dataSource: DataSource, name: string) {

--- a/packages/streamwall/src/main/favorites.test.ts
+++ b/packages/streamwall/src/main/favorites.test.ts
@@ -3,9 +3,9 @@ import { addFavorite, removeFavorite } from './favorites'
 
 describe('addFavorite', () => {
   test('appends a new url', () => {
-    expect(
-      addFavorite(['https://a.example/s'], 'https://b.example/s'),
-    ).toEqual(['https://a.example/s', 'https://b.example/s'])
+    expect(addFavorite(['https://a.example/s'], 'https://b.example/s')).toEqual(
+      ['https://a.example/s', 'https://b.example/s'],
+    )
   })
 
   test('appends to an empty list', () => {
@@ -32,9 +32,9 @@ describe('removeFavorite', () => {
 
   test('is a no-op (same array reference) when the url is not a favorite', () => {
     const favorites = ['https://a.example/s']
-    expect(
-      removeFavorite(favorites, 'https://not-a-favorite.example/s'),
-    ).toBe(favorites)
+    expect(removeFavorite(favorites, 'https://not-a-favorite.example/s')).toBe(
+      favorites,
+    )
   })
 
   test('removing from an empty list stays empty', () => {

--- a/packages/streamwall/src/main/favorites.test.ts
+++ b/packages/streamwall/src/main/favorites.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'vitest'
+import { addFavorite, removeFavorite } from './favorites'
+
+describe('addFavorite', () => {
+  test('appends a new url', () => {
+    expect(
+      addFavorite(['https://a.example/s'], 'https://b.example/s'),
+    ).toEqual(['https://a.example/s', 'https://b.example/s'])
+  })
+
+  test('appends to an empty list', () => {
+    expect(addFavorite([], 'https://a.example/s')).toEqual([
+      'https://a.example/s',
+    ])
+  })
+
+  test('is a no-op (same array reference) when the url is already a favorite', () => {
+    const favorites = ['https://a.example/s']
+    expect(addFavorite(favorites, 'https://a.example/s')).toBe(favorites)
+  })
+})
+
+describe('removeFavorite', () => {
+  test('removes an existing url', () => {
+    expect(
+      removeFavorite(
+        ['https://a.example/s', 'https://b.example/s'],
+        'https://a.example/s',
+      ),
+    ).toEqual(['https://b.example/s'])
+  })
+
+  test('is a no-op (same array reference) when the url is not a favorite', () => {
+    const favorites = ['https://a.example/s']
+    expect(
+      removeFavorite(favorites, 'https://not-a-favorite.example/s'),
+    ).toBe(favorites)
+  })
+
+  test('removing from an empty list stays empty', () => {
+    expect(removeFavorite([], 'https://a.example/s')).toEqual([])
+  })
+})

--- a/packages/streamwall/src/main/favorites.ts
+++ b/packages/streamwall/src/main/favorites.ts
@@ -1,0 +1,23 @@
+/**
+ * Appends `url` to `favorites` if it isn't already present. Returns the same
+ * array reference when `url` is already a favorite, so a redundant
+ * add-favorite command is a no-op rather than persisting/broadcasting an
+ * unnecessary update.
+ */
+export function addFavorite(favorites: string[], url: string): string[] {
+  if (favorites.includes(url)) {
+    return favorites
+  }
+  return [...favorites, url]
+}
+
+/**
+ * Removes `url` from `favorites`. Returns the same array reference when
+ * `url` isn't present, so removing a non-favorite is a no-op.
+ */
+export function removeFavorite(favorites: string[], url: string): string[] {
+  if (!favorites.includes(url)) {
+    return favorites
+  }
+  return favorites.filter((favoriteUrl) => favoriteUrl !== url)
+}

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -43,9 +43,11 @@ import {
   combineDataSources,
   markDataSource,
   pollDataURL,
+  presetDataSource,
   watchDataFile,
 } from './data'
 import { DataSourceHealthTracker } from './dataSourceHealth'
+import { addFavorite, removeFavorite } from './favorites'
 import { applyGridResize } from './gridResize'
 import {
   addLayoutPreset,
@@ -57,6 +59,7 @@ import { installApplicationMenu } from './menu'
 import { denyWindowOpen } from './navigationSecurity'
 import { BROWSE_PARTITION, hardenSession } from './partitions'
 import { PlaylistScheduler } from './playlist'
+import { loadPresetPack } from './presets'
 import { flushStorage, loadStorage, safeUpdate } from './storage'
 import StreamdelayClient from './StreamdelayClient'
 import StreamWindow from './StreamWindow'
@@ -127,6 +130,7 @@ export interface StreamwallConfig {
     'json-url': string[]
     'toml-file': string[]
   }
+  presets: string[]
   streamdelay: {
     endpoint: string
     key: string | null
@@ -281,6 +285,13 @@ function parseArgs(): StreamwallConfig {
       normalize: true,
       array: true,
       default: [],
+    })
+    .group(['presets'], 'Presets')
+    .option('presets', {
+      describe: 'Enabled built-in preset stream packs (e.g. "de-tv")',
+      array: true,
+      string: true,
+      default: ['de-tv'],
     })
     .group(['streamdelay.endpoint', 'streamdelay.key'], 'Streamdelay')
     .option('streamdelay.endpoint', {
@@ -475,6 +486,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     views: [],
     streamdelay: null,
     layoutPresets: db.data.layoutPresets,
+    favorites: db.data.favorites,
     dataSourceHealth: [],
   }
 
@@ -698,6 +710,24 @@ async function main(argv: ReturnType<typeof parseArgs>) {
         data.layoutPresets = layoutPresets
       })
       updateState({ layoutPresets })
+    } else if (msg.type === 'add-favorite') {
+      const favorites = addFavorite(clientState.favorites, msg.url)
+      if (favorites !== clientState.favorites) {
+        log.debug('Adding favorite:', msg.url)
+        safeUpdate(db, (data) => {
+          data.favorites = favorites
+        })
+        updateState({ favorites })
+      }
+    } else if (msg.type === 'remove-favorite') {
+      const favorites = removeFavorite(clientState.favorites, msg.url)
+      if (favorites !== clientState.favorites) {
+        log.debug('Removing favorite:', msg.url)
+        safeUpdate(db, (data) => {
+          data.favorites = favorites
+        })
+        updateState({ favorites })
+      }
     }
   }
 
@@ -939,6 +969,15 @@ async function main(argv: ReturnType<typeof parseArgs>) {
         watchDataFile(path, trackDataSourceHealth(path, 'toml-file')),
         'toml-file',
       )
+    }),
+    ...argv.presets.flatMap((packId) => {
+      const pack = loadPresetPack(packId)
+      if (!pack) {
+        log.warn(`Unknown preset pack "${packId}", skipping`)
+        return []
+      }
+      log.debug('Loading preset pack:', pack.id)
+      return [markDataSource(presetDataSource(pack), `preset:${pack.id}`)]
     }),
     markDataSource(localStreamData.gen(), 'custom'),
     markDataSource(overlayStreamData.gen(), OVERLAY_DATA_SOURCE_NAME),

--- a/packages/streamwall/src/main/presets/de-tv.json
+++ b/packages/streamwall/src/main/presets/de-tv.json
@@ -1,0 +1,145 @@
+[
+  {
+    "link": "https://daserste-live.ard-mcdn.de/daserste/live/hls/int/master.m3u8",
+    "kind": "video",
+    "label": "ARD (Das Erste)",
+    "source": "ARD",
+    "notes": "Public broadcaster live stream; verified reachable, segment playback may be geo-restricted to Germany."
+  },
+  {
+    "link": "https://zdf-hls-15.akamaized.net/hls/live/2016498/de/high/master.m3u8",
+    "kind": "video",
+    "label": "ZDF",
+    "source": "ZDF",
+    "notes": "Public broadcaster live stream; verified reachable, segment playback may be geo-restricted to Germany."
+  },
+  {
+    "link": "https://zdf-hls-16.akamaized.net/hls/live/2016499/de/high/master.m3u8",
+    "kind": "video",
+    "label": "ZDFneo",
+    "source": "ZDF",
+    "notes": "Public broadcaster live stream; verified reachable, segment playback may be geo-restricted to Germany."
+  },
+  {
+    "link": "https://zdf-hls-17.akamaized.net/hls/live/2016500/de/high/master.m3u8",
+    "kind": "video",
+    "label": "ZDFinfo",
+    "source": "ZDF",
+    "notes": "Public broadcaster live stream; verified reachable, segment playback may be geo-restricted to Germany."
+  },
+  {
+    "link": "https://tagesschau.akamaized.net/hls/live/2020115/tagesschau/tagesschau_1/master.m3u8",
+    "kind": "video",
+    "label": "tagesschau24",
+    "source": "ARD",
+    "notes": "Public broadcaster live stream; verified reachable, segment playback may be geo-restricted to Germany."
+  },
+  {
+    "link": "https://zdf-hls-19.akamaized.net/hls/live/2016502/de/high/master.m3u8",
+    "kind": "video",
+    "label": "phoenix",
+    "source": "ZDF",
+    "notes": "Public broadcaster live stream; verified reachable, segment playback may be geo-restricted to Germany."
+  },
+  {
+    "link": "https://zdf-hls-18.akamaized.net/hls/live/2016501/dach/high/master.m3u8",
+    "kind": "video",
+    "label": "3sat",
+    "source": "ZDF",
+    "notes": "Public broadcaster live stream; verified reachable, segment playback may be geo-restricted to Germany."
+  },
+  {
+    "link": "https://kikahls.akamaized.net/hls/live/2022690/livetvkika_ww/master.m3u8",
+    "kind": "video",
+    "label": "KiKA",
+    "source": "KiKA",
+    "notes": "Public broadcaster live stream; verified reachable, segment playback may be geo-restricted to Germany."
+  },
+  {
+    "link": "https://artesimulcast.akamaized.net/hls/live/2030993/artelive_de/index.m3u8",
+    "kind": "video",
+    "label": "arte",
+    "source": "arte",
+    "notes": "Public broadcaster live stream; verified reachable, segment playback may be geo-restricted to Germany."
+  },
+  {
+    "link": "https://mcdn.br.de/br/fs/bfs_nord/hls/de/master.m3u8",
+    "kind": "video",
+    "label": "BR Fernsehen Nord",
+    "source": "BR",
+    "state": "Bayern",
+    "notes": "Public broadcaster live stream; verified reachable, segment playback may be geo-restricted to Germany."
+  },
+  {
+    "link": "https://mcdn.br.de/br/fs/bfs_sued/hls/de/master.m3u8",
+    "kind": "video",
+    "label": "BR Fernsehen Süd",
+    "source": "BR",
+    "state": "Bayern",
+    "notes": "Public broadcaster live stream; verified reachable, segment playback may be geo-restricted to Germany."
+  },
+  {
+    "link": "https://mcdn.ndr.de/ndr/hls/ndr_fs/ndr_nds/master.m3u8",
+    "kind": "video",
+    "label": "NDR Fernsehen",
+    "source": "NDR",
+    "state": "Niedersachsen",
+    "notes": "Public broadcaster live stream; verified reachable, segment playback may be geo-restricted to Germany."
+  },
+  {
+    "link": "https://wdr-live.ard-mcdn.de/wdr/live/hls/de/master.m3u8",
+    "kind": "video",
+    "label": "WDR Fernsehen",
+    "source": "WDR",
+    "state": "Nordrhein-Westfalen",
+    "notes": "Public broadcaster live stream; verified reachable, segment playback may be geo-restricted to Germany."
+  },
+  {
+    "link": "https://swrbwd-hls.akamaized.net/hls/live/2018672/swrbwd/master.m3u8",
+    "kind": "video",
+    "label": "SWR Fernsehen Baden-Württemberg",
+    "source": "SWR",
+    "state": "Baden-Württemberg",
+    "notes": "Public broadcaster live stream; verified reachable, segment playback may be geo-restricted to Germany."
+  },
+  {
+    "link": "https://swrrpd-hls.akamaized.net/hls/live/2018676/swrrpd/master.m3u8",
+    "kind": "video",
+    "label": "SWR Fernsehen Rheinland-Pfalz",
+    "source": "SWR",
+    "state": "Rheinland-Pfalz",
+    "notes": "Public broadcaster live stream; verified reachable, segment playback may be geo-restricted to Germany."
+  },
+  {
+    "link": "https://hrhls.akamaized.net/hls/live/2024525/hrhls/index.m3u8",
+    "kind": "video",
+    "label": "HR Fernsehen",
+    "source": "HR",
+    "state": "Hessen",
+    "notes": "Public broadcaster live stream; verified reachable, segment playback may be geo-restricted to Germany."
+  },
+  {
+    "link": "https://mdrtvsnhls.akamaized.net/hls/live/2016928/mdrtvsn/index.m3u8",
+    "kind": "video",
+    "label": "MDR Fernsehen Sachsen",
+    "source": "MDR",
+    "state": "Sachsen",
+    "notes": "Public broadcaster live stream; verified reachable, segment playback may be geo-restricted to Germany."
+  },
+  {
+    "link": "https://rbb-hls-berlin.akamaized.net/hls/live/2017824/rbb_berlin/index.m3u8",
+    "kind": "video",
+    "label": "rbb Fernsehen Berlin",
+    "source": "rbb",
+    "state": "Berlin",
+    "notes": "Public broadcaster live stream; verified reachable, segment playback may be geo-restricted to Germany."
+  },
+  {
+    "link": "https://srfs.akamaized.net/hls/live/689649/srfsgeo/index.m3u8",
+    "kind": "video",
+    "label": "SR Fernsehen",
+    "source": "SR",
+    "state": "Saarland",
+    "notes": "Public broadcaster live stream; verified reachable, segment playback may be geo-restricted to Germany."
+  }
+]

--- a/packages/streamwall/src/main/presets/index.test.ts
+++ b/packages/streamwall/src/main/presets/index.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'vitest'
+import { buildPresetPack, loadPresetPack } from './index'
+
+describe('buildPresetPack', () => {
+  test('keeps valid entries and drops invalid ones', () => {
+    const pack = buildPresetPack('test-pack', 'Test Pack', [
+      { link: 'https://a.example/s', kind: 'video', label: 'A' },
+      { kind: 'video' }, // missing link - dropped
+      { link: 'https://b.example/s', kind: 'video', label: 'B' },
+    ])
+
+    expect(pack).toEqual({
+      id: 'test-pack',
+      name: 'Test Pack',
+      entries: [
+        { link: 'https://a.example/s', kind: 'video', label: 'A' },
+        { link: 'https://b.example/s', kind: 'video', label: 'B' },
+      ],
+    })
+  })
+
+  test('produces an empty entries list when every input entry is invalid', () => {
+    const pack = buildPresetPack('test-pack', 'Test Pack', [
+      { kind: 'video' },
+    ])
+    expect(pack.entries).toEqual([])
+  })
+
+  test('produces an empty entries list for non-array input', () => {
+    const pack = buildPresetPack('test-pack', 'Test Pack', 'not an array')
+    expect(pack.entries).toEqual([])
+  })
+})
+
+describe('loadPresetPack', () => {
+  test('returns the bundled German free-TV pack with every entry a valid https video stream', () => {
+    const pack = loadPresetPack('de-tv')
+
+    expect(pack).toBeDefined()
+    expect(pack?.id).toBe('de-tv')
+    expect(pack?.name).toBe('German Free-TV')
+    expect(pack?.entries.length).toBeGreaterThanOrEqual(19)
+    for (const entry of pack?.entries ?? []) {
+      expect(entry.link.startsWith('https://')).toBe(true)
+      expect(entry.kind).toBe('video')
+      expect(entry.label).toBeTruthy()
+    }
+  })
+
+  test('every bundled de-tv entry has a unique link', () => {
+    const pack = loadPresetPack('de-tv')
+    const links = pack?.entries.map((e) => e.link) ?? []
+    expect(new Set(links).size).toBe(links.length)
+  })
+
+  test('returns undefined for an unknown pack id', () => {
+    expect(loadPresetPack('not-a-real-pack')).toBeUndefined()
+  })
+})

--- a/packages/streamwall/src/main/presets/index.test.ts
+++ b/packages/streamwall/src/main/presets/index.test.ts
@@ -20,9 +20,7 @@ describe('buildPresetPack', () => {
   })
 
   test('produces an empty entries list when every input entry is invalid', () => {
-    const pack = buildPresetPack('test-pack', 'Test Pack', [
-      { kind: 'video' },
-    ])
+    const pack = buildPresetPack('test-pack', 'Test Pack', [{ kind: 'video' }])
     expect(pack.entries).toEqual([])
   })
 

--- a/packages/streamwall/src/main/presets/index.ts
+++ b/packages/streamwall/src/main/presets/index.ts
@@ -1,0 +1,53 @@
+import { parseStreamList, type StreamDataInput } from 'streamwall-shared'
+import log from '../logger'
+import deTvEntries from './de-tv.json'
+
+export interface PresetPack {
+  id: string
+  name: string
+  entries: StreamDataInput[]
+}
+
+interface PresetPackDefinition {
+  name: string
+  rawEntries: unknown[]
+}
+
+/** Built-in preset packs, keyed by the id an operator references via the `presets` config/CLI option. */
+const packDefinitions: Record<string, PresetPackDefinition> = {
+  'de-tv': { name: 'German Free-TV', rawEntries: deTvEntries },
+}
+
+/**
+ * Validates `rawEntries` the same way any other stream data source is
+ * validated, dropping and logging invalid entries rather than failing the
+ * whole pack. Exported separately from `loadPresetPack` so this tolerance
+ * behavior is directly testable without needing to inject a malformed
+ * bundled file.
+ */
+export function buildPresetPack(
+  id: string,
+  name: string,
+  rawEntries: unknown,
+): PresetPack {
+  const { streams, errors } = parseStreamList(rawEntries)
+  if (errors.length) {
+    log.warn(
+      `ignoring ${errors.length} invalid entr${errors.length === 1 ? 'y' : 'ies'} in preset pack "${id}"`,
+    )
+  }
+  return { id, name, entries: streams }
+}
+
+/**
+ * Loads and validates a built-in preset pack by id. Returns undefined for an
+ * unknown pack id so the caller can warn and skip it rather than crash
+ * startup over an operator typo in the `presets` config/CLI option.
+ */
+export function loadPresetPack(id: string): PresetPack | undefined {
+  const definition = packDefinitions[id]
+  if (!definition) {
+    return undefined
+  }
+  return buildPresetPack(id, definition.name, definition.rawEntries)
+}

--- a/packages/streamwall/src/main/storage.test.ts
+++ b/packages/streamwall/src/main/storage.test.ts
@@ -16,6 +16,7 @@ function makeDB(initial: Partial<StreamwallStoredData> = {}): StorageDB {
     stateDoc: '',
     localStreamData: [],
     layoutPresets: [],
+    favorites: [],
     ...initial,
   })
 }
@@ -122,6 +123,36 @@ describe('loadStorage', () => {
       expect(db.data.layoutPresets).toEqual([
         { id: 'p1', name: 'My Layout', cols: 2, rows: 2, views: {} },
       ])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('favorites persistence', () => {
+  test('defaults favorites to an empty array for a fresh db', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'streamwall-storage-test-'))
+    try {
+      const dbPath = join(dir, 'storage.json')
+      const db = await loadStorage(dbPath)
+
+      expect(db.data.favorites).toEqual([])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('db.update persists a saved favorite onto db.data', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'streamwall-storage-test-'))
+    try {
+      const dbPath = join(dir, 'storage.json')
+      const db = await loadStorage(dbPath)
+
+      await db.update((data) => {
+        data.favorites = ['https://example.com/stream']
+      })
+
+      expect(db.data.favorites).toEqual(['https://example.com/stream'])
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }

--- a/packages/streamwall/src/main/storage.ts
+++ b/packages/streamwall/src/main/storage.ts
@@ -7,12 +7,14 @@ export interface StreamwallStoredData {
   stateDoc: string
   localStreamData: StreamDataContent[]
   layoutPresets: LayoutPreset[]
+  favorites: string[]
 }
 
 const defaultData: StreamwallStoredData = {
   stateDoc: '',
   localStreamData: [],
   layoutPresets: [],
+  favorites: [],
 }
 
 export type StorageDB = Low<StreamwallStoredData>


### PR DESCRIPTION
## Summary
- Add a bundled, enabled-by-default "German Free-TV" preset stream pack (ARD, ZDF, ZDFneo/info, tagesschau24, phoenix, 3sat, KiKA, arte, BR, NDR, WDR, SWR, HR, MDR, rbb, SR — 19 channels, each verified reachable), loaded as its own data source and extensible via new preset packs without touching the core pipeline
- Add a global "favorite" mechanism (`add-favorite`/`remove-favorite`) so any stream — preset, custom, or from a regular data source — can be starred for quick access from a dedicated Favorites section in the control UI
- Favorites follow the same persisted, role-gated, team-shared pattern as the existing Custom Streams and Layout Presets features

## Details
- **Shared**: `favorites: string[]` on `StreamwallState`, two new `ControlCommand`s + zod schema entries, gated to the operator role tier
- **Streamwall (main process)**: favorites persisted via lowdb; presets loaded through the existing `combineDataSources`/`markDataSource` pipeline as a one-shot data source; new `presets` config option (default `['de-tv']`)
- **Control-server**: `favorites` added to the role-scoped state view so it reaches every connected client, not just the local desktop UI
- **Control-UI**: star toggle on every stream row; new "Favorites" section above Viewing/Live/Offline, showing favorited streams from any source

## Test plan
- [x] `npm run typecheck` — clean across all workspaces
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm test` — all green (streamwall, streamwall-shared, streamwall-control-client, streamwall-control-server, streamwall-control-ui)
- [x] Manual smoke test via the control-client dev harness: Favorites section renders with correct count, star toggle fills/empties and dispatches `add-favorite`/`remove-favorite` without also selecting the stream into a grid cell