### PR TITLE
chore(release): streamwall v0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15132,7 +15132,7 @@
       }
     },
     "packages/streamwall": {
-      "version": "2.0.0-pre2",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/packages/streamwall/package.json
+++ b/packages/streamwall/package.json
@@ -1,7 +1,7 @@
 {
   "name": "streamwall",
   "productName": "Streamwall",
-  "version": "2.0.0-pre2",
+  "version": "0.9.0",
   "description": "Watch streams in a grid layout",
   "main": ".vite/build/index.js",
   "repository": "github:NilsR0711/streamwall",


### PR DESCRIPTION
## What

Bumps the \`streamwall\` app package from \`2.0.0-pre2\` to \`0.9.0\` (first tagged release; intentionally sub-1.0 to signal "not yet stable").

## How the release happens

This repo already ships a complete, token-free release pipeline for the Electron app. No npm registry, no npm token, no Trusted Publisher is involved — \`streamwall\` is a desktop app distributed as binaries, not an installable library.

Once this is merged, pushing the \`v0.9.0\` tag triggers [\`release.yml\`](.github/workflows/release.yml):

1. Quality gate (lint, typecheck, test)
2. Builds Linux / Windows / macOS via \`electron-forge publish\`
3. Creates the GitHub release under **NilsR0711/streamwall** (target derived from the \`repository\` field \`github:NilsR0711/streamwall\`), marked as a pre-release

Signing stays opt-in (unsigned builds, unchanged) until the Apple/Windows secrets are provisioned.

## Scope

Only \`packages/streamwall\` is versioned/released here. The other workspaces (control-server/client etc.) are untouched.