### PR TITLE
test(streamwall): add main-process orchestrator wiring coverage

### DIFF
--- a/packages/streamwall/src/main/configInitError.test.ts
+++ b/packages/streamwall/src/main/configInitError.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { ConfigError } from './config'
+import { resolveConfigInitError } from './configInitError'
+
+describe('resolveConfigInitError', () => {
+  it('returns a clean exit outcome for a ConfigError', () => {
+    const err = new ConfigError(
+      'Invalid config in "/tmp/config.toml": bad grid.cols',
+    )
+
+    expect(resolveConfigInitError(err)).toEqual({
+      action: 'exit',
+      message: err.message,
+      exitCode: 1,
+    })
+  })
+
+  it('rethrows unexpected errors', () => {
+    const err = new Error('disk full')
+
+    expect(resolveConfigInitError(err)).toEqual({ action: 'rethrow' })
+  })
+})

--- a/packages/streamwall/src/main/configInitError.ts
+++ b/packages/streamwall/src/main/configInitError.ts
@@ -1,0 +1,16 @@
+import { ConfigError } from './config'
+
+export type ConfigInitErrorOutcome =
+  { action: 'exit'; message: string; exitCode: 1 } | { action: 'rethrow' }
+
+/**
+ * Maps a config/bootstrap failure during app init to either a clean exit or a
+ * rethrow for unexpected errors.
+ */
+export function resolveConfigInitError(err: unknown): ConfigInitErrorOutcome {
+  if (err instanceof ConfigError) {
+    return { action: 'exit', message: err.message, exitCode: 1 }
+  }
+
+  return { action: 'rethrow' }
+}

--- a/packages/streamwall/src/main/controlEndpointConnection.test.ts
+++ b/packages/streamwall/src/main/controlEndpointConnection.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { decideControlEndpointConnection } from './controlEndpointConnection'
+
+describe('decideControlEndpointConnection', () => {
+  it('skips when no control endpoint is configured', () => {
+    expect(decideControlEndpointConnection(null)).toEqual({
+      action: 'skip',
+      reason: 'none',
+    })
+    expect(decideControlEndpointConnection(undefined)).toEqual({
+      action: 'skip',
+      reason: 'none',
+    })
+    expect(decideControlEndpointConnection('')).toEqual({
+      action: 'skip',
+      reason: 'none',
+    })
+  })
+
+  it('refuses an insecure remote endpoint', () => {
+    expect(
+      decideControlEndpointConnection('ws://example.com/streamwall/ws?token=x'),
+    ).toEqual({
+      action: 'skip',
+      reason: 'insecure',
+      endpoint: 'ws://example.com/streamwall/ws?token=x',
+    })
+  })
+
+  it('allows a secure wss endpoint', () => {
+    expect(
+      decideControlEndpointConnection(
+        'wss://control.example.com/streamwall/abc/ws?token=xyz',
+      ),
+    ).toEqual({
+      action: 'connect',
+      endpoint: 'wss://control.example.com/streamwall/abc/ws?token=xyz',
+    })
+  })
+
+  it('allows a loopback ws endpoint for local development', () => {
+    expect(decideControlEndpointConnection('ws://localhost:8080/ws')).toEqual({
+      action: 'connect',
+      endpoint: 'ws://localhost:8080/ws',
+    })
+  })
+})

