### PR TITLE
feat(streamwall): stop HLS segment loading for parked views

### DIFF
--- a/packages/streamwall/src/preload/mediaParkEvents.ts
+++ b/packages/streamwall/src/preload/mediaParkEvents.ts
@@ -1,0 +1,14 @@
+// Same-document channel between mediaPreload.ts and the bundled HLS player
+// page (renderer/playHLS.ts), used to stop segment fetching for a parked view
+// rather than only pausing its <video> (issue #384).
+//
+// These must be dispatched on `document`, not `window`: under
+// contextIsolation the preload's isolated world has its own `window` object,
+// so a window-dispatched event never reaches the page's own listeners, while
+// DOM nodes -- `document` included -- are shared between the worlds.
+//
+// This file deliberately carries constants only. playHLS.ts is renderer
+// bundle code and must not pull in mediaPreload.ts's `electron` imports, so
+// the names cannot simply live there alongside the IPC handlers.
+export const MEDIA_PAUSE_EVENT = 'streamwall:media-pause'
+export const MEDIA_RESUME_EVENT = 'streamwall:media-resume'

--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -314,6 +314,58 @@ describe('mediaPreload pause/resume handling (issue #374)', () => {
     expect(video.paused).toBe(false)
   })
 
+  // The bundled HLS player page (renderer/playHLS.ts) keeps its hls.js
+  // instance in a closure the preload cannot reach, so pausing the <video>
+  // alone leaves segment fetching to taper off on its own. These events are
+  // the same-document channel that lets it call stopLoad()/startLoad()
+  // instead (issue #384).
+  function parkEventNames(): string[] {
+    const names: string[] = []
+    const record = (event: Event) => names.push(event.type)
+    document.addEventListener('streamwall:media-pause', record)
+    document.addEventListener('streamwall:media-resume', record)
+    return names
+  }
+
+  it('announces a pause to the page world so an HLS player can stop loading segments', async () => {
+    await loadAcquiredVideo()
+    const events = parkEventNames()
+
+    registeredHandler('pause')()
+
+    expect(events).toEqual(['streamwall:media-pause'])
+  })
+
+  it('announces a resume to the page world so an HLS player can start loading again', async () => {
+    await loadAcquiredVideo()
+    const events = parkEventNames()
+
+    registeredHandler('resume')()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(events).toEqual(['streamwall:media-resume'])
+  })
+
+  it('announces pause/resume even when no media element has been acquired yet', async () => {
+    invoke.mockResolvedValueOnce({
+      content: { kind: 'video', link: 'https://example.com/stream' },
+      options: {},
+      volume: 1,
+    })
+    await import('./mediaPreload')
+    process.emit('loaded' as never)
+    await vi.advanceTimersByTimeAsync(0)
+    const events = parkEventNames()
+
+    registeredHandler('pause')()
+    registeredHandler('resume')()
+
+    expect(events).toEqual([
+      'streamwall:media-pause',
+      'streamwall:media-resume',
+    ])
+  })
+
   it('does not throw when a pause/resume message arrives before any media has been acquired', async () => {
     invoke.mockResolvedValueOnce({
       content: { kind: 'video', link: 'https://example.com/stream' },

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer, webFrame } from 'electron'
 import throttle from 'lodash/throttle'
 import { ContentDisplayOptions } from 'streamwall-shared'
+import { MEDIA_PAUSE_EVENT, MEDIA_RESUME_EVENT } from './mediaParkEvents'
 import { VolumeController } from './volumeController'
 
 const SCAN_THROTTLE = 500
@@ -452,6 +453,11 @@ async function main() {
   // hidden behind a fullscreen expansion (issue #374). No-ops when no media
   // has been acquired yet (e.g. a 'web' kind view, or one still loading).
   ipcRenderer.on('pause', () => {
+    // Announced unconditionally, before the media guard below: the bundled
+    // HLS player page keeps its hls.js instance in a closure this preload
+    // cannot reach, and it should stop fetching segments whether or not a
+    // <video> has been acquired here yet (issue #384).
+    document.dispatchEvent(new CustomEvent(MEDIA_PAUSE_EVENT))
     if (!currentMedia) {
       return
     }
@@ -462,6 +468,7 @@ async function main() {
     HTMLMediaElement.prototype.pause.call(currentMedia)
   })
   ipcRenderer.on('resume', () => {
+    document.dispatchEvent(new CustomEvent(MEDIA_RESUME_EVENT))
     // Live streams are typically not seekable on-demand video, so resuming
     // after a pause may briefly re-buffer or land slightly behind the live
     // edge -- both cheaper than a full reload and expected to self-correct

--- a/packages/streamwall/src/renderer/playHLS.test.ts
+++ b/packages/streamwall/src/renderer/playHLS.test.ts
@@ -26,6 +26,7 @@ class MockHls {
   attachMedia = vi.fn()
   loadSource = vi.fn()
   startLoad = vi.fn()
+  stopLoad = vi.fn()
   recoverMediaError = vi.fn()
   destroy = vi.fn()
 
@@ -198,6 +199,38 @@ describe('playHLS', () => {
     window.dispatchEvent(new Event('pagehide'))
 
     expect(lastInstance!.destroy).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops hls.js segment loading when the view is parked (issue #384)', async () => {
+    setSrc('https://stream.example/live.m3u8')
+    await import('./playHLS')
+
+    document.dispatchEvent(new CustomEvent('streamwall:media-pause'))
+
+    expect(lastInstance!.stopLoad).toHaveBeenCalledTimes(1)
+    expect(lastInstance!.destroy).not.toHaveBeenCalled()
+  })
+
+  it('resumes hls.js segment loading when the parked view is unparked', async () => {
+    setSrc('https://stream.example/live.m3u8')
+    await import('./playHLS')
+
+    document.dispatchEvent(new CustomEvent('streamwall:media-pause'))
+    document.dispatchEvent(new CustomEvent('streamwall:media-resume'))
+
+    expect(lastInstance!.startLoad).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores park events after teardown instead of touching a destroyed instance', async () => {
+    setSrc('https://stream.example/live.m3u8')
+    await import('./playHLS')
+
+    window.dispatchEvent(new Event('pagehide'))
+    document.dispatchEvent(new CustomEvent('streamwall:media-pause'))
+    document.dispatchEvent(new CustomEvent('streamwall:media-resume'))
+
+    expect(lastInstance!.stopLoad).not.toHaveBeenCalled()
+    expect(lastInstance!.startLoad).not.toHaveBeenCalled()
   })
 
   it('falls back to native playback and appends the video once metadata loads', async () => {

--- a/packages/streamwall/src/renderer/playHLS.ts
+++ b/packages/streamwall/src/renderer/playHLS.ts
@@ -1,4 +1,8 @@
 import Hls, { ErrorTypes, Events, type ErrorData } from 'hls.js'
+import {
+  MEDIA_PAUSE_EVENT,
+  MEDIA_RESUME_EVENT,
+} from '../preload/mediaParkEvents'
 import type { StreamwallMediaGlobal } from '../preload/mediaPreload'
 
 declare global {
@@ -29,9 +33,27 @@ function loadWithHlsJs(src: string) {
   let fatalErrorRetries = 0
   let destroyed = false
 
+  // Dispatched on `document` by mediaPreload.ts when this view is parked
+  // behind a fullscreen expansion (issue #384). Pausing the <video> alone
+  // only lets segment fetching taper off once hls.js reaches its buffer
+  // target; stopLoad() ends it outright. startLoad() resumes from wherever
+  // hls.js's own live-edge logic lands, so no catch-up handling is needed.
+  const onPark = () => {
+    if (destroyed) return
+    hls.stopLoad()
+  }
+  const onUnpark = () => {
+    if (destroyed) return
+    hls.startLoad()
+  }
+  document.addEventListener(MEDIA_PAUSE_EVENT, onPark)
+  document.addEventListener(MEDIA_RESUME_EVENT, onUnpark)
+
   const teardown = () => {
     if (destroyed) return
     destroyed = true
+    document.removeEventListener(MEDIA_PAUSE_EVENT, onPark)
+    document.removeEventListener(MEDIA_RESUME_EVENT, onUnpark)
     hls.destroy()
   }
 


### PR DESCRIPTION
## Problem

`--park.pause` (opt-in, added in #383 for #374) pauses a parked view's `<video>`/`<audio>` element via `HTMLMediaElement.prototype.pause.call(...)`. That stops decoding and rendering, but for the app's bundled HLS player (`renderer/playHLS.ts`) it does **not** stop segment fetching outright — hls.js keeps loading until its own `maxBufferLength`/`maxMaxBufferLength` target is reached, so network cost only tapers off rather than ending.

This was deliberately scoped out of #383: the `Hls` instance lives in a closure inside `loadWithHlsJs()` and is not reachable from `mediaPreload.ts`, and the existing `window.streamwallMedia` bridge is one-way (page → preload, error reporting only).

## Solution

A same-document channel between preload and page:

- `mediaPreload.ts`'s `pause`/`resume` IPC handlers dispatch `streamwall:media-pause` / `streamwall:media-resume` on `document`.
- `playHLS.ts` listens for them and calls `hls.stopLoad()` / `hls.startLoad()` on its own instance.

## Architecture decisions

- **Dispatched on `document`, not `window`.** Under `contextIsolation` the preload's isolated world has its own `window` object, so a window-dispatched event never reaches the page's main-world listeners. DOM nodes — `document` included — are shared between worlds, which makes this the working channel.
- **Event names live in a dependency-free `preload/mediaParkEvents.ts`.** `playHLS.ts` is renderer bundle code and must not pull in `mediaPreload.ts`'s `electron` imports, so the constants cannot simply sit next to the IPC handlers (the existing import from that module is `import type` only, which erases at build time).
- **Dispatch happens before the `currentMedia` guard**, so an HLS page that has not yet had its `<video>` acquired by the preload still stops loading.
- **Listeners are removed in `teardown()`**, so a destroyed instance is never touched — belt-and-braces alongside the existing `destroyed` flag, which the handlers also check.
- **No catch-up logic on resume.** `hls.startLoad()` already resumes from wherever hls.js's own live-edge logic lands, as noted in the issue.

## Testing

TDD; all five new tests were watched failing first.

`playHLS.test.ts` (mock `Hls` gained a `stopLoad` spy):
- a pause event calls `stopLoad()` exactly once and does not destroy the instance
- a resume event calls `startLoad()`
- park events after `pagehide` teardown touch neither `stopLoad` nor `startLoad`

`mediaPreload.test.ts`:
- the `pause` IPC handler dispatches `streamwall:media-pause`
- the `resume` IPC handler dispatches `streamwall:media-resume`
- both are announced even when no media element has been acquired yet

Full gate green locally: `format:check`, `lint`, `typecheck`, `npm test`, `streamwall-control-client` build.

## Risks / breaking changes

None expected. The behaviour only activates behind the opt-in, default-off `--park.pause` flag, and only for the bundled HLS player page — remote stream views are unaffected beyond receiving two custom events they have no listeners for. No IPC surface changed.

Closes #384