### PR TITLE
test(control-e2e): extend the control-client E2E suite beyond the smoke tests

### DIFF
--- a/packages/streamwall-control-e2e/tests/forwarded-commands.spec.ts
+++ b/packages/streamwall-control-e2e/tests/forwarded-commands.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from './harness.ts'
+
+/**
+ * Coverage for a `ControlCommand` driven from the UI actually reaching the
+ * Streamwall peer as the server-forwarded JSON message it expects (issue
+ * #343): the grid-size preset buttons are a convenient trigger because,
+ * unlike blur/listen controls, they don't require a running view.
+ */
+
+test('clicking a grid-size preset forwards a set-grid-size command to the Streamwall peer', async ({
+  page,
+  harness,
+}) => {
+  await page.goto(await harness.createInviteLink())
+  await expect(page.getByTestId('grid')).toBeVisible()
+
+  const commandPromise = harness.waitForCommand('set-grid-size')
+  await page.getByRole('button', { name: '2×2' }).click()
+
+  const command = await commandPromise
+  expect(command).toMatchObject({ type: 'set-grid-size', cols: 2, rows: 2 })
+})
+
+test('typing a custom column count forwards the committed dimensions', async ({
+  page,
+  harness,
+}) => {
+  await page.goto(await harness.createInviteLink())
+  await expect(page.getByTestId('grid')).toBeVisible()
+
+  const commandPromise = harness.waitForCommand('set-grid-size')
+  const columnsInput = page.getByLabel('Columns')
+  await columnsInput.fill('4')
+  await columnsInput.blur()
+
+  const command = await commandPromise
+  expect(command).toMatchObject({
+    type: 'set-grid-size',
+    cols: 4,
+    rows: harness.rows,
+  })
+})

--- a/packages/streamwall-control-e2e/tests/harness.ts
+++ b/packages/streamwall-control-e2e/tests/harness.ts
@@ -1,6 +1,6 @@
 import { test as base } from '@playwright/test'
 import { Low, Memory } from 'lowdb'
-import { once } from 'node:events'
+import { EventEmitter, once } from 'node:events'
 import { existsSync } from 'node:fs'
 import type { AddressInfo } from 'node:net'
 import net from 'node:net'
@@ -110,6 +110,16 @@ export interface Harness {
     streamId: string,
     timeoutMs?: number,
   ): Promise<void>
+  /**
+   * Resolves with the next JSON `ControlCommand` message of the given `type`
+   * the fake uplink receives — i.e. a UI-driven action (grid resize, blur
+   * toggle, ...) reached the Streamwall peer over the wire, forwarded by the
+   * control server. Rejects on timeout.
+   */
+  waitForCommand<T extends { type: string } = { type: string }>(
+    type: T['type'],
+    timeoutMs?: number,
+  ): Promise<T>
   close(): Promise<void>
 }
 
@@ -196,9 +206,28 @@ export async function startHarness(): Promise<Harness> {
     }
   })
 
+  // Text frames on the uplink socket are the server-forwarded JSON
+  // `ControlCommand` messages (see control-server's ws handler): re-emitted
+  // here, keyed by `type`, so `waitForCommand` can observe a UI-driven action
+  // reaching the peer without every test having to parse frames itself.
+  const commandEvents = new EventEmitter()
   ws.on('message', (data: WebSocket.RawData, isBinary: boolean) => {
     if (isBinary) {
       Y.applyUpdate(peerDoc, toUint8Array(data), 'server')
+      return
+    }
+    let msg: unknown
+    try {
+      msg = JSON.parse(data.toString())
+    } catch {
+      return
+    }
+    if (
+      typeof msg === 'object' &&
+      msg !== null &&
+      typeof (msg as { type?: unknown }).type === 'string'
+    ) {
+      commandEvents.emit((msg as { type: string }).type, msg)
     }
   })
 
@@ -315,6 +344,26 @@ export async function startHarness(): Promise<Harness> {
       peerDoc.on('update', onUpdate)
     })
 
