### PR TITLE
fix(control-ui): validate invite role before creating invite

### DIFF
--- a/packages/streamwall-control-ui/src/AccessPanel.test.tsx
+++ b/packages/streamwall-control-ui/src/AccessPanel.test.tsx
@@ -71,6 +71,52 @@ describe('CreateInviteInput', () => {
     expect(nameInput.value).toBe('')
     expect(select.value).toBe('operator')
   })
+
+  test('only offers invitable roles, excluding the local role reserved for the app itself', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      render(<CreateInviteInput onCreateInvite={() => {}} />, container!)
+    })
+
+    const options = Array.from(
+      container.querySelectorAll('option'),
+      (option) => (option as HTMLOptionElement).value,
+    )
+
+    expect(options).toEqual(['admin', 'operator', 'monitor'])
+  })
+
+  test('does not create an invite if the role somehow desyncs from the invitable options', () => {
+    const onCreateInvite = vi.fn()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      render(<CreateInviteInput onCreateInvite={onCreateInvite} />, container!)
+    })
+
+    const nameInput = container.querySelector('input') as HTMLInputElement
+    const select = container.querySelector('select') as HTMLSelectElement
+    const form = container.querySelector('form') as HTMLFormElement
+
+    act(() => {
+      nameInput.value = 'Jamie'
+      nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    act(() => {
+      // Not one of the rendered <option>s, so the browser resets the
+      // select's value to the empty string rather than accepting it.
+      select.value = 'local'
+      select.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    act(() => {
+      form.dispatchEvent(
+        new Event('submit', { bubbles: true, cancelable: true }),
+      )
+    })
+
+    expect(onCreateInvite).not.toHaveBeenCalled()
+  })
 })
 
 describe('AuthTokenLine', () => {

--- a/packages/streamwall-control-ui/src/AccessPanel.tsx
+++ b/packages/streamwall-control-ui/src/AccessPanel.tsx
@@ -1,6 +1,10 @@
 import { type JSX } from 'preact'
 import { useCallback, useState } from 'preact/hooks'
-import { type StreamwallRole } from 'streamwall-shared'
+import {
+  invitableRoles,
+  isInvitableRole,
+  type StreamwallRole,
+} from 'streamwall-shared'
 
 export function CreateInviteInput({
   onCreateInvite,
@@ -26,9 +30,12 @@ export function CreateInviteInput({
   const handleSubmit = useCallback<JSX.SubmitEventHandler<HTMLFormElement>>(
     (ev) => {
       ev.preventDefault()
+      if (!isInvitableRole(inviteRole)) {
+        return
+      }
       setInviteName('')
       setInviteRole('operator')
-      onCreateInvite({ name: inviteName, role: inviteRole as StreamwallRole }) // TODO: validate
+      onCreateInvite({ name: inviteName, role: inviteRole })
     },
     [onCreateInvite, inviteName, inviteRole],
   )
@@ -41,9 +48,11 @@ export function CreateInviteInput({
           value={inviteName}
         />
         <select onChange={handleChangeRole} value={inviteRole}>
-          <option value="admin">admin</option>
-          <option value="operator">operator</option>
-          <option value="monitor">monitor</option>
+          {invitableRoles.map((role) => (
+            <option key={role} value={role}>
+              {role}
+            </option>
+          ))}
         </select>
         <button type="submit">create invite</button>
       </form>

--- a/packages/streamwall-shared/src/roles.test.ts
+++ b/packages/streamwall-shared/src/roles.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
+  invitableRoles,
   inviteLink,
+  isInvitableRole,
   roleCan,
   type StreamwallAction,
   validRoles,
@@ -99,6 +101,34 @@ describe('roleCan default-deny for unlisted actions', () => {
   })
   it('denies unauthenticated clients an action absent from every set', () => {
     expect(roleCan(null, unlisted)).toBe(false)
+  })
+})
+
+describe('invitableRoles', () => {
+  it('excludes the local role, which is reserved for the app itself', () => {
+    expect(invitableRoles).not.toContain('local')
+  })
+
+  it('contains every other valid role', () => {
+    expect([...invitableRoles].sort()).toEqual(
+      validRoles.filter((role) => role !== 'local').sort(),
+    )
+  })
+})
+
+describe('isInvitableRole', () => {
+  for (const role of invitableRoles) {
+    it(`accepts ${role}`, () => {
+      expect(isInvitableRole(role)).toBe(true)
+    })
+  }
+
+  it('rejects the local role', () => {
+    expect(isInvitableRole('local')).toBe(false)
+  })
+
+  it('rejects an arbitrary string', () => {
+    expect(isInvitableRole('totally-not-a-role')).toBe(false)
   })
 })
 

--- a/packages/streamwall-shared/src/roles.ts
+++ b/packages/streamwall-shared/src/roles.ts
@@ -24,6 +24,24 @@ const operatorActions = [
 const monitorActions = ['set-view-blurred', 'set-stream-censored'] as const
 
 export type StreamwallRole = (typeof validRoles)[number]
+
+// Roles that may be granted to a new user via an invite token. `local` is
+// reserved for the Streamwall app's own IPC connection (see `roleCan` below,
+// where it is treated as all-powerful just like `admin`) and is never
+// something an admin should be able to invite someone else into.
+export const invitableRoles = [
+  'admin',
+  'operator',
+  'monitor',
+] as const satisfies readonly StreamwallRole[]
+export type InvitableRole = (typeof invitableRoles)[number]
+
+const invitableRoleSet = new Set<string>(invitableRoles)
+
+export function isInvitableRole(role: string): role is InvitableRole {
+  return invitableRoleSet.has(role)
+}
+
 export type StreamwallAction =
   | AdminAction
   | (typeof operatorActions)[number]


### PR DESCRIPTION
## Problem

`CreateInviteInput` (`packages/streamwall-control-ui/src/AccessPanel.tsx`) tracked the selected invite role as a plain `string` and cast it to `StreamwallRole` when calling `onCreateInvite`:

```ts
onCreateInvite({ name: inviteName, role: inviteRole as StreamwallRole }) // TODO: validate
```

This cast was only safe because the `<select>`'s hardcoded `<option>` list happened to match the invitable subset of `StreamwallRole` (`admin`/`operator`/`monitor`). Nothing enforced that relationship at compile time or runtime — if the option list and the role type ever drifted apart, the mismatch would only surface as a runtime `unauthorized` rejection from the server, or worse, a role value that isn't a valid `StreamwallRole` at all being silently forwarded.

Found while resolving #296 (PR #324).

## Solution

- Added `invitableRoles` and a `isInvitableRole` type guard to `streamwall-shared`'s `roles.ts`. `invitableRoles` is `validRoles` minus `local`, since `local` is reserved for the Streamwall app's own IPC connection (`roleCan` already treats it as all-powerful, just like `admin`) and was never meant to be assignable through an invite.
- `CreateInviteInput` now derives its `<option>` list directly from `invitableRoles` instead of a hand-maintained list, so the UI can no longer drift out of sync with the type.
- The submit handler validates `inviteRole` with `isInvitableRole` before calling `onCreateInvite`, giving a real runtime check in place of the unchecked cast, and bails out (without resetting the form) if the value is somehow invalid.

## Testing

- `streamwall-shared`: added tests asserting `invitableRoles` excludes `local` and contains every other role, plus table-driven coverage of `isInvitableRole` for every invitable role, the `local` role, and an arbitrary string.
- `streamwall-control-ui`: added a test asserting the rendered `<option>` list exactly matches `invitableRoles`, and a regression test that forces the select's value into an invalid state (simulating an option/role desync) and asserts `onCreateInvite` is never called with it.
- Full quality gate run locally: `format:check`, `lint`, `typecheck` (all workspaces), `test` (all workspaces) — all green.

## Risks / breaking changes

None. This only tightens client-side validation for the invite-creation form; the set of assignable roles in the UI (`admin`/`operator`/`monitor`) is unchanged from before.

Closes #321
