### PR TITLE
feat(control-server): report version and notify about new releases

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -44,6 +44,12 @@ STREAMWALL_TRUST_PROXY=true
 #STREAMWALL_WS_MSG_RATE=100
 #STREAMWALL_WS_MSG_BURST=1000
 
+# Optional: the daily check against the GitHub Releases API that logs when a
+# newer control-server release exists (see docs/self-hosting.md). It only ever
+# notifies -- the server never updates itself. Set to false for a deployment
+# that must make no outbound connections at all.
+#STREAMWALL_UPDATE_CHECK=false
+
 # Optional: crash reporting to your own Sentry project (off by default).
 #STREAMWALL_SENTRY_ENABLED=true
 #STREAMWALL_SENTRY_DSN=

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -121,6 +121,54 @@ for the bundled stack.
   trust proxy if the process is reachable directly from the internet without
   a trusted reverse proxy in front.
 
+## Version and update notifications
+
+The server prints its version on every start:
+
+```sh
+docker compose logs control-server | grep 'Starting streamwall-control-server'
+```
+
+```
+Starting streamwall-control-server 0.9.1
+```
+
+Once a day it asks the GitHub Releases API whether a newer release exists,
+and logs a single line per newly discovered version:
+
+```
+⬆️  streamwall-control-server 1.0.0 is available (running 0.9.1): https://github.com/NilsR0711/streamwall/releases/tag/v1.0.0
+```
+
+The same information is available to a signed-in **admin** at
+`GET /admin/status` (any other role, or no session, gets a `403`):
+
+```json
+{
+  "version": "0.9.1",
+  "latestVersion": "1.0.0",
+  "updateAvailable": true,
+  "releaseUrl": "https://github.com/NilsR0711/streamwall/releases/tag/v1.0.0",
+  "lastCheckedAt": "2026-07-20T09:00:00.000Z",
+  "checkEnabled": true
+}
+```
+
+This is **notify-only** — the server never updates itself. Applying an
+update is deliberately a decision you make (see below); an unattended
+rebuild-and-restart would drop live uplink and client connections at an
+arbitrary moment.
+
+The check is the server's only outbound connection. To run fully
+egress-free, disable it in `.env`:
+
+```sh
+STREAMWALL_UPDATE_CHECK=false
+```
+
+`updateAvailable` then stays `false` and `checkEnabled` reports `false`, so
+the endpoint still tells you the running version.
+
 ## Updating
 
 ```sh
@@ -131,7 +179,23 @@ docker compose up -d --build
 ```
 
 The `control-server-data` volume (and its `storage.json` inside) is
