### PR TITLE
fix(streamwall): make watchDataFile() a Repeater so an early return() can't hang

### DIFF
--- a/packages/streamwall/src/main/data.test.ts
+++ b/packages/streamwall/src/main/data.test.ts
@@ -255,6 +255,38 @@ link = "https://a.example/s"
       await gen.return(undefined)
     }
   })
+
+  // Regression test for #339: once a value has been yielded, the generator
+  // suspends waiting for the *next* filesystem event, which may never come.
+  // A plain `await once(watcher, 'all')` there would queue an early
+  // `.return()` behind that pending wait per the async generator spec,
+  // hanging teardown forever (see the investigation notes in #337).
+  test('return() resolves immediately while an event-wait is in flight, even though no event ever fires', async () => {
+    const file = writeTomlFile(`
+[[streams]]
+link = "https://a.example/s"
+`)
+    const gen = watchDataFile(file)
+    await gen.next()
+
+    // A second, unawaited next() resumes the generator past the yield and
+    // into the wait for the next filesystem event, leaving that next()
+    // call permanently in flight since no event is ever emitted below.
+    const pendingNext = gen.next()
+    pendingNext.catch(() => {})
+    await waitForListener(fakeWatcher!, 'all')
+
+    // No filesystem event is ever emitted here: the fix must settle
+    // return() without waiting on one.
+    await expect(
+      Promise.race([
+        gen.return(undefined),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error('return() hung')), 500),
+        ),
+      ]),
+    ).resolves.toBeDefined()
+  })
 })
 
 describe('pollDataURL', () => {

--- a/packages/streamwall/src/main/data.ts
+++ b/packages/streamwall/src/main/data.ts
@@ -56,57 +56,74 @@ export async function* pollDataURL(
   }
 }
 
-export async function* watchDataFile(
+// Built as a Repeater rather than a plain `async function*`: once a value
+// has been yielded, this generator suspends waiting for the *next*
+// filesystem event, which may never happen. A native async generator
+// queues an early `.return()` call behind that in-flight wait per the
+// ECMAScript spec, hanging teardown forever. Repeater.return() instead
+// settles immediately, which is what lets the race against `stop` below
+// return without waiting on an event (see #339, and the markDataSource fix
+// in #337 this mirrors).
+export function watchDataFile(
   path: string,
   onHealth?: DataSourceHealthCallback,
 ): DataSource {
-  const watcher = watch(path)
-  // chokidar emits 'error' for issues like a removed watch directory; an
-  // unhandled 'error' event on an EventEmitter throws, so a permanent
-  // listener is required to keep the watcher (and this generator) alive.
-  watcher.on('error', (err) => {
-    log.warn('error watching data file', path, err)
-  })
-  try {
-    let lastStreams: StreamDataContent[] = []
-    while (true) {
-      let streams: StreamDataContent[] = []
-      try {
-        const text = await fsPromises.readFile(path)
-        const data = TOML.parse(text.toString())
-        const parsed = parseStreamList(data?.streams)
-        if (parsed.errors.length) {
-          log.warn(
-            `ignoring ${parsed.errors.length} invalid stream(s) in ${path}`,
-          )
+  return new Repeater(async (push, stop) => {
+    const watcher = watch(path)
+    // chokidar emits 'error' for issues like a removed watch directory; an
+    // unhandled 'error' event on an EventEmitter throws, so a permanent
+    // listener is required to keep the watcher (and this generator) alive.
+    watcher.on('error', (err) => {
+      log.warn('error watching data file', path, err)
+    })
+    try {
+      let lastStreams: StreamDataContent[] = []
+      while (true) {
+        let streams: StreamDataContent[] = []
+        try {
+          const text = await fsPromises.readFile(path)
+          const data = TOML.parse(text.toString())
+          const parsed = parseStreamList(data?.streams)
+          if (parsed.errors.length) {
+            log.warn(
+              `ignoring ${parsed.errors.length} invalid stream(s) in ${path}`,
+            )
+          }
+          streams = parsed.streams as StreamDataContent[]
+          onHealth?.(true)
+        } catch (err) {
+          log.warn('error reading data file', err)
+          onHealth?.(false, err instanceof Error ? err.message : String(err))
         }
-        streams = parsed.streams as StreamDataContent[]
-        onHealth?.(true)
-      } catch (err) {
-        log.warn('error reading data file', err)
-        onHealth?.(false, err instanceof Error ? err.message : String(err))
-      }
 
-      // If the read/parse fails and we already have data, keep serving it
-      // instead of wiping out every stream (mirrors pollDataURL).
-      if (!streams.length && lastStreams.length) {
-        log.warn('using cached stream data')
-      } else {
-        yield streams
-        lastStreams = streams
-      }
+        // If the read/parse fails and we already have data, keep serving it
+        // instead of wiping out every stream (mirrors pollDataURL).
+        if (!streams.length && lastStreams.length) {
+          log.warn('using cached stream data')
+        } else {
+          await push(streams)
+          lastStreams = streams
+        }
 
-      try {
         // Wait for any filesystem event, not just 'change': an atomic
         // replace of the watched file can surface as unlink+add instead.
-        await once(watcher, 'all')
-      } catch (err) {
-        log.warn('error watching data file', path, err)
+        // Raced against `stop` so an early return() settles immediately
+        // instead of queuing behind an event that may never fire.
+        const eventP = once(watcher, 'all')
+        eventP.catch(() => {})
+        try {
+          const result = await Promise.race([eventP, stop])
+          if (result === undefined) {
+            return
+          }
+        } catch (err) {
+          log.warn('error watching data file', path, err)
+        }
       }
+    } finally {
+      await watcher.close()
     }
-  } finally {
-    await watcher.close()
-  }
+  })
 }
 
 // Built as a Repeater rather than a plain `async function*`: Repeater.latest()


### PR DESCRIPTION
## Problem

`watchDataFile()` (`packages/streamwall/src/main/data.ts`) is a plain `async function*` that, after yielding the current file contents, suspends at `await once(watcher, 'all')` waiting for the next filesystem event.

Per the ECMAScript spec, a native async generator queues a `.return()` call behind any in-flight wait. Since a filesystem event isn't guaranteed to ever happen again, calling `.return()` on `watchDataFile()` while it's suspended there can hang indefinitely.

`markDataSource()` was already rewritten as a `Repeater` in #337 so *it* can be torn down cleanly, but that fix only addressed `markDataSource()`'s own `.next()`/`.return()` queuing. Its teardown still calls `.return()` on the *wrapped* source, and when that source is `watchDataFile()` (a plain async generator), the same hang can occur one layer down.

This currently has no production impact — `main()` consumes the combined data sources for the app's entire lifetime and never tears them down early — but it's a latent bug for any future early-teardown path.

## Solution

Rewrite `watchDataFile()` as a `Repeater`, following the same pattern used for `markDataSource()` in #337: the wait for the next filesystem event is raced against the Repeater's own `stop` signal, so an early `.return()` settles immediately instead of queuing behind an event that may never fire. All existing read/parse/health-reporting/error-handling behavior is unchanged.

## Testing

- Added a regression test that resumes the generator past its first yield (leaving a `.next()` call in flight on the event wait, with no filesystem event ever emitted) and asserts `.return()` resolves within 500ms instead of hanging. Verified this test fails against the pre-fix implementation (times out) and passes after the fix.
- Full quality gate green: `npm run format:check`, `npm run lint`, `npm run typecheck` (all packages), `npm test` (all packages, 976 tests total), and `npm -w streamwall-control-client run build`.

## Risks / breaking changes

None. `watchDataFile()`'s external behavior (yielded values, health callback, error logging) is unchanged; only its internal teardown semantics differ.

Closes #339