### PR TITLE
test(control-e2e): add Playwright smoke tests for the control client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,26 @@ jobs:
       - uses: ./.github/actions/setup
       - run: npm -w streamwall-control-client run build
 
+  # End-to-end smoke tests: the control client in a real Chromium browser
+  # against a real control server + fake Streamwall uplink. Linux-only (the
+  # Playwright browser install with system deps is Linux-only), so this stays
+  # out of the cross-OS `test` matrix above.
+  e2e:
+    name: E2E smoke (control client)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+      - name: Run E2E smoke tests
+        run: npm -w streamwall-control-e2e run test:e2e
+
   # Reviews the dependency diff of a PR for known vulnerabilities.
   dependency-review:
     name: Dependency review
@@ -147,7 +167,7 @@ jobs:
   ci-ok:
     name: CI OK
     if: ${{ !cancelled() }}
-    needs: [changes, checks, test, build, dependency-review, actionlint]
+    needs: [changes, checks, test, build, e2e, dependency-review, actionlint]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,12 @@ storage.json
 .eslintcache
 .npm/
 
+# Playwright (E2E) artifacts
+test-results/
+playwright-report/
+blob-report/
+.playwright/
+
 # Editors / IDEs
 .vscode/
 .idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
         "packages/streamwall-shared",
         "packages/streamwall-control-client",
         "packages/streamwall-control-server",
-        "packages/streamwall-control-ui"
+        "packages/streamwall-control-ui",
+        "packages/streamwall-control-e2e"
       ],
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -3575,6 +3576,22 @@
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@preact/preset-vite": {
       "version": "2.10.5",
@@ -11703,6 +11720,53 @@
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
     },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/plist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
@@ -13001,6 +13065,10 @@
     },
     "node_modules/streamwall-control-client": {
       "resolved": "packages/streamwall-control-client",
+      "link": true
+    },
+    "node_modules/streamwall-control-e2e": {
+      "resolved": "packages/streamwall-control-e2e",
       "link": true
     },
     "node_modules/streamwall-control-server": {
@@ -15227,6 +15295,46 @@
           "optional": true
         },
         "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "packages/streamwall-control-e2e": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@playwright/test": "^1.61.1",
+        "@tsconfig/node-ts": "^23.6.4",
+        "@tsconfig/node22": "^22.0.5",
+        "@tsconfig/recommended": "^1.0.13",
+        "@types/ws": "^8.18.1",
+        "lowdb": "^7.0.1",
+        "streamwall-control-server": "*",
+        "streamwall-shared": "*",
+        "tsx": "^4.23.1",
+        "typescript": "^6.0.3",
+        "ws": "^8.21.1",
+        "yjs": "^13.6.31"
+      }
+    },
+    "packages/streamwall-control-e2e/node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "packages/streamwall-shared",
     "packages/streamwall-control-client",
     "packages/streamwall-control-server",