-untouched by rebuilds.
+untouched by rebuilds, so uplink and session tokens survive. Back that
+volume up before updating if you cannot afford to re-issue them:
+
+```sh
+docker compose stop control-server
+docker run --rm -v deploy_control-server-data:/data -v "$PWD:/backup" \
+  busybox tar czf /backup/streamwall-data-backup.tar.gz -C /data .
+docker compose up -d
+```
+
+Expect a short interruption while the container restarts: the desktop app
+and any web clients reconnect on their own, and the wall keeps rendering
+locally throughout (the Electron app composites the video, not the server).
+
+Check the release notes linked from the log line above before updating —
+they call out any change to the on-disk state format or to required
+environment variables.
 
 ## Troubleshooting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15380,7 +15380,7 @@
       }
     },
     "packages/streamwall-control-server": {
-      "version": "1.0.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@fastify/cookie": "^11.1.2",

--- a/packages/streamwall-control-server/README.md
+++ b/packages/streamwall-control-server/README.md
@@ -61,6 +61,33 @@ The Content-Security-Policy is kept compatible with the served control client.
 `upgrade-insecure-requests` is only emitted when `STREAMWALL_CONTROL_URL` uses
 `https`, so the plain-`http` local setup keeps working over `ws://`.
 
+### Update notifications
+
+The server logs its version at startup and, once a day, checks the GitHub
+Releases API for a newer release. It only ever notifies — it never updates
+itself. A signed-in **admin** can read the same state from
+`GET /admin/status` (`403` for every other role and for anonymous requests):
+
+```json
+{
+  "version": "0.9.1",
+  "latestVersion": "1.0.0",
+  "updateAvailable": true,
+  "releaseUrl": "https://github.com/NilsR0711/streamwall/releases/tag/v1.0.0",
+  "lastCheckedAt": "2026-07-20T09:00:00.000Z",
+  "checkEnabled": true
+}
+```
+
+| Variable                  | Default | Description                                                                                                    |
+| ------------------------- | ------- | -------------------------------------------------------------------------------------------------------------- |
+| `STREAMWALL_UPDATE_CHECK` | on      | Set to `false`/`0`/`no`/`off` to disable the release check. `/admin/status` still reports the running version. |
+
+This check is the server's only outbound connection; a failed check (offline
+host, rate limit, malformed response) is non-fatal and simply leaves the last
+known result in place. See
+[`docs/self-hosting.md`](../../docs/self-hosting.md) for the update procedure.
+
 ### Telemetry
 
 Crash reporting to [Sentry](https://sentry.io) (via `@sentry/node`) is

--- a/packages/streamwall-control-server/package.json
+++ b/packages/streamwall-control-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamwall-control-server",
-  "version": "1.0.0",
+  "version": "0.9.1",
   "description": "Multiplayer Streamwall: backend",
   "main": "src/index.ts",
   "type": "module",

--- a/packages/streamwall-control-server/src/adminStatus.test.ts
+++ b/packages/streamwall-control-server/src/adminStatus.test.ts
@@ -1,0 +1,165 @@
+import assert from 'node:assert/strict'
+import { after, describe, test } from 'node:test'
+import type { StreamwallRole } from 'streamwall-shared'
+
+import { SESSION_COOKIE_NAME } from './index.ts'
+import { buildTestApp } from './testHelpers.ts'
+import type { UpdateChecker, UpdateStatus } from './updateCheck.ts'
+
+/** A checker stub returning a fixed status, so the route never hits the network. */
+function stubUpdateChecker(status: Partial<UpdateStatus> = {}): UpdateChecker {
+  const full: UpdateStatus = {
+    version: '0.9.1',
+    latestVersion: '1.0.0',
+    updateAvailable: true,
+    releaseUrl: 'https://example.test/releases/v1.0.0',
+    lastCheckedAt: '2026-07-20T00:00:00.000Z',
+    checkEnabled: true,
+    ...status,
+  }
+  return {
+    getStatus: () => full,
+    checkNow: async () => full,
+    start: async () => {},
+    stop: () => {},
+  }
+}
+
+/** Builds an app and returns a session cookie header for the given role. */
+async function appWithSession(
+  role: StreamwallRole,
+  updateChecker: UpdateChecker = stubUpdateChecker(),
+) {
+  const { app, auth } = await buildTestApp({ updateChecker })
+  after(() => app.close())
+
+  const { tokenId, secret } = await auth.createToken({
+    kind: 'session',
+    role,
+    name: `${role} session`,
+  })
+
+  return { app, cookie: `${SESSION_COOKIE_NAME}=${tokenId}:${secret}` }
+}
+
+describe('GET /admin/status', () => {
+  test('rejects an admin cookie minted by a different server instance', async () => {
+    const { app } = await appWithSession('admin')
+    const { cookie } = await appWithSession('admin')
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/admin/status',
+      headers: { cookie },
+    })
+
+    assert.equal(
+      response.statusCode,
+      403,
+      'a cookie from another app must not authorize',
+    )
+  })
+
+  test('serves the update status for an admin session', async () => {
+    const { app, cookie } = await appWithSession('admin')
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/admin/status',
+      headers: { cookie },
+    })
+
+    assert.equal(response.statusCode, 200)
+    assert.deepEqual(response.json(), {
+      version: '0.9.1',
+      latestVersion: '1.0.0',
+      updateAvailable: true,
+      releaseUrl: 'https://example.test/releases/v1.0.0',
+      lastCheckedAt: '2026-07-20T00:00:00.000Z',
+      checkEnabled: true,
+    })
+  })
+
+  test('reports a disabled check without inventing an update', async () => {
+    const { app, cookie } = await appWithSession(
+      'admin',
+      stubUpdateChecker({
+        latestVersion: null,
+        updateAvailable: false,
+        releaseUrl: null,
+        lastCheckedAt: null,
+        checkEnabled: false,
+      }),
+    )
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/admin/status',
+      headers: { cookie },
+    })
+
+    assert.equal(response.statusCode, 200)
+    assert.equal(response.json().checkEnabled, false)
+    assert.equal(response.json().updateAvailable, false)
+  })
+
+  test('is denied to non-admin roles', async () => {
+    for (const role of ['operator', 'monitor'] as const) {
+      const { app, cookie } = await appWithSession(role)
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/admin/status',
+        headers: { cookie },
+      })
+
+      assert.equal(
+        response.statusCode,
+        403,
+        `${role} must not read server status`,
+      )
+      assert.equal(response.body, '')
+    }
+  })
+
+  test('is denied without a session cookie', async () => {
+    const { app } = await appWithSession('admin')
+
+    const response = await app.inject({ method: 'GET', url: '/admin/status' })
+
+    assert.equal(response.statusCode, 403)
+  })
+
+  test('is denied for an invite token presented as a session cookie', async () => {
+    const { app, auth } = await buildTestApp({
+      updateChecker: stubUpdateChecker(),
+    })
+    after(() => app.close())
+
+    const { tokenId, secret } = await auth.createToken({
+      kind: 'invite',
+      role: 'admin',
+      name: 'invite',
+    })
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/admin/status',
+      headers: { cookie: `${SESSION_COOKIE_NAME}=${tokenId}:${secret}` },
+    })
+
+    assert.equal(response.statusCode, 403)
+  })
+
+  test('never caches the status response', async () => {
+    const { app, cookie } = await appWithSession('admin')
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/admin/status',
+      headers: { cookie },
+    })
+
+    assert.match(String(response.headers['cache-control']), /no-store/)
+  })
+})

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -33,6 +33,11 @@ import {
   type DocUpdateLimits,
 } from './stateDocGuard.ts'
 import { loadStorage, type StorageDB } from './storage.ts'
