### PR TITLE
test(streamwall): cover preload IPC bridges (control, layer, sentry)

### DIFF
--- a/packages/streamwall/src/preload/controlPreload.test.ts
+++ b/packages/streamwall/src/preload/controlPreload.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const invoke = vi.fn()
+const on = vi.fn()
+const off = vi.fn()
+const exposeInMainWorld = vi.fn()
+
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld },
+  ipcRenderer: { invoke, on, off },
+}))
+
+// sentryPreload has its own dedicated test coverage; stub it here so
+// controlPreload tests exercise only the bridge this file declares.
+vi.mock('./sentryPreload', () => ({}))
+
+type ControlApi = {
+  load: () => unknown
+  openDevTools: () => unknown
+  invokeCommand: (msg: object) => unknown
+  updateYDoc: (update: Uint8Array) => unknown
+  getFirstRunInfo: () => unknown
+  openConfigFolder: () => unknown
+  createExampleConfig: () => unknown
+  onState: (handleState: (state: unknown) => void) => () => void
+  onYDoc: (handleUpdate: (update: Uint8Array) => void) => () => void
+}
+
+function importedControlApi(): ControlApi {
+  const call = exposeInMainWorld.mock.calls.find(
+    ([name]) => name === 'streamwallControl',
+  )
+  if (!call) throw new Error('streamwallControl was not exposed')
+  return call[1] as ControlApi
+}
+
+afterEach(() => {
+  vi.resetModules()
+  invoke.mockClear()
+  on.mockClear()
+  off.mockClear()
+  exposeInMainWorld.mockClear()
+})
+
+describe('controlPreload bridge shape', () => {
+  it('exposes exactly the expected keys on streamwallControl', async () => {
+    await import('./controlPreload')
+
+    expect(Object.keys(importedControlApi()).sort()).toEqual(
+      [
+        'createExampleConfig',
+        'getFirstRunInfo',
+        'invokeCommand',
+        'load',
+        'onState',
+        'onYDoc',
+        'openConfigFolder',
+        'openDevTools',
+        'updateYDoc',
+      ].sort(),
+    )
+  })
+})
+
+describe('controlPreload channel wiring', () => {
+  it('forwards invokeCommand payloads unchanged to control:command', async () => {
+    await import('./controlPreload')
+    const msg = { type: 'set-view', id: 'abc' }
+
+    importedControlApi().invokeCommand(msg)
+
+    expect(invoke).toHaveBeenCalledWith('control:command', msg)
+  })
+
+  it('forwards updateYDoc payloads unchanged to control:ydoc', async () => {
+    await import('./controlPreload')
+    const update = new Uint8Array([1, 2, 3])
+
+    importedControlApi().updateYDoc(update)
+
+    expect(invoke).toHaveBeenCalledWith('control:ydoc', update)
+  })
+
+  it.each([
+    ['load', 'control:load'],
+    ['openDevTools', 'control:devtools'],
+    ['getFirstRunInfo', 'control:first-run-info'],
+    ['openConfigFolder', 'control:open-config-folder'],
+    ['createExampleConfig', 'control:create-example-config'],
+  ] as const)('invokes %s on the %s channel', async (method, channel) => {
+    await import('./controlPreload')
+
+    importedControlApi()[method]()
+
+    expect(invoke).toHaveBeenCalledWith(channel)
+  })
+})
+
+describe('controlPreload onState listener lifecycle', () => {
+  it('subscribes to the state IPC channel and forwards the state payload', async () => {
+    await import('./controlPreload')
+    const handleState = vi.fn()
+
+    importedControlApi().onState(handleState)
+
+    expect(on).toHaveBeenCalledWith('state', expect.any(Function))
+    const [, internalHandler] = on.mock.calls.find(([ch]) => ch === 'state')!
+    const state = { streams: [] }
+    internalHandler({}, state)
+
+    expect(handleState).toHaveBeenCalledWith(state)
+  })
+
+  it('removes the same listener it registered when unsubscribed', async () => {
+    await import('./controlPreload')
+
+    const unsubscribe = importedControlApi().onState(vi.fn())
+    const [, internalHandler] = on.mock.calls.find(([ch]) => ch === 'state')!
+
+    unsubscribe()
+
+    expect(off).toHaveBeenCalledWith('state', internalHandler)
+  })
+})
+
+describe('controlPreload onYDoc listener lifecycle', () => {
+  it('subscribes to the ydoc IPC channel and forwards the update payload', async () => {
+    await import('./controlPreload')
+    const handleUpdate = vi.fn()
+
+    importedControlApi().onYDoc(handleUpdate)
+
+    expect(on).toHaveBeenCalledWith('ydoc', expect.any(Function))
+    const [, internalHandler] = on.mock.calls.find(([ch]) => ch === 'ydoc')!
+    const update = new Uint8Array([9, 8, 7])
+    internalHandler({}, update)
+
+    expect(handleUpdate).toHaveBeenCalledWith(update)
+  })
+
+  it('removes the same listener it registered when unsubscribed', async () => {
+    await import('./controlPreload')
+
+    const unsubscribe = importedControlApi().onYDoc(vi.fn())
+    const [, internalHandler] = on.mock.calls.find(([ch]) => ch === 'ydoc')!
+
+    unsubscribe()
+
+    expect(off).toHaveBeenCalledWith('ydoc', internalHandler)
+  })
+})