+  const waitForCommand = <T extends { type: string } = { type: string }>(
+    type: T['type'],
+    timeoutMs = 5000,
+  ) =>
+    new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        commandEvents.off(type, onCommand)
+        reject(
+          new Error(
+            `Timed out waiting for a "${type}" command to reach the uplink`,
+          ),
+        )
+      }, timeoutMs)
+      const onCommand = (msg: T) => {
+        clearTimeout(timer)
+        resolve(msg)
+      }
+      commandEvents.once(type, onCommand)
+    })
+
   const close = async () => {
     ws.terminate()
     peerDoc.destroy()
@@ -328,6 +377,7 @@ export async function startHarness(): Promise<Harness> {
     streamIds: DEMO_STREAMS.map((s) => s._id),
     createInviteLink,
     waitForViewAssignment,
+    waitForCommand,
     close,
   }
 }

--- a/packages/streamwall-control-e2e/tests/invite-management.spec.ts
+++ b/packages/streamwall-control-e2e/tests/invite-management.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from './harness.ts'
+
+/**
+ * Coverage for the Access panel's invite round-trip (issue #343): submitting
+ * the create-invite form sends a `create-invite` command, and the server's
+ * response must be parsed and rendered — both as the direct "invite link
+ * created" callout and as a new line in the persistent Invites list (the
+ * latter regression-covers #351: creating a token used to only reach an
+ * already-connected client on the next unrelated state push from the
+ * Streamwall uplink, not immediately).
+ */
+
+test('creating an invite from the Access panel renders the resulting link and list entry', async ({
+  page,
+  harness,
+}) => {
+  await page.goto(await harness.createInviteLink())
+
+  await expect(page.getByRole('heading', { name: 'Access' })).toBeVisible()
+
+  const createInviteForm = page
+    .locator('form')
+    .filter({ has: page.getByRole('button', { name: 'create invite' }) })
+  await createInviteForm
+    .getByPlaceholder('Name', { exact: true })
+    .fill('field-crew')
+  await createInviteForm.getByRole('combobox').selectOption('operator')
+  await createInviteForm.getByRole('button', { name: 'create invite' }).click()
+
+  // The server's direct `create-invite` response is parsed into a real
+  // invite link and rendered as the "invite link created" callout.
+  await expect(page.getByRole('link', { name: '"field-crew"' })).toBeVisible()
+
+  // ...and the token now shows up live in the persistent Invites list.
+  await expect(page.getByText('field-crew: operator')).toBeVisible()
+})

