### PR TITLE
ci: add Electron package smoke build to PR and release pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,30 @@ jobs:
       - uses: ./.github/actions/setup
       - run: npm -w streamwall-control-client run build
 
+  # Packaging smoke test for the Electron desktop app. Catches Vite/Forge
+  # misconfiguration, native module unpacking (bufferutil, utf-8-validate)
+  # and missing packaged assets at PR time instead of during a release,
+  # where the same failure burns runner minutes across three OS legs.
+  #
+  # `package` only, not `make`: it exercises the Vite builds, asar packing
+  # and native rebuild without paying for the maker-specific installer
+  # steps (Squirrel, deb, rpm), which are release concerns. Ubuntu alone is
+  # enough for a smoke test — the shared failure modes are OS-independent.
+  # Runtime: ~45 seconds (measured on ubuntu-latest, cached npm), and it runs
+  # in parallel with the other jobs, so wall-clock CI time is unchanged.
+  package:
+    name: Package smoke (Electron app)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - run: npm -w streamwall run package
+
   # End-to-end smoke tests: the control client in a real Chromium browser
   # against a real control server + fake Streamwall uplink. Linux-only (the
   # Playwright browser install with system deps is Linux-only), so this stays
@@ -167,7 +191,17 @@ jobs:
   ci-ok:
     name: CI OK
     if: ${{ !cancelled() }}
-    needs: [changes, checks, test, build, e2e, dependency-review, actionlint]
+    needs:
+      [
+        changes,
+        checks,
+        test,
+        build,
+        package,
+        e2e,
+        dependency-review,
+        actionlint,
+      ]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,8 @@ jobs:
   quality-gate:
     name: Quality gate
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Raised from 15 to cover the added packaging step.
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -32,6 +33,12 @@ jobs:
         run: npm run typecheck
       - name: Test
         run: npm test
+      # Packaging smoke test before the three-OS publish matrix fans out: a
+      # Vite/Forge misconfiguration or a native-module unpacking failure
+      # fails here once (~45 seconds) instead of three times in parallel,
+      # each after a full Electron download.
+      - name: Package smoke build
+        run: npm -w streamwall run package
 
   publish:
     name: Publish (${{ matrix.platform.name }})


### PR DESCRIPTION
## Problem

CI built the control-client web bundle but never compiled or packaged the Electron desktop app. `release.yml` jumped straight from lint/typecheck/test to `electron-forge publish` on tag push, so packaging failures surfaced only during releases — after the publish matrix had already fanned out across three OS legs, each having downloaded a full Electron binary.

Failure modes this leaves uncovered: Vite/Forge misconfiguration for a renderer entry point, native module unpacking (`bufferutil`, `utf-8-validate`), and missing assets in packaged `file://` loads.

## Solution

- **`ci.yml`**: new `package` job (Ubuntu, `npm -w streamwall run package`), wired into the `ci-ok` required check and gated on the existing `changes.outputs.code` filter so docs-only PRs still skip it.
- **`release.yml`**: the same step added to `quality-gate`, before the publish matrix. Job timeout raised 15 → 25 minutes to cover it.

## Decisions

- **`package`, not `make`.** `package` exercises the Vite builds, asar packing and native rebuild — the shared failure modes. `make` would add maker-specific installer steps (Squirrel, deb, rpm) that are release concerns and cost significantly more runner time for little extra smoke-test signal.
- **Ubuntu only.** The failure modes above are OS-independent; the three-OS matrix stays a release concern.
- **No artifact upload.** The issue lists it as optional. A packaged Electron app is a ~200 MB artifact per PR run, and Forge/Vite already write actionable build output to the job log, which is what a failing smoke test needs.

## Testing

- `npm -w streamwall run package` verified locally (macOS/arm64): completes in ~15 s with a warm `node_modules`, producing `packages/streamwall/out/` (gitignored).
- `npm run format:check` — clean.
- `actionlint 1.7.12` (same pinned image CI uses) run against both workflows — clean.

No unit tests: this change is workflow configuration with no runtime behaviour to assert on. Its verification is the CI run on this PR itself, where the new `Package smoke (Electron app)` job must go green.

## Duration impact

~45 seconds on ubuntu-latest with the npm cache warm (measured on this PR). In PR CI the job runs in parallel with the existing ones, so wall-clock CI time is essentially unchanged. In the release quality gate it is serial and adds ~45 seconds ahead of publish — paid once, against three parallel legs saved on failure. Documented inline in both workflow files.

## Risks

Low. Additive CI configuration; no production code touched. The one behavioural risk is a flaky packaging step blocking otherwise-good PRs — mitigated by the 20-minute job timeout and by `package` avoiding the more failure-prone maker steps.

Closes #400