-    "packages/streamwall-control-ui"
+    "packages/streamwall-control-ui",
+    "packages/streamwall-control-e2e"
   ],
   "overrides": {
     "tar": "^7.5.16",

--- a/packages/streamwall-control-e2e/README.md
+++ b/packages/streamwall-control-e2e/README.md
@@ -1,0 +1,32 @@
+# streamwall-control-e2e
+
+Playwright end-to-end smoke tests for the **control client** running against a
+real **control server** and a **fake Streamwall uplink** (issue #55).
+
+Unlike the happy-dom/jsdom unit tests in the other packages, these boot the full
+stack — Vite-built client → Fastify/WebSocket server → mocked Streamwall peer —
+in a real Chromium browser, so they cover things that only manifest with real
+networking and real layout:
+
+- the invite-link → session-cookie sign-in flow and grid render from injected state,
+- unauthorized access being rejected,
+- a grid-cell edit propagating over the wire to the Streamwall peer (Yjs), and
+- horizontal-overflow layout regressions (issue #225/#239) that no unit test can catch.
+
+## Running
+
+```sh
+# once, to fetch the browser (Linux CI uses `--with-deps`):
+npx playwright install chromium
+
+# build the client and run the suite:
+npm -w streamwall-control-e2e run test:e2e
+```
+
+`test:e2e` builds the control client first (the server serves its `dist/`), then
+runs Playwright. Each test spins up its own server + uplink on a fresh port, so
+there is no shared global setup or fixed port.
+
+The suite is intentionally kept out of the per-workspace `npm test` matrix (it
+has no `test` script) because it needs a browser and only runs on Linux/macOS —
+CI runs it in a dedicated job behind `npx playwright install --with-deps chromium`.

--- a/packages/streamwall-control-e2e/package.json
+++ b/packages/streamwall-control-e2e/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "streamwall-control-e2e",
+  "version": "1.0.0",
+  "description": "Multiplayer Streamwall: control-client end-to-end smoke tests",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:e2e": "NODE_OPTIONS=\"--import tsx\" playwright test",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "repository": "github:NilsR0711/streamwall",
+  "author": "Nils Reeh <info@nilsreeh.de>",
+  "license": "MIT",
+  "devDependencies": {
+    "@playwright/test": "^1.61.1",
+    "@tsconfig/node-ts": "^23.6.4",
+    "@tsconfig/node22": "^22.0.5",
+    "@tsconfig/recommended": "^1.0.13",
+    "@types/ws": "^8.18.1",
+    "lowdb": "^7.0.1",
+    "streamwall-control-server": "*",
+    "streamwall-shared": "*",
+    "tsx": "^4.23.1",
+    "typescript": "^6.0.3",
+    "ws": "^8.21.1",
+    "yjs": "^13.6.31"
+  }
+}

--- a/packages/streamwall-control-e2e/playwright.config.ts
+++ b/packages/streamwall-control-e2e/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// Each test boots its own control server + fake Streamwall uplink on a fresh
+// ephemeral port (see tests/harness.ts), so there is no shared `webServer` or
+// global `baseURL` here — tests navigate to the per-harness URL directly.
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.spec.ts',
+  globalSetup: './tests/global-setup.ts',
+  fullyParallel: false,
+  // Serial: every test spins up a real Fastify server + WebSocket uplink, and
+  // the handful of smoke tests are cheap enough that one worker keeps them
+  // deterministic (no port-allocation races, no resource contention).
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: 'list',
+  use: {
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+})

--- a/packages/streamwall-control-e2e/tests/global-setup.ts
+++ b/packages/streamwall-control-e2e/tests/global-setup.ts
@@ -1,0 +1,21 @@
+import { execFileSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Builds the control client once before the suite runs, so the control server
+ * has real `dist/` assets to serve. The build is spawned with `NODE_OPTIONS`
+ * cleared so the harness's `--import tsx` loader can't interfere with Vite's
+ * own config loading.
+ */
+export default function globalSetup() {
+  const clientDir = path.resolve(
+    fileURLToPath(new URL('.', import.meta.url)),
+    '../../streamwall-control-client',
+  )
+  execFileSync('npm', ['run', 'build'], {
+    cwd: clientDir,
+    stdio: 'inherit',
+    env: { ...process.env, NODE_OPTIONS: '' },
+  })
+}

--- a/packages/streamwall-control-e2e/tests/harness.ts
+++ b/packages/streamwall-control-e2e/tests/harness.ts
@@ -1,0 +1,347 @@
+import { test as base } from '@playwright/test'
+import { Low, Memory } from 'lowdb'
+import { once } from 'node:events'
+import { existsSync } from 'node:fs'
+import type { AddressInfo } from 'node:net'
+import net from 'node:net'
+import path from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
+import { fileURLToPath } from 'node:url'
+import { initApp } from 'streamwall-control-server'
+import type { StoredData } from 'streamwall-control-server/src/storage.ts'
+import {
+  inviteLink,
+  type StreamData,
+  type StreamwallRole,
+  type StreamwallState,
+} from 'streamwall-shared'
+import WebSocket from 'ws'
+import * as Y from 'yjs'
+
+const COLS = 3
+const ROWS = 3
+const CELL_COUNT = COLS * ROWS
+
+/** Absolute path to the built control-client assets the server serves. */
+const CLIENT_DIST = path.resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../streamwall-control-client/dist',
+)
+
+/**
+ * Three demo streams, mirroring the dev harness fixtures. Only their `_id`s
+ * matter to the tests: a grid cell only commits a typed value when it matches
+ * a known stream `_id` (see `resolveEagerWriteStreamId`).
+ */
+const DEMO_STREAMS: StreamData[] = [
+  {
+    _id: 'wok',
+    _dataSource: 'e2e',
+    kind: 'video',
+    link: 'https://twitch.tv/woke',
+    label: 'PDX Live',
+    source: 'woke.net',
+    status: 'Live',
+  },
+  {
+    _id: 'oma',
+    _dataSource: 'e2e',
+    kind: 'video',
+    link: 'https://youtube.com/watch?v=oma',
+    label: 'Capitol Hill',
+    source: 'Omari Salisbury',
+    status: 'Live',
+  },
+  {
+    _id: 'uni',
+    _dataSource: 'e2e',
+    kind: 'video',
+    link: 'https://facebook.com/unicornriot/v/1',
+    label: 'South MPLS',
+    source: 'Unicorn Riot',
+    status: 'Live',
+  },
+]
+
+/**
+ * A minimal but complete admin `StreamwallState` the fake uplink pushes on
+ * connect. `views` is intentionally empty (no running streams) — the grid still
+ * renders all `COLS*ROWS` cell inputs, which the tests drive directly.
+ */
+const E2E_STATE: StreamwallState = {
+  identity: { role: 'admin' },
+  auth: { invites: [], sessions: [] },
+  config: {
+    cols: COLS,
+    rows: ROWS,
+    width: 1920,
+    height: 1080,
+    frameless: false,
+    fullscreen: false,
+    activeColor: '#f24d2e',
+    backgroundColor: '#000000',
+  },
+  streams: DEMO_STREAMS,
+  customStreams: [],
+  views: [],
+  streamdelay: null,
+  layoutPresets: [],
+  dataSourceHealth: [],
+}
+
+/** A handle to one running control server + connected fake Streamwall uplink. */
+export interface Harness {
+  /** Origin the browser must use (matches the server's expected WS origin). */
+  readonly baseURL: string
+  readonly cols: number
+  readonly rows: number
+  /** The stream `_id`s the seeded state knows about. */
+  readonly streamIds: readonly string[]
+  /** Mints an invite and returns its full `/invite/:id#token=…` link. */
+  createInviteLink(role?: StreamwallRole): Promise<string>
+  /**
+   * Resolves once the fake uplink has observed `streamId` assigned to grid cell
+   * `idx` in the shared Yjs doc — i.e. the browser's grid-cell edit reached the
+   * Streamwall peer over the wire. Rejects on timeout.
+   */
+  waitForViewAssignment(
+    idx: number,
+    streamId: string,
+    timeoutMs?: number,
+  ): Promise<void>
+  close(): Promise<void>
+}
+
+/** Reserves a free localhost TCP port by briefly binding port 0. */
+async function getFreePort(): Promise<number> {
+  const srv = net.createServer()
+  try {
+    await new Promise<void>((resolve, reject) => {
+      srv.once('error', reject)
+      srv.listen(0, '127.0.0.1', resolve)
+    })
+    return (srv.address() as AddressInfo).port
+  } finally {
+    await new Promise<void>((resolve) => srv.close(() => resolve()))
+  }
+}
+
+/** Normalizes a `ws` binary frame to the `Uint8Array` Yjs expects. */
+function toUint8Array(data: WebSocket.RawData): Uint8Array {
+  if (Array.isArray(data)) {
+    return new Uint8Array(Buffer.concat(data))
+  }
+  if (data instanceof ArrayBuffer) {
+    return new Uint8Array(data)
+  }
+  return new Uint8Array(data)
+}
+
+/**
+ * Boots a control server backed by in-memory storage and throwaway state,
+ * connects a fake Streamwall uplink to it, and seeds a `COLS*ROWS` grid of
+ * (empty) view cells into the shared Yjs doc so the browser can edit them.
+ */
+export async function startHarness(): Promise<Harness> {
+  if (!existsSync(path.join(CLIENT_DIST, 'index.html'))) {
+    throw new Error(
+      `Control client build not found at ${CLIENT_DIST}. Run ` +
+        '`npm -w streamwall-control-client run build` first (the `test:e2e` ' +
+        'script does this automatically).',
+    )
+  }
+
+  // Give the browser plenty of request headroom: loading the app pulls many
+  // font/asset requests that would otherwise brush against the per-IP limit.
+  process.env.STREAMWALL_RATE_LIMIT_MAX ??= '100000'
+
+  const port = await getFreePort()
+  const baseURL = `http://127.0.0.1:${port}`
+
+  const initialData: StoredData = {
+    auth: { salt: null, tokens: [] },
+    streamwallToken: null,
+  }
+  const db = new Low<StoredData>(new Memory<StoredData>(), initialData)
+
+  const { app, auth } = await initApp({
+    baseURL,
+    clientStaticPath: CLIENT_DIST,
+    db,
+  })
+  await app.listen({ port, host: '127.0.0.1' })
+
+  // Connect the fake Streamwall uplink (the trusted authority for shared state).
+  const uplink = await auth.createToken({
+    kind: 'streamwall',
+    role: 'admin',
+    name: 'e2e-uplink',
+  })
+  const ws = new WebSocket(
+    `ws://127.0.0.1:${port}/streamwall/${uplink.tokenId}/ws`,
+    { headers: { authorization: `Bearer ${uplink.secret}` } },
+  )
+  ws.binaryType = 'arraybuffer'
+
+  // The peer's mirror of the shared doc: seeded here, then kept in sync with
+  // every update the server forwards, so tests can observe client grid edits.
+  const peerDoc = new Y.Doc()
+  peerDoc.transact(() => {
+    const views = peerDoc.getMap<Y.Map<string | undefined>>('views')
+    for (let idx = 0; idx < CELL_COUNT; idx++) {
+      const cell = new Y.Map<string | undefined>()
+      cell.set('streamId', undefined)
+      views.set(String(idx), cell)
+    }
+  })
+
+  ws.on('message', (data: WebSocket.RawData, isBinary: boolean) => {
+    if (isBinary) {
+      Y.applyUpdate(peerDoc, toUint8Array(data), 'server')
+    }
+  })
+
+  await once(ws, 'open')
+  ws.send(JSON.stringify({ type: 'state', state: E2E_STATE }))
+  ws.send(Y.encodeStateAsUpdate(peerDoc))
+
+  const redeemSessionCookie = async (role: StreamwallRole) => {
+    const invite = await auth.createToken({ kind: 'invite', role, name: 'e2e' })
+    const res = await app.inject({
+      method: 'POST',
+      url: `/invite/${invite.tokenId}`,
+      headers: { 'content-type': 'application/json' },
+      payload: { token: invite.secret },
+    })
+    const rawCookie = res.headers['set-cookie']
+    return (Array.isArray(rawCookie) ? rawCookie[0] : String(rawCookie)).split(
+      ';',
+    )[0]
+  }
+
+  // The server only echoes the uplink's *own* seed back once it has fully wired
+  // up the connection, so we can't confirm the seed landed by listening on the
+  // uplink. Instead, connect a throwaway client and wait until it sees the full
+  // grid in the shared doc — a deterministic barrier that the browser client
+  // (which connects much later) will find the cells it needs to edit.
+  const probeSharedDocSize = async (cookie: string) => {
+    const probe = new WebSocket(`ws://127.0.0.1:${port}/client/ws`, {
+      headers: { Cookie: cookie, Origin: baseURL },
+    })
+    probe.binaryType = 'arraybuffer'
+    const doc = new Y.Doc()
+    try {
+      return await new Promise<number>((resolve, reject) => {
+        const settle = () => resolve(doc.getMap('views').size)
+        const timer = setTimeout(settle, 1000)
+        probe.on('message', (data: WebSocket.RawData, isBinary: boolean) => {
+          if (!isBinary) {
+            return
+          }
+          Y.applyUpdate(doc, toUint8Array(data))
+          if (doc.getMap('views').size >= CELL_COUNT) {
+            clearTimeout(timer)
+            settle()
+          }
+        })
+        probe.on('close', () => {
+          clearTimeout(timer)
+          settle()
+        })
+        probe.on('error', (err) => {
+          clearTimeout(timer)
+          reject(err)
+        })
+      })
+    } finally {
+      probe.terminate()
+      doc.destroy()
+    }
+  }
+
+  const sessionCookie = await redeemSessionCookie('admin')
+  const deadline = Date.now() + 10_000
+  while (
+    (await probeSharedDocSize(sessionCookie).catch(() => 0)) < CELL_COUNT
+  ) {
+    if (Date.now() > deadline) {
+      throw new Error('Timed out confirming the shared grid doc was seeded.')
+    }
+    await delay(50)
+  }
+
+  const createInviteLink = async (role: StreamwallRole = 'admin') => {
+    const invite = await auth.createToken({ kind: 'invite', role, name: 'e2e' })
+    return inviteLink({
+      baseURL,
+      tokenId: invite.tokenId,
+      secret: invite.secret,
+    })
+  }
+
+  const waitForViewAssignment = (
+    idx: number,
+    streamId: string,
+    timeoutMs = 5000,
+  ) =>
+    new Promise<void>((resolve, reject) => {
+      const current = () =>
+        peerDoc.getMap<Y.Map<string | undefined>>('views').get(String(idx))
+      const matches = () => current()?.get('streamId') === streamId
+      if (matches()) {
+        resolve()
+        return
+      }
+      const onUpdate = () => {
+        if (matches()) {
+          cleanup()
+          resolve()
+        }
+      }
+      const timer = setTimeout(() => {
+        cleanup()
+        reject(
+          new Error(
+            `Timed out waiting for cell ${idx} to become "${streamId}" ` +
+              `(saw "${current()?.get('streamId')}")`,
+          ),
+        )
+      }, timeoutMs)
+      const cleanup = () => {
+        clearTimeout(timer)
+        peerDoc.off('update', onUpdate)
+      }
+      peerDoc.on('update', onUpdate)
+    })
+
+  const close = async () => {
+    ws.terminate()
+    peerDoc.destroy()
+    await app.close()
+  }
+
+  return {
+    baseURL,
+    cols: COLS,
+    rows: ROWS,
+    streamIds: DEMO_STREAMS.map((s) => s._id),
+    createInviteLink,
+    waitForViewAssignment,
+    close,
+  }
+}
+
+/** Playwright fixture that provides a fresh, isolated harness per test. */
+export const test = base.extend<{ harness: Harness }>({
+  // eslint-disable-next-line no-empty-pattern
+  harness: async ({}, use) => {
+    const harness = await startHarness()
+    try {
+      await use(harness)
+    } finally {
+      await harness.close()
+    }
+  },
+})
+
+export { expect } from '@playwright/test'

--- a/packages/streamwall-control-e2e/tests/smoke.spec.ts
+++ b/packages/streamwall-control-e2e/tests/smoke.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from './harness.ts'
+
+/**
+ * End-to-end smoke coverage for the control client against a real control
+ * server + fake Streamwall uplink, driven in a real browser (issue #55). These
+ * exercise the cookie/invite flow, the unauthorized path, the Yjs grid-edit
+ * round-trip, and real-layout regressions (issue #225/#239) that no
+ * happy-dom/jsdom unit test can catch.
+ */
+
+test('an admin invite link signs in and renders the grid from injected state', async ({
+  page,
+  harness,
+}) => {
+  // Navigating the invite link runs the exchange page, which POSTs the token,
+  // receives the session cookie, and redirects to the app.
+  await page.goto(await harness.createInviteLink())
+
+  const grid = page.locator('.grid')
+  await expect(grid).toBeVisible()
+  await expect(page.locator('.grid input')).toHaveCount(
+    harness.cols * harness.rows,
+  )
+  // Header status flips to "connected" only once the client's socket is up and
+  // the injected state has arrived.
+  await expect(page.locator('.status')).toContainText('connected')
+})
+
+test('an unauthenticated visitor is rejected with an unauthorized banner', async ({
+  page,
+  harness,
+}) => {
+  // No invite, no session cookie: the static app still loads, but its client
+  // socket is refused and the disconnect banner explains why.
+  await page.goto(`${harness.baseURL}/`)
+
+  await expect(page.getByRole('status')).toContainText('Session invalid')
+  // Without any state push the grid never renders.
+  await expect(page.locator('.grid')).toHaveCount(0)
+})
+
+test('a grid-cell edit reaches the Streamwall peer as a shared-doc update', async ({
+  page,
+  harness,
+}) => {
+  await page.goto(await harness.createInviteLink())
+
+  const cells = page.locator('.grid input')
+  await expect(cells).toHaveCount(harness.cols * harness.rows)
+
+  const targetIdx = 4 // center cell of the 3×3 grid
+  const [streamId] = harness.streamIds
+
+  await page.locator('.grid').hover()
+  await cells.nth(targetIdx).fill(streamId)
+  await cells.nth(targetIdx).blur()
+
+  // The edit must travel: browser → Yjs doc → control server → uplink peer.
+  await harness.waitForViewAssignment(targetIdx, streamId)
+  // …and the browser reflects the committed assignment.
+  await expect(cells.nth(targetIdx)).toHaveValue(streamId)
+})
+
+test('the layout never overflows horizontally across viewport widths', async ({
+  page,
+  harness,
+}) => {
+  await page.goto(await harness.createInviteLink())
+  await expect(page.locator('.grid')).toBeVisible()
+
+  // Real-browser layout measurement — the only way to catch min-content /
+  // margin overflow regressions (issue #225/#239) that unit tests miss.
+  for (const width of [360, 768, 1024, 1440]) {
+    await page.setViewportSize({ width, height: 900 })
+    const { scrollWidth, innerWidth } = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      innerWidth: window.innerWidth,
+    }))
+    expect(
+      scrollWidth,
+      `horizontal overflow at ${width}px viewport`,
+    ).toBeLessThanOrEqual(innerWidth)
+  }
+})