--- a/packages/streamwall-control-e2e/tests/reconnect.spec.ts
+++ b/packages/streamwall-control-e2e/tests/reconnect.spec.ts
@@ -1,0 +1,69 @@
+import type { WebSocketRoute } from '@playwright/test'
+import { expect, test } from './harness.ts'
+
+/**
+ * End-to-end regression coverage for issue #37/#283: a websocket blip must
+ * not blank the grid or drop its last-known cell assignments.
+ *
+ * `context.setOffline` doesn't sever an already-open WebSocket in Chromium
+ * (confirmed empirically: the client stayed "connected" through it), so the
+ * blip is instead simulated by routing the client's `/client/ws` connection
+ * through `page.routeWebSocket` and closing it on demand — closing one side
+ * closes the other by default, giving the page's `ReconnectingWebSocket` a
+ * real `close` event to react to, the same as a dropped connection would.
+ */
+
+test('a websocket blip keeps the grid mounted with its last-known assignment, then resyncs', async ({
+  page,
+  harness,
+}) => {
+  // A plain mutable ref (rather than a reassigned `let`) so the assignment
+  // made inside the routing callback is visible without TS narrowing the
+  // outer binding back to its initial `null`.
+  const socketRef: { current: WebSocketRoute | null } = { current: null }
+  await page.routeWebSocket('**/client/ws', (ws) => {
+    socketRef.current = ws
+    ws.connectToServer()
+  })
+
+  await page.goto(await harness.createInviteLink())
+
+  const grid = page.getByTestId('grid')
+  await expect(grid).toBeVisible()
+  await expect(page.getByTestId('header-connection-status')).toContainText(
+    'connected',
+  )
+
+  const targetIdx = 4
+  const [streamId] = harness.streamIds
+  const cells = page.getByTestId('grid-cell')
+  await grid.hover()
+  await cells.nth(targetIdx).fill(streamId)
+  await cells.nth(targetIdx).blur()
+  await harness.waitForViewAssignment(targetIdx, streamId)
+  await expect(cells.nth(targetIdx)).toHaveValue(streamId)
+
+  await socketRef.current?.close()
+
+  // The grid must stay mounted, dimmed, with its last-known assignment —
+  // never unmount or blank to "loading..." (issue #37) — and the explicit
+  // reconnect banner must explain why.
+  await expect(page.getByTestId('connection-status-banner')).toContainText(
+    'reconnecting',
+    { ignoreCase: true },
+  )
+  await expect(grid).toBeVisible()
+  await expect(cells.nth(targetIdx)).toHaveValue(streamId)
+  await expect(page.getByTestId('header-connection-status')).toContainText(
+    'connecting...',
+  )
+
+  // Once the transport recovers, the server's full resync on reconnect
+  // clears the banner and the grid keeps showing the same assignment
+  // throughout — it never flashes empty in between (issue #283).
+  await expect(page.getByTestId('connection-status-banner')).toHaveCount(0)
+  await expect(page.getByTestId('header-connection-status')).toContainText(
+    'connected',
+  )
+  await expect(cells.nth(targetIdx)).toHaveValue(streamId)
+})

--- a/packages/streamwall-control-e2e/tests/role-gating.spec.ts
+++ b/packages/streamwall-control-e2e/tests/role-gating.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from './harness.ts'
+
+/**
+ * Coverage for role gating (issue #343): `roleCan` is unit-tested in
+ * isolation elsewhere, but these drive a real invite of each restricted role
+ * through a real browser and assert the actual rendered grid respects it —
+ * not just that the pure function returns the right boolean.
+ */
+
+test('a monitor invite renders the grid and layout controls disabled', async ({
+  page,
+  harness,
+}) => {
+  await page.goto(await harness.createInviteLink('monitor'))
+
+  const grid = page.getByTestId('grid')
+  await expect(grid).toBeVisible()
+
+  // `mutate-state-doc` is not a monitor action (see streamwall-shared's
+  // `roleCan`): every grid-cell input must render disabled, and typing into
+  // one must not change its value.
+  const cells = page.getByTestId('grid-cell')
+  await expect(cells).toHaveCount(harness.cols * harness.rows)
+  for (let idx = 0; idx < harness.cols * harness.rows; idx++) {
+    await expect(cells.nth(idx)).toBeDisabled()
+  }
+
+  // `set-grid-size` is likewise not a monitor action: the preset buttons and
+  // the raw Columns/Rows inputs must be disabled too.
+  await expect(page.getByRole('button', { name: '2×2' })).toBeDisabled()
+  await expect(page.getByLabel('Columns')).toBeDisabled()
+  await expect(page.getByLabel('Rows')).toBeDisabled()
+
+  // `create-invite` is admin-only: the Access panel must not render at all
+  // for a monitor.
+  await expect(page.getByRole('heading', { name: 'Access' })).toHaveCount(0)
+})
+
+test('an operator invite can resize the grid and edit cells like an admin', async ({
+  page,
+  harness,
+}) => {
+  await page.goto(await harness.createInviteLink('operator'))
+
+  const grid = page.getByTestId('grid')
+  await expect(grid).toBeVisible()
+
+  // `mutate-state-doc` and `set-grid-size` are both operator actions: the
+  // grid and layout controls must be fully interactive.
+  const cells = page.getByTestId('grid-cell')
+  await expect(cells.first()).toBeEnabled()
+  await expect(page.getByRole('button', { name: '2×2' })).toBeEnabled()
+
+  const targetIdx = 4
+  const [streamId] = harness.streamIds
+  await grid.hover()
+  await cells.nth(targetIdx).fill(streamId)
+  await cells.nth(targetIdx).blur()
+  await harness.waitForViewAssignment(targetIdx, streamId)
+  await expect(cells.nth(targetIdx)).toHaveValue(streamId)
+
+  // `create-invite` is admin-only: an operator must not see the Access panel.
+  await expect(page.getByRole('heading', { name: 'Access' })).toHaveCount(0)
+})


