### PR TITLE
feat(deploy): Docker + Caddy self-host stack for control-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,11 @@ invites), **operator** (control the grid and streams), and **monitor**
 See
 [`packages/streamwall-control-server/README.md`](packages/streamwall-control-server/README.md)
 for environment variable configuration (hostname/port, storage location, rate
-limits) and a production deployment walkthrough.
+limits).
+
+To put the control server on a public domain with HTTPS (Docker + Caddy), see
+[`docs/self-hosting.md`](docs/self-hosting.md) and the files under
+[`deploy/`](deploy/).
 
 **Known limitation:** grid edits (swap, drag-move, resize) sync as
 independent per-cell updates in the shared Yjs document. If two operators

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,13 @@
+# Copy to .env and fill in before `docker compose up`.
+
+# Public hostname only (no https://). Must resolve to this machine.
+STREAMWALL_DOMAIN=wall.example.com
+
+# Public URL as clients and the desktop app see it (https, no path).
+# Scheme selects secure cookies / CSP. Port omitted is fine (server uses 443 default).
+STREAMWALL_CONTROL_URL=https://wall.example.com
+
+# Optional tuning (defaults are safe for most self-hosts)
+# STREAMWALL_RATE_LIMIT_MAX=100
+# STREAMWALL_AUTH_RATE_LIMIT_MAX=10
+# STREAMWALL_RATE_LIMIT_WINDOW=1 minute

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,6 @@
+# Automatic HTTPS for the control server.
+# STREAMWALL_DOMAIN must match STREAMWALL_CONTROL_URL's host (no scheme).
+{$STREAMWALL_DOMAIN} {
+	encode gzip
+	reverse_proxy control:3000
+}

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+# Production image for streamwall-control-server (+ built control client).
+# Build from repo root: docker build -f deploy/Dockerfile .
+
+FROM node:22-bookworm-slim AS build
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+COPY packages ./packages
+
+# Full workspace install so local package links resolve (streamwall-shared, etc.).
+RUN npm ci
+
+# Static web control UI served by the control server.
+RUN npm -w streamwall-control-client run build
+
+FROM node:22-bookworm-slim AS run
+WORKDIR /app
+
+RUN groupadd --system streamwall \
+  && useradd --system --gid streamwall --create-home --home-dir /data streamwall
+
+COPY --from=build /app /app
+
+ENV NODE_ENV=production \
+    DB_PATH=/data/storage.json \
+    STREAMWALL_CONTROL_HOSTNAME=0.0.0.0 \
+    STREAMWALL_CONTROL_PORT=3000 \
+    STREAMWALL_CONTROL_STATIC=/app/packages/streamwall-control-client/dist \
+    STREAMWALL_TRUST_PROXY=true
+
+USER streamwall
+EXPOSE 3000
+VOLUME ["/data"]
+
+# Server runs TypeScript via the package's start script (tsx).
+CMD ["npm", "-w", "streamwall-control-server", "start"]

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,44 @@
+# Self-host streamwall-control-server behind Caddy (TLS).
+# From this directory: cp .env.example .env  # then edit domain
+#                   docker compose up -d --build
+#
+# Requires DNS for STREAMWALL_DOMAIN pointing at this host, and ports 80/443 open.
+
+services:
+  control:
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile
+    env_file:
+      - .env
+    environment:
+      # Bound inside the container; Caddy is the only public entry.
+      STREAMWALL_CONTROL_HOSTNAME: "0.0.0.0"
+      STREAMWALL_CONTROL_PORT: "3000"
+      STREAMWALL_TRUST_PROXY: "true"
+      DB_PATH: /data/storage.json
+    volumes:
+      - control-data:/data
+    restart: unless-stopped
+    expose:
+      - "3000"
+
+  caddy:
+    image: caddy:2-alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      STREAMWALL_DOMAIN: ${STREAMWALL_DOMAIN}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    depends_on:
+      - control
+    restart: unless-stopped
+
+volumes:
+  control-data:
+  caddy-data:
+  caddy-config:

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,92 @@
+# Self-hosting the control server
+
+Run `streamwall-control-server` on a VPS or home server with **HTTPS**, then point the desktop Streamwall app and browser operators at your domain.
+
+This is **control and state only**. The composited wall video still renders on the machine running the Electron app. Phones and remote browsers can rearrange the grid; they do not receive the wall video stream.
+
+## Prerequisites
+
+- A domain name with **A/AAAA** records pointing at the host
+- Ports **80** and **443** open to the host (Let's Encrypt + HTTPS)
+- [Docker](https://docs.docker.com/get-docker/) and Docker Compose v2
+- Streamwall desktop app on the machine that displays the wall
+
+## Quick start
+
+```bash
+cd deploy
+cp .env.example .env
+# edit STREAMWALL_DOMAIN and STREAMWALL_CONTROL_URL
+docker compose up -d --build
+```
+
+Watch control-server logs for the **admin invite** URL (printed on every start):
+
+```bash
+docker compose logs -f control
+```
+
+Open that invite once in a browser (or copy the path onto your domain) to create an admin session. Keep invite links private.
+
+## What the stack does
+
+| Service   | Role |
+|-----------|------|
+| `control` | Node control server + static control UI. Listens on container port 3000 only. |
+| `caddy`   | Terminates TLS, reverse-proxies to `control`. |
+
+Important env (see `.env.example` and the [control-server README](../packages/streamwall-control-server/README.md)):
+
+| Variable | Why |
+|----------|-----|
+| `STREAMWALL_CONTROL_URL` | Public `https://…` URL; drives secure cookies and CSP. |
+| `STREAMWALL_TRUST_PROXY` | Set `true` in compose so per-IP rate limits use real client IPs behind Caddy. **Do not** enable if the process is exposed directly to the internet. |
+| `DB_PATH` | Auth tokens live on the `control-data` volume (`/data/storage.json`). |
+
+## Connect the desktop app (uplink)
+
+1. Start the control stack and obtain an admin session (invite link).
+2. In the control UI, create a **Streamwall** (uplink) token if the server printed one, or use the uplink endpoint the server logs at bootstrap.
+3. On the wall PC, set the control uplink in config (see root `example.config.toml`):
+
+```toml
+[control]
+# Use wss:// against your public domain. The exact path and token are printed
+# by the control server when the Streamwall uplink credential is created.
+endpoint = "wss://wall.example.com/streamwall/<id>/ws"
+```
+
+The app injects the uplink secret as an `Authorization` header (not a query string). Prefer `wss://` whenever `STREAMWALL_CONTROL_URL` is `https://`.
+
+4. Restart or reload the desktop app so it connects. Operators can then open `https://wall.example.com` from another device.
+
+## Security notes
+
+- **TLS required** for real deployments — use the Caddy stack (or equivalent).
+- Treat **admin invite links** like passwords; anyone with a link can mint a session for that role.
+- Rate limits and Helmet headers are already on; with `STREAMWALL_TRUST_PROXY=true`, limits are per client behind Caddy.
+- The control server does **not** stream wall video. Compromising control still lets an operator change layout and sources on the wall machine — lock roles accordingly (`admin` / `operator` / `monitor`).
+
+## Local dry-run without TLS
+
+For a quick smoke test on one machine (no domain):
+
+```bash
+npm ci
+npm -w streamwall-control-client run build
+STREAMWALL_CONTROL_URL=http://localhost:3000 \
+STREAMWALL_CONTROL_HOSTNAME=127.0.0.1 \
+STREAMWALL_CONTROL_PORT=3000 \
+npm -w streamwall-control-server start
+```
+
+Do not use `STREAMWALL_TRUST_PROXY=true` on a port bound to the public internet without a trusted reverse proxy in front.
+
+## Troubleshooting
+
+| Symptom | Check |
+|---------|--------|
+| Caddy fails ACME | DNS points here; 80/443 free; domain matches `.env` |
+| Cookies / login odd | `STREAMWALL_CONTROL_URL` scheme and host match the browser URL |
+| All clients share one rate-limit bucket | `STREAMWALL_TRUST_PROXY=true` and only Caddy can reach port 3000 |
+| Desktop app won't uplink | `wss://` URL, token, and server logs for refused uplink |

--- a/packages/streamwall-control-server/README.md
+++ b/packages/streamwall-control-server/README.md
@@ -50,6 +50,7 @@ each WebSocket connection. The limits are tunable:
 | `STREAMWALL_RATE_LIMIT_MAX`      | `100`      | Max HTTP requests per IP per window (global).                    |
 | `STREAMWALL_AUTH_RATE_LIMIT_MAX` | `10`       | Stricter max for the `/invite/:id` auth route per IP per window. |
 | `STREAMWALL_RATE_LIMIT_WINDOW`   | `1 minute` | Rate-limit window (any `@fastify/rate-limit` time value).        |
+| `STREAMWALL_TRUST_PROXY`         | off        | Opt-in Fastify `trustProxy` so rate limits use client IPs from `X-Forwarded-For` when behind a reverse proxy. `true`/`false`, or an IP/CIDR list. **Leave off** if the server is exposed directly to the internet (header is spoofable). Enable only when a trusted proxy (e.g. Caddy) is the only hop that can reach the process. |
 | `STREAMWALL_WS_MSG_RATE`         | `100`      | Sustained inbound WebSocket messages per second, per connection. |
 | `STREAMWALL_WS_MSG_BURST`        | `1000`     | Burst allowance of inbound WebSocket messages, per connection.   |
 

--- a/packages/streamwall-control-server/src/index.test.ts
+++ b/packages/streamwall-control-server/src/index.test.ts
@@ -2,7 +2,11 @@ import { Low, Memory } from 'lowdb'
 import assert from 'node:assert/strict'
 import { after, describe, test } from 'node:test'
 
-import { initApp, SESSION_COOKIE_NAME } from './index.ts'
+import {
+  initApp,
+  resolveListenPort,
+  SESSION_COOKIE_NAME,
+} from './index.ts'
 import type { StoredData } from './storage.ts'
 
 const ONE_YEAR_IN_SECONDS = 365 * 24 * 60 * 60
@@ -100,5 +104,31 @@ describe('session cookie security attributes', () => {
 
     assert.equal(response.statusCode, 403)
     assert.equal(response.headers['set-cookie'], undefined)
+  })
+})
+
+describe('resolveListenPort', () => {
+  test('https URL with no explicit port defaults to 443 (not 0)', () => {
+    assert.equal(resolveListenPort('https://wall.example.com'), 443)
+  })
+
+  test('http URL with no explicit port defaults to 80 (not 0)', () => {
+    assert.equal(resolveListenPort('http://wall.example.com'), 80)
+  })
+
+  test('explicit URL port is used when present', () => {
+    assert.equal(resolveListenPort('https://wall.example.com:8443'), 8443)
+    assert.equal(resolveListenPort('http://localhost:3000'), 3000)
+  })
+
+  test('override port wins over URL (including scheme default)', () => {
+    assert.equal(resolveListenPort('https://wall.example.com', '8080'), 8080)
+    assert.equal(resolveListenPort('https://wall.example.com:8443', '9090'), 9090)
+  })
+
+  test('empty override falls through to URL / scheme default', () => {
+    assert.equal(resolveListenPort('https://wall.example.com', ''), 443)
+    assert.equal(resolveListenPort('https://wall.example.com', '   '), 443)
+    assert.equal(resolveListenPort('http://localhost:3000', ''), 3000)
   })
 })

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -152,6 +152,29 @@ function getRateLimitConfig(): RateLimitConfig {
   }
 }
 