+import {
+  createUpdateChecker,
+  SERVER_VERSION,
+  type UpdateChecker,
+} from './updateCheck.ts'
 
 export const SESSION_COOKIE_NAME = 's'
 // `@fastify/cookie` serializes `maxAge` into the RFC 6265 `Max-Age` attribute,
@@ -308,6 +313,7 @@ export async function initApp({
   sentryEnabled: injectedSentryEnabled,
   sentryClient,
   trustProxy: injectedTrustProxy,
+  updateChecker: injectedUpdateChecker,
 }: AppOptions & {
   db?: StorageDB
   /** Test-only override so specs can exercise Sentry-enabled paths without a real DSN. */
@@ -316,6 +322,8 @@ export async function initApp({
   sentryClient?: SentryCaptureClient
   /** Test-only override for Fastify trustProxy (else STREAMWALL_TRUST_PROXY / false). */
   trustProxy?: boolean | string
+  /** Injectable so specs exercise `/admin/status` without reaching GitHub. */
+  updateChecker?: UpdateChecker
 }) {
   const expectedOrigin = new URL(baseURL).origin
   const clients = new Map<string, Client>()
@@ -326,6 +334,7 @@ export async function initApp({
 
   const db = injectedDb ?? (await loadStorage())
   const auth = new Auth(db.data.auth)
+  const updateChecker = injectedUpdateChecker ?? createUpdateChecker()
 
   const trustProxy =
     injectedTrustProxy ?? parseTrustProxy(process.env.STREAMWALL_TRUST_PROXY)
@@ -666,6 +675,19 @@ export async function initApp({
       }
     })
 
+    // Deployment status for self-hosters (issue #382): the running version
+    // plus whether a newer release exists. Admin-only — the version of a
+    // publicly reachable server is exactly the kind of detail that helps
+    // someone shop for a known vulnerability, so it stays behind auth.
+    fastify.get('/admin/status', async (request, reply) => {
+      if (!roleCan(request.identity?.role ?? null, 'view-server-status')) {
+        return reply.code(403).send()
+      }
+      return reply
+        .header('cache-control', 'no-store')
+        .send(updateChecker.getStatus())
+    })
+
     // Serve frontend assets
     await fastify.register(fastifyStatic, {
       root: clientStaticPath,
@@ -868,7 +890,7 @@ export async function initApp({
     currentStreamwallConn?.clientState.update({ auth: auth.getState() })
   })
 
-  return { app, db, auth }
+  return { app, db, auth, updateChecker }
 }
 
 /** Builds the uplink WebSocket endpoint URL, which never embeds the secret. */
@@ -1014,8 +1036,9 @@ export default async function runServer({
   const hostname = overrideHostname ?? url.hostname
   const port = resolveListenPort(baseURL, overridePort)
 
+  console.log(`Starting streamwall-control-server ${SERVER_VERSION}`)
   console.debug('Initializing web server:', { hostname, port })
-  const { app, db, auth } = await initApp({
+  const { app, db, auth, updateChecker } = await initApp({
     baseURL,
     clientStaticPath,
   })
@@ -1024,6 +1047,12 @@ export default async function runServer({
   logBootstrap(bootstrap)
 
   await app.listen({ port, host: hostname })
+
+  // Fire-and-forget: a slow or unreachable GitHub must never delay serving.
+  void updateChecker.start()
+  app.addHook('onClose', async () => {
+    updateChecker.stop()
+  })
 
   return { server: app.server }
 }

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -15,6 +15,7 @@ import WebSocket from 'ws'
 import { type AppOptions, initApp } from './index.ts'
 import type { SentryCaptureClient } from './sentry.ts'
 import type { StorageDB, StoredData } from './storage.ts'
+import type { UpdateChecker } from './updateCheck.ts'
 
 /**
  * Creates a throwaway directory containing a minimal index.html so that
@@ -46,6 +47,7 @@ export function buildTestApp(
     db?: StorageDB
     sentryEnabled?: boolean
     sentryClient?: SentryCaptureClient
+    updateChecker?: UpdateChecker
   } = {},
 ) {
   return initApp({

--- a/packages/streamwall-control-server/src/updateCheck.test.ts
+++ b/packages/streamwall-control-server/src/updateCheck.test.ts
@@ -1,0 +1,334 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+
+import {
+  createUpdateChecker,
+  fetchLatestRelease,
+  isNewerVersion,
+  isUpdateCheckEnabled,
+  SERVER_VERSION,
+} from './updateCheck.ts'
+
+/** A `fetch`-shaped stub resolving to a JSON body with the given status. */
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('SERVER_VERSION', () => {
+  test('reports the control-server package version', () => {
+    assert.match(SERVER_VERSION, /^\d+\.\d+\.\d+/)
+  })
+})
+
+describe('isNewerVersion', () => {
+  test('detects a newer major/minor/patch release', () => {
+    assert.equal(isNewerVersion('1.0.0', '0.9.1'), true)
+    assert.equal(isNewerVersion('0.10.0', '0.9.1'), true)
+    assert.equal(isNewerVersion('0.9.2', '0.9.1'), true)
+  })
+
+  test('ignores an equal or older release', () => {
+    assert.equal(isNewerVersion('0.9.1', '0.9.1'), false)
+    assert.equal(isNewerVersion('0.9.0', '0.9.1'), false)
+    assert.equal(isNewerVersion('0.9.1', '0.10.0'), false)
+  })
+
+  test('tolerates a leading "v" on either side (release tags carry one)', () => {
+    assert.equal(isNewerVersion('v1.0.0', '0.9.1'), true)
+    assert.equal(isNewerVersion('v0.9.1', 'v0.9.1'), false)
+  })
+
+  test('compares numeric segments numerically, not lexically', () => {
+    assert.equal(isNewerVersion('0.9.10', '0.9.9'), true)
+    assert.equal(isNewerVersion('0.9.9', '0.9.10'), false)
+  })
+
+  test('ranks a prerelease below its own release', () => {
+    assert.equal(isNewerVersion('2.0.0-pre1', '2.0.0'), false)
+    assert.equal(isNewerVersion('2.0.0', '2.0.0-pre1'), true)
+    assert.equal(isNewerVersion('2.0.0-pre2', '2.0.0-pre1'), true)
+  })
+
+  test('treats an unparsable version as "no update" rather than throwing', () => {
+    assert.equal(isNewerVersion('not-a-version', '0.9.1'), false)
+    assert.equal(isNewerVersion('1.0.0', 'not-a-version'), false)
+    assert.equal(isNewerVersion('', '0.9.1'), false)
+  })
+})
+
+describe('isUpdateCheckEnabled', () => {
+  test('defaults to enabled when unset or empty', () => {
+    assert.equal(isUpdateCheckEnabled(undefined), true)
+    assert.equal(isUpdateCheckEnabled(''), true)
+  })
+
+  test('is disabled by the documented off values', () => {
+    for (const raw of ['false', 'FALSE', '0', 'no', 'off', ' off ']) {
+      assert.equal(
+        isUpdateCheckEnabled(raw),
+        false,
+        `expected ${raw} to disable`,
+      )
+    }
+  })
+
+  test('stays enabled for explicit on values', () => {
+    for (const raw of ['true', '1', 'yes', 'on']) {
+      assert.equal(isUpdateCheckEnabled(raw), true, `expected ${raw} to enable`)
+    }
+  })
+})
+
+describe('fetchLatestRelease', () => {
+  test('returns the tag and html_url of the latest release', async () => {
+    const result = await fetchLatestRelease({
+      fetchImpl: async () =>
+        jsonResponse({
+          tag_name: 'v1.2.3',
+          html_url: 'https://example.test/releases/v1.2.3',
+        }),
+    })
+
+    assert.deepEqual(result, {
+      version: '1.2.3',
+      url: 'https://example.test/releases/v1.2.3',
+    })
+  })
+
+  test('skips draft and prerelease entries', async () => {
+    for (const flags of [{ draft: true }, { prerelease: true }]) {
+      const result = await fetchLatestRelease({
+        fetchImpl: async () =>
+          jsonResponse({
+            tag_name: 'v1.2.3',
+            html_url: 'https://example.test/r',
+            ...flags,
+          }),
+      })
+      assert.equal(result, null)
+    }
+  })
+
+  test('returns null on a non-2xx response', async () => {
+    const result = await fetchLatestRelease({
+      fetchImpl: async () => jsonResponse({ message: 'Not Found' }, 404),
+    })
+    assert.equal(result, null)
+  })
+
+  test('returns null on a malformed payload instead of throwing', async () => {
+    const result = await fetchLatestRelease({
+      fetchImpl: async () => jsonResponse({ nope: true }),
+    })
+    assert.equal(result, null)
+  })
+
+  test('returns null when the request fails (offline, DNS, timeout)', async () => {
+    const result = await fetchLatestRelease({
+      fetchImpl: async () => {
+        throw new Error('getaddrinfo ENOTFOUND api.github.com')
+      },
+    })
+    assert.equal(result, null)
+  })
+
+  test('aborts a hung request via the request signal', async () => {
+    const result = await fetchLatestRelease({
+      timeoutMs: 10,
+      fetchImpl: (_url, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () =>
+            reject(new Error('aborted')),
+          )
+        }),
+    })
+    assert.equal(result, null)
+  })
+})
+
+describe('createUpdateChecker', () => {
+  test('reports the running version and no update before the first check', () => {
+    const checker = createUpdateChecker({
+      currentVersion: '0.9.1',
+      fetchImpl: async () => jsonResponse({}),
+    })
+
+    assert.deepEqual(checker.getStatus(), {
+      version: '0.9.1',
+      latestVersion: null,
+      updateAvailable: false,
+      releaseUrl: null,
+      lastCheckedAt: null,
+      checkEnabled: true,
+    })
+  })
+
+  test('flags an available update after a check', async () => {
+    const checker = createUpdateChecker({
+      currentVersion: '0.9.1',
+      fetchImpl: async () =>
+        jsonResponse({
+          tag_name: 'v1.0.0',
+          html_url: 'https://example.test/releases/v1.0.0',
+        }),
+    })
+
+    const status = await checker.checkNow()
+
+    assert.equal(status.latestVersion, '1.0.0')
+    assert.equal(status.updateAvailable, true)
+    assert.equal(status.releaseUrl, 'https://example.test/releases/v1.0.0')
+    assert.match(status.lastCheckedAt ?? '', /^\d{4}-\d{2}-\d{2}T/)
+    assert.deepEqual(checker.getStatus(), status)
+  })
+
+  test('reports no update when the latest release is the running version', async () => {
+    const checker = createUpdateChecker({
+      currentVersion: '1.0.0',
+      fetchImpl: async () =>
+        jsonResponse({
+          tag_name: 'v1.0.0',
+          html_url: 'https://example.test/r',
+        }),
+    })
+
+    const status = await checker.checkNow()
+
+    assert.equal(status.latestVersion, '1.0.0')
+    assert.equal(status.updateAvailable, false)
+  })
+
+  test('logs once per newly discovered version, not on every check', async () => {
+    const logged: string[] = []
+    const checker = createUpdateChecker({
+      currentVersion: '0.9.1',
+      log: (msg) => logged.push(msg),
+      fetchImpl: async () =>
+        jsonResponse({
+          tag_name: 'v1.0.0',
+          html_url: 'https://example.test/r',
+        }),
+    })
+
+    await checker.checkNow()
+    await checker.checkNow()
+
+    assert.equal(logged.length, 1)
+    assert.match(logged[0], /1\.0\.0/)
+  })
+
+  test('keeps the last known result when a check fails', async () => {
+    let failNext = false
+    const checker = createUpdateChecker({
+      currentVersion: '0.9.1',
+      fetchImpl: async () => {
+        if (failNext) {
+          throw new Error('network down')
+        }
+        return jsonResponse({
+          tag_name: 'v1.0.0',
+          html_url: 'https://example.test/r',
+        })
+      },
+    })
+
+    const first = await checker.checkNow()
+    failNext = true
+    const second = await checker.checkNow()
+
+    assert.equal(second.latestVersion, '1.0.0')
+    assert.equal(second.updateAvailable, true)
+    assert.equal(second.lastCheckedAt, first.lastCheckedAt)
+  })
+
+  test('never performs a request when disabled', async () => {
+    let calls = 0
+    const checker = createUpdateChecker({
+      currentVersion: '0.9.1',
+      enabled: false,
+      fetchImpl: async () => {
+        calls++
+        return jsonResponse({ tag_name: 'v1.0.0', html_url: 'https://x.test' })
+      },
+    })
+
+    const status = await checker.checkNow()
+
+    assert.equal(calls, 0)
+    assert.equal(status.checkEnabled, false)
+    assert.equal(status.latestVersion, null)
+    assert.equal(status.updateAvailable, false)
+  })
+
+  test('start() schedules periodic checks and stop() clears them', async () => {
+    let calls = 0
+    const timers: { fn: () => void; ms: number }[] = []
+    const checker = createUpdateChecker({
+      currentVersion: '0.9.1',
+      intervalMs: 1000,
+      fetchImpl: async () => {
+        calls++
+        return jsonResponse({ tag_name: 'v0.9.1', html_url: 'https://x.test' })
+      },
+      setIntervalImpl: (fn, ms) => {
+        timers.push({ fn, ms })
+        return timers.length
+      },
+      clearIntervalImpl: (handle) => {
+        timers.splice(Number(handle) - 1, 1)
+      },
+    })
+
+    await checker.start()
+
+    assert.equal(calls, 1, 'start() runs an immediate check')
+    assert.equal(timers.length, 1)
+    assert.equal(timers[0].ms, 1000)
+
+    checker.stop()
+    assert.equal(timers.length, 0)
+  })
+
+  test('start() is idempotent (no duplicate intervals)', async () => {
+    const timers: unknown[] = []
+    const checker = createUpdateChecker({
+      currentVersion: '0.9.1',
+      fetchImpl: async () =>
+        jsonResponse({ tag_name: 'v0.9.1', html_url: 'https://x.test' }),
+      setIntervalImpl: () => {
+        timers.push({})
+        return timers.length
+      },
+      clearIntervalImpl: () => {
+        timers.pop()
+      },
+    })
+
+    await checker.start()
+    await checker.start()
+
+    assert.equal(timers.length, 1)
+    checker.stop()
+  })
+
+  test('start() does not schedule anything when disabled', async () => {
+    let scheduled = 0
+    const checker = createUpdateChecker({
+      currentVersion: '0.9.1',
+      enabled: false,
+      fetchImpl: async () => jsonResponse({}),
+      setIntervalImpl: () => {
+        scheduled++
+        return scheduled
+      },
+      clearIntervalImpl: () => {},
+    })
+
+    await checker.start()
+
+    assert.equal(scheduled, 0)
+  })
+})

--- a/packages/streamwall-control-server/src/updateCheck.ts
+++ b/packages/streamwall-control-server/src/updateCheck.ts
@@ -1,0 +1,307 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+
+/**
+ * Update *notification* for self-hosted deployments (issue #382).
+ *
+ * Deliberately notify-only: the server tells the operator that a newer release
+ * exists and never touches the running deployment. An unattended in-place
+ * self-update would have to rebuild the image and restart the process while
+ * holding live uplink/client sockets — far riskier than the desktop app case,
+ * and the documented Compose update (`git pull && docker compose up -d
+ * --build`, see docs/self-hosting.md) is a single command anyway.
+ */
+
+const RELEASES_API_URL =
+  'https://api.github.com/repos/NilsR0711/streamwall/releases/latest'
+
+/** Once a day: releases are rare, and this keeps the GitHub API load trivial. */
+const DEFAULT_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000
+
+const DEFAULT_FETCH_TIMEOUT_MS = 10_000
+
+/** Read once at module load: the file cannot change under a running process. */
+export const SERVER_VERSION = readServerVersion()
+
+/**
+ * The running server's version, read from this package's own manifest. Kept in
+ * lockstep with the repo's release tags (see the version-sync test), so it is
+ * directly comparable to the `vX.Y.Z` tag of a GitHub release.
+ */
+function readServerVersion(): string {
+  const manifestPath = path.join(import.meta.dirname, '../package.json')
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+    version?: unknown
+  }
+  if (typeof manifest.version !== 'string') {
+    throw new Error(`Missing "version" in ${manifestPath}`)
+  }
+  return manifest.version
+}
+
+interface ParsedVersion {
+  core: number[]
+  prerelease: string[]
+}
+
+/**
+ * Parses the `MAJOR.MINOR.PATCH[-prerelease]` subset of semver we actually
+ * publish (`v0.9.1`, `v2.0.0-pre3`). Build metadata is ignored, and anything
+ * that does not match returns null so callers can degrade to "no update".
+ */
+function parseVersion(raw: string): ParsedVersion | null {
+  const match =
+    /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[\w.-]+)?$/.exec(
+      raw.trim(),
+    )
+  if (!match) {
+    return null
+  }
+  return {
+    core: [Number(match[1]), Number(match[2]), Number(match[3])],
+    prerelease: match[4] ? match[4].split('.') : [],
+  }
+}
+
+/** Semver precedence for prerelease identifiers: numeric < alphanumeric. */
+function comparePrerelease(a: string[], b: string[]): number {
+  // A version without a prerelease outranks the same core with one (1.0.0 > 1.0.0-pre1).
+  if (a.length === 0 || b.length === 0) {
+    return a.length === b.length ? 0 : a.length === 0 ? 1 : -1
+  }
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const left = a[i]
+    const right = b[i]
+    if (left === undefined) {
+      return -1
+    }
+    if (right === undefined) {
+      return 1
+    }
+    const leftNumeric = /^\d+$/.test(left)
+    const rightNumeric = /^\d+$/.test(right)
+    if (leftNumeric && rightNumeric) {
+      if (Number(left) !== Number(right)) {
+        return Number(left) < Number(right) ? -1 : 1
+      }
+      continue
+    }
+    if (leftNumeric !== rightNumeric) {
+      return leftNumeric ? -1 : 1
+    }
+    if (left !== right) {
+      return left < right ? -1 : 1
+    }
+  }
+  return 0
+}
+
+/**
+ * True when `candidate` is strictly newer than `current`. Unparsable input on
+ * either side yields false: a version we cannot reason about must never
+ * produce a bogus "update available" notice.
+ */
+export function isNewerVersion(candidate: string, current: string): boolean {
+  const a = parseVersion(candidate)
+  const b = parseVersion(current)
+  if (!a || !b) {
+    return false
+  }
+  for (let i = 0; i < 3; i++) {
+    if (a.core[i] !== b.core[i]) {
+      return a.core[i] > b.core[i]
+    }
+  }
+  return comparePrerelease(a.prerelease, b.prerelease) > 0
+}
+
+/**
+ * The update check reaches out to the GitHub API, so operators who want a
+ * fully egress-free deployment can turn it off. Enabled by default; the same
+ * off-values as `STREAMWALL_TRUST_PROXY` are honoured for consistency.
+ */
+export function isUpdateCheckEnabled(raw: string | undefined): boolean {
+  if (raw == null || raw.trim() === '') {
+    return true
+  }
+  const v = raw.trim().toLowerCase()
+  return !(v === '0' || v === 'false' || v === 'no' || v === 'off')
+}
+
+export interface LatestRelease {
+  version: string
+  url: string
+}
+
+type FetchImpl = (
+  url: string,
+  init?: { signal?: AbortSignal; headers?: Record<string, string> },
+) => Promise<Response>
+
+/**
+ * Fetches the latest published (non-draft, non-prerelease) release. Every
+ * failure mode — offline host, rate limit, malformed body, hung connection —
+ * resolves to null: an update check must never take the server down with it.
+ */
+export async function fetchLatestRelease({
+  fetchImpl = fetch as FetchImpl,
+  url = RELEASES_API_URL,
+  timeoutMs = DEFAULT_FETCH_TIMEOUT_MS,
+}: {
+  fetchImpl?: FetchImpl
+  url?: string
+  timeoutMs?: number
+} = {}): Promise<LatestRelease | null> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await fetchImpl(url, {
+      signal: controller.signal,
+      headers: {
+        accept: 'application/vnd.github+json',
+        'user-agent': `streamwall-control-server/${SERVER_VERSION}`,
+      },
+    })
+    if (!response.ok) {
+      return null
+    }
+    const body = (await response.json()) as {
+      tag_name?: unknown
+      html_url?: unknown
+      draft?: unknown
+      prerelease?: unknown
+    }
+    if (body.draft === true || body.prerelease === true) {
+      return null
+    }
+    if (
+      typeof body.tag_name !== 'string' ||
+      typeof body.html_url !== 'string'
+    ) {
+      return null
+    }
+    return {
+      version: body.tag_name.replace(/^v/, ''),
+      url: body.html_url,
+    }
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export interface UpdateStatus {
+  /** Version of the running server. */
+  version: string
+  /** Latest release seen by the most recent successful check, if any. */
+  latestVersion: string | null
+  updateAvailable: boolean
+  releaseUrl: string | null
+  /** ISO timestamp of the last *successful* check. */
+  lastCheckedAt: string | null
+  checkEnabled: boolean
+}
+
+export interface UpdateChecker {
+  getStatus(): UpdateStatus
+  /** Runs a check immediately; resolves with the resulting status. */
+  checkNow(): Promise<UpdateStatus>
+  /** Runs an initial check and schedules periodic ones. Idempotent. */
+  start(): Promise<void>
+  stop(): void
+}
+
+export interface UpdateCheckerOptions {
+  currentVersion?: string
+  enabled?: boolean
+  intervalMs?: number
+  fetchImpl?: FetchImpl
+  url?: string
+  log?: (message: string) => void
+  setIntervalImpl?: (fn: () => void, ms: number) => unknown
+  clearIntervalImpl?: (handle: unknown) => void
+}
+
+/**
+ * Node's `setInterval` handle keeps the event loop alive; unref'ing it means a
+ * pending update check never delays process shutdown.
+ */
+function defaultSetInterval(fn: () => void, ms: number): unknown {
+  const handle = setInterval(fn, ms)
+  handle.unref?.()
+  return handle
+}
+
+export function createUpdateChecker({
+  currentVersion = SERVER_VERSION,
+  enabled = isUpdateCheckEnabled(process.env.STREAMWALL_UPDATE_CHECK),
+  intervalMs = DEFAULT_CHECK_INTERVAL_MS,
+  fetchImpl,
+  url,
+  log = console.log,
+  setIntervalImpl = defaultSetInterval,
+  clearIntervalImpl = (handle) => clearInterval(handle as NodeJS.Timeout),
+}: UpdateCheckerOptions = {}): UpdateChecker {
+  let latest: LatestRelease | null = null
+  let lastCheckedAt: string | null = null
+  let announcedVersion: string | null = null
+  let timer: unknown = null
+
+  const getStatus = (): UpdateStatus => ({
+    version: currentVersion,
+    latestVersion: latest?.version ?? null,
+    updateAvailable: latest
+      ? isNewerVersion(latest.version, currentVersion)
+      : false,
+    releaseUrl: latest?.url ?? null,
+    lastCheckedAt,
+    checkEnabled: enabled,
+  })
+
+  const checkNow = async (): Promise<UpdateStatus> => {
+    if (!enabled) {
+      return getStatus()
+    }
+    const release = await fetchLatestRelease({ fetchImpl, url })
+    if (release) {
+      latest = release
+      lastCheckedAt = new Date().toISOString()
+    }
+    const status = getStatus()
+    // Announce each newer version once, so a daily check does not repeat the
+    // same line in the operator's logs forever.
+    if (
+      status.updateAvailable &&
+      status.latestVersion !== null &&
+      status.latestVersion !== announcedVersion
+    ) {
+      announcedVersion = status.latestVersion
+      log(
+        `⬆️  streamwall-control-server ${status.latestVersion} is available (running ${currentVersion}): ${status.releaseUrl}`,
+      )
+    }
+    return status
+  }
+
+  return {
+    getStatus,
+    checkNow,
+    async start() {
+      if (!enabled || timer !== null) {
+        return
+      }
+      await checkNow()
+      timer = setIntervalImpl(() => {
+        void checkNow()
+      }, intervalMs)
+    },
+    stop() {
+      if (timer !== null) {
+        clearIntervalImpl(timer)
+        timer = null
+      }
+    },
+  }
+}

--- a/packages/streamwall-control-server/src/version.test.ts
+++ b/packages/streamwall-control-server/src/version.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, test } from 'node:test'
+
+import { SERVER_VERSION } from './updateCheck.ts'
+
+function packageVersion(relativePath: string): string {
+  const manifest = JSON.parse(
+    readFileSync(path.join(import.meta.dirname, relativePath), 'utf8'),
+  ) as { version: string }
+  return manifest.version
+}
+
+describe('release version alignment', () => {
+  // The update check compares SERVER_VERSION against the repo's `vX.Y.Z`
+  // release tags, which electron-forge derives from the `streamwall` package
+  // version. If the two drift, a self-hoster is told an update is available
+  // (or not) based on a version that never existed — so pin them together.
+  test('control-server version matches the released streamwall version', () => {
+    assert.equal(
+      SERVER_VERSION,
+      packageVersion('../../streamwall/package.json'),
+    )
+  })
+
+  test('SERVER_VERSION is read from the control-server manifest', () => {
+    assert.equal(SERVER_VERSION, packageVersion('../package.json'))
+  })
+})

--- a/packages/streamwall-shared/src/roles.test.ts
+++ b/packages/streamwall-shared/src/roles.test.ts
@@ -20,6 +20,7 @@ const adminOnlyActions = [
   'browse',
   'create-invite',
   'delete-token',
+  'view-server-status',
 ] as const satisfies readonly StreamwallAction[]
 
 // Actions an operator may perform that a monitor may not.

--- a/packages/streamwall-shared/src/roles.ts
+++ b/packages/streamwall-shared/src/roles.ts
@@ -1,7 +1,12 @@
 export const validRoles = ['local', 'admin', 'operator', 'monitor'] as const
 export const validRolesSet = new Set(validRoles)
 
-type AdminAction = 'dev-tools' | 'browse' | 'create-invite' | 'delete-token'
+type AdminAction =
+  | 'dev-tools'
+  | 'browse'
+  | 'create-invite'
+  | 'delete-token'
+  | 'view-server-status'
 
 const operatorActions = [
   'set-listening-view',


### PR DESCRIPTION
## Problem

Self-hosted `streamwall-control-server` operators had no way to see which
version they were running, and no way to learn that a newer release exists
short of watching the repo. #381 covers this for the Electron app but
explicitly excludes the server.

## Solution

Notify-only update awareness, plus a documented update path.

- **Version at startup** — `Starting streamwall-control-server 0.9.1` on
  every boot.
- **Daily release check** — queries the GitHub Releases API once a day and
  logs a single line per newly discovered version (not once per check).
- **`GET /admin/status`** — admin-only JSON with `version`, `latestVersion`,
  `updateAvailable`, `releaseUrl`, `lastCheckedAt`, `checkEnabled`. Every
  other role and anonymous requests get `403`, gated through the existing
  `roleCan` default-deny matrix via a new `view-server-status` admin action.
- **`STREAMWALL_UPDATE_CHECK=false`** disables the check (the server's only
  outbound connection) for egress-free deployments; the endpoint still
  reports the running version.
- **Docs** — `docs/self-hosting.md` gains a version/update-notification
  section, and the update procedure now covers backing up the
  `control-server-data` volume and what to expect during the restart.

## Architecture decisions

- **Notify-only, not self-updating.** An unattended rebuild-and-restart
  would drop live uplink and client sockets at an arbitrary moment, and the
  Compose update is a single command anyway. The issue reaches the same
  conclusion.
- **Admin-gated status.** The version of a publicly reachable server is
  exactly the detail that helps someone shop for a known vulnerability, so
  it stays behind auth rather than sitting on an open `/status`.
- **Fail-soft check.** Offline host, rate limit, malformed body and hung
  connection all degrade to "no update known" and keep the last known
  result; an unparsable version never yields a bogus "update available".
  The interval timer is `unref`'d so a pending check cannot delay shutdown.
- **Version alignment.** The check compares against `vX.Y.Z` release tags,
  which electron-forge derives from the `streamwall` package version. The
  control-server manifest was on an unrelated `1.0.0`; it is now aligned to
  the release line (`0.9.1`) and pinned there by a test, so a release bump
  cannot silently desync the two.

## Testing

- 34 new tests: version comparison (incl. prerelease precedence and
  unparsable input), env parsing, every `fetchLatestRelease` failure mode,
  checker state/logging/scheduling, and the full `/admin/status`
  authorization matrix.
- Verified end-to-end over real HTTP against a listening server: admin
  `200` + `cache-control: no-store`, operator `403`, anonymous `403`.
- Verified the checker against the live GitHub API: correctly reports
  running `0.9.1` == latest `0.9.1`, `updateAvailable: false`.
- Full quality gate green locally: `format:check`, `lint`, `typecheck`,
  `npm test` (all workspaces).

## Risks / breaking changes

None breaking. New behaviour is one outbound HTTPS request per day, opt-out
via `STREAMWALL_UPDATE_CHECK=false` and documented as such.

Closes #382
