### PR TITLE
fix(streamwall): retry unresolved playlist URLs when stream data updates

### DIFF
--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -1018,6 +1018,10 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   for await (const streams of combineDataSources(dataSources, idGen)) {
     updateState({ streams })
     updateViewsFromStateDoc()
+    // Newly-loaded stream data may resolve a playlist URL that failed to
+    // resolve on startup or a prior interval tick; fill it in immediately
+    // rather than leaving the view empty until the next tick.
+    playlistScheduler.retryPending()
   }
 }
 

--- a/packages/streamwall/src/main/playlist.test.ts
+++ b/packages/streamwall/src/main/playlist.test.ts
@@ -122,4 +122,77 @@ describe('PlaylistScheduler', () => {
     vi.advanceTimersByTime(60_000)
     expect(deps.setViewStream).not.toHaveBeenCalled()
   })
+
+  describe('retryPending', () => {
+    test('resolves a view whose URL only becomes available after startup', () => {
+      const streamIdByURL: Record<string, string | undefined> = { a: undefined }
+      const deps = makeDeps(streamIdByURL)
+      const scheduler = new PlaylistScheduler(
+        [{ view: 0, interval: 10, urls: ['a'] }],
+        deps,
+      )
+
+      scheduler.start()
+      expect(deps.setViewStream).not.toHaveBeenCalled()
+
+      streamIdByURL.a = 'stream-a'
+      scheduler.retryPending()
+
+      expect(deps.setViewStream).toHaveBeenCalledExactlyOnceWith(0, 'stream-a')
+    })
+
+    test('re-resolves the same URL rather than skipping ahead to the next one', () => {
+      const streamIdByURL: Record<string, string | undefined> = {
+        a: undefined,
+        b: 'stream-b',
+      }
+      const deps = makeDeps(streamIdByURL)
+      const scheduler = new PlaylistScheduler(
+        [{ view: 0, interval: 10, urls: ['a', 'b'] }],
+        deps,
+      )
+
+      scheduler.start()
+      streamIdByURL.a = 'stream-a'
+      scheduler.retryPending()
+      expect(deps.setViewStream).toHaveBeenCalledExactlyOnceWith(0, 'stream-a')
+
+      deps.setViewStream.mockClear()
+      vi.advanceTimersByTime(10_000)
+      expect(deps.setViewStream).toHaveBeenCalledExactlyOnceWith(0, 'stream-b')
+    })
+
+    test('is a no-op for views that already resolved', () => {
+      const deps = makeDeps({ a: 'stream-a' })
+      const scheduler = new PlaylistScheduler(
+        [{ view: 0, interval: 10, urls: ['a'] }],
+        deps,
+      )
+
+      scheduler.start()
+      deps.setViewStream.mockClear()
+      deps.resolveStreamId.mockClear()
+
+      scheduler.retryPending()
+
+      expect(deps.resolveStreamId).not.toHaveBeenCalled()
+      expect(deps.setViewStream).not.toHaveBeenCalled()
+    })
+
+    test('does nothing once the scheduler has been stopped', () => {
+      const deps = makeDeps({ a: undefined })
+      const scheduler = new PlaylistScheduler(
+        [{ view: 0, interval: 10, urls: ['a'] }],
+        deps,
+      )
+
+      scheduler.start()
+      scheduler.stop()
+      deps.resolveStreamId.mockClear()
+
+      scheduler.retryPending()
+
+      expect(deps.resolveStreamId).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/streamwall/src/main/playlist.ts
+++ b/packages/streamwall/src/main/playlist.ts
@@ -23,6 +23,7 @@ export interface PlaylistSchedulerDeps {
 export class PlaylistScheduler {
   private readonly timers: ReturnType<typeof setInterval>[] = []
   private readonly cursors = new Map<number, number>()
+  private readonly pending = new Set<PlaylistConfig>()
 
   constructor(
     private readonly playlists: PlaylistConfig[],
@@ -32,7 +33,7 @@ export class PlaylistScheduler {
   start() {
     for (const playlist of this.playlists) {
       this.cursors.set(playlist.view, 0)
-      this.advance(playlist)
+      this.resolve(playlist)
       this.timers.push(
         setInterval(() => this.advance(playlist), playlist.interval * 1000),
       )
@@ -44,19 +45,40 @@ export class PlaylistScheduler {
       clearInterval(timer)
     }
     this.timers.length = 0
+    this.pending.clear()
+  }
+
+  /**
+   * Re-resolves the current URL for every view that failed to resolve on
+   * its last advance, without moving on to the next URL in the playlist.
+   * Call this whenever stream data refreshes so a view fills in as soon as
+   * its URL becomes resolvable, instead of staying empty until the next
+   * interval tick.
+   */
+  retryPending() {
+    for (const playlist of this.pending) {
+      this.resolve(playlist)
+    }
   }
 
   private advance(playlist: PlaylistConfig) {
+    const cursor = (this.cursors.get(playlist.view) ?? 0) + 1
+    this.cursors.set(playlist.view, cursor)
+    this.resolve(playlist)
+  }
+
+  private resolve(playlist: PlaylistConfig) {
     const cursor = this.cursors.get(playlist.view) ?? 0
     const url = playlist.urls[cursor % playlist.urls.length]
     const streamId = this.deps.resolveStreamId(url)
     if (streamId === undefined) {
+      this.pending.add(playlist)
       log.warn(
         `Playlist for view ${playlist.view}: no stream found for URL "${url}", skipping`,
       )
     } else {
+      this.pending.delete(playlist)
       this.deps.setViewStream(playlist.view, streamId)
     }
-    this.cursors.set(playlist.view, cursor + 1)
   }
 }


### PR DESCRIPTION
## Problem

`PlaylistScheduler.start()` resolves each configured view's first playlist URL synchronously at startup, before any async data source (`de-tv` preset, `json-url`, `toml-file`, …) has populated `clientState.streams`. The URL→stream-id lookup misses, the miss is logged as *"no stream found for URL … skipping"*, and the view stays blank until the next `setInterval` tick fires — up to the full configured `interval` seconds later.

## Solution

Added `PlaylistScheduler.retryPending()`, which re-resolves the *current* URL for any view whose last resolution attempt failed, without advancing the playlist cursor to the next URL. The scheduler now tracks which views are pending resolution internally (a `Set<PlaylistConfig>`).

`retryPending()` is called from the main-process data-source update loop (`packages/streamwall/src/main/index.ts`) every time `combineDataSources` emits a new batch of streams — i.e. whenever stream data actually changes. A view that missed on startup now fills in on the very next data-source update instead of waiting for its playlist interval to elapse.

### Architecture notes

- Kept the fix scoped to the playlist scheduler itself rather than reordering startup (starting the scheduler after the first data batch would still leave the "walk in cold with no data source configured" case unhandled, and would delay every other playlist behavior on the first source's latency).
- `resolve()` was factored out of `advance()` so both the interval-driven cursor advance and the pending-retry path share the same resolution/logging logic; only `advance()` moves the cursor forward.

## Testing

- Added unit tests in `packages/streamwall/src/main/playlist.test.ts` covering: `retryPending()` filling in a view once its URL resolves, `retryPending()` not skipping ahead to the next playlist URL, `retryPending()` being a no-op once a view has already resolved, and `retryPending()` doing nothing after `stop()`.
- `npm run test --workspace packages/streamwall` — 417/417 passing.
- `npm run typecheck --workspace packages/streamwall` — clean.
- `npm run lint --workspace packages/streamwall` — clean.
- `npx prettier --check` on changed files — clean.
- `npm run package --workspace packages/streamwall` — packages successfully.

## Risks / breaking changes

None. `retryPending()` is additive; existing scheduling behavior (cursor advance on each interval) is unchanged and covered by the pre-existing test suite.

Closes #364