### PR TITLE
fix(streamwall): make findMedia's playing wait honor elementTimeout

### DIFF
--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -191,7 +191,7 @@ describe("mediaPreload emptied handler's re-acquisition rejection", () => {
     return send.mock.calls.filter(([channel]) => channel === 'view-error')
   }
 
-  it("reports the emptied handler's re-acquisition timeout instead of leaving it an unhandled rejection", async () => {
+  it("honors the unbounded elementTimeout passed to the emptied handler's re-acquisition instead of always falling back to INITIAL_TIMEOUT", async () => {
     const video = document.createElement('video')
     // happy-dom's HTMLVideoElement never implements videoWidth (always
     // undefined), so give it a truthy value here to skip findMedia's "wait
@@ -217,21 +217,24 @@ describe("mediaPreload emptied handler's re-acquisition rejection", () => {
     expect(send).toHaveBeenCalledWith('view-loaded')
 
     // A real emptied element resets its own readiness; re-acquisition finds
-    // the same <video> again, but this time nothing ever fires 'playing',
-    // so findMedia's fixed-INITIAL_TIMEOUT wait rejects.
+    // the same <video> again, but this time nothing fires 'playing' for a
+    // while. The 'emptied' handler calls acquireMedia(Infinity), so this
+    // wait must not time out even long past INITIAL_TIMEOUT.
     ;(video as unknown as { videoWidth: number }).videoWidth = 0
     video.dispatchEvent(new Event('emptied'))
-    await vi.advanceTimersByTimeAsync(INITIAL_TIMEOUT_MS)
+    await vi.advanceTimersByTimeAsync(INITIAL_TIMEOUT_MS * 10)
 
-    expect(viewErrorCalls()).toEqual([
-      [
-        'view-error',
-        {
-          error: expect.objectContaining({
-            message: 'timeout waiting for video to start',
-          }),
-        },
-      ],
-    ])
+    expect(viewErrorCalls()).toEqual([])
+
+    // The stream eventually recovers and starts playing; the unbounded wait
+    // resolves instead of having already rejected.
+    ;(video as unknown as { videoWidth: number }).videoWidth = 100
+    video.dispatchEvent(new Event('playing'))
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(
+      send.mock.calls.filter(([channel]) => channel === 'view-loaded'),
+    ).toHaveLength(2)
+    expect(viewErrorCalls()).toEqual([])
   })
 })

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -286,10 +286,13 @@ async function findMedia(
 
   if (video instanceof HTMLVideoElement && !video.videoWidth) {
     console.log(`video isn't playing yet. waiting for it to start...`)
-    const videoReady = new Promise((resolve) =>
+    let videoReady: Promise<unknown> = new Promise((resolve) =>
       video.addEventListener('playing', resolve, { once: true }),
     )
-    await Promise.race([videoReady, sleep(INITIAL_TIMEOUT)])
+    if (elementTimeout !== Infinity) {
+      videoReady = Promise.race([videoReady, sleep(elementTimeout)])
+    }
+    await videoReady
     if (!video.videoWidth) {
       throw new Error('timeout waiting for video to start')
     }


### PR DESCRIPTION
## Problem

In `packages/streamwall/src/preload/mediaPreload.ts`, `findMedia(kind, elementTimeout)` accepts an `elementTimeout` parameter that callers use to control how long to wait for the media element to appear and start playing. `waitForVideo`'s element-query race correctly honors `elementTimeout` (including disabling the wait entirely when it's `Infinity`), but the second wait inside `findMedia` — for a found element to actually start playing — always raced against the fixed module-level `INITIAL_TIMEOUT` constant (10s) instead of the `elementTimeout` argument.

`acquireMedia`'s `emptied`-handler re-acquisition path calls `findMedia` with `elementTimeout: Infinity`, intending an unbounded wait. Because of this bug, a media element that was found quickly but took longer than 10s to fire `playing` (e.g. a slow-to-buffer stream reappearing after `emptied`) would still throw `'timeout waiting for video to start'`, defeating the caller's explicit unbounded-wait request and causing the re-acquisition path (#316) to fail spuriously for streams that would have recovered given more time.

## Solution

`findMedia`'s "wait for playing" race now follows the same `Infinity`-safe pattern already used by `waitForVideo`: it only races the `playing` event against `sleep(elementTimeout)` when `elementTimeout !== Infinity`; otherwise it awaits the `playing` event directly with no timeout.

## Testing

- Replaced the existing re-acquisition test (which asserted the buggy fixed-10s-timeout behavior) with one that:
  - advances fake timers 10x past `INITIAL_TIMEOUT` after an `emptied` re-acquisition and asserts no `view-error` is reported (proving the unbounded wait is actually unbounded), then
  - fires `playing` and asserts the re-acquisition still resolves successfully (a second `view-loaded`).
- Full existing suite for the initial-acquisition timeout path (which still passes a finite `elementTimeout`) continues to pass unchanged, confirming the finite-timeout behavior is untouched.
- Ran the full quality gate locally: `format:check`, `lint`, `typecheck`, `npm test` (all workspaces), and the control-client build — all green.

## Risks / breaking changes

None. This only changes an internal preload-script timing detail; no public API changes.

Closes #319