### PR TITLE
fix(control-server): live-push auth-only changes to connected clients

### DIFF
--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -323,6 +323,34 @@ export async function initApp({
   const reportCaughtError = (err: unknown) =>
     captureException(err, sentryEnabled, sentryClient)
 
+  /**
+   * Diffs `clientState`'s current view against what each connected client last
+   * saw and sends only the delta. Subscribed to `clientState`'s own `'state'`
+   * event (see the Streamwall connection handler below) so it also runs for
+   * auth-only changes — e.g. `auth.on('state', ...)` calling
+   * `clientState.update({ auth: ... })` when an invite/session is
+   * created or deleted — not only when the desktop pushes a full state.
+   */
+  const broadcastStateDeltas = (clientState: StateWrapper) => {
+    for (const client of clients.values()) {
+      try {
+        if (client.ws.readyState !== WebSocket.OPEN) {
+          continue
+        }
+        const stateView = clientState.view(client.identity.role)
+        const delta = stateDiff.diff(client.lastStateSent, stateView)
+        if (!delta) {
+          continue
+        }
+        client.ws.send(JSON.stringify({ type: 'state-delta', delta }))
+        client.lastStateSent = stateView
+      } catch (err) {
+        console.error('failed to send client state delta', client, err)
+        reportCaughtError(err)
+      }
+    }
+  }
+
   await app.register(fastifyCookie)
 
   // Security headers. The CSP is kept in sync with the control client, which
@@ -538,7 +566,15 @@ export async function initApp({
 
         try {
           if (clientState === null) {
-            clientState = new StateWrapper(state)
+            const newClientState = new StateWrapper(state)
+            // Broadcasting on every `'state'` event (rather than only here)
+            // is what makes auth-only changes — invite/session created or
+            // deleted while the desktop pushes no new state — reach already
+            // connected clients; see `auth.on('state', ...)` below.
+            newClientState.on('state', () =>
+              broadcastStateDeltas(newClientState),
+            )
+            clientState = newClientState
             clientState.update({ auth: auth.getState() })
             currentStreamwallConn = {
               ws,
@@ -549,24 +585,6 @@ export async function initApp({
             console.log('Streamwall connected from', request.ip, tokenInfo)
           } else {
             clientState.update(state)
-          }
-
-          for (const client of clients.values()) {
-            try {
-              if (client.ws.readyState !== WebSocket.OPEN) {
-                continue
-              }
-              const stateView = clientState.view(client.identity.role)
-              const delta = stateDiff.diff(client.lastStateSent, stateView)
-              if (!delta) {
-                continue
-              }
-              client.ws.send(JSON.stringify({ type: 'state-delta', delta }))
-              client.lastStateSent = stateView
-            } catch (err) {
-              console.error('failed to send client state delta', client, err)
-              reportCaughtError(err)
-            }
           }
         } catch (err) {
           console.error('Failed to handle ws message:', rawData, err)

--- a/packages/streamwall-control-server/src/multiplexing.test.ts
+++ b/packages/streamwall-control-server/src/multiplexing.test.ts
@@ -4,12 +4,16 @@ import { after, test } from 'node:test'
 import { setTimeout as delay } from 'node:timers/promises'
 import WebSocket from 'ws'
 
-import type {
-  ClientCommandResponse,
-  ClientStateMessage,
-  ControlCommandMessage,
-  ServerToClientMessage,
-  StreamwallRole,
+import type { Delta } from 'jsondiffpatch'
+import {
+  stateDiff,
+  type ClientCommandResponse,
+  type ClientStateDeltaMessage,
+  type ClientStateMessage,
+  type ControlCommandMessage,
+  type ServerToClientMessage,
+  type StreamwallRole,
+  type StreamwallState,
 } from 'streamwall-shared'
 import {
   buildTestApp,
@@ -38,6 +42,14 @@ function isCommandType<Type extends ControlCommandMessage['type']>(type: Type) {
 
 const isStateMessage = (m: ServerToClientMessage): m is ClientStateMessage =>
   'type' in m && m.type === 'state'
+
+const isStateDelta = (m: ServerToClientMessage): m is ClientStateDeltaMessage =>
+  'type' in m && m.type === 'state-delta'
+
+/** Applies a `state-delta`'s patch to a client's last-known state, as a real client would. */
+function applyDelta(state: StreamwallState, delta: Delta): StreamwallState {
+  return stateDiff.patch(structuredClone(state), delta) as StreamwallState
+}
 
 /** Temporarily replaces `console.warn`, capturing every call made while active. */
 function spyOnConsoleWarn() {
@@ -350,5 +362,49 @@ test('a state message sent immediately on connect is not dropped while auth vali
     stateMsg.state.config,
     VALID_STATE.config,
     'the state message sent immediately on open must have been applied, not dropped',
+  )
+})
+
+test('creating an invite live-pushes a state-delta to an already-connected admin client', async () => {
+  const { auth, connectClient } = await bootServerWithUplink()
+  const { client: adminClient } = await connectClient('admin')
+
+  // Consume the initial `state` message so later assertions only see deltas
+  // caused by the invite below, not the connect-time snapshot.
+  let state = (await adminClient.waitFor(isStateMessage)).state
+
+  await auth.createToken({ kind: 'invite', role: 'operator', name: 'new op' })
+
+  const delta = await adminClient.waitFor(isStateDelta)
+  state = applyDelta(state, delta.delta)
+  assert.ok(
+    state.auth?.invites.some((invite) => invite.name === 'new op'),
+    'the new invite must appear via a live delta, without waiting for an unrelated desktop state push',
+  )
+})
+
+test('deleting a token live-pushes a state-delta to an already-connected admin client', async () => {
+  const { auth, connectClient } = await bootServerWithUplink()
+  const { client: adminClient } = await connectClient('admin')
+  let state = (await adminClient.waitFor(isStateMessage)).state
+
+  const invite = await auth.createToken({
+    kind: 'invite',
+    role: 'operator',
+    name: 'to revoke',
+  })
+  const createDelta = await adminClient.waitFor(isStateDelta)
+  state = applyDelta(state, createDelta.delta)
+  assert.ok(state.auth?.invites.some((i) => i.tokenId === invite.tokenId))
+
+  auth.deleteToken(invite.tokenId)
+
+  const deleteDelta = await adminClient.waitFor(
+    (m): m is ClientStateDeltaMessage => isStateDelta(m) && m !== createDelta,
+  )
+  state = applyDelta(state, deleteDelta.delta)
+  assert.ok(
+    !state.auth?.invites.some((i) => i.tokenId === invite.tokenId),
+    'the revoked invite must disappear via a live delta, without waiting for an unrelated desktop state push',
   )
 })


### PR DESCRIPTION
## Problem

The control server's per-client `state-delta` broadcast only ran inside the Streamwall uplink's own `state`-message handler (`packages/streamwall-control-server/src/index.ts`). It never fired for an auth-only change: creating or deleting an invite/session calls `auth.emitState()`, which the server's `auth.on('state', ...)` handler picks up and forwards into `clientState.update({ auth: auth.getState() })` — but nothing was subscribed to the resulting `'state'` event on `clientState` to actually diff and send it to connected clients.

Consequence: an admin creating or revoking an invite/session from the Access panel would see the direct response to their own command (the "invite link created" callout), but the persistent Invites/Sessions list — for that admin and any other connected admin — would not update until some unrelated full-state push happened to arrive from the desktop app afterwards. In a quiet session, the list could stay stale indefinitely.

## Solution

Extracted the per-client diff/broadcast loop into a `broadcastStateDeltas(clientState)` function, and subscribed it to `clientState`'s own `'state'` event exactly once, right when the `StateWrapper` is constructed for a connection. Since `StateWrapper.update()` always emits `'state'`, this one subscription now covers both broadcast triggers that previously required separate code paths:

- the desktop pushing a new `state` message (previously the only path that broadcast)
- `auth.on('state', ...)` calling `clientState.update({ auth: auth.getState() })` after a token is created or deleted (previously silent)

This matches the fix suggested in the issue and keeps the change minimal — no new broadcast call sites, no duplicated diff logic.

## Testing

Added two regression tests to `multiplexing.test.ts` covering the previously-broken path:
- creating an invite while an admin client is connected must push a `state-delta` reflecting the new invite, without any desktop state push
- deleting a token must push a follow-up `state-delta` with the token removed

Both tests apply the `state-delta` via `stateDiff.patch(...)` (the same `jsondiffpatch` instance the real client would use) to reconstruct the client's materialized state and assert on it directly, rather than asserting on the raw delta shape.

Confirmed both tests fail (time out) against the pre-fix code, and pass after the fix.

Full quality gate green locally: `format:check`, `lint`, `typecheck` (all workspaces), and `npm test` (all workspaces, 102/102 in `streamwall-control-server`).

## Risk / compatibility

Purely additive broadcast behavior on the server; no wire-format or client-side changes. No breaking changes.

Closes #351
