### PR TITLE
fix(streamwall-shared): validate create-invite role against invitableRoles

### DIFF
--- a/packages/streamwall-shared/src/schemas.test.ts
+++ b/packages/streamwall-shared/src/schemas.test.ts
@@ -296,6 +296,17 @@ describe('controlCommandMessageSchema', () => {
     ).toBe(false)
   })
 
+  test('rejects create-invite with the local role', () => {
+    expect(
+      controlCommandMessageSchema.safeParse({
+        id: 1,
+        type: 'create-invite',
+        role: 'local',
+        name: 'x',
+      }).success,
+    ).toBe(false)
+  })
+
   test('accepts a save-layout-preset command with a non-empty name', () => {
     expect(
       controlCommandMessageSchema.safeParse({

--- a/packages/streamwall-shared/src/schemas.ts
+++ b/packages/streamwall-shared/src/schemas.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { GRID_MAX, GRID_MIN } from './geometry.ts'
-import { validRoles } from './roles.ts'
+import { invitableRoles } from './roles.ts'
 
 /**
  * Runtime schemas for every piece of external, untrusted input that crosses a
@@ -182,7 +182,7 @@ export const controlCommandSchema = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal('create-invite'),
-    role: z.enum(validRoles),
+    role: z.enum(invitableRoles),
     name: z.string(),
   }),
   z.object({


### PR DESCRIPTION
## Problem

`packages/streamwall-shared/src/schemas.ts`'s `create-invite` control command schema validated `role` against the full `validRoles` list, which includes `'local'`. `local` is reserved for the Streamwall app's own IPC connection (`roleCan` in `roles.ts` treats it as all-powerful, exactly like `admin`) and was never meant to be assignable to an invited user.

Today the client UI can't send `role: 'local'` since its invite form only offers `invitableRoles` (see #321/#347), but the server-side schema is the actual trust boundary: `controlCommandMessageSchema.safeParse` is the only check standing between a raw client message and the desktop, since an `admin`-role client passes every `roleCan` authorization check regardless of the command. Any other client speaking the control protocol directly (not just the bundled UI) could therefore request a `local`-role invite token and the server would accept it — letting a `local` token leak into a remote client, which is semantically wrong (the control UI hides connection-status/role display specifically because it assumes `role === 'local'` only ever means the trusted local Electron connection).

## Solution

Changed the `create-invite` schema's `role` field from `z.enum(validRoles)` to `z.enum(invitableRoles)` (exported from `streamwall-shared`'s `roles.ts` since #347), so the server rejects `local`-role invite requests at the validation boundary.

No breaking type changes: `InvitableRole` is a subset of `StreamwallRole`, so every existing typed caller (`handleCreateInvite` in `streamwall-control-ui`, the server's `auth.createToken` call) remains assignable without modification.

## Testing

- Added a test asserting `controlCommandMessageSchema` rejects a `create-invite` command with `role: 'local'` (previously accepted).
- Full quality gate run locally: `format:check`, `lint`, `typecheck` (all workspaces), `test` (all workspaces), and the control-client `build` — all green except a pre-existing, unrelated `streamwall-control-e2e` typecheck failure already tracked in #350 (introduced on `main` by an unrelated merge, not touched by this change).

## Risks / breaking changes

None. This only tightens server-side validation for invite creation; the set of assignable roles is unchanged from what the UI already offers.

Closes #349