### PR TITLE
fix(control-ui): validate the Yjs doc snapshot in useYDoc against a schema

### DIFF
--- a/packages/streamwall-control-client/src/dev.tsx
+++ b/packages/streamwall-control-client/src/dev.tsx
@@ -12,6 +12,7 @@ import { render } from 'preact'
 import { useEffect } from 'preact/hooks'
 import {
   type CollabData,
+  collabDataSchema,
   ControlUI,
   GlobalStyle,
   type StreamwallConnection,
@@ -174,7 +175,7 @@ function useMockConnection(): StreamwallConnection {
     docValue: sharedState,
     doc: stateDoc,
     undoManager,
-  } = useYDoc<CollabData>(['views'])
+  } = useYDoc<CollabData>(['views'], collabDataSchema)
   const appState = useStreamwallState(demoState)
 
   useEffect(() => {

--- a/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.ts
+++ b/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'preact/hooks'
 import ReconnectingWebSocket from 'reconnecting-websocket'
 import {
   type CollabData,
+  collabDataSchema,
   type StreamwallConnection,
   useStreamwallState,
   useYDoc,
@@ -32,7 +33,7 @@ export function useStreamwallWebsocketConnection(
     doc: stateDoc,
     setDoc: setStateDoc,
     undoManager,
-  } = useYDoc<CollabData>(['views'], 'server')
+  } = useYDoc<CollabData>(['views'], collabDataSchema, 'server')
   const [streamwallState, setStreamwallState] = useState<StreamwallState>()
   const appState = useStreamwallState(streamwallState)
 

--- a/packages/streamwall-control-e2e/tests/harness.ts
+++ b/packages/streamwall-control-e2e/tests/harness.ts
@@ -86,6 +86,7 @@ const E2E_STATE: StreamwallState = {
   views: [],
   streamdelay: null,
   layoutPresets: [],
+  favorites: [],
   dataSourceHealth: [],
 }
 

--- a/packages/streamwall-control-ui/src/collabData.test.ts
+++ b/packages/streamwall-control-ui/src/collabData.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest'
+import { collabDataSchema } from './collabData.ts'
+
+describe('collabDataSchema', () => {
+  test('accepts an empty views map', () => {
+    expect(collabDataSchema.safeParse({ views: {} }).success).toBe(true)
+  })
+
+  test('accepts a view with a string streamId', () => {
+    expect(
+      collabDataSchema.safeParse({ views: { '0': { streamId: 'abc' } } })
+        .success,
+    ).toBe(true)
+  })
+
+  test('accepts a view with no streamId', () => {
+    expect(collabDataSchema.safeParse({ views: { '0': {} } }).success).toBe(
+      true,
+    )
+  })
+
+  test('rejects a view with a non-string streamId', () => {
+    expect(
+      collabDataSchema.safeParse({ views: { '0': { streamId: 42 } } }).success,
+    ).toBe(false)
+  })
+
+  test('rejects a missing views key', () => {
+    expect(collabDataSchema.safeParse({}).success).toBe(false)
+  })
+
+  test('rejects a non-object snapshot', () => {
+    expect(collabDataSchema.safeParse(undefined).success).toBe(false)
+    expect(collabDataSchema.safeParse(null).success).toBe(false)
+    expect(collabDataSchema.safeParse('views').success).toBe(false)
+  })
+})

--- a/packages/streamwall-control-ui/src/collabData.ts
+++ b/packages/streamwall-control-ui/src/collabData.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+
+/**
+ * Runtime shape of the collaborative `views` state shared between every
+ * connected client and the Electron main process over the Yjs doc. `useYDoc`
+ * validates each doc snapshot against this schema rather than casting it, so
+ * a stale client on an old schema, a manual doc edit, or a future field
+ * rename surfaces as a dropped update instead of silently corrupting the UI
+ * (issue #322).
+ */
+export const collabDataSchema = z.object({
+  views: z.record(z.string(), z.object({ streamId: z.string().optional() })),
+})
+
+export type CollabData = z.infer<typeof collabDataSchema>

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -36,6 +36,7 @@ import { matchesState } from 'xstate'
 import * as Y from 'yjs'
 import { AuthTokenLine, CreateInviteInput } from './AccessPanel.tsx'
 import { copyTextToClipboard } from './clipboard.ts'
+import { type CollabData } from './collabData.ts'
 import { createErrorSurfacingSend } from './commandError.ts'
 import { CommandErrorBanner } from './CommandErrorBanner.tsx'
 import { ConnectionStatusBanner } from './ConnectionStatusBanner.tsx'
@@ -120,11 +121,8 @@ function filterStreams(
   return [wallStreams, liveStreams, otherStreams, favoriteStreams]
 }
 
+export { collabDataSchema, type CollabData } from './collabData.ts'
 export { useYDoc } from './useYDoc.ts'
-
-export interface CollabData {
-  views: { [viewIdx: string]: { streamId: string | undefined } }
-}
 
 export interface StreamwallConnection {
   isConnected: boolean

--- a/packages/streamwall-control-ui/src/useTileResize.ts
+++ b/packages/streamwall-control-ui/src/useTileResize.ts
@@ -2,6 +2,7 @@ import { useCallback, useLayoutEffect, useState } from 'preact/hooks'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { roleCan, type StreamwallRole } from 'streamwall-shared'
 import * as Y from 'yjs'
+import { type CollabData } from './collabData.ts'
 import { isPrimaryButton } from './gestures'
 import {
   computeKeyboardResizeHoverIdx,
@@ -10,13 +11,9 @@ import {
   type ResizeHandle,
 } from './gridInteractions'
 
-interface CollabViews {
-  views: { [viewIdx: string]: { streamId: string | undefined } }
-}
-
-/** Snapshots a `CollabViews.views` map into the `Map<idx, streamId>` shape `resizeWouldOverwriteOtherStream` expects. */
+/** Snapshots a `CollabData.views` map into the `Map<idx, streamId>` shape `resizeWouldOverwriteOtherStream` expects. */
 function collectCurrentAssignments(
-  views: CollabViews['views'] | undefined,
+  views: CollabData['views'] | undefined,
 ): Map<number, string | undefined> {
   const currentAssignments = new Map<number, string | undefined>()
   for (const [idx, view] of Object.entries(views ?? {})) {
@@ -44,7 +41,7 @@ export function useTileResize({
   rows: number | null | undefined
   hoveringIdx: number | undefined
   stateDoc: Y.Doc
-  sharedState: CollabViews | undefined
+  sharedState: CollabData | undefined
   role: StreamwallRole | null
 }) {
   const [resize, setResize] = useState<

--- a/packages/streamwall-control-ui/src/useYDoc.test.tsx
+++ b/packages/streamwall-control-ui/src/useYDoc.test.tsx
@@ -2,6 +2,7 @@ import { render } from 'preact'
 import { act } from 'preact/test-utils'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import * as Y from 'yjs'
+import { z } from 'zod'
 import { useYDoc } from './useYDoc.ts'
 
 const { docConstructorSpy } = vi.hoisted(() => ({
@@ -29,13 +30,18 @@ afterEach(() => {
   }
 })
 
-function renderUseYDoc(): {
-  get: () => ReturnType<typeof useYDoc<{ views: unknown }>>
+const viewsSchema = z.object({
+  views: z.record(z.string(), z.object({ streamId: z.string().optional() })),
+})
+type ViewsDoc = z.infer<typeof viewsSchema>
+
+function renderUseYDoc(schema: z.ZodType<ViewsDoc> = viewsSchema): {
+  get: () => ReturnType<typeof useYDoc<ViewsDoc>>
   rerender: () => void
 } {
-  let latest: ReturnType<typeof useYDoc<{ views: unknown }>> | undefined
+  let latest: ReturnType<typeof useYDoc<ViewsDoc>> | undefined
   function Harness() {
-    latest = useYDoc<{ views: unknown }>(['views'])
+    latest = useYDoc<ViewsDoc>(['views'], schema)
     return null
   }
   container = document.createElement('div')
@@ -78,5 +84,54 @@ describe('useYDoc', () => {
 
     expect(destroySpy).toHaveBeenCalledTimes(1)
     expect(harness.get().doc).toBe(replacementDoc)
+  })
+
+  it('sets docValue to the validated snapshot after a valid update', () => {
+    const harness = renderUseYDoc()
+
+    act(() => {
+      harness.get().doc.getMap('views').set('0', { streamId: 'abc' })
+    })
+
+    expect(harness.get().docValue).toEqual({
+      views: { '0': { streamId: 'abc' } },
+    })
+  })
+
+  it('rejects an update that fails schema validation, logs a warning, and keeps the last known-good value', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const harness = renderUseYDoc()
+    expect(harness.get().docValue).toEqual({ views: {} })
+
+    act(() => {
+      // `streamId` must be a string per `viewsSchema`.
+      harness.get().doc.getMap('views').set('0', { streamId: 42 })
+    })
+
+    expect(harness.get().docValue).toEqual({ views: {} })
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('keeps a non-empty known-good value when a later update fails validation', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const harness = renderUseYDoc()
+
+    act(() => {
+      harness.get().doc.getMap('views').set('0', { streamId: 'abc' })
+    })
+    expect(harness.get().docValue).toEqual({
+      views: { '0': { streamId: 'abc' } },
+    })
+
+    act(() => {
+      harness.get().doc.getMap('views').set('1', { streamId: 42 })
+    })
+
+    expect(harness.get().docValue).toEqual({
+      views: { '0': { streamId: 'abc' } },
+    })
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
   })
 })

--- a/packages/streamwall-control-ui/src/useYDoc.ts
+++ b/packages/streamwall-control-ui/src/useYDoc.ts
@@ -1,9 +1,18 @@
 import { useCallback, useEffect, useState } from 'preact/hooks'
 import * as Y from 'yjs'
+import { type ZodType, prettifyError } from 'zod'
 import { createSharedUndoManager } from './yUndo.ts'
 
 export function useYDoc<T>(
   keys: string[],
+  // Validates each doc snapshot before it replaces `docValue`. The doc is
+  // shared/collaborative state - written to by every connected client and,
+  // on the Electron side, synced from the main process - so a malformed
+  // snapshot (a stale client on an old schema, a manual doc edit, a future
+  // field rename) must be rejected rather than cast, or it would corrupt the
+  // UI silently and only surface later, far from the actual cause (issue
+  // #322).
+  schema: ZodType<T>,
   // Origin string used by this connection when applying remote updates to
   // `doc` (e.g. `'server'` for the websocket client, `'app'` for the
   // Electron IPC renderer). Passed through to the doc's `Y.UndoManager` so
@@ -34,17 +43,25 @@ export function useYDoc<T>(
       const valueCopy = Object.fromEntries(
         keys.map((k) => [k, doc.getMap(k).toJSON()]),
       )
-      // TODO: validate using zod
-      setDocValue(valueCopy as T)
+      const result = schema.safeParse(valueCopy)
+      if (result.success) {
+        setDocValue(result.data)
+      } else {
+        console.warn(
+          'useYDoc: doc snapshot failed validation, keeping the last known-good value',
+          prettifyError(result.error),
+        )
+      }
     }
     updateDocValue()
     doc.on('update', updateDocValue)
     return () => {
       doc.off('update', updateDocValue)
     }
-    // `keys` is deliberately omitted: every caller passes a literal array,
-    // so including it would re-subscribe the listener on every render
-    // without any behavioral benefit.
+    // `keys` and `schema` are deliberately omitted: every caller passes a
+    // literal array/module-level schema, so including them would
+    // re-subscribe the listener on every render without any behavioral
+    // benefit.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [doc])
 

--- a/packages/streamwall-control-ui/src/viewPlacement.ts
+++ b/packages/streamwall-control-ui/src/viewPlacement.ts
@@ -1,9 +1,8 @@
 import { range } from 'lodash-es'
+import { type CollabData } from './collabData.ts'
 
 /** A collaborative view cell as mirrored from the Yjs `views` map. */
-interface ViewSlot {
-  streamId: string | undefined
-}
+type ViewSlot = CollabData['views'][string]
 
 /**
  * Decide which grid cell a stream-id click should fill.

--- a/packages/streamwall/src/renderer/control.tsx
+++ b/packages/streamwall/src/renderer/control.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from 'preact/hooks'
 import { useHotkeys } from 'react-hotkeys-hook'
 import {
   CollabData,
+  collabDataSchema,
   ControlUI,
   GlobalStyle,
   StreamwallConnection,
@@ -33,7 +34,7 @@ function useStreamwallIPCConnection(): StreamwallConnection {
     docValue: sharedState,
     doc: stateDoc,
     undoManager,
-  } = useYDoc<CollabData>(['views'], 'app')
+  } = useYDoc<CollabData>(['views'], collabDataSchema, 'app')
 
   const [streamwallState, setStreamwallState] = useState<StreamwallState>()
   const appState = useStreamwallState(streamwallState)


### PR DESCRIPTION
## Problem

`useYDoc<T>` built `valueCopy` by walking the caller-supplied `keys` and calling `.toJSON()` on each corresponding `Y.Map`, then cast the result straight to the generic `T` with no runtime check:

```ts
// TODO: validate using zod
setDocValue(valueCopy as T)
```

The Yjs doc is shared/collaborative state — written to by every connected client and, on the Electron side, synced from the main process. A malformed or unexpected shape (a stale client on an old schema, a manual doc edit, a future field rename) was accepted silently and would only surface later as a `TypeError` or corrupted UI state, far from the actual cause.

## Solution

- `useYDoc` now takes a required Zod `schema` parameter and `safeParse`s the doc snapshot before accepting it.
- A snapshot that fails validation is dropped: the previous known-good `docValue` is kept (or stays `undefined` before the first valid snapshot), and a warning is logged with `zod`'s `prettifyError`. This mirrors the approach already used for `create-invite` (#324) and for control commands in `streamwall-shared/src/schemas.ts`.
- Extracted `collabDataSchema`/`CollabData` into a new `packages/streamwall-control-ui/src/collabData.ts` as the single source of truth for the shared-state shape, and updated all three `useYDoc` call sites (`streamwall-control-ui`'s dev harness, `streamwall-control-client`'s websocket connection, and `streamwall`'s Electron IPC renderer) to pass it.
- Two local ad-hoc interfaces that duplicated the exact same shape (`CollabViews` in `useTileResize.ts`, `ViewSlot` in `viewPlacement.ts`) now derive from `CollabData` instead of re-declaring it, removing the duplication that the original `TODO` had already hinted at.

## Architecture decisions

- Schema is a required parameter (not optional/defaulted) so every call site is forced to declare what shape it expects, matching the issue's suggested approach and the `create-invite` precedent.
- On validation failure the hook keeps the *previous* value rather than falling back to `undefined` unconditionally — a single corrupt update from one client shouldn't blank out the whole UI for everyone if a good value is already in hand.
- `collabDataSchema` lives in `streamwall-control-ui` (next to the `CollabData` type it was extracted from) rather than in `streamwall-shared`, since it validates a Yjs-internal wire shape used only by the three `useYDoc` callers, not the cross-boundary control-channel messages `streamwall-shared/schemas.ts` is scoped to.

## Testing performed

- Added `useYDoc.test.tsx` cases: accepts a valid update, rejects an update failing validation while logging a warning and keeping the last known-good value, and confirms a later invalid update doesn't clobber a non-empty known-good value.
- Added `collabData.test.ts` covering `collabDataSchema` acceptance/rejection cases (empty views, valid/invalid `streamId`, missing/non-object snapshots).
- Full quality gate green: `npm run format:check`, `npm run lint`, `npm run typecheck` (all workspaces), `npm run test` (all workspaces), and a `streamwall-control-client` production build.

## Risks / breaking changes

None expected — this only tightens runtime validation on state that was already expected to match `CollabData`; well-formed docs (the only kind produced by the current client/server code) are unaffected. `useYDoc` is not part of any published/external API (all three packages are private workspace packages), so the added required `schema` parameter isn't a public breaking change.

Closes #322