### PR TITLE
fix(control-server): opt-in trustProxy for per-client rate limits

### DIFF
--- a/packages/streamwall-control-server/README.md
+++ b/packages/streamwall-control-server/README.md
@@ -45,13 +45,14 @@ server applies per-IP rate limiting (via `@fastify/rate-limit`), sends hardened
 response headers (via `@fastify/helmet`), and caps the inbound message rate of
 each WebSocket connection. The limits are tunable:
 
-| Variable                         | Default    | Description                                                      |
-| -------------------------------- | ---------- | ---------------------------------------------------------------- |
-| `STREAMWALL_RATE_LIMIT_MAX`      | `100`      | Max HTTP requests per IP per window (global).                    |
-| `STREAMWALL_AUTH_RATE_LIMIT_MAX` | `10`       | Stricter max for the `/invite/:id` auth route per IP per window. |
-| `STREAMWALL_RATE_LIMIT_WINDOW`   | `1 minute` | Rate-limit window (any `@fastify/rate-limit` time value).        |
-| `STREAMWALL_WS_MSG_RATE`         | `100`      | Sustained inbound WebSocket messages per second, per connection. |
-| `STREAMWALL_WS_MSG_BURST`        | `1000`     | Burst allowance of inbound WebSocket messages, per connection.   |
+| Variable                         | Default    | Description                                                                                                                                                                                                                                                                                                                        |
+| -------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `STREAMWALL_RATE_LIMIT_MAX`      | `100`      | Max HTTP requests per IP per window (global).                                                                                                                                                                                                                                                                                      |
+| `STREAMWALL_AUTH_RATE_LIMIT_MAX` | `10`       | Stricter max for the `/invite/:id` auth route per IP per window.                                                                                                                                                                                                                                                                   |
+| `STREAMWALL_RATE_LIMIT_WINDOW`   | `1 minute` | Rate-limit window (any `@fastify/rate-limit` time value).                                                                                                                                                                                                                                                                          |
+| `STREAMWALL_TRUST_PROXY`         | off        | Opt-in Fastify `trustProxy` so rate limits use client IPs from `X-Forwarded-For` when behind a reverse proxy. `true`/`false`, or an IP/CIDR list. **Leave off** if the server is exposed directly to the internet (header is spoofable). Enable only when a trusted proxy (e.g. Caddy) is the only hop that can reach the process. |
+| `STREAMWALL_WS_MSG_RATE`         | `100`      | Sustained inbound WebSocket messages per second, per connection.                                                                                                                                                                                                                                                                   |
+| `STREAMWALL_WS_MSG_BURST`        | `1000`     | Burst allowance of inbound WebSocket messages, per connection.                                                                                                                                                                                                                                                                     |
 
 A WebSocket connection that exceeds its message budget is closed with code
 `1008` (policy violation); clients reconnect and resync automatically.

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -152,6 +152,27 @@ function getRateLimitConfig(): RateLimitConfig {
   }
 }
 
