### PR TITLE
fix(control-e2e): add missing favorites field to the E2E harness state

### DIFF
--- a/packages/streamwall-control-e2e/tests/harness.ts
+++ b/packages/streamwall-control-e2e/tests/harness.ts
@@ -86,6 +86,7 @@ const E2E_STATE: StreamwallState = {
   views: [],
   streamdelay: null,
   layoutPresets: [],
+  favorites: [],
   dataSourceHealth: [],
 }
 


### PR DESCRIPTION
## Problem

`main`'s typecheck has been broken since commit d1f7d8c (merge of #342): `tests/harness.ts` in the new `streamwall-control-e2e` package builds a `StreamwallState` literal that's missing the `favorites` field, which #341 made required on that interface shortly before #342 merged. The `#342` branch was cut before #341 landed, so its own CI never saw the conflict - it only surfaces once both are on `main` together.

```
tests/harness.ts(71,7): error TS2741: Property 'favorites' is missing in type '...' but required in type 'StreamwallState'.
```

This has been failing CI on every push to `main` since (`#342`, `#345`, `#346`).

## Solution

Add `favorites: []` to the harness's `E2E_STATE` fixture, matching the empty-array default used elsewhere (e.g. `packages/streamwall-shared/src/stateDiff.test.ts`).

## Testing

- `npm run typecheck` passes across all workspaces
- `npm -w streamwall-control-e2e run test:e2e` passes (4/4)