### PR DESCRIPTION
## Summary

Follow-up to #55/#342, which landed the initial Playwright smoke suite for the control client. Adds the four scenarios named in #343 as further specs in `packages/streamwall-control-e2e`, reusing the existing harness (`tests/harness.ts`).

Rebased onto `main` after opening: two other in-flight fixes landed in the meantime that directly interact with this PR's scope (see below).

## Technical solution

- **`reconnect.spec.ts`** — regression cover for #37/#283: drops the client's `/client/ws` connection and asserts the grid stays mounted, dimmed, with its last-known cell assignment, and shows the reconnect banner; then asserts the banner clears and the assignment survives once the transport recovers.

  `context.setOffline` does **not** sever an already-open WebSocket in Chromium (confirmed empirically — the client stayed `connected` through it), so the blip is instead simulated with `page.routeWebSocket('**/client/ws', ...)`, proxying the connection to the real server and calling `.close()` on demand. Closing one side closes the other by default, giving the page's `ReconnectingWebSocket` a real `close` event to react to.

- **`forwarded-commands.spec.ts`** — drives a `set-grid-size` command from the UI (a grid-size preset button, and the raw Columns input) and asserts the fake Streamwall uplink receives the expected forwarded JSON message. Required a new `harness.waitForCommand(type)` helper: the harness's uplink socket previously only handled binary (Yjs) frames, so it's extended to also parse JSON text frames and re-emit them by `type` via a small `EventEmitter`.

- **`role-gating.spec.ts`** — connects as `monitor` and asserts the grid-cell inputs, grid-size preset buttons, and Columns/Rows inputs all render disabled, and the Access panel is absent — end-to-end in a real browser, not just at the `roleCan()` unit level. A second test connects as `operator` and asserts they *can* resize the grid and edit cells like an admin, but still never see the (admin-only) Access panel.

- **`invite-management.spec.ts`** — submits the Access panel's create-invite form and asserts the server's response is parsed and rendered, both as the direct "invite link created" callout and as a live new entry in the persistent Invites list.

  While first writing this test I found the list entry did **not** update live — filed as #351. That got independently fixed and merged as #357 while this PR was open; after rebasing, the full round-trip (including the list entry) now passes as originally intended.

No CI changes needed — the `e2e` job already runs every `**/*.spec.ts` file via `npm -w streamwall-control-e2e run test:e2e`.

### Picked up from `main` during rebase

- #352 already added the `favorites` field this branch also needed on `E2E_STATE` — dropped my duplicate.
- #355 added stable `data-testid` hooks (`grid`, `grid-cell`, `header-connection-status`, `connection-status-banner`) and switched `smoke.spec.ts` to them. Switched all four new specs to the same selectors for consistency.

## Testing performed

- `npx playwright install chromium` (already cached locally)
- `npm -w streamwall-control-e2e run test:e2e` — all 10 specs (4 existing smoke + 6 new) pass
- `npm run typecheck` — clean across all workspaces
- `npm run lint` / `npm run format:check` — clean
- `npm test` — all workspace test suites green (streamwall 413, streamwall-shared 279, control-client 16, control-server 100, control-ui 248)

No production behavior changed — this PR only adds tests and extends the E2E test harness, so per the TDD exception for non-behavioral changes, "red" here means confirming each new spec fails for the right reason (e.g. `harness.waitForCommand is not a function`) before implementing the harness support and watching it go green.

## Risks / breaking changes

None — test-only change, no application code touched.

## Follow-ups

None new — #351 was filed and already resolved by #357 during this PR's review cycle.

Closes #343