+/**
+ * Parse `STREAMWALL_TRUST_PROXY` for Fastify's `trustProxy` option.
+ * Off by default so a bare internet-facing server never trusts client-supplied
+ * `X-Forwarded-For`. Behind a reverse proxy, set `true` (or an IP/CIDR list).
+ * @see https://fastify.dev/docs/latest/Reference/Server/#trustproxy
+ */
+export function parseTrustProxy(
+  raw: string | undefined,
+): boolean | string {
+  if (raw == null || raw.trim() === '') {
+    return false
+  }
+  const v = raw.trim().toLowerCase()
+  if (v === '1' || v === 'true' || v === 'yes' || v === 'on') {
+    return true
+  }
+  if (v === '0' || v === 'false' || v === 'no' || v === 'off') {
+    return false
+  }
+  // IP, CIDR, or comma-separated list — pass through for Fastify.
+  return raw.trim()
+}
+
 interface WsMessageLimitConfig {
   capacity: number
   refillPerSec: number
@@ -286,12 +309,15 @@ export async function initApp({
   db: injectedDb,
   sentryEnabled: injectedSentryEnabled,
   sentryClient,
+  trustProxy: injectedTrustProxy,
 }: AppOptions & {
   db?: StorageDB
   /** Test-only override so specs can exercise Sentry-enabled paths without a real DSN. */
   sentryEnabled?: boolean
   /** Test-only override for the client `captureException(...)` reports to. */
   sentryClient?: SentryCaptureClient
+  /** Test-only override for Fastify trustProxy (else STREAMWALL_TRUST_PROXY / false). */
+  trustProxy?: boolean | string
 }) {
   const expectedOrigin = new URL(baseURL).origin
   const clients = new Map<string, Client>()
@@ -303,7 +329,9 @@ export async function initApp({
   const db = injectedDb ?? (await loadStorage())
   const auth = new Auth(db.data.auth)
 
-  const app = Fastify()
+  const trustProxy =
+    injectedTrustProxy ?? parseTrustProxy(process.env.STREAMWALL_TRUST_PROXY)
+  const app = Fastify({ trustProxy })
 
   // Opt-in crash reporting (see sentry.ts for why there is no default DSN).
   // Must be wired up before routes are registered so their errors are covered.

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -946,6 +946,26 @@ function logBootstrap({
   console.log('🔑 Admin invite:', adminInviteLink)
 }
 
+/**
+ * Resolve the TCP listen port for the control server.
+ * `URL.port` is `""` (not undefined) when the URL has no explicit port, so
+ * `??` alone would leave an empty string and `Number('') === 0` (ephemeral bind).
+ * Prefer an explicit override, else URL port, else the scheme default.
+ */
+export function resolveListenPort(
+  baseURL: string,
+  overridePort?: string,
+): number {
+  const url = new URL(baseURL)
+  const explicit =
+    overridePort != null && String(overridePort).trim() !== ''
+      ? String(overridePort).trim()
+      : undefined
+  const fromUrl =
+    url.port || (url.protocol === 'https:' ? '443' : '80')
+  return Number(explicit ?? fromUrl)
+}
+
 export default async function runServer({
   port: overridePort,
   hostname: overrideHostname,
@@ -954,7 +974,7 @@ export default async function runServer({
 }: AppOptions & { hostname?: string; port?: string }) {
   const url = new URL(baseURL)
   const hostname = overrideHostname ?? url.hostname
-  const port = Number(overridePort ?? url.port ?? '80')
+  const port = resolveListenPort(baseURL, overridePort)
 
   console.debug('Initializing web server:', { hostname, port })
   const { app, db, auth } = await initApp({

--- a/packages/streamwall-control-server/src/rateLimit.test.ts
+++ b/packages/streamwall-control-server/src/rateLimit.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
+import { parseTrustProxy } from './index.ts'
 import { buildTestApp } from './testHelpers.ts'
 
 test('rate-limits the invite auth route with a strict per-route budget', async () => {
@@ -67,4 +68,51 @@ test('the auth route budget is stricter than the global budget', async () => {
   assert.equal(inviteCodes[2], 429)
 
   await app.close()
+})
+
+test('parseTrustProxy is off by default and accepts boolean-ish or proxy lists', () => {
+  assert.equal(parseTrustProxy(undefined), false)
+  assert.equal(parseTrustProxy(''), false)
+  assert.equal(parseTrustProxy('true'), true)
+  assert.equal(parseTrustProxy('1'), true)
+  assert.equal(parseTrustProxy('false'), false)
+  assert.equal(parseTrustProxy('127.0.0.1'), '127.0.0.1')
+  assert.equal(parseTrustProxy('10.0.0.0/8'), '10.0.0.0/8')
+})
+
+test('with trustProxy, distinct X-Forwarded-For clients keep separate rate-limit budgets', async () => {
+  process.env.STREAMWALL_RATE_LIMIT_MAX = '2'
+  delete process.env.STREAMWALL_AUTH_RATE_LIMIT_MAX
+  process.env.STREAMWALL_TRUST_PROXY = 'true'
+  const { app } = await buildTestApp()
+
+  for (let i = 0; i < 2; i++) {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/',
+      headers: { 'x-forwarded-for': '198.51.100.10' },
+    })
+    assert.notEqual(res.statusCode, 429)
+  }
+  const exhausted = await app.inject({
+    method: 'GET',
+    url: '/',
+    headers: { 'x-forwarded-for': '198.51.100.10' },
+  })
+  assert.equal(exhausted.statusCode, 429)
+
+  // A different client IP must not share the exhausted bucket.
+  const other = await app.inject({
+    method: 'GET',
+    url: '/',
+    headers: { 'x-forwarded-for': '198.51.100.20' },
+  })
+  assert.notEqual(
+    other.statusCode,
+    429,
+    'second client should not inherit the first client budget when trustProxy is on',
+  )
+
+  await app.close()
+  delete process.env.STREAMWALL_TRUST_PROXY
 })


### PR DESCRIPTION
## Summary
Self-host packaging for the control server: Docker image, Caddy TLS reverse proxy, env example, and end-to-end docs.

## Problem
Fixes #367 — no path from localhost-only control to a domain with TLS.

Also includes (same branch, needed for a correct reverse-proxy deploy):
- #371 listen port when public URL has no port
- #372 opt-in `STREAMWALL_TRUST_PROXY` so per-IP limits work behind Caddy

## Approach
- `deploy/Dockerfile` — multi-stage Node 22, builds control client, non-root, `DB_PATH` on volume
- `deploy/docker-compose.yml` + `Caddyfile` — control internal, Caddy 80/443
- `deploy/.env.example` — domain + public URL
- `docs/self-hosting.md` — uplink, security, local dry-run
- README link under Remote control server

## How I tested
- Unit: `rateLimit.test.ts` + `index.test.ts` (port + trustProxy) pass
- Docker image not built in this environment (needs host Docker); compose layout matches the issue checklist

## Out of scope (per #367)
- Streaming wall video to remote devices