--- a/packages/streamwall-control-e2e/tsconfig.json
+++ b/packages/streamwall-control-e2e/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": [
+    "@tsconfig/recommended/tsconfig",
+    "@tsconfig/node22/tsconfig",
+    "@tsconfig/node-ts/tsconfig"
+  ],
+  "compilerOptions": {
+    // Mirror @tsconfig/node22's `lib` (it typechecks the imported server
+    // sources too) and add the DOM libs, since Playwright `page.evaluate`
+    // callbacks run in the browser and need `document`/`window`.
+    "lib": [
+      "es2024",
+      "ESNext.Array",
+      "ESNext.Collection",
+      "ESNext.Iterator",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "types": ["node"]
+  },
+  "include": ["tests", "playwright.config.ts"]
+}


### PR DESCRIPTION
## Problem

The full control stack — Vite client → Fastify/WebSocket server → mocked Streamwall socket — had **zero** end-to-end coverage (issue #55). The invite/session cookie flow, WebSocket auth/reconnect, the Yjs grid-edit round-trip, and real-layout regressions only manifest in a real browser, so happy-dom/jsdom unit tests can't reach them. The motivating example is the #225/#239 horizontal-overflow bug, whose `min-width: 0` half only showed up when measuring `scrollWidth` vs `innerWidth` in a real browser.

## Solution

A new **`streamwall-control-e2e`** workspace with a Playwright suite that boots the whole stack in a real Chromium browser:

- **`tests/harness.ts`** — boots `initApp` on an ephemeral port with in-memory storage and the built client's `dist/`, connects a **fake Streamwall uplink** (the trusted state authority), pushes an admin `state` message, and seeds a 3×3 grid of view cells into the shared Yjs doc. Exposes `createInviteLink()`, `waitForViewAssignment()` (observes the peer's mirror of the doc), and a Playwright fixture that gives each test a fresh, isolated server + uplink.
- **`tests/smoke.spec.ts`** — four smoke tests:
  1. an admin invite link signs in (session cookie) and renders the grid from injected state,
  2. an unauthenticated visitor is rejected with the unauthorized banner,
  3. a grid-cell edit propagates over the wire to the Streamwall peer as a shared Yjs doc update,
  4. the layout never overflows horizontally across viewport widths (360/768/1024/1440) — regression cover for #225/#239.

