### PR TITLE
test(control-ui): add stable data-testid hooks for the E2E grid and status surfaces

### DIFF
--- a/packages/streamwall-control-e2e/tests/smoke.spec.ts
+++ b/packages/streamwall-control-e2e/tests/smoke.spec.ts
@@ -16,14 +16,16 @@ test('an admin invite link signs in and renders the grid from injected state', a
   // receives the session cookie, and redirects to the app.
   await page.goto(await harness.createInviteLink())
 
-  const grid = page.locator('.grid')
+  const grid = page.getByTestId('grid')
   await expect(grid).toBeVisible()
-  await expect(page.locator('.grid input')).toHaveCount(
+  await expect(page.getByTestId('grid-cell')).toHaveCount(
     harness.cols * harness.rows,
   )
   // Header status flips to "connected" only once the client's socket is up and
   // the injected state has arrived.
-  await expect(page.locator('.status')).toContainText('connected')
+  await expect(page.getByTestId('header-connection-status')).toContainText(
+    'connected',
+  )
 })
 
 test('an unauthenticated visitor is rejected with an unauthorized banner', async ({
@@ -34,9 +36,11 @@ test('an unauthenticated visitor is rejected with an unauthorized banner', async
   // socket is refused and the disconnect banner explains why.
   await page.goto(`${harness.baseURL}/`)
 
-  await expect(page.getByRole('status')).toContainText('Session invalid')
+  await expect(page.getByTestId('connection-status-banner')).toContainText(
+    'Session invalid',
+  )
   // Without any state push the grid never renders.
-  await expect(page.locator('.grid')).toHaveCount(0)
+  await expect(page.getByTestId('grid')).toHaveCount(0)
 })
 
 test('a grid-cell edit reaches the Streamwall peer as a shared-doc update', async ({
@@ -45,13 +49,13 @@ test('a grid-cell edit reaches the Streamwall peer as a shared-doc update', asyn
 }) => {
   await page.goto(await harness.createInviteLink())
 
-  const cells = page.locator('.grid input')
+  const cells = page.getByTestId('grid-cell')
   await expect(cells).toHaveCount(harness.cols * harness.rows)
 
   const targetIdx = 4 // center cell of the 3×3 grid
   const [streamId] = harness.streamIds
 
-  await page.locator('.grid').hover()
+  await page.getByTestId('grid').hover()
   await cells.nth(targetIdx).fill(streamId)
   await cells.nth(targetIdx).blur()
 
@@ -66,7 +70,7 @@ test('the layout never overflows horizontally across viewport widths', async ({
   harness,
 }) => {
   await page.goto(await harness.createInviteLink())
-  await expect(page.locator('.grid')).toBeVisible()
+  await expect(page.getByTestId('grid')).toBeVisible()
 
   // Real-browser layout measurement — the only way to catch min-content /
   // margin overflow regressions (issue #225/#239) that unit tests miss.

--- a/packages/streamwall-control-ui/src/ConnectionStatusBanner.test.tsx
+++ b/packages/streamwall-control-ui/src/ConnectionStatusBanner.test.tsx
@@ -68,4 +68,14 @@ describe('ConnectionStatusBanner', () => {
     expect(banner?.textContent).toContain('Too many messages')
     expect(banner?.className).toContain('rate-limited')
   })
+
+  // The E2E suite targets the disconnect banner via this hook rather than
+  // its `role="status"` (which stays for accessibility), so a markup
+  // refactor can't silently break the test (issue #344).
+  test('exposes a stable data-testid for E2E targeting', () => {
+    const el = renderBanner({ isConnected: false, reason: null })
+    expect(
+      el.querySelector('[data-testid="connection-status-banner"]'),
+    ).not.toBeNull()
+  })
 })

--- a/packages/streamwall-control-ui/src/ConnectionStatusBanner.tsx
+++ b/packages/streamwall-control-ui/src/ConnectionStatusBanner.tsx
@@ -42,7 +42,11 @@ export function ConnectionStatusBanner({
   }
 
   return (
-    <StyledConnectionStatusBanner className={reason ?? undefined} role="status">
+    <StyledConnectionStatusBanner
+      className={reason ?? undefined}
+      role="status"
+      data-testid="connection-status-banner"
+    >
       <FaExclamationTriangle />
       {reason ? MESSAGE_BY_REASON[reason] : GENERIC_MESSAGE}
     </StyledConnectionStatusBanner>

--- a/packages/streamwall-control-ui/src/GridInput.test.tsx
+++ b/packages/streamwall-control-ui/src/GridInput.test.tsx
@@ -61,4 +61,15 @@ describe('GridInput', () => {
 
     expect(onPointerDown).not.toHaveBeenCalled()
   })
+
+  // The E2E suite (packages/streamwall-control-e2e) targets cells via these
+  // hooks instead of styled-components class names, so a markup/styling
+  // refactor can't silently break it (issue #344).
+  test('exposes a stable data-testid and data-idx for E2E cell targeting', () => {
+    const box = renderInput({ idx: 3 })
+    const input = box.querySelector('input')!
+
+    expect(input.getAttribute('data-testid')).toBe('grid-cell')
+    expect(input.getAttribute('data-idx')).toBe('3')
+  })
 })

--- a/packages/streamwall-control-ui/src/GridInput.tsx
+++ b/packages/streamwall-control-ui/src/GridInput.tsx
@@ -78,6 +78,8 @@ export function GridInput({
         onPointerDown={onPointerDown}
         onChange={handleChange}
         isEager
+        data-testid="grid-cell"
+        data-idx={idx}
       />
     </StyledGridInputContainer>
   )

--- a/packages/streamwall-control-ui/src/gridTestHooks.test.tsx
+++ b/packages/streamwall-control-ui/src/gridTestHooks.test.tsx
@@ -1,0 +1,106 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import type { StreamDelayStatus, StreamWindowConfig } from 'streamwall-shared'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import * as Y from 'yjs'
+import { ControlUI, type StreamwallConnection } from './index.tsx'
+
+// react-icons renders through preact/compat's Context.Consumer, which
+// currently crashes under this package's happy-dom test environment
+// (unrelated to the test hooks under test here) - stub the icons out so
+// ControlUI's own rendering can be exercised in isolation.
+vi.mock('react-icons/fa', () => ({
+  FaExchangeAlt: () => null,
+  FaExclamationTriangle: () => null,
+  FaRedoAlt: () => null,
+  FaRegLifeRing: () => null,
+  FaRegWindowMaximize: () => null,
+  FaSyncAlt: () => null,
+  FaVideoSlash: () => null,
+  FaVolumeUp: () => null,
+}))
+vi.mock('react-icons/md', () => ({
+  MdOutlineStayCurrentLandscape: () => null,
+  MdOutlineStayCurrentPortrait: () => null,
+}))
+vi.mock('react-hotkeys-hook', () => ({
+  useHotkeys: () => {},
+}))
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+const config: StreamWindowConfig = {
+  cols: 2,
+  rows: 1,
+  width: 800,
+  height: 400,
+  frameless: false,
+  fullscreen: false,
+  activeColor: '#fff',
+  backgroundColor: '#000',
+}
+
+function renderControlUI(isConnected: boolean): HTMLDivElement {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+
+  const delayState: StreamDelayStatus = {
+    isConnected: true,
+    delaySeconds: 0,
+    restartSeconds: 0,
+    isCensored: false,
+    isStreamRunning: true,
+    startTime: 0,
+    state: 'idle',
+  }
+
+  const connection: StreamwallConnection = {
+    isConnected,
+    role: 'operator',
+    send: () => {},
+    sharedState: { views: {} },
+    stateDoc: new Y.Doc(),
+    config,
+    streams: [],
+    customStreams: [],
+    views: [],
+    stateIdxMap: new Map(),
+    delayState,
+    authState: undefined,
+    layoutPresets: [],
+    favorites: [],
+    dataSourceHealth: [],
+  }
+
+  act(() => {
+    render(<ControlUI connection={connection} />, container!)
+  })
+  return container
+}
+
+// The E2E suite (packages/streamwall-control-e2e) drives these landmarks via
+// `data-testid` rather than the styled-components class names used for
+// layout/CSS, so a rendering refactor can't silently break the tests
+// (issue #344).
+describe('E2E test hooks', () => {
+  test('exposes a stable data-testid on the grid container', () => {
+    const root = renderControlUI(true)
+    expect(root.querySelector('[data-testid="grid"]')).not.toBeNull()
+  })
+
+  test('exposes a stable data-testid on the header connection status', () => {
+    const root = renderControlUI(true)
+    const status = root.querySelector(
+      '[data-testid="header-connection-status"]',
+    )
+    expect(status?.textContent).toBe('connected · operator')
+  })
+})

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -748,7 +748,7 @@ export function ControlUI({
             <div className="livecount">● {liveStreams.length} On Air</div>
           )}
           {role !== 'local' && (
-            <div className="status">
+            <div className="status" data-testid="header-connection-status">
               <span className={`dot ${isConnected ? 'on' : 'off'}`} />
               {isConnected ? 'connected' : 'connecting...'} · {role}
             </div>
@@ -785,6 +785,7 @@ export function ControlUI({
           {cols != null && rows != null && (
             <StyledGridContainer
               className="grid"
+              data-testid="grid"
               onPointerMove={updateHoveringIdx}
               onPointerLeave={clearHoveringIdx}
               $windowWidth={windowWidth}


### PR DESCRIPTION
## Problem

The Playwright E2E suite (`packages/streamwall-control-e2e`, added in #342) selects grid cells and connection state via styled-components class names and element structure - `.grid`, `.grid input`, `.status`, and `getByRole('status')` for the disconnect banner. These work today but couple the tests to rendering internals: a refactor of the grid markup or a class rename would silently break the E2E selectors without any type/lint signal.

Closes #344.

## Solution

Added stable `data-testid` hooks to the durable UI landmarks the E2E suite targets, and switched the E2E selectors to them:

- `GridInput.tsx`: each grid cell input now carries `data-testid="grid-cell"` and `data-idx={idx}`.
- `index.tsx`: the grid container carries `data-testid="grid"` (alongside its existing `className="grid"`, kept for styling), and the header connection status carries `data-testid="header-connection-status"`.
- `ConnectionStatusBanner.tsx`: carries `data-testid="connection-status-banner"`. Its `role="status"` stays - that's an accessibility hook, not removed.
- `smoke.spec.ts`: switched every CSS-class/role selector to the corresponding `getByTestId(...)` call.

Scope is intentionally small: only the elements the E2E suite depends on. No behavior change.

## Architecture decisions

- Kept `className="grid"` on the grid container alongside the new `data-testid` - the class still drives CSS/layout (see `responsiveLayout.test.tsx`, `gridDragMoveRoleGating.test.tsx`), only the *test* selector moved.
- Kept `role="status"` on `ConnectionStatusBanner` for screen readers; added `data-testid` as an explicit, non-semantic test hook alongside it rather than repurposing the a11y attribute for testing.

## Unrelated fix bundled in for context

While rebasing onto `main`, discovered and separately shipped (#352, already merged) a broken `main` typecheck: `streamwall-control-e2e`'s test harness was missing the `favorites` field that #341 made required on `StreamwallState` (its branch predated #341). That fix landed as its own PR/commit before this one and is not part of this diff.

## Testing

- `npm run typecheck` - clean across all workspaces
- `npm run test` - all workspace suites pass (control-ui: 37 files / 248 tests, incl. 4 new tests covering the data-testid hooks)
- `npm -w streamwall-control-client run build` - clean
- `npm -w streamwall-control-e2e run test:e2e` - 4/4 smoke tests pass against the new selectors
- `npm run lint` / `npm run format:check` - clean

## Risks / breaking changes

None - purely additive markup attributes and a test-selector swap; no behavior change.