### PR TITLE
feat(streamwall): optionally pause parked views during a fullscreen expansion

### DIFF
--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -47,6 +47,7 @@ function makeStreamWindow(config: StreamWindowConfig) {
   >
   sw.config = config
   sw.parkedViews = new Map()
+  sw.pauseParkedViews = false
   return sw
 }
 
@@ -712,6 +713,154 @@ describe('StreamWindow.setViews parking unused views during a fullscreen expansi
         2,
       ),
     ).toBe(false)
+  })
+})
+
+describe('StreamWindow parking pauses playback when pauseParkedViews is enabled (issue #374)', () => {
+  it('sends PAUSE to a view when it is parked', () => {
+    const sw = makeStreamWindow(makeConfig({ cols: 2, rows: 2 }))
+    sw.pauseParkedViews = true
+    sw.win = {
+      contentView: { removeChildView: vi.fn() },
+    } as unknown as InstanceType<typeof StreamWindow>['win']
+
+    const streamA: ViewContent = { url: 'https://example.com/a', kind: 'video' }
+    const streamB: ViewContent = { url: 'https://example.com/b', kind: 'video' }
+    const expanding = makeReuseTestActor({
+      id: 1,
+      content: streamB,
+      spaces: [1],
+      running: true,
+    })
+    const other = makeReuseTestActor({
+      id: 2,
+      content: streamA,
+      spaces: [0],
+      running: true,
+    })
+    sw.views = new Map([
+      [1, expanding.actor],
+      [2, other.actor],
+    ])
+    sw.createView = vi.fn()
+
+    sw.setViews(
+      fullscreenViewContentMap(2, 2, streamB),
+      { byURL: new Map([[streamB.url, {}]]) },
+      { parkUnused: true },
+    )
+
+    expect(other.send).toHaveBeenCalledWith({ type: 'PAUSE' })
+  })
+
+  it('does not send PAUSE to a parked view when pauseParkedViews is disabled (default)', () => {
+    const sw = makeStreamWindow(makeConfig({ cols: 2, rows: 2 }))
+    sw.win = {
+      contentView: { removeChildView: vi.fn() },
+    } as unknown as InstanceType<typeof StreamWindow>['win']
+
+    const streamA: ViewContent = { url: 'https://example.com/a', kind: 'video' }
+    const streamB: ViewContent = { url: 'https://example.com/b', kind: 'video' }
+    const expanding = makeReuseTestActor({
+      id: 1,
+      content: streamB,
+      spaces: [1],
+      running: true,
+    })
+    const other = makeReuseTestActor({
+      id: 2,
+      content: streamA,
+      spaces: [0],
+      running: true,
+    })
+    sw.views = new Map([
+      [1, expanding.actor],
+      [2, other.actor],
+    ])
+    sw.createView = vi.fn()
+
+    sw.setViews(
+      fullscreenViewContentMap(2, 2, streamB),
+      { byURL: new Map([[streamB.url, {}]]) },
+      { parkUnused: true },
+    )
+
+    expect(other.send).not.toHaveBeenCalledWith({ type: 'PAUSE' })
+  })
+
+  it('sends RESUME to a previously-parked view once it is reused after collapse', () => {
+    const sw = makeStreamWindow(makeConfig({ cols: 2, rows: 2 }))
+    sw.pauseParkedViews = true
+    sw.win = {
+      contentView: { removeChildView: vi.fn() },
+    } as unknown as InstanceType<typeof StreamWindow>['win']
+
+    const streamA: ViewContent = { url: 'https://example.com/a', kind: 'video' }
+    const streamB: ViewContent = { url: 'https://example.com/b', kind: 'video' }
+    const expanding = makeReuseTestActor({
+      id: 1,
+      content: streamB,
+      spaces: [1],
+      running: true,
+    })
+    const other = makeReuseTestActor({
+      id: 2,
+      content: streamA,
+      spaces: [0],
+      running: true,
+    })
+    sw.views = new Map([
+      [1, expanding.actor],
+      [2, other.actor],
+    ])
+    sw.createView = vi.fn()
+
+    // Expand: `other` is parked and paused.
+    sw.setViews(
+      fullscreenViewContentMap(2, 2, streamB),
+      { byURL: new Map([[streamB.url, {}]]) },
+      { parkUnused: true },
+    )
+    expect(other.send).toHaveBeenCalledWith({ type: 'PAUSE' })
+
+    // Collapse: the normal per-cell layout is restored, reusing `other`.
+    const viewContentMap: ViewContentMap = new Map([
+      ['0', streamA],
+      ['1', streamB],
+    ])
+    sw.setViews(viewContentMap, {
+      byURL: new Map([
+        [streamA.url, {}],
+        [streamB.url, {}],
+      ]),
+    })
+
+    expect(other.send).toHaveBeenCalledWith({ type: 'RESUME' })
+  })
+
+  it('does not send RESUME to a view that was reused but was never parked', () => {
+    const sw = makeStreamWindow(makeConfig({ cols: 1, rows: 1 }))
+    sw.pauseParkedViews = true
+    sw.win = {
+      contentView: { removeChildView: vi.fn() },
+    } as unknown as InstanceType<typeof StreamWindow>['win']
+
+    const streamA: ViewContent = { url: 'https://example.com/a', kind: 'video' }
+    const actor = makeReuseTestActor({
+      id: 1,
+      content: streamA,
+      spaces: [0],
+      running: true,
+    })
+    sw.views = new Map([[1, actor.actor]])
+    sw.createView = vi.fn()
+
+    // Ordinary re-display of an already-running, never-parked view.
+    sw.setViews(new Map([['0', streamA]]), {
+      byURL: new Map([[streamA.url, {}]]),
+    })
+
+    expect(actor.send).not.toHaveBeenCalledWith({ type: 'RESUME' })
   })
 })
 

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -52,6 +52,11 @@ export interface StreamWindowEventMap {
 export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
   config: StreamWindowConfig
   retryConfig: RetryConfig
+  // Whether a parked (hidden) view also has its underlying media playback
+  // paused, instead of being kept fully live off-screen. Optional (issue
+  // #374): trades the parked view's instant-resume smoothness for lower
+  // CPU/network usage while it's hidden behind a fullscreen expansion.
+  pauseParkedViews: boolean
   win: BrowserWindow
   backgroundView: WebContentsView
   overlayView: WebContentsView
@@ -74,10 +79,12 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
   constructor(
     config: StreamWindowConfig,
     retryConfig: RetryConfig = DEFAULT_RETRY_CONFIG,
+    pauseParkedViews = false,
   ) {
     super()
     this.config = config
     this.retryConfig = retryConfig
+    this.pauseParkedViews = pauseParkedViews
     this.views = new Map()
     this.parkedViews = new Map()
     this.viewsByWebContentsId = new Map()
@@ -354,6 +361,9 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
     offscreenWin.contentView.addChildView(view)
     const { width, height } = offscreenWin.getBounds()
     view.setBounds({ x: 0, y: 0, width, height })
+    if (this.pauseParkedViews) {
+      actor.send({ type: 'PAUSE' })
+    }
   }
 
   createView() {
@@ -453,6 +463,11 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
       ...views.values(),
       ...this.parkedViews.values(),
     ])
