### PR TITLE
fix(streamwall): keep non-focused streams alive across a fullscreen expand/collapse

### DIFF
--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -46,6 +46,7 @@ function makeStreamWindow(config: StreamWindowConfig) {
     typeof StreamWindow
   >
   sw.config = config
+  sw.parkedViews = new Map()
   return sw
 }
 
@@ -270,14 +271,24 @@ function makeReuseTestActor(opts: {
   const send = vi.fn()
   const stop = vi.fn()
   const disposeView = vi.fn()
+  const setBounds = vi.fn()
+  const removeChildViewOnWin = vi.fn()
+  const addChildViewOnOffscreen = vi.fn()
+  const view = { setBounds }
+  const win = { contentView: { removeChildView: removeChildViewOnWin } }
+  const offscreenWin = {
+    contentView: { addChildView: addChildViewOnOffscreen },
+    getBounds: () => ({ width: 100, height: 100 }),
+  }
   const actor = {
     getSnapshot: () => ({
       context: {
         id: opts.id,
         content: opts.content,
         pos: { spaces: opts.spaces },
-        view: {},
-        offscreenWin: {},
+        view,
+        win,
+        offscreenWin,
         next: null,
         disposeView,
       },
@@ -287,7 +298,15 @@ function makeReuseTestActor(opts: {
     send,
     stop,
   } as unknown as ReturnType<typeof StreamWindow.prototype.createView>
-  return { actor, send, stop, disposeView }
+  return {
+    actor,
+    send,
+    stop,
+    disposeView,
+    setBounds,
+    removeChildViewOnWin,
+    addChildViewOnOffscreen,
+  }
 }
 
 describe('StreamWindow.setViews reusing an actor across a genuine content change', () => {
@@ -518,6 +537,181 @@ describe('StreamWindow.setViews expanding a view to fill the wall (issue #362)',
     expect(other.stop).toHaveBeenCalled()
     expect(sw.views.size).toBe(1)
     expect(sw.views.get(1)).toBe(expanding.actor)
+  })
+})
+
+describe('StreamWindow.setViews parking unused views during a fullscreen expansion (issue #369)', () => {
+  it('hides a non-focused running view instead of tearing it down when parkUnused is requested', () => {
+    const sw = makeStreamWindow(makeConfig({ cols: 2, rows: 2 }))
+    sw.win = {
+      contentView: { removeChildView: vi.fn() },
+    } as unknown as InstanceType<typeof StreamWindow>['win']
+
+    const streamA: ViewContent = {
+      url: 'https://example.com/a',
+      kind: 'video',
+    }
+    const streamB: ViewContent = {
+      url: 'https://example.com/b',
+      kind: 'video',
+    }
+    const expanding = makeReuseTestActor({
+      id: 1,
+      content: streamB,
+      spaces: [1],
+      running: true,
+    })
+    const other = makeReuseTestActor({
+      id: 2,
+      content: streamA,
+      spaces: [0],
+      running: true,
+    })
+    sw.views = new Map([
+      [1, expanding.actor],
+      [2, other.actor],
+    ])
+    sw.createView = vi.fn()
+
+    sw.setViews(
+      fullscreenViewContentMap(2, 2, streamB),
+      { byURL: new Map([[streamB.url, {}]]) },
+      { parkUnused: true },
+    )
+
+    // The non-focused actor survives instead of being stopped/disposed...
+    expect(other.stop).not.toHaveBeenCalled()
+    expect(other.disposeView).not.toHaveBeenCalled()
+    // ...but is moved off the visible wall onto its own offscreen host so it
+    // does not render on top of (or behind) the expanded view.
+    expect(other.removeChildViewOnWin).toHaveBeenCalled()
+    expect(other.addChildViewOnOffscreen).toHaveBeenCalled()
+    // It no longer appears in the emitted view states (only the expanded
+    // view is visible, matching the pre-#369 behavior)...
+    expect(sw.views.size).toBe(1)
+    expect(sw.views.get(1)).toBe(expanding.actor)
+    // ...but StreamWindow retains it internally so a later collapse can
+    // reuse it instead of recreating it from scratch.
+    expect(
+      (sw as unknown as { parkedViews: Map<number, unknown> }).parkedViews.get(
+        2,
+      ),
+    ).toBe(other.actor)
+  })
+
+  it('reuses a parked view instead of creating a new one when the fullscreen view collapses', () => {
+    const sw = makeStreamWindow(makeConfig({ cols: 2, rows: 2 }))
+    sw.win = {
+      contentView: { removeChildView: vi.fn() },
+    } as unknown as InstanceType<typeof StreamWindow>['win']
+
+    const streamA: ViewContent = {
+      url: 'https://example.com/a',
+      kind: 'video',
+    }
+    const streamB: ViewContent = {
+      url: 'https://example.com/b',
+      kind: 'video',
+    }
+    const expanding = makeReuseTestActor({
+      id: 1,
+      content: streamB,
+      spaces: [1],
+      running: true,
+    })
+    const other = makeReuseTestActor({
+      id: 2,
+      content: streamA,
+      spaces: [0],
+      running: true,
+    })
+    sw.views = new Map([
+      [1, expanding.actor],
+      [2, other.actor],
+    ])
+    sw.createView = vi.fn()
+
+    // Expand: `other` is parked instead of disposed.
+    sw.setViews(
+      fullscreenViewContentMap(2, 2, streamB),
+      { byURL: new Map([[streamB.url, {}]]) },
+      { parkUnused: true },
+    )
+
+    // Collapse: the normal per-cell layout is restored.
+    const viewContentMap: ViewContentMap = new Map([
+      ['0', streamA],
+      ['1', streamB],
+    ])
+    sw.setViews(viewContentMap, {
+      byURL: new Map([
+        [streamA.url, {}],
+        [streamB.url, {}],
+      ]),
+    })
+
+    // The parked actor is reused for its original space instead of a new
+    // view being created for it (which would show a reload/black flash).
+    expect(sw.createView).not.toHaveBeenCalled()
+    expect(other.send).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'DISPLAY', content: streamA }),
+    )
+    expect(sw.views.size).toBe(2)
+    expect(sw.views.get(2)).toBe(other.actor)
+  })
+
+  it('still tears down a view left unused after collapse (its cell was cleared while expanded)', () => {
+    const sw = makeStreamWindow(makeConfig({ cols: 2, rows: 2 }))
+    sw.win = {
+      contentView: { removeChildView: vi.fn() },
+    } as unknown as InstanceType<typeof StreamWindow>['win']
+
+    const streamA: ViewContent = {
+      url: 'https://example.com/a',
+      kind: 'video',
+    }
+    const streamB: ViewContent = {
+      url: 'https://example.com/b',
+      kind: 'video',
+    }
+    const expanding = makeReuseTestActor({
+      id: 1,
+      content: streamB,
+      spaces: [1],
+      running: true,
+    })
+    const other = makeReuseTestActor({
+      id: 2,
+      content: streamA,
+      spaces: [0],
+      running: true,
+    })
+    sw.views = new Map([
+      [1, expanding.actor],
+      [2, other.actor],
+    ])
+    sw.createView = vi.fn()
+
+    sw.setViews(
+      fullscreenViewContentMap(2, 2, streamB),
+      { byURL: new Map([[streamB.url, {}]]) },
+      { parkUnused: true },
+    )
+
+    // Collapse, but the cell `other` used to occupy was cleared while
+    // expanded: the normal layout no longer has any box for streamA.
+    const viewContentMap: ViewContentMap = new Map([['1', streamB]])
+    sw.setViews(viewContentMap, { byURL: new Map([[streamB.url, {}]]) })
+
+    // The parked actor is genuinely no longer needed, so it is torn down
+    // instead of being parked forever.
+    expect(other.stop).toHaveBeenCalled()
+    expect(other.disposeView).toHaveBeenCalledTimes(1)
+    expect(
+      (sw as unknown as { parkedViews: Map<number, unknown> }).parkedViews.has(
+        2,
+      ),
+    ).toBe(false)
   })
 })
 

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -56,6 +56,13 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
   backgroundView: WebContentsView
   overlayView: WebContentsView
   views: Map<number, ViewActor>
+  // Actors temporarily excluded from `views` (and therefore from
+  // `emitState()`) while a fullscreen expansion hides them behind the
+  // expanded view, kept alive instead of torn down so a later collapse can
+  // reposition them without a reload (issue #369). Populated by `setViews`
+  // when called with `{ parkUnused: true }`; cleared and re-considered as
+  // reuse candidates on every subsequent `setViews` call.
+  parkedViews: Map<number, ViewActor>
   // Routes IPC messages from a specific WebContentsView back to whichever
   // actor owns it. Keyed by live `webContents.id`, unlike `views` (keyed by
   // each actor's stable `context.id`, fixed at creation): once a content swap
@@ -72,6 +79,7 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
     this.config = config
     this.retryConfig = retryConfig
     this.views = new Map()
+    this.parkedViews = new Map()
     this.viewsByWebContentsId = new Map()
 
     const {
@@ -331,6 +339,23 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
     offscreenWin.destroy()
   }
 
+  /**
+   * Moves a running actor's view off the visible wall onto its own offscreen
+   * host window, without touching the actor's state. Used to keep a
+   * non-focused view alive (rather than torn down) across a fullscreen
+   * expansion: `setViews`' own matchers can then find and reposition it again
+   * on collapse -- via a normal `DISPLAY` event -- instead of recreating it
+   * from scratch (issue #369). Mirrors `viewStateMachine`'s `offscreenView`
+   * action, which the actor itself uses while a fresh view is loading.
+   */
+  private hideView(actor: ViewActor) {
+    const { view, win, offscreenWin } = actor.getSnapshot().context
+    win.contentView.removeChildView(view)
+    offscreenWin.contentView.addChildView(view)
+    const { width, height } = offscreenWin.getBounds()
+    view.setBounds({ x: 0, y: 0, width, height })
+  }
+
   createView() {
     const { win } = this
     assert(win != null, 'Window must be initialized')
@@ -412,12 +437,23 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
     this.config.rows = rows
   }
 
-  setViews(viewContentMap: ViewContentMap, streams: StreamList) {
+  setViews(
+    viewContentMap: ViewContentMap,
+    streams: StreamList,
+    { parkUnused = false }: { parkUnused?: boolean } = {},
+  ) {
     const { width, height, cols, rows } = this.config
     const { views } = this
     const boxes = boxesFromViewContentMap(cols, rows, viewContentMap)
     const remainingBoxes = new Set(boxes)
-    const unusedViews = new Set(views.values())
+    // Views parked by a previous `parkUnused` call are reuse candidates too,
+    // so a fullscreen collapse can find and reposition them via the matchers
+    // below instead of creating new ones (issue #369).
+    const unusedViews = new Set([
+      ...views.values(),
+      ...this.parkedViews.values(),
+    ])
+    this.parkedViews.clear()
     const viewsToDisplay = []
 
     // We try to find the best match for moving / reusing existing views to match the new positions.
@@ -506,6 +542,13 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
       newViews.set(view.getSnapshot().context.id, view)
     }
     for (const view of unusedViews) {
+      if (parkUnused) {
+        // Keep the actor alive, just hidden -- see `hideView` and the
+        // `parkedViews` field.
+        this.hideView(view)
+        this.parkedViews.set(view.getSnapshot().context.id, view)
+        continue
+      }
       view.stop()
       const {
         view: contentView,

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -521,10 +521,13 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     try {
       // When a view is expanded to fullscreen (issue #362), override the
       // derived layout so the expanded stream fills every grid cell -- one
-      // wall-spanning box, with the other views torn down. This override is
-      // transient: it reads the expanded stream from `viewsState` but never
-      // writes back, so the persisted grid assignments are untouched and a
-      // later collapse restores the normal layout verbatim.
+      // wall-spanning box, with the other views parked (hidden but kept
+      // alive, not torn down) behind it, so a later collapse can reposition
+      // them instead of reloading them from scratch (issue #369). This
+      // override is transient: it reads the expanded stream from
+      // `viewsState` but never writes back, so the persisted grid
+      // assignments are untouched and a later collapse restores the normal
+      // layout verbatim.
       const { fullscreenViewIdx } = clientState
       if (fullscreenViewIdx != null) {
         const streamId = viewsState
@@ -539,6 +542,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
               { url: stream.link, kind: stream.kind || 'video' },
             ),
             clientState.streams,
+            { parkUnused: true },
           )
           return
         }


### PR DESCRIPTION
## Problem

Follow-up from #362 / PR #368, which added double-click-to-expand for a grid stream.

When a view is expanded to fullscreen, `StreamWindow.setViews` tears down every other view's actor entirely (`stop()` + dispose) since the fullscreen content map has no box for their cells. The focused stream is reused and keeps playing, but on **collapse** the other streams are recreated from scratch and therefore reload (a brief black flash / buffering per tile).

## Solution

`StreamWindow.setViews` now accepts an options argument, `{ parkUnused: true }`:

- Instead of disposing an actor that no longer matches any box, it moves the actor's `WebContentsView` onto its own offscreen host window (mirroring the state machine's existing `offscreenView` action) and keeps the actor in a new `parkedViews` map rather than tearing it down.
- Parked actors are folded back into the next `setViews()` call's reuse candidates (`unusedViews`), so the existing matcher logic (same URL + running) finds and repositions them via a normal `DISPLAY` event once the layout returns to normal — no new view is created, no reload.
- A parked actor whose cell was genuinely cleared while expanded is still torn down normally on the next call (it just isn't matched by any box).
- `parkedViews` is excluded from `emitState()`/`this.views`, so the control UI still only renders the single expanded box during fullscreen — unchanged from before.

`main/index.ts`'s fullscreen branch in `updateViewsFromStateDoc` now passes `{ parkUnused: true }` when overriding the layout for the expanded view. The normal (non-fullscreen) call path is untouched, so cells that are actually removed from the grid are still disposed as before.

## Testing

- Added `StreamWindow.test.ts` coverage (issue #369):
  - a non-focused running view is hidden (moved to its own offscreen host) instead of stopped/disposed when `parkUnused` is requested, and is tracked in `parkedViews`.
  - a parked view is reused (repositioned via `DISPLAY`, no `createView()` call) when the fullscreen view collapses back to the normal layout.
  - a parked view whose cell was cleared while expanded is still torn down on collapse (no permanent leak).
- Full local quality gate: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm run test` — all green across every workspace.

## Risks / limitations

- Parked (hidden) streams keep decoding/playing while off-screen instead of pausing — this trades a small amount of CPU/network for the instant-resume UX. The issue's own suggested solution flagged "pause while hidden" as an optional, separately-decidable enhancement; I kept this change scoped to the core "don't reload" ask.

Closes #369