### PR TITLE
fix(streamwall): return IPC command errors to CommandErrorBanner

### DIFF
--- a/packages/streamwall/src/main/ControlWindow.test.ts
+++ b/packages/streamwall/src/main/ControlWindow.test.ts
@@ -156,7 +156,6 @@ describe('ControlWindow open-config-folder', () => {
   })
 })
 
-
 describe('ControlWindow command IPC', () => {
   it('returns an error response from the registered handler to the renderer', async () => {
     const controlWindow = new ControlWindow(configInfo)

--- a/packages/streamwall/src/main/ControlWindow.test.ts
+++ b/packages/streamwall/src/main/ControlWindow.test.ts
@@ -155,3 +155,48 @@ describe('ControlWindow open-config-folder', () => {
     expect(openPath).not.toHaveBeenCalled()
   })
 })
+
+
+describe('ControlWindow command IPC', () => {
+  it('returns an error response from the registered handler to the renderer', async () => {
+    const controlWindow = new ControlWindow(configInfo)
+    const sender = (controlWindow.win as unknown as FakeBrowserWindow)
+      .webContents
+    controlWindow.setCommandHandler(async () => ({ error: 'invalid url' }))
+
+    const result = await ipcHandlers.get('control:command')!(
+      { sender },
+      { type: 'browse', url: 'file:///etc/passwd' },
+    )
+
+    expect(result).toEqual({ error: 'invalid url' })
+  })
+
+  it('returns undefined when the handler succeeds', async () => {
+    const controlWindow = new ControlWindow(configInfo)
+    const sender = (controlWindow.win as unknown as FakeBrowserWindow)
+      .webContents
+    controlWindow.setCommandHandler(async () => undefined)
+
+    const result = await ipcHandlers.get('control:command')!(
+      { sender },
+      { type: 'set-grid-size', cols: 2, rows: 2 },
+    )
+
+    expect(result).toBeUndefined()
+  })
+
+  it('ignores requests from a sender other than its own window', async () => {
+    const controlWindow = new ControlWindow(configInfo)
+    const handler = vi.fn().mockResolvedValue({ error: 'nope' })
+    controlWindow.setCommandHandler(handler)
+
+    const result = await ipcHandlers.get('control:command')!(
+      { sender: { send: vi.fn() } },
+      { type: 'ping' },
+    )
+
+    expect(result).toBeUndefined()
+    expect(handler).not.toHaveBeenCalled()
+  })
+})

--- a/packages/streamwall/src/main/ControlWindow.ts
+++ b/packages/streamwall/src/main/ControlWindow.ts
@@ -3,13 +3,17 @@ import EventEmitter from 'events'
 import { dirname } from 'node:path'
 import path from 'path'
 import { ControlCommand, StreamwallState } from 'streamwall-shared'
+import { type ControlCommandResult } from './commandDispatch'
 import { createExampleConfig } from './exampleConfig'
 import { loadHTML } from './loadHTML'
+
+export type ControlCommandHandler = (
+  command: ControlCommand,
+) => Promise<void | ControlCommandResult>
 
 export interface ControlWindowEventMap {
   load: []
   close: [ElectronEvent]
-  command: [ControlCommand]
   ydoc: [Uint8Array]
 }
 
@@ -21,6 +25,7 @@ export interface ConfigInfo {
 
 export default class ControlWindow extends EventEmitter<ControlWindowEventMap> {
   win: BrowserWindow
+  private commandHandler?: ControlCommandHandler
 
   constructor(configInfo: ConfigInfo) {
     super()
@@ -52,11 +57,14 @@ export default class ControlWindow extends EventEmitter<ControlWindowEventMap> {
       this.win.webContents.openDevTools()
     })
 
-    ipcMain.handle('control:command', (ev, command) => {
+    ipcMain.handle('control:command', async (ev, command) => {
       if (ev.sender !== this.win.webContents) {
         return
       }
-      this.emit('command', command)
+      if (!this.commandHandler) {
+        return
+      }
+      return this.commandHandler(command)
     })
 
     ipcMain.handle('control:ydoc', (ev, update) => {
@@ -89,6 +97,10 @@ export default class ControlWindow extends EventEmitter<ControlWindowEventMap> {
       // rather than being swallowed (#246).
       createExampleConfig(configInfo.configPath)
     })
+  }
+
+  setCommandHandler(handler: ControlCommandHandler) {
+    this.commandHandler = handler
   }
 
   onState(state: StreamwallState) {

--- a/packages/streamwall/src/main/commandDispatch.test.ts
+++ b/packages/streamwall/src/main/commandDispatch.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { afterEach, beforeEach, test, vi } from 'vitest'
 
-import { dispatchCommand } from './commandDispatch'
+import { dispatchCommand, dispatchLocalCommand } from './commandDispatch'
 import log from './logger'
 
 let unhandledRejections: unknown[] = []
@@ -55,4 +55,38 @@ test('dispatchCommand tags the logged error with the local source', async () => 
 
   const [message] = log.error.mock.calls[0]
   assert.match(message, /local/)
+})
+
+
+test('dispatchLocalCommand returns an error result from onCommand', async () => {
+  const onCommand = vi.fn().mockResolvedValue({ error: 'invalid url' })
+
+  const result = await dispatchLocalCommand(onCommand, {
+    type: 'browse',
+    url: 'file:///etc/passwd',
+  })
+
+  assert.deepEqual(result, { error: 'invalid url' })
+  assert.deepEqual(onCommand.mock.calls, [
+    [{ type: 'browse', url: 'file:///etc/passwd' }, 'local'],
+  ])
+})
+
+test('dispatchLocalCommand converts a rejection into an error result', async () => {
+  const err = new Error('boom')
+  const onCommand = vi.fn().mockRejectedValue(err)
+  vi.spyOn(log, 'error').mockImplementation(() => undefined)
+
+  const result = await dispatchLocalCommand(onCommand, { type: 'ping' })
+
+  assert.deepEqual(result, { error: 'boom' })
+  assert.equal(log.error.mock.calls.length, 1)
+})
+
+test('dispatchLocalCommand returns undefined when onCommand succeeds', async () => {
+  const onCommand = vi.fn().mockResolvedValue(undefined)
+
+  const result = await dispatchLocalCommand(onCommand, { type: 'ping' })
+
+  assert.equal(result, undefined)
 })

--- a/packages/streamwall/src/main/commandDispatch.test.ts
+++ b/packages/streamwall/src/main/commandDispatch.test.ts
@@ -57,7 +57,6 @@ test('dispatchCommand tags the logged error with the local source', async () => 
   assert.match(message, /local/)
 })
 
-
 test('dispatchLocalCommand returns an error result from onCommand', async () => {
   const onCommand = vi.fn().mockResolvedValue({ error: 'invalid url' })
 

--- a/packages/streamwall/src/main/commandDispatch.ts
+++ b/packages/streamwall/src/main/commandDispatch.ts
@@ -2,18 +2,47 @@ import log from './logger'
 
 export type CommandSource = 'local' | 'uplink'
 
-// onCommand is async and is invoked fire-and-forget from two event handlers:
-// the control window's 'command' event and the uplink WebSocket's 'message'
-// event. Neither awaits or catches it, so a rejecting downstream `await`
-// inside onCommand would otherwise escape as an unhandled promise rejection
-// for every dispatched command (issue #256). Routing both call sites through
-// here logs the failure instead.
+/** Mirrors the control-server `{ error }` response shape for local IPC (#388). */
+export type ControlCommandResult = { error: string }
+
+function commandErrorFromThrown(err: unknown): ControlCommandResult {
+  const message = err instanceof Error ? err.message : String(err)
+  return { error: message }
+}
+
+// onCommand is async and is invoked fire-and-forget from the uplink
+// WebSocket's 'message' event. That call site does not await or catch it,
+// so a rejecting downstream `await` inside onCommand would otherwise escape
+// as an unhandled promise rejection for every dispatched command (issue #256).
+// Routing the uplink call site through here logs the failure instead.
 export function dispatchCommand<Msg>(
-  onCommand: (msg: Msg, source: CommandSource) => Promise<void>,
+  onCommand: (
+    msg: Msg,
+    source: CommandSource,
+  ) => Promise<void | ControlCommandResult>,
   msg: Msg,
   source: CommandSource,
 ): void {
   onCommand(msg, source).catch((err) => {
     log.error(`Unhandled error while processing a ${source} command:`, err)
   })
+}
+
+/**
+ * Awaits a local control-window command and returns any `{ error }` result to
+ * the renderer over IPC, matching the WebSocket command contract (issue #388).
+ */
+export async function dispatchLocalCommand<Msg>(
+  onCommand: (
+    msg: Msg,
+    source: 'local',
+  ) => Promise<void | ControlCommandResult>,
+  msg: Msg,
+): Promise<void | ControlCommandResult> {
+  try {
+    return await onCommand(msg, 'local')
+  } catch (err) {
+    log.error('Unhandled error while processing a local command:', err)
+    return commandErrorFromThrown(err)
+  }
 }

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -30,7 +30,7 @@ import {
   sentryEnabledSwitchValue,
 } from '../sentryConfig'
 import { createSessionHostResolver, ensureValidURL } from '../util'
-import { dispatchCommand } from './commandDispatch'
+import { dispatchCommand, dispatchLocalCommand } from './commandDispatch'
 import {
   ConfigError,
   findUnknownConfigKeys,
@@ -633,7 +633,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   const onCommand = async (
     msg: ControlCommand,
     source: 'local' | 'uplink' = 'local',
-  ) => {
+  ): Promise<{ error: string } | void> => {
     log.debug('Received message:', msg)
 
     // The remote control-server uplink is untrusted: re-validate every command
@@ -716,6 +716,7 @@ async function main(argv: ReturnType<typeof parseArgs>) {
         } catch (error) {
           log.error('Invalid URL:', msg.url)
           log.error('Error:', error)
+          return { error: 'invalid url' }
         }
       } else if (msg.type === 'dev-tools') {
         log.debug('Opening DevTools for view:', msg.viewIdx)
@@ -859,8 +860,8 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   controlWindow.on('ydoc', (update) =>
     Y.applyUpdate(stateDoc, update, CONTROL_WINDOW_ORIGIN),
   )
-  controlWindow.on('command', (command) =>
-    dispatchCommand(onCommand, command, 'local'),
+  controlWindow.setCommandHandler((command) =>
+    dispatchLocalCommand(onCommand, command),
   )
 
   // Closing either top-level window quits the app, except on macOS where the


### PR DESCRIPTION
## Summary

- Switches local Electron control commands from fire-and-forget IPC to request/response IPC that returns `{ error?: string }`, matching the WebSocket control contract.
- Adds `dispatchLocalCommand` and `ControlWindow.setCommandHandler` so rejected commands (e.g. invalid browse URLs) reach `createErrorSurfacingSend` and `CommandErrorBanner`.
- Web client behavior is unchanged.

## Technical approach

Option A from the issue: the `control:command` IPC handler now awaits command dispatch and returns the result to the renderer. `onCommand` returns `{ error: 'invalid url' }` for rejected browse URLs; unexpected throws are converted to `{ error: message }` by `dispatchLocalCommand`.

## Testing

- `dispatchLocalCommand` unit tests (success, explicit error, thrown error)
- `ControlWindow` IPC tests (error round-trip, success, sender validation)
- Full workspace: `npm run lint`, `npm run typecheck`, `npm test`

## Risks

- Low: only the local IPC path changes; uplink dispatch remains fire-and-forget via `dispatchCommand`.

Closes #388

Made with [Cursor](https://cursor.com)