--- a/packages/streamwall/src/preload/layerPreload.test.ts
+++ b/packages/streamwall/src/preload/layerPreload.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const invoke = vi.fn()
+const send = vi.fn()
+const on = vi.fn()
+const off = vi.fn()
+const exposeInMainWorld = vi.fn()
+
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld },
+  ipcRenderer: { invoke, send, on, off },
+}))
+
+// sentryPreload has its own dedicated test coverage; stub it here so
+// layerPreload tests exercise only the bridge this file declares.
+vi.mock('./sentryPreload', () => ({}))
+
+type LayerApi = {
+  openDevTools: () => unknown
+  load: () => unknown
+  onState: (handleState: (state: unknown) => void) => () => void
+}
+
+function importedLayerApi(): LayerApi {
+  const call = exposeInMainWorld.mock.calls.find(
+    ([name]) => name === 'streamwallLayer',
+  )
+  if (!call) throw new Error('streamwallLayer was not exposed')
+  return call[1] as LayerApi
+}
+
+afterEach(() => {
+  vi.resetModules()
+  invoke.mockClear()
+  send.mockClear()
+  on.mockClear()
+  off.mockClear()
+  exposeInMainWorld.mockClear()
+})
+
+describe('layerPreload bridge shape', () => {
+  it('exposes exactly the expected keys on streamwallLayer', async () => {
+    await import('./layerPreload')
+
+    expect(Object.keys(importedLayerApi()).sort()).toEqual(
+      ['load', 'onState', 'openDevTools'].sort(),
+    )
+  })
+
+  it('does not expose any Node/Electron globals beyond the declared streamwallLayer bridge', async () => {
+    await import('./layerPreload')
+
+    expect(exposeInMainWorld).toHaveBeenCalledTimes(1)
+    expect(exposeInMainWorld).toHaveBeenCalledWith(
+      'streamwallLayer',
+      expect.any(Object),
+    )
+  })
+})
+
+describe('layerPreload channel wiring', () => {
+  it('sends devtools-overlay (fire-and-forget) instead of invoking it', async () => {
+    await import('./layerPreload')
+
+    importedLayerApi().openDevTools()
+
+    expect(send).toHaveBeenCalledWith('devtools-overlay')
+    expect(invoke).not.toHaveBeenCalled()
+  })
+
+  it('invokes layer:load', async () => {
+    await import('./layerPreload')
+
+    importedLayerApi().load()
+
+    expect(invoke).toHaveBeenCalledWith('layer:load')
+  })
+})
+
+describe('layerPreload onState listener lifecycle', () => {
+  it('subscribes to the state IPC channel and forwards the state payload', async () => {
+    await import('./layerPreload')
+    const handleState = vi.fn()
+
+    importedLayerApi().onState(handleState)
+
+    expect(on).toHaveBeenCalledWith('state', expect.any(Function))
+    const [, internalHandler] = on.mock.calls.find(([ch]) => ch === 'state')!
+    const state = { streams: [] }
+    internalHandler({}, state)
+
+    expect(handleState).toHaveBeenCalledWith(state)
+  })
+
+  it('removes the same listener it registered when unsubscribed', async () => {
+    await import('./layerPreload')
+
+    const unsubscribe = importedLayerApi().onState(vi.fn())
+    const [, internalHandler] = on.mock.calls.find(([ch]) => ch === 'state')!
+
+    unsubscribe()
+
+    expect(off).toHaveBeenCalledWith('state', internalHandler)
+  })
+})