+    // Snapshot which actor ids were parked coming into this call, so a view
+    // matched back into a box below can be told to resume playback (issue
+    // #374) -- `this.parkedViews` itself is cleared right after and
+    // repopulated with whatever is still unused once this call is done.
+    const previouslyParkedIds = new Set(this.parkedViews.keys())
     this.parkedViews.clear()
     const viewsToDisplay = []
 
@@ -539,7 +554,11 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
 
       view.send({ type: 'DISPLAY', pos, content })
       view.send({ type: 'OPTIONS', options: getDisplayOptions(stream) })
-      newViews.set(view.getSnapshot().context.id, view)
+      const viewId = view.getSnapshot().context.id
+      if (this.pauseParkedViews && previouslyParkedIds.has(viewId)) {
+        view.send({ type: 'RESUME' })
+      }
+      newViews.set(viewId, view)
     }
     for (const view of unusedViews) {
       if (parkUnused) {

--- a/packages/streamwall/src/main/config.test.ts
+++ b/packages/streamwall/src/main/config.test.ts
@@ -29,6 +29,7 @@ function baseConfig() {
       'max-retries': 5,
       'stalled-timeout': 30,
     },
+    park: { pause: false },
     twitch: {
       channel: null,
       username: null,

--- a/packages/streamwall/src/main/config.ts
+++ b/packages/streamwall/src/main/config.ts
@@ -86,6 +86,9 @@ const streamwallConfigSchema = z.object({
     'max-retries': z.number().int().nonnegative(),
     'stalled-timeout': nonNegativeNumber,
   }),
+  park: z.object({
+    pause: z.boolean(),
+  }),
   twitch: z.object({
     channel: z.string().nullable(),
     username: z.string().nullable(),

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -160,6 +160,9 @@ export interface StreamwallConfig {
     'max-retries': number
     'stalled-timeout': number
   }
+  park: {
+    pause: boolean
+  }
   twitch: {
     channel: string | null
     username: string | null
@@ -364,6 +367,13 @@ function parseArgs(): StreamwallConfig {
       number: true,
       default: 30,
     })
+    .group(['park.pause'], 'Fullscreen Parking')
+    .option('park.pause', {
+      describe:
+        'Pause playback of parked (hidden) views instead of keeping them fully live while a stream is expanded to fullscreen',
+      boolean: true,
+      default: false,
+    })
     .group(
       [
         'twitch.channel',
@@ -492,7 +502,11 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     maxRetries: argv.retry['max-retries'],
     stalledTimeout: argv.retry['stalled-timeout'] * 1000,
   }
-  const streamWindow = new StreamWindow(streamWindowConfig, retryConfig)
+  const streamWindow = new StreamWindow(
+    streamWindowConfig,
+    retryConfig,
+    argv.park.pause,
+  )
   const controlWindow = new ControlWindow({
     configPath: userConfigPath,
     hasUserConfig,

--- a/packages/streamwall/src/main/viewStateMachine.test.ts
+++ b/packages/streamwall/src/main/viewStateMachine.test.ts
@@ -53,6 +53,8 @@ function makeActor(retry: RetryConfig, loadPageImpl?: () => Promise<void>) {
       openDevTools: noop,
       sendViewOptions: noop,
       sendViewVolume: noop,
+      sendViewPause: noop,
+      sendViewResume: noop,
       logError: noop,
     },
     actors: {
@@ -341,6 +343,8 @@ describe('viewStateMachine volume control', () => {
         openDevTools: noop,
         sendViewOptions: noop,
         sendViewVolume,
+        sendViewPause: noop,
+        sendViewResume: noop,
         logError: noop,
       },
       actors: {
@@ -450,6 +454,8 @@ describe('viewStateMachine content swap while running (seamless preload)', () =>
         openDevTools: noop,
         sendViewOptions: noop,
         sendViewVolume: noop,
+        sendViewPause: noop,
+        sendViewResume: noop,
         logError: noop,
       },
       actors: {
@@ -708,6 +714,8 @@ describe('viewStateMachine loadPage navigation', () => {
         openDevTools: noop,
         sendViewOptions: noop,
         sendViewVolume: noop,
+        sendViewPause: noop,
+        sendViewResume: noop,
         logError: noop,
       },
     })
@@ -1123,5 +1131,207 @@ describe('viewStateMachine deferred MUTE/BLUR/BACKGROUND requests', () => {
       matchesState('displaying.running.audio.background', snapshot.value),
     ).toBe(true)
     expect(snapshot.context.desiredAudio).toBe('background')
+  })
+})
+
+describe('viewStateMachine deferred PAUSE/RESUME requests (issue #374)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('defaults desiredPaused to false', () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+
+    expect(actor.getSnapshot().context.desiredPaused).toBe(false)
+  })
+
+  it('applies a deferred PAUSE requested while still loading once running is reached', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    display(actor)
+    expect(matchesState('displaying.loading', actor.getSnapshot().value)).toBe(
+      true,
+    )
+
+    actor.send({ type: 'PAUSE' })
+    // Still loading: the pause region doesn't exist yet, so nothing visible
+    // changes yet -- the request is only recorded.
+    expect(matchesState('displaying.loading', actor.getSnapshot().value)).toBe(
+      true,
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'VIEW_INIT' })
+    actor.send({ type: 'VIEW_LOADED' })
+
+    expect(
+      matchesState(
+        'displaying.running.pause.paused',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+  })
+
+  it('applies a deferred PAUSE requested while recovering from an error', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    display(actor)
+    actor.send({ type: 'VIEW_ERROR', error: new Error('boom') })
+    expect(matchesState('displaying.error', actor.getSnapshot().value)).toBe(
+      true,
+    )
+
+    actor.send({ type: 'PAUSE' })
+
+    await vi.advanceTimersByTimeAsync(1000) // delay * 2^0 -> back to loading
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'VIEW_INIT' })
+    actor.send({ type: 'VIEW_LOADED' })
+
+    expect(
+      matchesState(
+        'displaying.running.pause.paused',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+  })
+
+  it('keeps a paused view paused across an automatic stalled reload', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'PAUSE' })
+    expect(
+      matchesState(
+        'displaying.running.pause.paused',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+
+    actor.send({ type: 'VIEW_STALLED' })
+    await vi.advanceTimersByTimeAsync(2000) // stalledTimeout -> reload
+    expect(matchesState('displaying.loading', actor.getSnapshot().value)).toBe(
+      true,
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'VIEW_INIT' })
+    actor.send({ type: 'VIEW_LOADED' })
+
+    expect(
+      matchesState(
+        'displaying.running.pause.paused',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+  })
+
+  it('returns to unpaused on RESUME and clears the desired-paused flag', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'PAUSE' })
+
+    actor.send({ type: 'RESUME' })
+
+    const snapshot = actor.getSnapshot()
+    expect(
+      matchesState('displaying.running.pause.unpaused', snapshot.value),
+    ).toBe(true)
+    expect(snapshot.context.desiredPaused).toBe(false)
+  })
+
+  it('does not pause a freshly-running view that was never asked to pause', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+
+    expect(
+      matchesState(
+        'displaying.running.pause.unpaused',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+  })
+})
+
+describe('viewStateMachine pause/resume IPC (issue #374)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // Same setup as makeActor, but with spies on sendViewPause/sendViewResume
+  // so tests can assert on what was forwarded to the view's webContents.
+  function makeActorWithPauseSpies(retry: RetryConfig) {
+    const sendViewPause = vi.fn()
+    const sendViewResume = vi.fn()
+    const machine = viewStateMachine.provide({
+      actions: {
+        offscreenView: noop,
+        positionView: noop,
+        offscreenNextView: noop,
+        performSwap: noop,
+        resyncSwappedView: noop,
+        muteAudio: noop,
+        unmuteAudio: noop,
+        openDevTools: noop,
+        sendViewOptions: noop,
+        sendViewVolume: noop,
+        sendViewPause,
+        sendViewResume,
+        logError: noop,
+      },
+      actors: {
+        loadPage: fromPromise(async () => {}),
+      },
+    })
+    const actor = createActor(machine, {
+      input: {
+        id: 1,
+        view: {} as never,
+        win: {} as never,
+        offscreenWin: {} as never,
+        retry,
+        createNextView: noopCreateNextView,
+        disposeView: noopDisposeView,
+      },
+    })
+    return { actor, sendViewPause, sendViewResume }
+  }
+
+  it('sends a pause message to the view on PAUSE while running', async () => {
+    const { actor, sendViewPause } = makeActorWithPauseSpies(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+
+    actor.send({ type: 'PAUSE' })
+
+    expect(sendViewPause).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not send a pause message for a view that was never asked to pause', async () => {
+    const { actor, sendViewPause } = makeActorWithPauseSpies(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+
+    expect(sendViewPause).not.toHaveBeenCalled()
+  })
+
+  it('sends a resume message to the view on RESUME after a PAUSE', async () => {
+    const { actor, sendViewResume } = makeActorWithPauseSpies(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'PAUSE' })
+
+    actor.send({ type: 'RESUME' })
+
+    expect(sendViewResume).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -119,6 +119,13 @@ const viewStateMachine = setup({
       desiredAudio: 'muted' | 'listening' | 'background'
       // Same idea as `desiredAudio`, for BLUR/UNBLUR.
       desiredBlurred: boolean
+      // Same idea as `desiredAudio`, for PAUSE/RESUME: whether this view's
+      // underlying media playback should be paused. Distinct from BLUR,
+      // which only hides the video visually via the overlay -- this stops
+      // the view actually decoding/fetching. Used by StreamWindow to pause a
+      // parked (hidden) view instead of keeping it fully live while it's
+      // hidden behind a fullscreen expansion (issue #374).
+      desiredPaused: boolean
     },
 
     events: {} as
@@ -146,6 +153,8 @@ const viewStateMachine = setup({
       | { type: 'UNBACKGROUND' }
       | { type: 'BLUR' }
       | { type: 'UNBLUR' }
+      | { type: 'PAUSE' }
+      | { type: 'RESUME' }
       | { type: 'RELOAD' }
       | { type: 'DEVTOOLS'; inWebContents: WebContents },
   },
@@ -201,6 +210,16 @@ const viewStateMachine = setup({
     sendViewVolume: ({ context }, params: { volume: number }) => {
       const { view } = context
       view.webContents.send('volume', params.volume)
+    },
+
+    sendViewPause: ({ context }) => {
+      const { view } = context
+      view.webContents.send('pause')
+    },
+
+    sendViewResume: ({ context }) => {
+      const { view } = context
+      view.webContents.send('resume')
     },
 
     offscreenView: ({ context }) => {
@@ -337,6 +356,7 @@ const viewStateMachine = setup({
     desiredAudioIsBackground: ({ context }) =>
       context.desiredAudio === 'background',
     desiredVideoIsBlurred: ({ context }) => context.desiredBlurred,
+    desiredPlaybackIsPaused: ({ context }) => context.desiredPaused,
   },
 
   delays: {
@@ -400,6 +420,7 @@ const viewStateMachine = setup({
     volume: 1,
     desiredAudio: 'muted',
     desiredBlurred: false,
+    desiredPaused: false,
   }),
   on: {
     DISPLAY: {
@@ -502,6 +523,8 @@ const viewStateMachine = setup({
             UNBACKGROUND: { actions: assign({ desiredAudio: 'muted' }) },
             BLUR: { actions: assign({ desiredBlurred: true }) },
             UNBLUR: { actions: assign({ desiredBlurred: false }) },
+            PAUSE: { actions: assign({ desiredPaused: true }) },
+            RESUME: { actions: assign({ desiredPaused: false }) },
           },
           // If the whole loading phase stalls (e.g. the renderer never sends
           // VIEW_INIT/VIEW_LOADED), fail the view instead of hanging forever.
@@ -707,6 +730,37 @@ const viewStateMachine = setup({
                 blurred: {},
               },
             },
+            // Whether this view's underlying media playback is paused,
+            // independent of `video` (BLUR) above -- see `desiredPaused`.
+            // Used by StreamWindow to stop a parked (hidden) view actually
+            // decoding/fetching instead of keeping it fully live while it's
+            // hidden behind a fullscreen expansion (issue #374).
+            pause: {
+              initial: 'unpaused',
+              on: {
+                PAUSE: {
+                  target: '.paused',
+                  actions: assign({ desiredPaused: true }),
+                },
+                RESUME: {
+                  target: '.unpaused',
+                  actions: [assign({ desiredPaused: false }), 'sendViewResume'],
+                },
+              },
+              states: {
+                unpaused: {
+                  // Applies a PAUSE requested while the view was still
+                  // loading (or recovering from an error).
+                  always: {
+                    target: 'paused',
+                    guard: 'desiredPlaybackIsPaused',
+                  },
+                },
+                paused: {
+                  entry: 'sendViewPause',
+                },
+              },
+            },
             // Preloads the next WebContentsView for a content swap in the
             // background, independent of playback/audio/video above, so the
             // currently displayed view is never disturbed until the new one
@@ -841,6 +895,8 @@ const viewStateMachine = setup({
             UNBACKGROUND: { actions: assign({ desiredAudio: 'muted' }) },
             BLUR: { actions: assign({ desiredBlurred: true }) },
             UNBLUR: { actions: assign({ desiredBlurred: false }) },
+            PAUSE: { actions: assign({ desiredPaused: true }) },
+            RESUME: { actions: assign({ desiredPaused: false }) },
           },
           // Automatically reload after the backoff delay until the retry budget
           // is spent; then this is a terminal state surfaced to the operator.

--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -6,11 +6,12 @@ const executeJavaScript = vi.fn()
 // does not wait on the view-init round trip before running.
 const invoke = vi.fn(() => new Promise(() => {}))
 const send = vi.fn()
+const on = vi.fn()
 const exposeInMainWorld = vi.fn()
 
 vi.mock('electron', () => ({
   contextBridge: { exposeInMainWorld },
-  ipcRenderer: { invoke, send, on: vi.fn() },
+  ipcRenderer: { invoke, send, on },
   webFrame: { executeJavaScript, insertCSS: vi.fn() },
 }))
 
@@ -30,6 +31,7 @@ describe('mediaPreload visibility spoofing', () => {
     executeJavaScript.mockClear()
     invoke.mockClear()
     send.mockClear()
+    on.mockClear()
     exposeInMainWorld.mockClear()
   })
 
@@ -54,6 +56,7 @@ describe('mediaPreload error channel', () => {
   afterEach(() => {
     vi.resetModules()
     send.mockClear()
+    on.mockClear()
     exposeInMainWorld.mockClear()
   })
 
@@ -109,6 +112,7 @@ describe('mediaPreload initial acquireMedia rejection', () => {
     vi.resetModules()
     invoke.mockClear()
     send.mockClear()
+    on.mockClear()
     exposeInMainWorld.mockClear()
   })
 
@@ -183,6 +187,7 @@ describe("mediaPreload emptied handler's re-acquisition rejection", () => {
     vi.resetModules()
     invoke.mockClear()
     send.mockClear()
+    on.mockClear()
     exposeInMainWorld.mockClear()
     document.body.innerHTML = ''
   })
@@ -236,5 +241,92 @@ describe("mediaPreload emptied handler's re-acquisition rejection", () => {
       send.mock.calls.filter(([channel]) => channel === 'view-loaded'),
     ).toHaveLength(2)
     expect(viewErrorCalls()).toEqual([])
+  })
+})
+
+describe('mediaPreload pause/resume handling (issue #374)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.resetModules()
+    invoke.mockClear()
+    send.mockClear()
+    on.mockClear()
+    exposeInMainWorld.mockClear()
+    document.body.innerHTML = ''
+  })
+
+  function registeredHandler(channel: string): () => void {
+    const call = on.mock.calls.find(([ch]) => ch === channel)
+    if (!call) {
+      throw new Error(`no ipcRenderer.on('${channel}', ...) handler registered`)
+    }
+    return call[1] as () => void
+  }
+
+  // Same acquisition setup as the emptied-handler tests above: a real <video>
+  // with a truthy videoWidth so findMedia() resolves immediately instead of
+  // waiting for a 'playing' event.
+  async function loadAcquiredVideo(): Promise<HTMLVideoElement> {
+    const video = document.createElement('video')
+    ;(video as unknown as { videoWidth: number }).videoWidth = 100
+    document.body.appendChild(video)
+
+    invoke.mockResolvedValueOnce({
+      content: { kind: 'video', link: 'https://example.com/stream' },
+      options: {},
+      volume: 1,
+    })
+
+    await import('./mediaPreload')
+    document.dispatchEvent(new Event('DOMContentLoaded'))
+    process.emit('loaded' as never)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(send).toHaveBeenCalledWith('view-loaded')
+    return video
+  }
+
+  it('pauses the acquired media element on a pause message, bypassing an instance-level pause override', async () => {
+    const video = await loadAcquiredVideo()
+    // Mirrors lockdownMediaTags' own shadowing of `pause` with a no-op (done
+    // for real via webFrame.executeJavaScript against the page's main world,
+    // which this preload-only harness can't exercise) -- proves the handler
+    // reaches the native implementation instead of a shadowed one.
+    Object.defineProperty(video, 'pause', { writable: false, value: () => {} })
+
+    registeredHandler('pause')()
+
+    expect(video.paused).toBe(true)
+  })
+
+  it('resumes a paused media element on a resume message', async () => {
+    const video = await loadAcquiredVideo()
+    video.pause()
+    expect(video.paused).toBe(true)
+
+    registeredHandler('resume')()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(video.paused).toBe(false)
+  })
+
+  it('does not throw when a pause/resume message arrives before any media has been acquired', async () => {
+    invoke.mockResolvedValueOnce({
+      content: { kind: 'video', link: 'https://example.com/stream' },
+      options: {},
+      volume: 1,
+    })
+    await import('./mediaPreload')
+    process.emit('loaded' as never)
+    await vi.advanceTimersByTimeAsync(0)
+    // No DOMContentLoaded is dispatched, so the module-scope pageReady used
+    // by waitForQuery never resolves and acquireMedia never finds a video.
+
+    expect(() => registeredHandler('pause')()).not.toThrow()
+    expect(() => registeredHandler('resume')()).not.toThrow()
   })
 })

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -355,12 +355,17 @@ async function main() {
   let rotationController: RotationController | undefined
   let volumeController: VolumeController | undefined
   let latestVolume = initialVolume ?? 1
+  // The most recently acquired media element (reassigned across a re-
+  // acquisition, e.g. the 'emptied' handler below), so a PAUSE/RESUME
+  // message received at any point can act on whichever one is current.
+  let currentMedia: HTMLMediaElement | undefined
   async function acquireMedia(elementTimeout: number) {
     let snapshotInterval: number | undefined
 
     const media = await findMedia(content.kind, elementTimeout)
     console.log('media acquired', media)
 
+    currentMedia = media
     volumeController = new VolumeController(media, latestVolume)
     ipcRenderer.send('view-loaded')
 
@@ -441,6 +446,28 @@ async function main() {
     volumeController?.setVolume(volume)
   }
   ipcRenderer.on('volume', (ev, volume) => updateVolume(volume))
+
+  // Stops/resumes the acquired media element's own playback -- used to pause
+  // a parked (hidden) view instead of keeping it fully live while it's
+  // hidden behind a fullscreen expansion (issue #374). No-ops when no media
+  // has been acquired yet (e.g. a 'web' kind view, or one still loading).
+  ipcRenderer.on('pause', () => {
+    if (!currentMedia) {
+      return
+    }
+    // lockdownMediaTags() permanently shadows the element's own `pause`
+    // method with a no-op (to stop sites like Facebook from auto-pausing),
+    // so call the native implementation directly instead of
+    // `currentMedia.pause()`, which would silently do nothing.
+    HTMLMediaElement.prototype.pause.call(currentMedia)
+  })
+  ipcRenderer.on('resume', () => {
+    // Live streams are typically not seekable on-demand video, so resuming
+    // after a pause may briefly re-buffer or land slightly behind the live
+    // edge -- both cheaper than a full reload and expected to self-correct
+    // as playback continues.
+    currentMedia?.play().catch(() => {})
+  })
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Problem

Follow-up from #369 / PR #373, which stopped tearing down non-focused streams when a grid view is expanded to fullscreen (#362): parked (hidden) views are moved to their own offscreen host window instead of being disposed, so a later collapse can reposition them instantly. But they keep decoding/playing at full rate while hidden -- PR #373 deliberately scoped pausing out to keep that fix minimal, flagging it as a separately-decidable enhancement.

## Solution

Adds an opt-in `--park.pause` flag (default `false`, so existing behavior is unchanged unless explicitly enabled) that pauses a parked view's own media playback instead of keeping it fully live:

- **`viewStateMachine.ts`**: a new `PAUSE`/`RESUME` event pair and `running.pause` parallel region, mirroring the existing `BLUR`/`UNBLUR` pattern (including deferred application if the request arrives while the view is still loading or recovering from an error). Unlike `BLUR` -- a purely cosmetic overlay effect with no action tied to it, and therefore not reusable as-is for this -- entering `paused` sends a `pause` IPC message to the view's `webContents`, and leaving it sends `resume`.
- **`mediaPreload.ts`**: `ipcRenderer.on('pause'/'resume', ...)` handlers act on the currently-acquired `<video>`/`<audio>` element (tracked across re-acquisition, e.g. the `'emptied'` handler). `pause` calls `HTMLMediaElement.prototype.pause` directly rather than `media.pause()`, since `lockdownMediaTags()` permanently shadows the element's own `pause` method with a no-op (to stop sites like Facebook from auto-pausing) -- calling it directly would silently do nothing. `resume` just calls `.play()`; since these are typically live (non-seekable) streams, resuming may briefly re-buffer or land slightly behind the live edge, which is expected and far cheaper than a full reload.
- **`StreamWindow.ts`**: `hideView()` sends `PAUSE` when parking a view (if `pauseParkedViews` is enabled); `setViews()` sends `RESUME` to a view that was parked coming into the call and gets matched back into a box (a fullscreen collapse), also gated on the flag. The parked actor's own state (content, position, retry budget) is untouched either way -- only its playback is paused/resumed, so a later collapse still repositions it instantly via the existing `DISPLAY`-based reuse path from #373; the only change when the option is enabled is a brief resume/re-buffer.
- **`config.ts`/`index.ts`**: wires `park.pause` through the same schema → CLI flag → runtime config chain as `retry.*`.

## Testing

- `viewStateMachine.test.ts`: deferred `PAUSE` while loading/recovering from an error, survival across an automatic stalled reload, `RESUME` clearing `desiredPaused`, and that `sendViewPause`/`sendViewResume` fire (or don't) exactly when expected.
- `mediaPreload.test.ts`: a `pause` message pauses the acquired `<video>` even with an instance-level `pause` override in place (proving the native-implementation bypass works), a `resume` message resumes it, and both no-op safely before any media has been acquired.
- `StreamWindow.test.ts`: parking sends `PAUSE` only when `pauseParkedViews` is enabled, and a previously-parked view reused after collapse sends `RESUME` only when enabled (and never for a view that was never parked).
- Full local quality gate: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm run test` -- all green across every workspace.

## Risks / limitations

- Off by default -- no behavior change unless an operator opts in.
- Only pauses the `<video>`/`<audio>` element itself; it does not call `hls.stopLoad()` on the bundled HLS player, so segment fetching for the local HLS path isn't stopped outright (it naturally tapers off once hls.js's buffer target is reached while paused, capping most of the network cost). A full `stopLoad()`/`startLoad()` bridge would need a new same-document channel into `playHLS.ts` and was scoped out to keep this change minimal, consistent with how #373 scoped out pausing entirely.
- `content.kind === 'web'` views never acquire a media element, so pause/resume is a no-op for them -- expected, not a gap.

Closes #374