--- a/packages/streamwall/src/main/controlEndpointConnection.ts
+++ b/packages/streamwall/src/main/controlEndpointConnection.ts
@@ -1,0 +1,24 @@
+import { isSecureControlEndpoint } from 'streamwall-shared'
+
+export type ControlEndpointConnectDecision =
+  | { action: 'skip'; reason: 'none' }
+  | { action: 'skip'; reason: 'insecure'; endpoint: string }
+  | { action: 'connect'; endpoint: string }
+
+/**
+ * Decides whether the desktop app should open a control-server uplink for the
+ * configured endpoint. Insecure remote ws:// endpoints are refused.
+ */
+export function decideControlEndpointConnection(
+  endpoint: string | null | undefined,
+): ControlEndpointConnectDecision {
+  if (!endpoint) {
+    return { action: 'skip', reason: 'none' }
+  }
+
+  if (!isSecureControlEndpoint(endpoint)) {
+    return { action: 'skip', reason: 'insecure', endpoint }
+  }
+
+  return { action: 'connect', endpoint }
+}

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -12,13 +12,9 @@ import {
   ControlCommand,
   DataSourceType,
   StreamwallState,
-  UplinkErrorReason,
   fullscreenViewContentMap,
-  isCommandAllowedFromUplink,
-  isSecureControlEndpoint,
   isSocketOpen,
   parseControlEndpoint,
-  parseUplinkError,
 } from 'streamwall-shared'
 import { updateElectronApp } from 'update-electron-app'
 import WebSocket from 'ws'
