### PR TITLE
chore(release): streamwall v0.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15132,7 +15132,7 @@
       }
     },
     "packages/streamwall": {
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/packages/streamwall/package.json
+++ b/packages/streamwall/package.json
@@ -1,7 +1,7 @@
 {
   "name": "streamwall",
   "productName": "Streamwall",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Watch streams in a grid layout",
   "main": ".vite/build/index.js",
   "repository": "github:NilsR0711/streamwall",


### PR DESCRIPTION
## What

Bumps the `streamwall` app package from `0.9.0` to `0.9.1` (patch release; bugfixes and docs since the last tag).

## Changes since v0.9.0

- fix(streamwall): keep non-focused streams alive across a fullscreen expand/collapse (#373)
- fix(control-server): default listen port when URL has no port (#378)
- fix(control-server): opt-in trustProxy for per-client rate limits (#379)
- fix(streamwall): retry unresolved playlist URLs when stream data updates (#365)
- fix(release): publish GitHub releases as non-prerelease (#361)
- docs(deploy): align self-host stack with trustProxy and port defaults (#380)
- docs(control-server): add Docker + Caddy self-hosting deployment guide (#370)
- docs: refresh control UI screenshot and fix leftover German label (#366)
- docs: add wall grid screenshot to README (#363)
- docs(readme): add Download section, release/license badges (#360)

(feat(streamwall) commits #368 and #383 also landed since v0.9.0, but this release is scoped as a patch per explicit request.)

## How the release happens

Once this is merged, pushing the `v0.9.1` tag triggers [`release.yml`](.github/workflows/release.yml):

1. Quality gate (lint, typecheck, test)
2. Builds Linux / Windows / macOS via `electron-forge publish`
3. Creates the GitHub release under **NilsR0711/streamwall**, non-prerelease

## Scope

Only `packages/streamwall` is versioned/released here.