### PR TITLE
fix(control-ui): translate CommandErrorBanner strings to English

### DIFF
--- a/packages/streamwall-control-ui/src/CommandErrorBanner.test.tsx
+++ b/packages/streamwall-control-ui/src/CommandErrorBanner.test.tsx
@@ -41,6 +41,21 @@ describe('CommandErrorBanner', () => {
     )
   })
 
+  test('renders English copy', () => {
+    const el = renderBanner('unauthorized')
+    const text = el.querySelector('.command-error-banner')?.textContent
+    expect(text).toContain('Action failed: unauthorized')
+    expect(text).not.toContain('Aktion fehlgeschlagen')
+  })
+
+  test('labels the dismiss button in English', () => {
+    const el = renderBanner('unauthorized')
+    const dismissButton = el.querySelector(
+      '.command-error-banner button',
+    ) as HTMLButtonElement
+    expect(dismissButton.textContent).toBe('Dismiss')
+  })
+
   test('calls onDismiss when the dismiss control is clicked', () => {
     const onDismiss = vi.fn()
     const el = renderBanner('unauthorized', onDismiss)

--- a/packages/streamwall-control-ui/src/CommandErrorBanner.tsx
+++ b/packages/streamwall-control-ui/src/CommandErrorBanner.tsx
@@ -38,9 +38,9 @@ export function CommandErrorBanner({
   return (
     <StyledCommandErrorBanner className="command-error-banner">
       <FaExclamationTriangle />
-      <span>Aktion fehlgeschlagen: {error}</span>
+      <span>Action failed: {error}</span>
       <button type="button" onClick={onDismiss}>
-        Ausblenden
+        Dismiss
       </button>
     </StyledCommandErrorBanner>
   )


### PR DESCRIPTION
## Problem

`CommandErrorBanner` — the primary surface for surfacing failed control commands to operators — rendered German copy (`Aktion fehlgeschlagen: {error}` / `Ausblenden`) while every other control-ui string is English. This violates the repo's English-only convention and is a jarring inconsistency exactly when something has gone wrong for the operator.

## Solution

- Replaced the German copy in `CommandErrorBanner.tsx` with `Action failed: {error}` and `Dismiss`.
- No other non-English user-visible strings were found in `streamwall-control-ui` (searched for German-specific characters and common German words across the package).

## Testing

- Added two tests to `CommandErrorBanner.test.tsx` asserting the banner renders `Action failed: ...` and the dismiss button is labeled `Dismiss` (confirmed red before the fix, green after).
- Full quality gate run locally: `format:check`, `lint`, `typecheck`, `test` (all workspaces), and the control-client `build` — all green.

## Risks / breaking changes

None. Pure UI copy change with no behavioral impact.

Closes #386