+/**
+ * Parse `STREAMWALL_TRUST_PROXY` for Fastify's `trustProxy` option.
+ * Off by default so a bare internet-facing server never trusts client-supplied
+ * `X-Forwarded-For`. Behind a reverse proxy, set `true` (or an IP/CIDR list).
+ * @see https://fastify.dev/docs/latest/Reference/Server/#trustproxy
+ */
+export function parseTrustProxy(raw: string | undefined): boolean | string {
+  if (raw == null || raw.trim() === '') {
+    return false
+  }
+  const v = raw.trim().toLowerCase()
+  if (v === '1' || v === 'true' || v === 'yes' || v === 'on') {
+    return true
+  }
+  if (v === '0' || v === 'false' || v === 'no' || v === 'off') {
+    return false
+  }
+  // IP, CIDR, or comma-separated list — pass through for Fastify.
+  return raw.trim()
+}
+
 interface WsMessageLimitConfig {
   capacity: number
   refillPerSec: number
@@ -286,12 +307,15 @@ export async function initApp({
   db: injectedDb,
   sentryEnabled: injectedSentryEnabled,
   sentryClient,
+  trustProxy: injectedTrustProxy,
 }: AppOptions & {
   db?: StorageDB
   /** Test-only override so specs can exercise Sentry-enabled paths without a real DSN. */
   sentryEnabled?: boolean
   /** Test-only override for the client `captureException(...)` reports to. */
   sentryClient?: SentryCaptureClient
+  /** Test-only override for Fastify trustProxy (else STREAMWALL_TRUST_PROXY / false). */
+  trustProxy?: boolean | string
 }) {
   const expectedOrigin = new URL(baseURL).origin
   const clients = new Map<string, Client>()
@@ -303,7 +327,9 @@ export async function initApp({
   const db = injectedDb ?? (await loadStorage())
   const auth = new Auth(db.data.auth)
 
-  const app = Fastify()
+  const trustProxy =
+    injectedTrustProxy ?? parseTrustProxy(process.env.STREAMWALL_TRUST_PROXY)
+  const app = Fastify({ trustProxy })
 
   // Opt-in crash reporting (see sentry.ts for why there is no default DSN).
   // Must be wired up before routes are registered so their errors are covered.

--- a/packages/streamwall-control-server/src/rateLimit.test.ts
+++ b/packages/streamwall-control-server/src/rateLimit.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
+import { parseTrustProxy } from './index.ts'
 import { buildTestApp } from './testHelpers.ts'
 
 test('rate-limits the invite auth route with a strict per-route budget', async () => {
@@ -67,4 +68,51 @@ test('the auth route budget is stricter than the global budget', async () => {
   assert.equal(inviteCodes[2], 429)
 
   await app.close()
+})
+
+test('parseTrustProxy is off by default and accepts boolean-ish or proxy lists', () => {
+  assert.equal(parseTrustProxy(undefined), false)
+  assert.equal(parseTrustProxy(''), false)
+  assert.equal(parseTrustProxy('true'), true)
+  assert.equal(parseTrustProxy('1'), true)
+  assert.equal(parseTrustProxy('false'), false)
+  assert.equal(parseTrustProxy('127.0.0.1'), '127.0.0.1')
+  assert.equal(parseTrustProxy('10.0.0.0/8'), '10.0.0.0/8')
+})
+
+test('with trustProxy, distinct X-Forwarded-For clients keep separate rate-limit budgets', async () => {
+  process.env.STREAMWALL_RATE_LIMIT_MAX = '2'
+  delete process.env.STREAMWALL_AUTH_RATE_LIMIT_MAX
+  process.env.STREAMWALL_TRUST_PROXY = 'true'
+  const { app } = await buildTestApp()
+
+  for (let i = 0; i < 2; i++) {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/',
+      headers: { 'x-forwarded-for': '198.51.100.10' },
+    })
+    assert.notEqual(res.statusCode, 429)
+  }
+  const exhausted = await app.inject({
+    method: 'GET',
+    url: '/',
+    headers: { 'x-forwarded-for': '198.51.100.10' },
+  })
+  assert.equal(exhausted.statusCode, 429)
+
+  // A different client IP must not share the exhausted bucket.
+  const other = await app.inject({
+    method: 'GET',
+    url: '/',
+    headers: { 'x-forwarded-for': '198.51.100.20' },
+  })
+  assert.notEqual(
+    other.statusCode,
+    429,
+    'second client should not inherit the first client budget when trustProxy is on',
+  )
+
+  await app.close()
+  delete process.env.STREAMWALL_TRUST_PROXY
 })


### PR DESCRIPTION
Rebased and re-opened from #376 (by @YRWoods) after #378 landed on `main`.

## Problem
Fixes #372 — without `trustProxy`, every request behind Caddy/etc. shares the proxy's IP bucket.

## Approach
- `parseTrustProxy()`: off by default; `true`/`false` or IP/CIDR pass-through for Fastify
- `Fastify({ trustProxy })` in `initApp`
- README security table documents the var and spoof risk
- Test: two `X-Forwarded-For` clients keep separate budgets when trust is on

## TDD
Unit + integration tests in `rateLimit.test.ts`; all 109 control-server tests pass locally.

## Credit
Original implementation and tests by @YRWoods in #376.