@@ -32,11 +28,12 @@ import {
 import { createSessionHostResolver, ensureValidURL } from '../util'
 import { dispatchCommand } from './commandDispatch'
 import {
-  ConfigError,
   findUnknownConfigKeys,
   parseConfigToml,
   validateConfig,
 } from './config'
+import { resolveConfigInitError } from './configInitError'
+import { decideControlEndpointConnection } from './controlEndpointConnection'
 import ControlWindow from './ControlWindow'
 import {
   CONTROL_WINDOW_ORIGIN,
@@ -75,25 +72,14 @@ import { flushStorage, loadStorage, safeUpdate } from './storage'
 import StreamdelayClient from './StreamdelayClient'
 import StreamWindow from './StreamWindow'
 import TwitchBot from './TwitchBot'
+import { checkUplinkCommandGate } from './uplinkCommandGate'
 import { UPLINK_ORIGIN, shouldForwardUpdateToUplink } from './uplinkEcho'
+import { routeUplinkWsMessage } from './uplinkMessageRouting'
 import { initializeViewsState } from './viewsStateInit'
 import {
   shouldHideInsteadOfQuit,
   shouldQuitOnAllWindowsClosed,
 } from './windowCloseBehavior'
-
-/**
- * Human-readable explanation logged when the control server refuses the uplink
- * connection. These `{error: '...'}` messages carry no command `type`, so
- * without this they would otherwise be logged by `onCommand` as a misleading
- * "disallowed command: undefined" (issue #300).
- */
-const UPLINK_ERROR_MESSAGE: Record<UplinkErrorReason, string> = {
-  unauthorized:
-    'the control server rejected the uplink token (invalid or expired)',
-  'already-connected':
-    'another Streamwall instance is already connected to the control server',
-}
 
 /**
  * Builds a WebSocket subclass for the control uplink.
@@ -639,12 +625,13 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     // The remote control-server uplink is untrusted: re-validate every command
     // against the uplink allowlist so a compromised or man-in-the-middled
     // server cannot drive code execution (browse/dev-tools) on the desktop.
-    if (source === 'uplink') {
-      const type = (msg as { type?: unknown } | null)?.type
-      if (typeof type !== 'string' || !isCommandAllowedFromUplink(type)) {
-        log.warn('Rejecting disallowed command from control uplink:', type)
-        return
-      }
+    const uplinkGate = checkUplinkCommandGate(msg, source)
+    if (!uplinkGate.allowed) {
+      log.warn(
+        'Rejecting disallowed command from control uplink:',
+        uplinkGate.type,
+      )
+      return
     }
 
     if (msg.type === 'set-listening-view') {
@@ -920,20 +907,23 @@ async function main(argv: ReturnType<typeof parseArgs>) {
       })
   })
 
+  const controlConnection = decideControlEndpointConnection(
+    argv.control.endpoint,
+  )
   if (
-    argv.control.endpoint &&
-    !isSecureControlEndpoint(argv.control.endpoint)
+    controlConnection.action === 'skip' &&
+    controlConnection.reason === 'insecure'
   ) {
     log.error(
-      `Refusing to connect to insecure control endpoint "${argv.control.endpoint}". ` +
+      `Refusing to connect to insecure control endpoint "${controlConnection.endpoint}". ` +
         'The control connection must use wss:// (or ws:// to a loopback host).',
     )
-  } else if (argv.control.endpoint) {
+  } else if (controlConnection.action === 'connect') {
     log.debug('Connecting to control server...')
     // Move the uplink secret out of the URL query string and into an
     // Authorization header so it never reaches server or proxy access logs.
     const { url: controlURL, authorization } = parseControlEndpoint(
-      argv.control.endpoint,
+      controlConnection.endpoint,
     )
     const ws = new ReconnectingWebSocket(controlURL, [], {
       WebSocket: makeControlWebSocket(authorization),
@@ -957,33 +947,23 @@ async function main(argv: ReturnType<typeof parseArgs>) {
       log.debug('Control WebSocket disconnected.')
     })
     ws.addEventListener('message', (ev) => {
-      if (ev.data instanceof ArrayBuffer) {
-        Y.applyUpdate(stateDoc, new Uint8Array(ev.data), UPLINK_ORIGIN)
-        return
+      const route = routeUplinkWsMessage(ev.data)
+      switch (route.kind) {
+        case 'yjs-update':
+          Y.applyUpdate(stateDoc, route.update, UPLINK_ORIGIN)
+          return
+        case 'parse-error':
+          log.warn('Failed to parse control WebSocket message:', route.error)
+          return
+        case 'uplink-error':
+          log.warn(
+            'Control server refused the uplink connection:',
+            route.message,
+          )
+          return
+        case 'command':
+          dispatchCommand(onCommand, route.message as ControlCommand, 'uplink')
       }
-
-      let msg
-      try {
-        msg = JSON.parse(ev.data)
-      } catch (err) {
-        log.warn('Failed to parse control WebSocket message:', err)
-        return
-      }
-
-      // The server sends `{error: '...'}` right before closing the uplink when
-      // it refuses the connection. These carry no command `type`, so surface
-      // the real reason here instead of letting onCommand's uplink allowlist
-      // reject them as a "disallowed command: undefined" (issue #300).
-      const uplinkError = parseUplinkError(msg)
-      if (uplinkError) {
-        log.warn(
-          'Control server refused the uplink connection:',
-          UPLINK_ERROR_MESSAGE[uplinkError],
-        )
-        return
-      }
-
-      dispatchCommand(onCommand, msg, 'uplink')
     })
     stateEmitter.on('state', () => {
       if (!isSocketOpen(ws)) {
@@ -1089,10 +1069,11 @@ function init() {
   try {
     argv = parseArgs()
   } catch (err) {
-    if (err instanceof ConfigError) {
+    const outcome = resolveConfigInitError(err)
+    if (outcome.action === 'exit') {
       // Surface the offending file/key/line cleanly instead of a stack trace.
-      log.error(err.message)
-      process.exit(1)
+      log.error(outcome.message)
+      process.exit(outcome.exitCode)
     }
     throw err
   }

--- a/packages/streamwall/src/main/uplinkCommandGate.test.ts
+++ b/packages/streamwall/src/main/uplinkCommandGate.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { checkUplinkCommandGate } from './uplinkCommandGate'
+
+describe('checkUplinkCommandGate', () => {
+  it('allows every command from the local control window', () => {
+    expect(checkUplinkCommandGate({ type: 'browse' }, 'local')).toEqual({
+      allowed: true,
+    })
+    expect(checkUplinkCommandGate({ type: 'dev-tools' }, 'local')).toEqual({
+      allowed: true,
+    })
+  })
+
+  it('allows an uplink command on the remote allowlist', () => {
+    expect(
+      checkUplinkCommandGate(
+        { type: 'set-listening-view', viewIdx: 0 },
+        'uplink',
+      ),
+    ).toEqual({ allowed: true })
+  })
+
+  it('rejects a forbidden uplink command with its type for logging', () => {
+    expect(checkUplinkCommandGate({ type: 'browse' }, 'uplink')).toEqual({
+      allowed: false,
+      type: 'browse',
+    })
+    expect(checkUplinkCommandGate({ type: 'dev-tools' }, 'uplink')).toEqual({
+      allowed: false,
+      type: 'dev-tools',
+    })
+    expect(checkUplinkCommandGate({ type: 'create-invite' }, 'uplink')).toEqual(
+      {
+        allowed: false,
+        type: 'create-invite',
+      },
+    )
+  })
+
+  it('rejects an uplink message with no command type (issue #300)', () => {
+    expect(checkUplinkCommandGate({}, 'uplink')).toEqual({
+      allowed: false,
+      type: undefined,
+    })
+    expect(checkUplinkCommandGate(null, 'uplink')).toEqual({
+      allowed: false,
+      type: undefined,
+    })
+    expect(checkUplinkCommandGate({ type: 42 }, 'uplink')).toEqual({
+      allowed: false,
+      type: 42,
+    })
+  })
+})

--- a/packages/streamwall/src/main/uplinkCommandGate.ts
+++ b/packages/streamwall/src/main/uplinkCommandGate.ts
@@ -1,0 +1,25 @@
+import { isCommandAllowedFromUplink } from 'streamwall-shared'
+import type { CommandSource } from './commandDispatch'
+
+export type UplinkCommandGateResult =
+  { allowed: true } | { allowed: false; type: unknown }
+
+/**
+ * Re-validates a command received over the remote control uplink against the
+ * uplink allowlist. Local control-window commands bypass this gate.
+ */
+export function checkUplinkCommandGate(
+  msg: unknown,
+  source: CommandSource,
+): UplinkCommandGateResult {
+  if (source !== 'uplink') {
+    return { allowed: true }
+  }
+
+  const type = (msg as { type?: unknown } | null)?.type
+  if (typeof type !== 'string' || !isCommandAllowedFromUplink(type)) {
+    return { allowed: false, type }
+  }
+
+  return { allowed: true }
+}

--- a/packages/streamwall/src/main/uplinkMessageRouting.test.ts
+++ b/packages/streamwall/src/main/uplinkMessageRouting.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  routeUplinkWsMessage,
+  UPLINK_ERROR_MESSAGE,
+} from './uplinkMessageRouting'
+
+describe('routeUplinkWsMessage', () => {
+  it('routes binary frames as Yjs updates', () => {
+    const bytes = new Uint8Array([1, 2, 3])
+    const buffer = bytes.buffer.slice(
+      bytes.byteOffset,
+      bytes.byteOffset + bytes.byteLength,
+    )
+
+    expect(routeUplinkWsMessage(buffer)).toEqual({
+      kind: 'yjs-update',
+      update: bytes,
+    })
+  })
+
+  it('routes a valid uplink command as a command message', () => {
+    expect(
+      routeUplinkWsMessage(
+        JSON.stringify({ type: 'set-view-blurred', viewIdx: 0, blurred: true }),
+      ),
+    ).toEqual({
+      kind: 'command',
+      message: { type: 'set-view-blurred', viewIdx: 0, blurred: true },
+    })
+  })
+
+  it('routes a control-server refusal before command dispatch (issue #300)', () => {
+    expect(
+      routeUplinkWsMessage(JSON.stringify({ error: 'unauthorized' })),
+    ).toEqual({
+      kind: 'uplink-error',
+      reason: 'unauthorized',
+      message: UPLINK_ERROR_MESSAGE.unauthorized,
+    })
+    expect(
+      routeUplinkWsMessage(
+        JSON.stringify({ error: 'streamwall already connected' }),
+      ),
+    ).toEqual({
+      kind: 'uplink-error',
+      reason: 'already-connected',
+      message: UPLINK_ERROR_MESSAGE['already-connected'],
+    })
+  })
+
+  it('routes malformed JSON as a parse error', () => {
+    const result = routeUplinkWsMessage('{not json')
+
+    expect(result.kind).toBe('parse-error')
+    if (result.kind === 'parse-error') {
+      expect(result.error).toBeInstanceOf(SyntaxError)
+    }
+  })
+})

--- a/packages/streamwall/src/main/uplinkMessageRouting.ts
+++ b/packages/streamwall/src/main/uplinkMessageRouting.ts
@@ -1,0 +1,50 @@
+import { parseUplinkError, type UplinkErrorReason } from 'streamwall-shared'
+
+/**
+ * Human-readable explanation logged when the control server refuses the uplink
+ * connection. These `{error: '...'}` messages carry no command `type`, so
+ * without this they would otherwise be logged by `onCommand` as a misleading
+ * "disallowed command: undefined" (issue #300).
+ */
+export const UPLINK_ERROR_MESSAGE: Record<UplinkErrorReason, string> = {
+  unauthorized:
+    'the control server rejected the uplink token (invalid or expired)',
+  'already-connected':
+    'another Streamwall instance is already connected to the control server',
+}
+
+export type UplinkWsMessageRoute =
+  | { kind: 'yjs-update'; update: Uint8Array }
+  | { kind: 'uplink-error'; reason: UplinkErrorReason; message: string }
+  | { kind: 'command'; message: unknown }
+  | { kind: 'parse-error'; error: unknown }
+
+/**
+ * Classifies an incoming control uplink WebSocket frame before the main process
+ * applies Yjs updates or dispatches commands.
+ */
+export function routeUplinkWsMessage(
+  data: ArrayBuffer | string,
+): UplinkWsMessageRoute {
+  if (data instanceof ArrayBuffer) {
+    return { kind: 'yjs-update', update: new Uint8Array(data) }
+  }
+
+  let message: unknown
+  try {
+    message = JSON.parse(data)
+  } catch (error) {
+    return { kind: 'parse-error', error }
+  }
+
+  const uplinkError = parseUplinkError(message)
+  if (uplinkError) {
+    return {
+      kind: 'uplink-error',
+      reason: uplinkError,
+      message: UPLINK_ERROR_MESSAGE[uplinkError],
+    }
+  }
+
+  return { kind: 'command', message }
+}


### PR DESCRIPTION
## Summary

Extracts the remaining glue logic from `packages/streamwall/src/main/index.ts` into four small, unit-tested modules so uplink/multiplayer wiring can be validated without launching Electron.

- **`uplinkCommandGate.ts`** — uplink command allowlist gate (forbidden commands rejected before dispatch)
- **`uplinkMessageRouting.ts`** — WebSocket frame routing (Yjs binary updates, JSON parse errors, server refusal messages, commands)
- **`controlEndpointConnection.ts`** — secure control endpoint connection decision
- **`configInitError.ts`** — clean `ConfigError` exit path during app init

`index.ts` now delegates to these modules; existing coverage for Yjs echo filtering (`controlWindowEcho`, `uplinkEcho`), command dispatch, and shared helpers remains unchanged.

## Architecture decisions

Pure routing/decision logic is extracted; the large `onCommand` switch and Electron lifecycle wiring stay in `index.ts` for now. This matches the issue's minimal-slice approach and avoids a risky full orchestrator refactor in one PR.

## Testing performed

- [x] `npm -w packages/streamwall test` — 451 tests pass (14 new)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test` (full workspace)

Priority scenarios covered by new tests:
- Forbidden uplink command rejected (with type preserved for logging)
- Uplink server refusal surfaced before command dispatch (issue #300)
- Insecure control endpoint refused; secure/loopback endpoints allowed
- Invalid config maps to clean exit outcome

Closes #389

Made with [Cursor](https://cursor.com)