### PR TITLE
docs(deploy): align self-host stack with trustProxy and port defaults

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -24,18 +24,20 @@ STREAMWALL_ACME_EMAIL=you@example.com
 # with STREAMWALL_DOMAIN above; do not add a port here.
 STREAMWALL_CONTROL_URL=https://wall.example.com
 
-# The port the server listens on inside its container. Always set this
-# explicitly. STREAMWALL_CONTROL_URL above intentionally has no port (a
-# bare https://domain), and the server does not fill in the scheme's
-# conventional port (443) when one is missing from the URL -- so leaving
-# this unset would make it listen on an unusable port. Must match the
+# Port the server listens on inside its container. Must match the
 # `reverse_proxy control-server:<port>` target in Caddyfile (default 3000).
+# STREAMWALL_CONTROL_URL above has no port (bare https://domain); the server
+# falls back to the scheme default (443) when deriving a listen port, but
+# behind Caddy you still want the internal container port here.
 STREAMWALL_CONTROL_PORT=3000
 
+# Trust Caddy's X-Forwarded-For so per-IP rate limits apply per client, not
+# per proxy. docker-compose.yml also sets this for the bundled stack. Leave
+# off if the process is exposed directly to the internet (header is spoofable).
+STREAMWALL_TRUST_PROXY=true
+
 # Optional: tune abuse protection (defaults shown). See
-# packages/streamwall-control-server/README.md for the full list, and note
-# the rate-limiting caveat in docs/self-hosting.md when running behind a
-# reverse proxy.
+# packages/streamwall-control-server/README.md for the full list.
 #STREAMWALL_RATE_LIMIT_MAX=100
 #STREAMWALL_AUTH_RATE_LIMIT_MAX=10
 #STREAMWALL_RATE_LIMIT_WINDOW=1 minute

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -13,6 +13,9 @@ services:
       dockerfile: packages/streamwall-control-server/Dockerfile
     restart: unless-stopped
     env_file: .env
+    environment:
+      # Only Caddy can reach this service; trust its X-Forwarded-For for per-IP limits.
+      STREAMWALL_TRUST_PROXY: 'true'
     volumes:
       - control-server-data:/data
     # Not published to the host: only Caddy talks to this service, over the

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -98,12 +98,12 @@ of environment variables the server itself understands — including storage
 location and rate-limit tuning — see
 [`packages/streamwall-control-server/README.md`](../packages/streamwall-control-server/README.md#configuration).
 
-One default in that file is important to get right behind Caddy:
-`STREAMWALL_CONTROL_URL` should be a bare `https://your-domain` with **no
-port**, and `STREAMWALL_CONTROL_PORT` must then be set explicitly (the
-compose file already does this). The server does not fill in port 443 when
-`STREAMWALL_CONTROL_URL` omits one, so an explicit `STREAMWALL_CONTROL_PORT`
-is required — the `.env.example` comments explain why.
+Behind Caddy, set `STREAMWALL_CONTROL_URL` to a bare `https://your-domain`
+with **no port** (the public URL clients see). The server listens on
+`STREAMWALL_CONTROL_PORT` inside the container (3000 by default; see
+`.env.example`). Enable `STREAMWALL_TRUST_PROXY=true` so per-IP rate limits
+use each visitor's address rather than Caddy's — the compose file sets this
+for the bundled stack.
 
 ## Operational security notes
 
@@ -116,16 +116,10 @@ is required — the `.env.example` comments explain why.
 - **Rate limits are already enforced** by the server itself (per-IP HTTP
   limits, a stricter limit on the auth route, and per-connection WebSocket
   message caps — see the server README for the exact numbers and how to tune
-  them).
-- **Known limitation:** the server does not currently parse
-  `X-Forwarded-For`, so behind this (or any) reverse proxy, its per-IP rate
-  limiting sees every client as the proxy's own IP rather than each visitor's
-  real address. In practice this means the rate limits apply collectively
-  across all your operators/monitors rather than individually — it does not
-  disable rate limiting, but it is coarser than running the server exposed
-  directly. Tracked as a follow-up; tighten `STREAMWALL_RATE_LIMIT_MAX` /
-  `STREAMWALL_WS_MSG_RATE` accordingly if you expect many concurrent users
-  behind the proxy.
+  them). With `STREAMWALL_TRUST_PROXY=true` (set in the bundled compose
+  stack), those HTTP limits apply per client behind Caddy. Do **not** enable
+  trust proxy if the process is reachable directly from the internet without
+  a trusted reverse proxy in front.
 
 ## Updating
 
@@ -153,3 +147,6 @@ untouched by rebuilds.
   matches the port Caddy proxies to in `deploy/Caddyfile`
   (`reverse_proxy control-server:<port>`, default `3000` on both sides), and
   check `docker compose logs control-server` for a startup error.
+- **All clients share one rate-limit bucket** — confirm
+  `STREAMWALL_TRUST_PROXY=true` in `.env` or compose, and that only Caddy
+  can reach the control-server port (not published to the host).

--- a/packages/streamwall-control-server/src/deployStack.test.ts
+++ b/packages/streamwall-control-server/src/deployStack.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, test } from 'node:test'
+
+const repoRoot = path.resolve(import.meta.dirname, '../../..')
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8')
+}
+
+describe('self-host deploy stack contract', () => {
+  test('docker-compose enables trustProxy for the control server behind Caddy', () => {
+    const compose = readRepoFile('deploy/docker-compose.yml')
+    assert.match(
+      compose,
+      /STREAMWALL_TRUST_PROXY:\s*['"]?true['"]?/,
+      'control-server must trust the reverse proxy so per-IP rate limits use client IPs',
+    )
+  })
+
+  test('.env.example documents trustProxy for the Caddy stack', () => {
+    const envExample = readRepoFile('deploy/.env.example')
+    assert.match(envExample, /STREAMWALL_TRUST_PROXY/)
+    assert.doesNotMatch(
+      envExample,
+      /does not fill in the scheme's conventional port/i,
+      'port-default fix (#371) should remove the old workaround wording',
+    )
+  })
+
+  test('self-hosting guide documents per-client rate limits behind Caddy', () => {
+    const guide = readRepoFile('docs/self-hosting.md')
+    assert.match(guide, /STREAMWALL_TRUST_PROXY/)
+    assert.doesNotMatch(
+      guide,
+      /Known limitation:.*X-Forwarded-For/s,
+      'trustProxy fix (#372) should remove the reverse-proxy rate-limit caveat',
+    )
+    assert.doesNotMatch(
+      guide,
+      /does not fill in port 443/i,
+      'port-default fix (#371) should remove the explicit-port workaround note',
+    )
+  })
+})


### PR DESCRIPTION
Follow-up after #378 and #379.

## TDD
- Added `deployStack.test.ts` contract tests (red → green) asserting:
  - `docker-compose.yml` sets `STREAMWALL_TRUST_PROXY=true`
  - `.env.example` documents trust proxy and drops the old port-443 workaround text
  - `docs/self-hosting.md` documents per-client rate limits and removes the X-Forwarded-For caveat

## Changes
- Enable `STREAMWALL_TRUST_PROXY` in compose for the Caddy stack
- Update `.env.example` and self-hosting guide to match shipped behaviour
