### PR TITLE
fix(control-server): validate uplink state payload against a strict schema

### DIFF
--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -19,7 +19,7 @@ import {
   roleCan,
   stateDiff,
   type StreamwallRole,
-  type StreamwallState,
+  streamwallStateSchema,
 } from 'streamwall-shared'
 import { Auth, StateWrapper, uniqueRand62 } from './auth.ts'
 import { TokenBucket } from './rateLimiter.ts'
@@ -588,7 +588,20 @@ export async function initApp({
           )
           return
         }
-        const state = parsed.data.state as unknown as StreamwallState
+
+        // The envelope check above only guarantees "an object". Validate the
+        // full snapshot itself so a malformed or adversarial desktop build can
+        // never seed StateWrapper with garbage that crashes clients on
+        // view() or corrupts the role-scoped projection (issue #387).
+        const stateResult = streamwallStateSchema.safeParse(parsed.data.state)
+        if (!stateResult.success) {
+          console.warn(
+            'Rejected invalid Streamwall state payload:',
+            stateResult.error.issues[0]?.message,
+          )
+          return
+        }
+        const state = stateResult.data
 
         try {
           if (clientState === null) {

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -75,7 +75,11 @@ export const VALID_STATE = {
   streams: [],
   customStreams: [],
   views: [],
+  fullscreenViewIdx: null,
   streamdelay: null,
+  layoutPresets: [],
+  favorites: [],
+  dataSourceHealth: [],
 }
 
 /**

--- a/packages/streamwall-control-server/src/wsValidation.test.ts
+++ b/packages/streamwall-control-server/src/wsValidation.test.ts
@@ -37,6 +37,21 @@ function isCommandType<Type extends ControlCommandMessage['type']>(type: Type) {
 const isBareError = (m: ServerToClientMessage): m is ClientErrorMessage =>
   !('response' in m) && 'error' in m
 
+/** Temporarily replaces `console.warn`, capturing every call made while active. */
+function spyOnConsoleWarn() {
+  const calls: unknown[][] = []
+  const original = console.warn
+  console.warn = (...args: unknown[]) => {
+    calls.push(args)
+  }
+  return {
+    calls,
+    restore: () => {
+      console.warn = original
+    },
+  }
+}
+
 // A per-test override of the update cap must not leak into other test files.
 after(() => {
   delete process.env.STREAMWALL_WS_UPDATE_MAX_BYTES
@@ -140,6 +155,109 @@ test('rejects a state message with no payload instead of wiring a broken connect
 
   const response = await client.waitFor(isBareError)
   assert.equal(response.error, 'streamwall disconnected')
+})
+
+test('rejects an initial state payload missing a required field (issue #387)', async () => {
+  // The envelope schema only checks "an object" -- an object missing
+  // `streams` (or any other required StreamwallState field) must still be
+  // rejected by the full streamwallStateSchema check before a StateWrapper is
+  // ever built, exactly like a payload with no `state` key at all.
+  const { streams: _streams, ...withoutStreams } = VALID_STATE
+  const warn = spyOnConsoleWarn()
+
+  try {
+    const { client } = await connectStreamwallAndClient({
+      stateMessage: { type: 'state', state: withoutStreams },
+    })
+
+    const response = await client.waitFor(isBareError)
+    assert.equal(response.error, 'streamwall disconnected')
+    assert.ok(
+      warn.calls.some((args) =>
+        String(args[0]).includes('Rejected invalid Streamwall state payload'),
+      ),
+      'a structured warning must be logged for the rejected payload',
+    )
+  } finally {
+    warn.restore()
+  }
+})
+
+test('rejects an initial state payload with a malformed view state machine snapshot (issue #387)', async () => {
+  const malformed = {
+    ...VALID_STATE,
+    views: [
+      {
+        state: { displaying: { running: { playback: 'exploded' } } },
+        context: {
+          id: 0,
+          content: null,
+          info: null,
+          pos: null,
+          error: null,
+          volume: 1,
+        },
+      },
+    ],
+  }
+
+  const { client } = await connectStreamwallAndClient({
+    stateMessage: { type: 'state', state: malformed },
+  })
+
+  const response = await client.waitFor(isBareError)
+  assert.equal(response.error, 'streamwall disconnected')
+})
+
+test('accepts an initial state payload with legitimately empty views', async () => {
+  // Regression guard: an empty `views` array is a normal, valid snapshot (a
+  // freshly-started desktop with no grid populated yet) and must not be
+  // rejected by the stricter validation.
+  const { clientWs, streamwall } = await connectStreamwallAndClient()
+
+  clientWs.send(JSON.stringify({ id: 1, type: 'reload-view', viewIdx: 0 }))
+  await streamwall.waitFor((m) => m.type === 'reload-view')
+
+  assert.ok(
+    streamwall.messages.some((m) => m.type === 'reload-view'),
+    'the connection must be fully established for a valid, empty-views state',
+  )
+})
+
+test('drops a malformed state update on an already-connected uplink without crashing the session (issue #387)', async () => {
+  const { streamwallWs, clientWs, streamwall } =
+    await connectStreamwallAndClient()
+
+  const warn = spyOnConsoleWarn()
+  try {
+    // Malicious/buggy follow-up update: `streams` is not an array at all.
+    streamwallWs.send(
+      JSON.stringify({ type: 'state', state: { ...VALID_STATE, streams: {} } }),
+    )
+    await delay(150)
+
+    assert.ok(
+      warn.calls.some((args) =>
+        String(args[0]).includes('Rejected invalid Streamwall state payload'),
+      ),
+      'the malformed update must be rejected with a structured warning',
+    )
+  } finally {
+    warn.restore()
+  }
+
+  // The session must still be alive and functional: a subsequent valid
+  // command from the client is still forwarded to the (still-connected)
+  // uplink, proving the malformed update was cleanly dropped rather than
+  // tearing down or corrupting the connection.
+  clientWs.send(JSON.stringify({ id: 99, type: 'reload-view', viewIdx: 1 }))
+  await streamwall.waitFor((m) => m.type === 'reload-view' && m.viewIdx === 1)
+
+  assert.ok(
+    streamwall.messages.some(
+      (m) => m.type === 'reload-view' && m.viewIdx === 1,
+    ),
+  )
 })
 
 /** Polls `predicate` until it holds, or rejects after `timeoutMs`. */

--- a/packages/streamwall-shared/src/schemas.test.ts
+++ b/packages/streamwall-shared/src/schemas.test.ts
@@ -6,7 +6,32 @@ import {
   localStreamDataSchema,
   parseStreamList,
   streamDataInputSchema,
+  streamwallStateSchema,
 } from './schemas.ts'
+import type { StreamwallState } from './types.ts'
+
+/** A minimal, fully-populated valid state, mirroring what the desktop uplink sends. */
+const VALID_STATE = {
+  identity: { role: 'admin' },
+  config: {
+    cols: 3,
+    rows: 3,
+    width: 1920,
+    height: 1080,
+    frameless: false,
+    fullscreen: false,
+    activeColor: '#fff',
+    backgroundColor: '#000',
+  },
+  streams: [],
+  customStreams: [],
+  views: [],
+  fullscreenViewIdx: null,
+  streamdelay: null,
+  layoutPresets: [],
+  favorites: [],
+  dataSourceHealth: [],
+}
 
 describe('streamDataInputSchema', () => {
   test('accepts a minimal entry with just a link', () => {
@@ -525,5 +550,170 @@ describe('controlStateMessageSchema', () => {
       controlStateMessageSchema.safeParse({ type: 'state', state: 'nope' })
         .success,
     ).toBe(false)
+  })
+})
+
+describe('streamwallStateSchema', () => {
+  test('accepts a fully-populated valid state with empty views', () => {
+    const result = streamwallStateSchema.safeParse(VALID_STATE)
+    expect(result.success).toBe(true)
+  })
+
+  test('accepts a state with populated streams, views and layout presets', () => {
+    const full = {
+      ...VALID_STATE,
+      identity: { role: 'operator' },
+      auth: { invites: [], sessions: [] },
+      streams: [
+        {
+          link: 'https://example.com/s',
+          kind: 'video',
+          _id: 'id-1',
+          _dataSource: 'source-1',
+        },
+      ],
+      customStreams: [],
+      views: [
+        {
+          state: 'empty',
+          context: {
+            id: 0,
+            content: null,
+            info: null,
+            pos: null,
+            error: null,
+            volume: 1,
+          },
+        },
+        {
+          state: {
+            displaying: {
+              running: {
+                playback: 'playing',
+                video: 'normal',
+                audio: 'listening',
+              },
+            },
+          },
+          context: {
+            id: 1,
+            content: { url: 'https://example.com/s', kind: 'video' },
+            info: { title: 'A stream' },
+            pos: { x: 0, y: 0, width: 100, height: 100, spaces: [1] },
+            error: null,
+            volume: 0.5,
+          },
+        },
+      ],
+      layoutPresets: [
+        {
+          id: 'preset-1',
+          name: 'My Layout',
+          cols: 3,
+          rows: 3,
+          views: { '0': { streamId: 'id-1' } },
+        },
+      ],
+      favorites: ['https://example.com/s'],
+      dataSourceHealth: [
+        {
+          id: 'https://source.example/data.json',
+          type: 'json-url',
+          status: 'ok',
+          message: null,
+          updatedAt: 1700000000000,
+        },
+      ],
+    }
+    const result = streamwallStateSchema.safeParse(full)
+    expect(result.success).toBe(true)
+  })
+
+  test('rejects a state missing the required streams field', () => {
+    const { streams: _streams, ...withoutStreams } = VALID_STATE
+    expect(streamwallStateSchema.safeParse(withoutStreams).success).toBe(false)
+  })
+
+  test('rejects a state with a malformed view state machine snapshot', () => {
+    const malformed = {
+      ...VALID_STATE,
+      views: [
+        {
+          state: { displaying: { running: { playback: 'exploded' } } },
+          context: {
+            id: 0,
+            content: null,
+            info: null,
+            pos: null,
+            error: null,
+            volume: 1,
+          },
+        },
+      ],
+    }
+    expect(streamwallStateSchema.safeParse(malformed).success).toBe(false)
+  })
+
+  test('rejects a state with an unrecognized top-level view state string', () => {
+    const malformed = {
+      ...VALID_STATE,
+      views: [
+        {
+          state: 'not-a-real-state',
+          context: {
+            id: 0,
+            content: null,
+            info: null,
+            pos: null,
+            error: null,
+            volume: 1,
+          },
+        },
+      ],
+    }
+    expect(streamwallStateSchema.safeParse(malformed).success).toBe(false)
+  })
+
+  test('rejects a non-object payload', () => {
+    expect(streamwallStateSchema.safeParse('nope').success).toBe(false)
+    expect(streamwallStateSchema.safeParse(null).success).toBe(false)
+    expect(streamwallStateSchema.safeParse(undefined).success).toBe(false)
+  })
+
+  test('rejects an unknown identity role', () => {
+    const malformed = { ...VALID_STATE, identity: { role: 'superuser' } }
+    expect(streamwallStateSchema.safeParse(malformed).success).toBe(false)
+  })
+
+  test('rejects an out-of-bounds fullscreenViewIdx', () => {
+    const malformed = { ...VALID_STATE, fullscreenViewIdx: -1 }
+    expect(streamwallStateSchema.safeParse(malformed).success).toBe(false)
+  })
+
+  test('accepts a null fullscreenViewIdx and a populated streamdelay', () => {
+    const state = {
+      ...VALID_STATE,
+      fullscreenViewIdx: null,
+      streamdelay: {
+        isConnected: true,
+        delaySeconds: 30,
+        restartSeconds: 0,
+        isCensored: false,
+        isStreamRunning: true,
+        startTime: 1700000000000,
+        state: 'running',
+      },
+    }
+    expect(streamwallStateSchema.safeParse(state).success).toBe(true)
+  })
+
+  test('parsed state is assignable to StreamwallState at compile time', () => {
+    const result = streamwallStateSchema.safeParse(VALID_STATE)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      // Compile-time guard against schema/type drift.
+      const state: StreamwallState = result.data
+      expect(state.identity.role).toBe('admin')
+    }
   })
 })

--- a/packages/streamwall-shared/src/schemas.ts
+++ b/packages/streamwall-shared/src/schemas.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { GRID_MAX, GRID_MIN } from './geometry.ts'
-import { invitableRoles } from './roles.ts'
+import { invitableRoles, validRoles } from './roles.ts'
 
 /**
  * Runtime schemas for every piece of external, untrusted input that crosses a
@@ -241,10 +241,149 @@ export const controlCommandMessageSchema = z.intersection(
  * A `state` update message sent by the Streamwall desktop over its uplink. The
  * full `StreamwallState` is authored by the (authenticated) desktop, so this
  * only enforces the structural invariants the server relies on: a `state`
- * discriminator and a non-null object payload.
+ * discriminator and a non-null object payload. The payload itself is
+ * validated separately by {@link streamwallStateSchema} before it is ever
+ * used to build or update a `StateWrapper`.
  */
 export const controlStateMessageSchema = z.object({
   type: z.literal('state'),
   id: z.number().optional(),
   state: z.object({}).loose(),
+})
+
+const authTokenKindSchema = z.enum(['invite', 'session', 'streamwall'])
+
+const authTokenInfoSchema = z.object({
+  tokenId: z.string(),
+  kind: authTokenKindSchema,
+  role: z.enum(validRoles),
+  name: z.string(),
+})
+
+const streamWindowConfigSchema = z.object({
+  cols: gridDimensionSchema,
+  rows: gridDimensionSchema,
+  width: z.number(),
+  height: z.number(),
+  x: z.number().optional(),
+  y: z.number().optional(),
+  frameless: z.boolean(),
+  fullscreen: z.boolean(),
+  display: z.number().int().min(0).optional(),
+  activeColor: z.string(),
+  backgroundColor: z.string(),
+})
+
+/**
+ * A single stream entry as it appears inside a full `StreamwallState`
+ * snapshot: unlike {@link streamDataInputSchema}, `_id`/`_dataSource` are
+ * required here since the desktop always attaches them before broadcasting.
+ */
+const streamDataSchema = localStreamDataSchema.extend({
+  _id: z.string(),
+  _dataSource: z.string(),
+})
+
+const viewContentSchema = z.object({
+  url: z.string(),
+  kind: contentKindSchema,
+})
+
+const contentViewInfoSchema = z.object({
+  title: z.string(),
+})
+
+const viewPosSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+  width: z.number(),
+  height: z.number(),
+  spaces: z.array(z.number()),
+})
+
+/** Matches the shape produced by `viewStateMachine.ts`'s XState snapshot `.value`. */
+const viewStateValueSchema = z.union([
+  z.literal('empty'),
+  z.object({
+    displaying: z.union([
+      z.literal('error'),
+      z.object({
+        loading: z.enum(['navigate', 'waitForInit', 'waitForVideo']),
+      }),
+      z.object({
+        running: z.object({
+          playback: z.enum(['playing', 'stalled']),
+          video: z.enum(['normal', 'blurred']),
+          audio: z.enum(['background', 'muted', 'listening']),
+        }),
+      }),
+    ]),
+  }),
+])
+
+const viewStateSchema = z.object({
+  state: viewStateValueSchema,
+  context: z.object({
+    id: viewIdxSchema,
+    content: viewContentSchema.nullable(),
+    info: contentViewInfoSchema.nullable(),
+    pos: viewPosSchema.nullable(),
+    error: z.string().nullable(),
+    volume: volumeSchema,
+  }),
+})
+
+const streamDelayStatusSchema = z.object({
+  isConnected: z.boolean(),
+  delaySeconds: z.number(),
+  restartSeconds: z.number(),
+  isCensored: z.boolean(),
+  isStreamRunning: z.boolean(),
+  startTime: z.number(),
+  state: z.string(),
+})
+
+const layoutPresetSchema = z.object({
+  id: layoutPresetIdSchema,
+  name: layoutPresetNameSchema,
+  cols: gridDimensionSchema,
+  rows: gridDimensionSchema,
+  views: z.record(z.string(), z.object({ streamId: z.string() })),
+})
+
+const dataSourceHealthSchema = z.object({
+  id: z.string(),
+  type: z.enum(['json-url', 'toml-file']),
+  status: z.enum(['ok', 'error']),
+  message: z.string().nullable(),
+  updatedAt: z.number(),
+})
+
+/**
+ * The full `StreamwallState` snapshot broadcast by the Streamwall desktop
+ * over the trusted uplink. Every field the server actually reads is validated
+ * here, so a malformed or adversarial payload can never wrap `StateWrapper`
+ * around garbage and fan corrupted state out to connected clients (issue
+ * #387). `auth` is intentionally not required: the desktop's own snapshot
+ * never includes it, since the control server attaches it separately.
+ */
+export const streamwallStateSchema = z.object({
+  identity: z.object({
+    role: z.enum(validRoles),
+  }),
+  auth: z
+    .object({
+      invites: z.array(authTokenInfoSchema),
+      sessions: z.array(authTokenInfoSchema),
+    })
+    .optional(),
+  config: streamWindowConfigSchema,
+  streams: z.array(streamDataSchema),
+  customStreams: z.array(streamDataSchema),
+  views: z.array(viewStateSchema),
+  fullscreenViewIdx: viewIdxSchema.nullable(),
+  streamdelay: streamDelayStatusSchema.nullable(),
+  layoutPresets: z.array(layoutPresetSchema),
+  favorites: z.array(z.string()),
+  dataSourceHealth: z.array(dataSourceHealthSchema),
 })


### PR DESCRIPTION
## Problem

The control-server's uplink handler validated only the *envelope* of a
`state` message (`{ type: 'state', state: <object> }`) and then cast the
nested payload straight to `StreamwallState` with `as unknown as
StreamwallState` -- no runtime check on its actual contents. A malformed
or adversarial desktop build (or a future regression in state
serialization) could wrap garbage in `StateWrapper` and broadcast a
corrupted snapshot to every connected browser client, since
`StateWrapper.view()` assumes a well-formed `StreamwallState`.

## Solution

- Added `streamwallStateSchema` in `streamwall-shared`: a strict Zod
  schema covering every field of `StreamwallState` the server reads --
  `config`, `streams`/`customStreams`, `views` (including the nested
  XState view-machine snapshot shape), `fullscreenViewIdx`,
  `streamdelay`, `layoutPresets`, `favorites` and `dataSourceHealth`.
- In the control-server's uplink handler, the payload is now validated
  against `streamwallStateSchema` right after the existing envelope
  check, for both the initial snapshot and every subsequent update. On
  failure it logs a structured warning and drops the message instead of
  mutating `StateWrapper` -- no cast, no undefined behavior.
- Removed the `as unknown as StreamwallState` cast entirely; the parsed
  result is directly assignable to `StreamwallState`, so schema/type
  drift is now a compile error.

### Architecture note (from the issue's open question)

I checked whether the uplink channel ever sends partial updates
(`Partial<StreamwallState>`) versus full snapshots. It always sends the
full snapshot (`ControlUpdate.state: StreamwallState`, constructed fresh
in `packages/streamwall/src/main/index.ts`), so a single full-snapshot
schema is correct and sufficient -- no separate partial-update schema is
needed.

## Testing

- `streamwall-shared`: new `describe('streamwallStateSchema', ...)`
  block covering a fully-populated valid state, a populated state with
  streams/views/layout presets, a state missing the required `streams`
  field, a malformed view state-machine snapshot, an unrecognized
  top-level view state string, non-object payloads, an unknown identity
  role, an out-of-bounds `fullscreenViewIdx`, and a compile-time
  assignability guard against `StreamwallState`.
- `streamwall-control-server`: new integration tests in
  `wsValidation.test.ts` covering an initial state payload missing a
  required field, a malformed view state-machine snapshot, a
  legitimately empty `views` array (must still be accepted), and a
  malformed *subsequent* update on an already-connected uplink (dropped
  with a structured warning, connection stays alive and still forwards
  valid client commands).
- Updated the shared `VALID_STATE` test fixture (was missing
  `fullscreenViewIdx`, `layoutPresets`, `favorites`, `dataSourceHealth`)
  so it remains a fully valid snapshot under the new schema.
- Full quality gate green: `npm run format:check`, `npm run lint`,
  `npm run typecheck` (all workspaces), `npm test` (all workspaces:
  streamwall 40 files, streamwall-shared 11 files,
  streamwall-control-client 1 file, streamwall-control-server 116
  tests, streamwall-control-ui 38 files), and
  `streamwall-control-client`'s `vite build`.

## Risks / breaking changes

None expected. The new schema mirrors the shape the desktop has always
sent; a well-behaved desktop build's state messages continue to be
accepted unchanged. Only a payload that violates `StreamwallState`'s
own invariants is newly rejected (previously it would have been
accepted and could have crashed a client on `view()`).

Closes #387