### PR TITLE
fix(streamwall-shared): derive ControlCommand from controlCommandSchema

### DIFF
--- a/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.test.tsx
+++ b/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.test.tsx
@@ -83,7 +83,7 @@ function stateMessage() {
 const createInviteCommand: ControlCommand = {
   type: 'create-invite',
   name: 'x',
-  role: 'viewer',
+  role: 'operator',
 }
 
 function Harness({

--- a/packages/streamwall-control-ui/src/AccessPanel.tsx
+++ b/packages/streamwall-control-ui/src/AccessPanel.tsx
@@ -3,13 +3,14 @@ import { useCallback, useState } from 'preact/hooks'
 import {
   invitableRoles,
   isInvitableRole,
+  type InvitableRole,
   type StreamwallRole,
 } from 'streamwall-shared'
 
 export function CreateInviteInput({
   onCreateInvite,
 }: {
-  onCreateInvite: (invite: { name: string; role: StreamwallRole }) => void
+  onCreateInvite: (invite: { name: string; role: InvitableRole }) => void
 }) {
   const [inviteName, setInviteName] = useState('')
   const [inviteRole, setInviteRole] = useState('operator')

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -20,6 +20,7 @@ import {
   gridWouldDropAssignments,
   hasGridAssignments,
   idColor,
+  type InvitableRole,
   inviteLink,
   type LayoutPreset,
   type LocalStreamData,
@@ -501,7 +502,7 @@ export function ControlUI({
   const [newInvite, setNewInvite] = useState<Invite>()
 
   const handleCreateInvite = useCallback(
-    ({ name, role }: { name: string; role: StreamwallRole }) => {
+    ({ name, role }: { name: string; role: InvitableRole }) => {
       send(
         {
           type: 'create-invite',

--- a/packages/streamwall-shared/src/schemas.test.ts
+++ b/packages/streamwall-shared/src/schemas.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from 'vitest'
 import {
+  type ControlCommand,
   controlCommandMessageSchema,
   controlStateMessageSchema,
   localStreamDataSchema,
   parseStreamList,
   streamDataInputSchema,
 } from './schemas.ts'
-import type { ControlCommand } from './types.ts'
 
 describe('streamDataInputSchema', () => {
   test('accepts a minimal entry with just a link', () => {
@@ -450,6 +450,17 @@ describe('controlCommandMessageSchema', () => {
       const command: ControlCommand = result.data
       expect(command.type).toBe('reload-view')
     }
+  })
+
+  test('ControlCommand rejects a create-invite role outside InvitableRole at compile time', () => {
+    const command: ControlCommand = {
+      type: 'create-invite',
+      // @ts-expect-error - ControlCommand must derive `role` from the schema's
+      // InvitableRole enum, not accept an arbitrary string (regression for #354).
+      role: 'not-a-real-role',
+      name: 'x',
+    }
+    expect(command.type).toBe('create-invite')
   })
 })
 

--- a/packages/streamwall-shared/src/schemas.ts
+++ b/packages/streamwall-shared/src/schemas.ts
@@ -217,6 +217,12 @@ export const controlCommandSchema = z.discriminatedUnion('type', [
 ])
 
 /**
+ * Every control command a client may send, derived from `controlCommandSchema`
+ * so the static type and its runtime validation can never drift apart.
+ */
+export type ControlCommand = z.infer<typeof controlCommandSchema>
+
+/**
  * An inbound control-command message: a command plus the client-supplied
  * numeric `id` used to correlate responses. `clientId` is attached server-side
  * and is deliberately not required here.

--- a/packages/streamwall-shared/src/types.ts
+++ b/packages/streamwall-shared/src/types.ts
@@ -1,6 +1,7 @@
 import type { Delta } from 'jsondiffpatch'
 import type { ViewContent, ViewPos } from './geometry.ts'
 import type { StreamwallRole } from './roles.ts'
+import type { ControlCommand } from './schemas.ts'
 
 export interface StreamWindowConfig {
   cols: number
@@ -159,32 +160,6 @@ type MessageMeta = {
   id: number
   clientId: string
 }
-
-export type ControlCommand =
-  | { type: 'set-listening-view'; viewIdx: number | null }
-  | {
-      type: 'set-view-background-listening'
-      viewIdx: number
-      listening: boolean
-    }
-  | { type: 'set-view-blurred'; viewIdx: number; blurred: boolean }
-  | { type: 'set-view-volume'; viewIdx: number; volume: number }
-  | { type: 'rotate-stream'; url: string; rotation: number }
-  | { type: 'update-custom-stream'; url: string; data: LocalStreamData }
-  | { type: 'delete-custom-stream'; url: string }
-  | { type: 'reload-view'; viewIdx: number }
-  | { type: 'browse'; url: string }
-  | { type: 'dev-tools'; viewIdx: number }
-  | { type: 'set-stream-censored'; isCensored: boolean }
-  | { type: 'set-stream-running'; isStreamRunning: boolean }
-  | { type: 'create-invite'; role: string; name: string }
-  | { type: 'delete-token'; tokenId: string }
-  | { type: 'set-grid-size'; cols: number; rows: number }
-  | { type: 'save-layout-preset'; name: string }
-  | { type: 'load-layout-preset'; presetId: string }
-  | { type: 'delete-layout-preset'; presetId: string }
-  | { type: 'add-favorite'; url: string }
-  | { type: 'remove-favorite'; url: string }
 
 export type ControlUpdate = {
   type: 'state'

--- a/packages/streamwall-shared/src/uplink.ts
+++ b/packages/streamwall-shared/src/uplink.ts
@@ -1,4 +1,4 @@
-import type { ControlCommand } from './types.ts'
+import type { ControlCommand } from './schemas.ts'
 
 /**
  * Commands the Streamwall desktop accepts from its remote control-server


### PR DESCRIPTION
## Problem

`packages/streamwall-shared/src/types.ts` defined `ControlCommand` as a hand-maintained discriminated union that duplicated the shape already enforced by `controlCommandSchema` in `packages/streamwall-shared/src/schemas.ts`. The two were not derived from one another, so they could silently drift.

Concretely, `ControlCommand`'s `create-invite` variant typed `role` as a bare `string`, while the schema's inferred type for the same command was `InvitableRole` (`'admin' | 'operator' | 'monitor'`, tightened in #349/#353). Any code that typed a `create-invite` command through `ControlCommand` got no compile-time guarantee that `role` was a valid or invitable role — only the runtime `safeParse` at the trust boundary caught an invalid value. More broadly, every field in `ControlCommand` was typed with plain primitives rather than the schema's bounded types, so future schema tightening could leave `ControlCommand` silently stale.

## Solution

`ControlCommand` is now derived directly from the schema:

```ts
export type ControlCommand = z.infer<typeof controlCommandSchema>
```

- Moved the type into `schemas.ts` (next to `controlCommandSchema`) so the schema is the single source of truth.
- `types.ts` and `uplink.ts` now import the derived type instead of holding their own copy — no circular import issue, since `schemas.ts` doesn't depend on `types.ts`.
- `ControlCommandMessage` in `types.ts` still composes `MessageMeta & ControlCommand`, unchanged.

## Fallout from the stricter type

Deriving the type surfaced two latent gaps that the old bare `string` had been masking (both fixed here):

- `streamwall-control-ui`'s `CreateInviteInput`/`handleCreateInvite` accepted a `StreamwallRole` (which includes `'local'`) for a create-invite payload, even though the invite role `<select>` is already restricted to `invitableRoles` at runtime (and guarded by `isInvitableRole` before the value is used). Narrowed both to `InvitableRole` so the type matches what was already true at runtime.
- A `streamwall-control-client` test constructed a `create-invite` `ControlCommand` with `role: 'viewer'` — a value that was never a valid `StreamwallRole` to begin with. Fixed to a real role (`'operator'`); the test only needed *a* valid command, not that specific role.

## Testing

- Added a compile-time regression test in `schemas.test.ts`: constructing a `create-invite` `ControlCommand` with a non-invitable role now fails `tsc`, caught via `@ts-expect-error` (matching the existing pattern in `uplink.test.ts`). Confirmed this test fails before the fix (`Unused '@ts-expect-error' directive`) and passes after.
- Full quality gate run: `npm run format:check`, `npm run lint`, `npm run typecheck` (all workspaces), `npm run test` (all workspaces), and `npm -w packages/streamwall-control-client run build` — all green.

No behavioral/runtime changes: the schema's runtime validation was already correct; this only tightens the compile-time type to match it.

## Risks / breaking changes

None expected. This is a type-only refactor plus two narrower prop types in `control-ui` that reflect already-true runtime invariants. No public API or wire-format changes.

Closes #354