--- a/packages/streamwall/src/preload/sentryPreload.test.ts
+++ b/packages/streamwall/src/preload/sentryPreload.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const exposeInMainWorld = vi.fn()
+
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld },
+}))
+
+// The real module hooks up @sentry/electron's own IPC transport as a side
+// effect of being imported. That wiring is third-party behavior, not this
+// file's own logic, so it's stubbed out to isolate sentryPreload's own
+// contribution: exposing `sentryEnabled` from the --sentry-enabled=true arg.
+vi.mock('@sentry/electron/preload', () => ({}))
+
+const ORIGINAL_ARGV = process.argv
+
+afterEach(() => {
+  vi.resetModules()
+  exposeInMainWorld.mockClear()
+  process.argv = ORIGINAL_ARGV
+})
+
+describe('sentryPreload', () => {
+  it('exposes sentryEnabled=true when --sentry-enabled=true is present in argv', async () => {
+    process.argv = [...ORIGINAL_ARGV, '--sentry-enabled=true']
+
+    await import('./sentryPreload')
+
+    expect(exposeInMainWorld).toHaveBeenCalledWith('sentryEnabled', true)
+  })
+
+  it('exposes sentryEnabled=false when the switch is absent from argv', async () => {
+    process.argv = ORIGINAL_ARGV
+
+    await import('./sentryPreload')
+
+    expect(exposeInMainWorld).toHaveBeenCalledWith('sentryEnabled', false)
+  })
+
+  it('exposes sentryEnabled=false when the switch is present but set to false', async () => {
+    process.argv = [...ORIGINAL_ARGV, '--sentry-enabled=false']
+
+    await import('./sentryPreload')
+
+    expect(exposeInMainWorld).toHaveBeenCalledWith('sentryEnabled', false)
+  })
+})


### PR DESCRIPTION
## Problem

Preload scripts define the **only** JavaScript API exposed to renderer processes via `contextBridge`. `mediaPreload.ts` and `volumeController.ts` already had tests, but `controlPreload.ts`, `layerPreload.ts`, and `sentryPreload.ts` had none — despite exposing IPC surfaces that accept operator commands and Yjs binary updates. `controlPreload.ts` in particular is the trust boundary between the control UI and the main process, so changes to exposed methods, listener cleanup, or payload forwarding were unguarded.

## Solution

Added Vitest coverage for all three untested preload scripts, following the existing `mediaPreload.test.ts` pattern (mocked `electron` module, `exposeInMainWorld` capture helper):

- **`controlPreload.test.ts`** — snapshots the exact key set exposed on `window.streamwallControl`; verifies `invokeCommand`/`updateYDoc` forward their payload unchanged to `control:command`/`control:ydoc`; verifies every other method invokes its correct IPC channel; verifies `onState`/`onYDoc` register a listener that forwards the payload and that the returned unsubscribe function removes that exact listener.
- **`layerPreload.test.ts`** — snapshots the `window.streamwallLayer` bridge shape; asserts `exposeInMainWorld` is called exactly once (nothing beyond the declared bridge is exposed); verifies `openDevTools` uses `send` (fire-and-forget) rather than `invoke`; verifies `load` and the `onState` subscribe/unsubscribe lifecycle.
- **`sentryPreload.test.ts`** — verifies `sentryEnabled` on the main world reflects `isSentryEnabledArg(process.argv)` for the present/absent/explicitly-false cases.

`./sentryPreload` and `@sentry/electron/preload` (both side-effect-only imports) are stubbed via `vi.mock` in the control/layer tests so each file's own bridge is tested in isolation from the sentry wiring, which gets its own dedicated test.

No production code changed — this is test-only coverage for existing behavior, so TDD's red step isn't applicable per the skill's documented exception, though each test was verified to assert on real mocked call sites (channel names, listener add/remove pairs) rather than the trivial always-true.

## Testing performed

- `npm -w streamwall test` — new files: 21/21 passing; full package suite: 478/478 passing
- `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` (all workspaces) — all clean

## Risks / breaking changes

None — test-only change, no production code touched.

Closes #390