### PR TITLE
fix(control-server): default listen port when URL has no port

### DIFF
--- a/packages/streamwall-control-server/src/index.test.ts
+++ b/packages/streamwall-control-server/src/index.test.ts
@@ -2,7 +2,11 @@ import { Low, Memory } from 'lowdb'
 import assert from 'node:assert/strict'
 import { after, describe, test } from 'node:test'
 
-import { initApp, SESSION_COOKIE_NAME } from './index.ts'
+import {
+  initApp,
+  resolveListenPort,
+  SESSION_COOKIE_NAME,
+} from './index.ts'
 import type { StoredData } from './storage.ts'
 
 const ONE_YEAR_IN_SECONDS = 365 * 24 * 60 * 60
@@ -100,5 +104,31 @@ describe('session cookie security attributes', () => {
 
     assert.equal(response.statusCode, 403)
     assert.equal(response.headers['set-cookie'], undefined)
+  })
+})
+
+describe('resolveListenPort', () => {
+  test('https URL with no explicit port defaults to 443 (not 0)', () => {
+    assert.equal(resolveListenPort('https://wall.example.com'), 443)
+  })
+
+  test('http URL with no explicit port defaults to 80 (not 0)', () => {
+    assert.equal(resolveListenPort('http://wall.example.com'), 80)
+  })
+
+  test('explicit URL port is used when present', () => {
+    assert.equal(resolveListenPort('https://wall.example.com:8443'), 8443)
+    assert.equal(resolveListenPort('http://localhost:3000'), 3000)
+  })
+
+  test('override port wins over URL (including scheme default)', () => {
+    assert.equal(resolveListenPort('https://wall.example.com', '8080'), 8080)
+    assert.equal(resolveListenPort('https://wall.example.com:8443', '9090'), 9090)
+  })
+
+  test('empty override falls through to URL / scheme default', () => {
+    assert.equal(resolveListenPort('https://wall.example.com', ''), 443)
+    assert.equal(resolveListenPort('https://wall.example.com', '   '), 443)
+    assert.equal(resolveListenPort('http://localhost:3000', ''), 3000)
   })
 })

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -946,6 +946,26 @@ function logBootstrap({
   console.log('🔑 Admin invite:', adminInviteLink)
 }
 
+/**
+ * Resolve the TCP listen port for the control server.
+ * `URL.port` is `""` (not undefined) when the URL has no explicit port, so
+ * `??` alone would leave an empty string and `Number('') === 0` (ephemeral bind).
+ * Prefer an explicit override, else URL port, else the scheme default.
+ */
+export function resolveListenPort(
+  baseURL: string,
+  overridePort?: string,
+): number {
+  const url = new URL(baseURL)
+  const explicit =
+    overridePort != null && String(overridePort).trim() !== ''
+      ? String(overridePort).trim()
+      : undefined
+  const fromUrl =
+    url.port || (url.protocol === 'https:' ? '443' : '80')
+  return Number(explicit ?? fromUrl)
+}
+
 export default async function runServer({
   port: overridePort,
   hostname: overrideHostname,
@@ -954,7 +974,7 @@ export default async function runServer({
 }: AppOptions & { hostname?: string; port?: string }) {
   const url = new URL(baseURL)
   const hostname = overrideHostname ?? url.hostname
-  const port = Number(overridePort ?? url.port ?? '80')
+  const port = resolveListenPort(baseURL, overridePort)
 
   console.debug('Initializing web server:', { hostname, port })
   const { app, db, auth } = await initApp({


### PR DESCRIPTION
## Summary
Fix listen-port resolution when STREAMWALL_CONTROL_URL has no explicit port so the server no longer binds port 0.

## Problem
Fixes #371 — URL.port is empty string, so Number(overridePort ?? url.port ?? '80') became 0.

## Approach
- Add resolveListenPort() with scheme defaults (https 443, else 80)
- Explicit STREAMWALL_CONTROL_PORT still wins; empty override falls through
- Unit tests for bare hosts, explicit ports, empty override

## How I tested
- node --import tsx --test src/index.test.ts in packages/streamwall-control-server (10 pass)