### PR TITLE
docs: normalize license metadata across workspace packages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+## Quality gate
+
+Before opening a PR, run the same checks CI runs:
+
+```sh
+npm run lint
+npm run format:check
+npm run typecheck
+npm test
+```
+
+## License
+
+Streamwall is distributed under the [MIT License](LICENSE).
+
+- The copyright notice at the top of `LICENSE` must remain intact — it is a
+  condition of the license itself (see the "above copyright notice ... shall
+  be included" clause).
+- Every workspace `package.json` (root and each package under `packages/`)
+  must declare `"license": "MIT"`. This is enforced by
+  `test/workspace-metadata.test.mjs`, which runs as part of `npm test`.
+- Code adapted from other MIT-licensed projects must keep its original
+  attribution inline in the source (see
+  `packages/streamwall/src/renderer/TailSpin.tsx` for an example).
+- When adding a new production dependency, confirm its license permits
+  redistribution inside the packaged Electron app (MIT, Apache-2.0, BSD, and
+  ISC are all fine; anything copyleft, e.g. GPL/AGPL, needs discussion first).
+  Distributed release binaries do not currently bundle a consolidated
+  `THIRD_PARTY_NOTICES` file; each dependency's own license file remains the
+  source of truth via `node_modules`.

--- a/README.md
+++ b/README.md
@@ -333,3 +333,8 @@ temporary files for the Windows certificate and the Apple API key, and sets
 the corresponding `APPLE_*`/`WINDOWS_*` environment variables (see
 `packages/streamwall/forge.signing.ts`) before publishing. macOS and Windows
 signing are independent — provision either, both, or neither.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the local quality-gate commands
+and the license policy for workspace packages and dependencies.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "streamwall",
+  "license": "MIT",
   "engines": {
     "node": ">=22"
   },
@@ -10,7 +11,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "npm run typecheck --workspaces --if-present",
-    "test": "npm run test --workspaces --if-present"
+    "test": "node --test test/*.test.mjs && npm run test --workspaces --if-present"
   },
   "workspaces": [
     "packages/streamwall",

--- a/packages/streamwall-control-ui/package.json
+++ b/packages/streamwall-control-ui/package.json
@@ -2,6 +2,7 @@
   "name": "streamwall-control-ui",
   "private": true,
   "version": "0.0.0",
+  "license": "MIT",
   "type": "module",
   "main": "./src/index.tsx",
   "dependencies": {

--- a/packages/streamwall-shared/package.json
+++ b/packages/streamwall-shared/package.json
@@ -2,6 +2,7 @@
   "name": "streamwall-shared",
   "private": true,
   "version": "0.0.0",
+  "license": "MIT",
   "type": "module",
   "main": "./src/index.ts",
   "scripts": {

--- a/test/workspace-metadata.test.mjs
+++ b/test/workspace-metadata.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)))
+
+function readPackageJson(relativePath) {
+  return JSON.parse(readFileSync(join(rootDir, relativePath), 'utf8'))
+}
+
+test('every workspace package.json declares the MIT license', () => {
+  const rootPackageJson = readPackageJson('package.json')
+  const packageJsonPaths = [
+    'package.json',
+    ...rootPackageJson.workspaces.map((workspace) =>
+      join(workspace, 'package.json'),
+    ),
+  ]
+
+  for (const relativePath of packageJsonPaths) {
+    const { license } = readPackageJson(relativePath)
+    assert.equal(license, 'MIT', `${relativePath} is missing "license": "MIT"`)
+  }
+})


### PR DESCRIPTION
## Problem

Several workspace `package.json` files were missing the `license` field even
though the repo is MIT-licensed (`LICENSE`, README badge) and other packages
already declared it: root, `streamwall-shared`, and `streamwall-control-ui`.
There was also no documented policy for keeping this metadata consistent or
for third-party license compatibility in release binaries.

## Solution

- Add `"license": "MIT"` to root, `streamwall-shared`, and
  `streamwall-control-ui` package.json files.
- Add `test/workspace-metadata.test.mjs`, a Node test-runner regression test
  that reads the root `package.json` workspaces list and asserts every
  package.json (root + each workspace) declares `"license": "MIT"`. Wired
  into the root `test` script (`node --test test/*.test.mjs && ...`), so it
  runs in CI via the existing `npm test` invocation.
- Add `CONTRIBUTING.md` documenting the license policy: the `LICENSE`
  copyright line must stay intact, workspace packages must declare MIT
  (enforced by the new test), inline third-party attribution is required
  (using the existing `TailSpin.tsx` inlining as precedent), and new
  production dependencies must be license-compatible with MIT distribution
  since release binaries don't currently ship a consolidated
  `THIRD_PARTY_NOTICES` file.
- Link `CONTRIBUTING.md` from the README.

## Architecture decisions

- Used Node's built-in `node:test` + `node:assert` for the new regression
  test instead of adding a test framework dependency for a single
  assertion — the root package has no existing test runner, and Node 22
  (already required by `engines.node`) ships this natively.
- Derived the list of package.json paths to check from the root
  package.json's `workspaces` array rather than hardcoding paths, so a
  newly added workspace package is automatically covered.
- Did not add automated `THIRD_PARTY_NOTICES` generation or a
  `license-checker` CI step (mentioned as optional in the issue) — scoped
  this PR to the required acceptance criteria and documented the policy
  instead; the tooling is a reasonable follow-up if it's ever needed.

## Testing performed

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm test` (new root test + all workspace suites, 396 tests total)
- `npm -w streamwall-control-client run build`

## Risks / breaking changes

None — this is metadata and documentation only; no runtime behavior
changes.

Closes #414