## Architecture decisions

- **Dedicated workspace, no `test` script.** Playwright is heavy and browser-only; keeping it in its own package with a `test:e2e` (not `test`) script keeps it out of the cross-OS `npm test` matrix (which runs on Windows/macOS too, where `--with-deps` isn't available). Its `typecheck` still runs in the normal `checks` job.
- **In-process server + uplink** (imported via `--import tsx`) rather than a subprocess harness, so tests hold direct references to the fake peer and assert on decoded Yjs updates without a side-channel API.
- **Deterministic seed barrier.** The server doesn't echo the uplink's *own* seed back (its doc-update listener is wired up after the initial queued messages are processed), so the harness confirms the shared doc is seeded via a throwaway probe client rather than a fixed delay.
- **Linux-only CI job** behind `npx playwright install --with-deps chromium`, wired into the existing `CI OK` gate. Per the issue, Electron E2E is intentionally out of scope.

## Testing performed

- `npm run format:check`, `npm run lint`, `npm run typecheck` — clean across all workspaces.
- `npm test` — all existing suites pass; the e2e package is correctly skipped (no `test` script).
- `npm -w streamwall-control-client run build` — clean.
- `npm -w streamwall-control-e2e run test:e2e` — **4/4 passing** in a real Chromium.
- `actionlint` on the updated workflow — clean.

## Risks / breaking changes

None to shipped code — this is additive test infrastructure. Adds a new workspace, its dev-dependencies (`@playwright/test`, etc.), and one CI job. The E2E job downloads a Chromium browser on CI (cached by the setup action's npm cache; the browser binary itself is fetched per run).

Closes #55