### PR TITLE
fix(release): publish GitHub releases as non-prerelease

### DIFF
--- a/packages/streamwall/forge.config.ts
+++ b/packages/streamwall/forge.config.ts
@@ -38,7 +38,11 @@ const config: ForgeConfig = {
       name: '@electron-forge/publisher-github',
       config: {
         repository: publishRepository,
-        prerelease: true,
+        // Publish as a normal (non-prerelease) release so it becomes the
+        // repo's "Latest release": GitHub's latest-release logic — and the
+        // homepage sidebar "Releases" box — deliberately ignores
+        // prereleases, so a prerelease-only repo shows just a tag count.
+        prerelease: false,
       },
     },
   ],


### PR DESCRIPTION
## Problem

The repo homepage sidebar showed **"1 tags"** and no release, even though v0.9.0 was published. Cause: the electron-forge GitHub publisher was hardcoded to \`prerelease: true\`, so every release is flagged as a prerelease. GitHub's "latest release" logic — and the homepage **Releases** sidebar box — deliberately ignore prereleases, so a prerelease-only repo falls back to showing just a tag count.

## Fix

Set \`prerelease: false\` in the publisher config so future tagged releases publish as normal releases and surface as **Latest**.

(The existing v0.9.0 release was already flipped to non-prerelease manually; this makes the behavior stick for all future \`v*\` tags.)

## Note — still a draft first

The publisher still creates each release as a **draft** (its default). A release only appears once the draft is published. If you want tag pushes to publish a public Latest release with zero manual steps, we can also set \`draft: false\` — that removes the manual review gate. Left out of this PR on purpose; say the word and I'll add it.