### PR TITLE
feat(streamwall): add in-app update notification with install & restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,23 @@ The overlay window has its own hotkey:
 both warn or outright block unsigned apps for end users, and Electron's
 auto-updater requires a signed app on macOS.
 
+### In-app updates
+
+A packaged app checks GitHub Releases for a newer version on start and
+periodically afterwards. When one is found, Squirrel downloads it in the
+background and the control window shows a banner offering **Restart &
+Install**, plus a link to the release notes.
+
+Because Electron's built-in updater downloads automatically and reports no
+byte-level progress, the banner shows an indeterminate indicator rather than a
+percentage. Update-check failures are logged, not surfaced — they are usually
+just an offline machine.
+
+This only runs in packaged builds, and only on macOS and Windows; on Linux the
+updater is a no-op and users install from the released packages. Note that
+macOS additionally requires the app to be **signed** (see below) before updates
+can install.
+
 To produce signed, notarized builds, set these environment variables before
 running `make`/`publish` (see `packages/streamwall/forge.signing.ts`):
 

--- a/packages/streamwall/src/main/ControlWindow.test.ts
+++ b/packages/streamwall/src/main/ControlWindow.test.ts
@@ -199,3 +199,122 @@ describe('ControlWindow command IPC', () => {
     expect(handler).not.toHaveBeenCalled()
   })
 })
+
+describe('ControlWindow update notifications', () => {
+  it('pushes update status to the renderer so the banner can react without polling', () => {
+    const controlWindow = new ControlWindow(configInfo)
+    const { webContents } = controlWindow.win as unknown as FakeBrowserWindow
+
+    controlWindow.onUpdateStatus({ state: 'downloading' })
+
+    expect(webContents.send).toHaveBeenCalledWith('update-status', {
+      state: 'downloading',
+    })
+  })
+
+  it('serves the current status on request, so a renderer that mounts late is not stuck on idle', async () => {
+    const controlWindow = new ControlWindow(configInfo)
+    const sender = (controlWindow.win as unknown as FakeBrowserWindow)
+      .webContents
+    const status = {
+      state: 'ready' as const,
+      version: '0.9.2',
+      releaseNotesUrl: null,
+    }
+    controlWindow.setUpdateHandlers({
+      getAppVersion: () => '0.9.1',
+      getStatus: () => status,
+      install: vi.fn(),
+      openReleaseNotes: vi.fn(),
+    })
+
+    expect(await ipcHandlers.get('control:update-status')!({ sender })).toEqual(
+      status,
+    )
+  })
+
+  it('reports idle before any updater is wired up', async () => {
+    const controlWindow = new ControlWindow(configInfo)
+    const sender = (controlWindow.win as unknown as FakeBrowserWindow)
+      .webContents
+
+    expect(await ipcHandlers.get('control:update-status')!({ sender })).toEqual(
+      { state: 'idle' },
+    )
+  })
+
+  it('installs the update when the renderer asks', async () => {
+    const controlWindow = new ControlWindow(configInfo)
+    const sender = (controlWindow.win as unknown as FakeBrowserWindow)
+      .webContents
+    const install = vi.fn()
+    controlWindow.setUpdateHandlers({
+      getAppVersion: () => '0.9.1',
+      getStatus: () => ({ state: 'idle' }),
+      install,
+      openReleaseNotes: vi.fn(),
+    })
+
+    await ipcHandlers.get('control:install-update')!({ sender })
+
+    expect(install).toHaveBeenCalledOnce()
+  })
+
+  it('opens release notes without taking a URL from the renderer, so the target cannot be spoofed', async () => {
+    const controlWindow = new ControlWindow(configInfo)
+    const sender = (controlWindow.win as unknown as FakeBrowserWindow)
+      .webContents
+    const openReleaseNotes = vi.fn()
+    controlWindow.setUpdateHandlers({
+      getAppVersion: () => '0.9.1',
+      getStatus: () => ({ state: 'idle' }),
+      install: vi.fn(),
+      openReleaseNotes,
+    })
+
+    await ipcHandlers.get('control:open-release-notes')!(
+      { sender },
+      'https://evil.example/pwn',
+    )
+
+    expect(openReleaseNotes).toHaveBeenCalledOnce()
+    expect(openReleaseNotes).toHaveBeenCalledWith()
+  })
+
+  it('ignores update IPC from a sender other than its own window', async () => {
+    const controlWindow = new ControlWindow(configInfo)
+    const install = vi.fn()
+    controlWindow.setUpdateHandlers({
+      getAppVersion: () => '0.9.1',
+      getStatus: () => ({ state: 'checking' }),
+      install,
+      openReleaseNotes: vi.fn(),
+    })
+    const foreignSender = { sender: { send: vi.fn() } }
+
+    await ipcHandlers.get('control:install-update')!(foreignSender)
+
+    expect(install).not.toHaveBeenCalled()
+    expect(
+      await ipcHandlers.get('control:update-status')!(foreignSender),
+    ).toBeUndefined()
+  })
+})
+
+describe('ControlWindow app version', () => {
+  it('reports the running version so the update banner can name what is being replaced', async () => {
+    const controlWindow = new ControlWindow(configInfo)
+    const sender = (controlWindow.win as unknown as FakeBrowserWindow)
+      .webContents
+    controlWindow.setUpdateHandlers({
+      getAppVersion: () => '0.9.1',
+      getStatus: () => ({ state: 'idle' }),
+      install: vi.fn(),
+      openReleaseNotes: vi.fn(),
+    })
+
+    expect(await ipcHandlers.get('control:app-version')!({ sender })).toBe(
+      '0.9.1',
+    )
+  })
+})

--- a/packages/streamwall/src/main/ControlWindow.ts
+++ b/packages/streamwall/src/main/ControlWindow.ts
@@ -3,6 +3,7 @@ import EventEmitter from 'events'
 import { dirname } from 'node:path'
 import path from 'path'
 import { ControlCommand, StreamwallState } from 'streamwall-shared'
+import { type UpdateStatus } from '../updateStatus'
 import { type ControlCommandResult } from './commandDispatch'
 import { createExampleConfig } from './exampleConfig'
 import { loadHTML } from './loadHTML'
@@ -17,6 +18,18 @@ export interface ControlWindowEventMap {
   ydoc: [Uint8Array]
 }
 
+/**
+ * How the control window reaches the app updater (#381). Kept as a handler
+ * bundle rather than a constructor argument so ControlWindow stays independent
+ * of the updater's lifetime, matching `setCommandHandler`.
+ */
+export interface UpdateHandlers {
+  getAppVersion: () => string
+  getStatus: () => UpdateStatus
+  install: () => void
+  openReleaseNotes: () => void
+}
+
 /** Where the user data `config.toml` would live, and whether it exists yet. */
 export interface ConfigInfo {
   configPath: string
@@ -26,6 +39,7 @@ export interface ConfigInfo {
 export default class ControlWindow extends EventEmitter<ControlWindowEventMap> {
   win: BrowserWindow
   private commandHandler?: ControlCommandHandler
+  private updateHandlers?: UpdateHandlers
 
   constructor(configInfo: ConfigInfo) {
     super()
@@ -97,10 +111,52 @@ export default class ControlWindow extends EventEmitter<ControlWindowEventMap> {
       // rather than being swallowed (#246).
       createExampleConfig(configInfo.configPath)
     })
+
+    ipcMain.handle('control:update-status', (ev) => {
+      if (ev.sender !== this.win.webContents) {
+        return
+      }
+      // The renderer may mount after the updater already moved past `idle`,
+      // so it pulls the current status once instead of only listening for
+      // future transitions.
+      return this.updateHandlers?.getStatus() ?? { state: 'idle' }
+    })
+
+    ipcMain.handle('control:app-version', (ev) => {
+      if (ev.sender !== this.win.webContents) {
+        return
+      }
+      return this.updateHandlers?.getAppVersion() ?? ''
+    })
+
+    ipcMain.handle('control:install-update', (ev) => {
+      if (ev.sender !== this.win.webContents) {
+        return
+      }
+      this.updateHandlers?.install()
+    })
+
+    ipcMain.handle('control:open-release-notes', (ev) => {
+      if (ev.sender !== this.win.webContents) {
+        return
+      }
+      // Deliberately takes no URL from the renderer: main owns the updater
+      // status, so a compromised renderer cannot turn this into an
+      // open-anything shell.openExternal gadget.
+      this.updateHandlers?.openReleaseNotes()
+    })
   }
 
   setCommandHandler(handler: ControlCommandHandler) {
     this.commandHandler = handler
+  }
+
+  setUpdateHandlers(handlers: UpdateHandlers) {
+    this.updateHandlers = handlers
+  }
+
+  onUpdateStatus(status: UpdateStatus) {
+    this.win.webContents.send('update-status', status)
   }
 
   onState(state: StreamwallState) {

--- a/packages/streamwall/src/main/appUpdater.test.ts
+++ b/packages/streamwall/src/main/appUpdater.test.ts
@@ -1,0 +1,128 @@
+import EventEmitter from 'events'
+import { describe, expect, it, vi } from 'vitest'
+import { AppUpdater } from './appUpdater'
+
+// Electron's built-in autoUpdater is an EventEmitter with a quitAndInstall()
+// method, so a plain EventEmitter plus a spy models it faithfully without an
+// Electron runtime (and without a Squirrel feed to talk to).
+class FakeAutoUpdater extends EventEmitter {
+  quitAndInstall = vi.fn()
+}
+
+function createUpdater(repository: string | null = 'NilsR0711/streamwall') {
+  const autoUpdater = new FakeAutoUpdater()
+  const updater = new AppUpdater(autoUpdater, repository)
+  const statuses: unknown[] = []
+  updater.on('status', (status) => statuses.push(status))
+  return { autoUpdater, updater, statuses }
+}
+
+describe('AppUpdater status', () => {
+  it('starts idle so the renderer renders no banner before a check has run', () => {
+    const { updater } = createUpdater()
+
+    expect(updater.getStatus()).toEqual({ state: 'idle' })
+  })
+
+  it('reports checking while a check is in flight', () => {
+    const { autoUpdater, updater, statuses } = createUpdater()
+
+    autoUpdater.emit('checking-for-update')
+
+    expect(updater.getStatus()).toEqual({ state: 'checking' })
+    expect(statuses).toEqual([{ state: 'checking' }])
+  })
+
+  it('reports downloading once an update is found, since Squirrel downloads it automatically', () => {
+    const { autoUpdater, updater } = createUpdater()
+
+    autoUpdater.emit('checking-for-update')
+    autoUpdater.emit('update-available')
+
+    expect(updater.getStatus()).toEqual({ state: 'downloading' })
+  })
+
+  it('returns to idle when no update is available, so a stale banner does not linger', () => {
+    const { autoUpdater, updater } = createUpdater()
+
+    autoUpdater.emit('checking-for-update')
+    autoUpdater.emit('update-not-available')
+
+    expect(updater.getStatus()).toEqual({ state: 'idle' })
+  })
+
+  it('reports the downloaded version and a release notes link once install is possible', () => {
+    const { autoUpdater, updater } = createUpdater()
+
+    autoUpdater.emit('update-downloaded', {}, 'release notes', 'v0.9.2')
+
+    expect(updater.getStatus()).toEqual({
+      state: 'ready',
+      version: '0.9.2',
+      releaseNotesUrl:
+        'https://github.com/NilsR0711/streamwall/releases/tag/v0.9.2',
+    })
+  })
+
+  it('still reports ready without a link when the repository is unknown, so the update stays installable', () => {
+    const { autoUpdater, updater } = createUpdater(null)
+
+    autoUpdater.emit('update-downloaded', {}, 'release notes', '0.9.2')
+
+    expect(updater.getStatus()).toEqual({
+      state: 'ready',
+      version: '0.9.2',
+      releaseNotesUrl: null,
+    })
+  })
+
+  it('surfaces updater errors instead of leaving the banner stuck on downloading', () => {
+    const { autoUpdater, updater } = createUpdater()
+
+    autoUpdater.emit('update-available')
+    autoUpdater.emit('error', new Error('feed unreachable'))
+
+    expect(updater.getStatus()).toEqual({
+      state: 'error',
+      message: 'feed unreachable',
+    })
+  })
+
+  it('emits every transition so the control window can push each one to the renderer', () => {
+    const { autoUpdater, statuses } = createUpdater()
+
+    autoUpdater.emit('checking-for-update')
+    autoUpdater.emit('update-available')
+    autoUpdater.emit('update-downloaded', {}, '', 'v1.0.0')
+
+    expect(statuses).toEqual([
+      { state: 'checking' },
+      { state: 'downloading' },
+      {
+        state: 'ready',
+        version: '1.0.0',
+        releaseNotesUrl:
+          'https://github.com/NilsR0711/streamwall/releases/tag/v1.0.0',
+      },
+    ])
+  })
+})
+
+describe('AppUpdater install', () => {
+  it('quits and installs once an update has been downloaded', () => {
+    const { autoUpdater, updater } = createUpdater()
+    autoUpdater.emit('update-downloaded', {}, '', 'v0.9.2')
+
+    expect(updater.install()).toBe(true)
+    expect(autoUpdater.quitAndInstall).toHaveBeenCalledOnce()
+  })
+
+  it('refuses to install before an update is downloaded, so a stray IPC call cannot quit the app', () => {
+    const { autoUpdater, updater } = createUpdater()
+
+    autoUpdater.emit('update-available')
+
+    expect(updater.install()).toBe(false)
+    expect(autoUpdater.quitAndInstall).not.toHaveBeenCalled()
+  })
+})

--- a/packages/streamwall/src/main/appUpdater.ts
+++ b/packages/streamwall/src/main/appUpdater.ts
@@ -1,0 +1,103 @@
+import EventEmitter from 'node:events'
+import {
+  normalizeVersion,
+  releaseNotesUrl,
+  type UpdateStatus,
+} from '../updateStatus'
+
+type UpdaterListener = (...args: unknown[]) => void
+
+/**
+ * The slice of Electron's `autoUpdater` this module drives. Narrow on purpose:
+ * it keeps the updater testable against a plain EventEmitter, and documents
+ * that nothing here depends on Squirrel internals.
+ */
+export interface AutoUpdaterLike {
+  on(event: string, listener: UpdaterListener): unknown
+  quitAndInstall(): void
+}
+
+export interface AppUpdaterEventMap {
+  status: [UpdateStatus]
+}
+
+/**
+ * Translates Electron's `autoUpdater` events into the `UpdateStatus` the
+ * control window renders, and gates `quitAndInstall()` behind a downloaded
+ * update.
+ *
+ * `update-electron-app` (see main/index.ts) still owns the feed URL and the
+ * periodic check; it runs with `notifyUser: false` so its native dialog does
+ * not compete with the in-app banner this drives.
+ *
+ * Note what Squirrel does *not* give us, since it shapes the UI (#381):
+ * `update-available` fires without a version and the download starts
+ * immediately, and there is no download-progress event. So the banner shows an
+ * indeterminate "Downloading" state rather than a percentage, and the version
+ * only becomes known at `update-downloaded`. A determinate progress bar and a
+ * user-gated download would require swapping Squirrel for `electron-updater`
+ * (tracked separately).
+ */
+export class AppUpdater extends EventEmitter<AppUpdaterEventMap> {
+  private status: UpdateStatus = { state: 'idle' }
+
+  constructor(
+    private readonly autoUpdater: AutoUpdaterLike,
+    private readonly repository: string | null,
+  ) {
+    super()
+
+    this.autoUpdater.on('checking-for-update', () => {
+      this.setStatus({ state: 'checking' })
+    })
+
+    this.autoUpdater.on('update-available', () => {
+      this.setStatus({ state: 'downloading' })
+    })
+
+    this.autoUpdater.on('update-not-available', () => {
+      this.setStatus({ state: 'idle' })
+    })
+
+    this.autoUpdater.on('update-downloaded', (...args: unknown[]) => {
+      // Squirrel's signature is (event, releaseNotes, releaseName, ...).
+      const releaseName = typeof args[2] === 'string' ? args[2] : ''
+      this.setStatus({
+        state: 'ready',
+        version: normalizeVersion(releaseName),
+        releaseNotesUrl: releaseNotesUrl(this.repository, releaseName),
+      })
+    })
+
+    this.autoUpdater.on('error', (...args: unknown[]) => {
+      const error = args[0]
+      this.setStatus({
+        state: 'error',
+        message: error instanceof Error ? error.message : String(error),
+      })
+    })
+  }
+
+  getStatus(): UpdateStatus {
+    return this.status
+  }
+
+  /**
+   * Restarts into the downloaded update. Returns whether the install was
+   * actually started: the renderer's install button is only enabled in the
+   * `ready` state, but the IPC channel is guarded here too so a stray call
+   * cannot quit the app mid-stream.
+   */
+  install(): boolean {
+    if (this.status.state !== 'ready') {
+      return false
+    }
+    this.autoUpdater.quitAndInstall()
+    return true
+  }
+
+  private setStatus(status: UpdateStatus) {
+    this.status = status
+    this.emit('status', status)
+  }
+}

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -1,5 +1,11 @@
 import * as Sentry from '@sentry/electron/main'
-import { BrowserWindow, Event as ElectronEvent, app } from 'electron'
+import {
+  BrowserWindow,
+  Event as ElectronEvent,
+  app,
+  autoUpdater,
+  shell,
+} from 'electron'
 import started from 'electron-squirrel-startup'
 import fs from 'fs'
 import { throttle } from 'lodash-es'
@@ -20,12 +26,15 @@ import { updateElectronApp } from 'update-electron-app'
 import WebSocket from 'ws'
 import yargs from 'yargs'
 import * as Y from 'yjs'
+import packageJson from '../../package.json'
 import {
   SENTRY_DSN,
   SENTRY_ENABLED_SWITCH,
   sentryEnabledSwitchValue,
 } from '../sentryConfig'
+import { parseRepositorySlug } from '../updateStatus'
 import { createSessionHostResolver, ensureValidURL } from '../util'
+import { AppUpdater } from './appUpdater'
 import { dispatchCommand, dispatchLocalCommand } from './commandDispatch'
 import {
   findUnknownConfigKeys,
@@ -496,6 +505,32 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   const controlWindow = new ControlWindow({
     configPath: userConfigPath,
     hasUserConfig,
+  })
+
+  const appUpdater = new AppUpdater(
+    autoUpdater,
+    parseRepositorySlug(packageJson.repository),
+  )
+  appUpdater.on('status', (status) => {
+    if (status.state === 'error') {
+      // Not surfaced in the UI: a failed update check is routine (offline,
+      // rate limit) and not actionable by the user.
+      log.warn('Update check failed:', status.message)
+    } else {
+      log.debug('Update status:', status.state)
+    }
+    controlWindow.onUpdateStatus(status)
+  })
+  controlWindow.setUpdateHandlers({
+    getAppVersion: () => app.getVersion(),
+    getStatus: () => appUpdater.getStatus(),
+    install: () => appUpdater.install(),
+    openReleaseNotes: () => {
+      const status = appUpdater.getStatus()
+      if (status.state === 'ready' && status.releaseNotesUrl) {
+        shell.openExternal(status.releaseNotesUrl)
+      }
+    },
   })
 
   let browseWindow: BrowserWindow | null = null
@@ -1095,7 +1130,9 @@ function init() {
     sentryEnabledSwitchValue(argv.telemetry.sentry),
   )
 
-  updateElectronApp()
+  // Keeps update-electron-app as the feed/interval owner, but silences its
+  // native dialog: the in-app banner (#381) is the notification surface now.
+  updateElectronApp({ notifyUser: false })
 
   log.debug('Setting up Electron...')
   app.commandLine.appendSwitch('high-dpi-support', '1')

--- a/packages/streamwall/src/preload/controlPreload.test.ts
+++ b/packages/streamwall/src/preload/controlPreload.test.ts
@@ -23,8 +23,13 @@ type ControlApi = {
   getFirstRunInfo: () => unknown
   openConfigFolder: () => unknown
   createExampleConfig: () => unknown
+  getAppVersion: () => unknown
+  getUpdateStatus: () => unknown
+  installUpdate: () => unknown
+  openReleaseNotes: () => unknown
   onState: (handleState: (state: unknown) => void) => () => void
   onYDoc: (handleUpdate: (update: Uint8Array) => void) => () => void
+  onUpdateStatus: (handleStatus: (status: unknown) => void) => () => void
 }
 
 function importedControlApi(): ControlApi {
@@ -50,13 +55,18 @@ describe('controlPreload bridge shape', () => {
     expect(Object.keys(importedControlApi()).sort()).toEqual(
       [
         'createExampleConfig',
+        'getAppVersion',
         'getFirstRunInfo',
+        'getUpdateStatus',
+        'installUpdate',
         'invokeCommand',
         'load',
         'onState',
+        'onUpdateStatus',
         'onYDoc',
         'openConfigFolder',
         'openDevTools',
+        'openReleaseNotes',
         'updateYDoc',
       ].sort(),
     )
@@ -88,6 +98,10 @@ describe('controlPreload channel wiring', () => {
     ['getFirstRunInfo', 'control:first-run-info'],
     ['openConfigFolder', 'control:open-config-folder'],
     ['createExampleConfig', 'control:create-example-config'],
+    ['getAppVersion', 'control:app-version'],
+    ['getUpdateStatus', 'control:update-status'],
+    ['installUpdate', 'control:install-update'],
+    ['openReleaseNotes', 'control:open-release-notes'],
   ] as const)('invokes %s on the %s channel', async (method, channel) => {
     await import('./controlPreload')
 
@@ -148,5 +162,50 @@ describe('controlPreload onYDoc listener lifecycle', () => {
     unsubscribe()
 
     expect(off).toHaveBeenCalledWith('ydoc', internalHandler)
+  })
+})
+
+describe('controlPreload onUpdateStatus listener lifecycle', () => {
+  it('subscribes to the update-status IPC channel and forwards the status payload', async () => {
+    await import('./controlPreload')
+    const handleStatus = vi.fn()
+
+    importedControlApi().onUpdateStatus(handleStatus)
+
+    expect(on).toHaveBeenCalledWith('update-status', expect.any(Function))
+    const [, internalHandler] = on.mock.calls.find(
+      ([ch]) => ch === 'update-status',
+    )!
+    const status = { state: 'ready', version: '0.9.2', releaseNotesUrl: null }
+    internalHandler({}, status)
+
+    expect(handleStatus).toHaveBeenCalledWith(status)
+  })
+
+  it('removes the same listener it registered when unsubscribed', async () => {
+    await import('./controlPreload')
+
+    const unsubscribe = importedControlApi().onUpdateStatus(vi.fn())
+    const [, internalHandler] = on.mock.calls.find(
+      ([ch]) => ch === 'update-status',
+    )!
+
+    unsubscribe()
+
+    expect(off).toHaveBeenCalledWith('update-status', internalHandler)
+  })
+})
+
+describe('controlPreload update bridge safety', () => {
+  it('sends no renderer-supplied URL when opening release notes, so the target cannot be spoofed', async () => {
+    await import('./controlPreload')
+
+    // A compromised renderer could only ever call this with arguments; the
+    // bridge must drop them so main opens the release it actually downloaded.
+    ;(importedControlApi().openReleaseNotes as (...args: unknown[]) => unknown)(
+      'https://evil.example/pwn',
+    )
+
+    expect(invoke).toHaveBeenCalledWith('control:open-release-notes')
   })
 })

--- a/packages/streamwall/src/preload/controlPreload.ts
+++ b/packages/streamwall/src/preload/controlPreload.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron'
 import { StreamwallState } from 'streamwall-shared'
+import { type UpdateStatus } from '../updateStatus'
 import './sentryPreload'
 
 export interface FirstRunInfo {
@@ -18,6 +19,24 @@ const api = {
   openConfigFolder: () => ipcRenderer.invoke('control:open-config-folder'),
   createExampleConfig: (): Promise<void> =>
     ipcRenderer.invoke('control:create-example-config'),
+  getAppVersion: (): Promise<string> =>
+    ipcRenderer.invoke('control:app-version'),
+  getUpdateStatus: (): Promise<UpdateStatus> =>
+    ipcRenderer.invoke('control:update-status'),
+  installUpdate: (): Promise<void> =>
+    ipcRenderer.invoke('control:install-update'),
+  // Takes no URL: main opens the release page for the update it actually
+  // downloaded, so the renderer cannot steer shell.openExternal.
+  openReleaseNotes: (): Promise<void> =>
+    ipcRenderer.invoke('control:open-release-notes'),
+  onUpdateStatus: (handleStatus: (status: UpdateStatus) => void) => {
+    const internalHandler = (_ev: IpcRendererEvent, status: UpdateStatus) =>
+      handleStatus(status)
+    ipcRenderer.on('update-status', internalHandler)
+    return () => {
+      ipcRenderer.off('update-status', internalHandler)
+    }
+  },
   onState: (handleState: (state: StreamwallState) => void) => {
     const internalHandler = (_ev: IpcRendererEvent, state: StreamwallState) =>
       handleState(state)

--- a/packages/streamwall/src/renderer/UpdateBanner.test.tsx
+++ b/packages/streamwall/src/renderer/UpdateBanner.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment happy-dom
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { type UpdateStatus } from '../updateStatus'
+import { UpdateBanner } from './UpdateBanner'
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+function renderBanner(
+  status: UpdateStatus,
+  props: { currentVersion?: string } = {},
+) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  const onInstall = vi.fn()
+  const onOpenReleaseNotes = vi.fn()
+  const onDismiss = vi.fn()
+  act(() => {
+    render(
+      <UpdateBanner
+        status={status}
+        currentVersion={props.currentVersion ?? '0.9.1'}
+        onInstall={onInstall}
+        onOpenReleaseNotes={onOpenReleaseNotes}
+        onDismiss={onDismiss}
+      />,
+      container!,
+    )
+  })
+  return { onInstall, onOpenReleaseNotes, onDismiss }
+}
+
+function click(testId: string) {
+  const button = container!.querySelector<HTMLButtonElement>(
+    `[data-testid="${testId}"]`,
+  )
+  act(() => button!.click())
+}
+
+describe('UpdateBanner visibility', () => {
+  test('renders nothing while idle, so a healthy up-to-date app shows no chrome', () => {
+    renderBanner({ state: 'idle' })
+
+    expect(container!.textContent).toBe('')
+  })
+
+  test('renders nothing while checking, so a routine background check stays invisible', () => {
+    renderBanner({ state: 'checking' })
+
+    expect(container!.textContent).toBe('')
+  })
+
+  test('renders nothing on error, since a failed update check is not actionable for the user', () => {
+    renderBanner({ state: 'error', message: 'feed unreachable' })
+
+    expect(container!.textContent).toBe('')
+  })
+})
+
+describe('UpdateBanner downloading', () => {
+  test('tells the user an update is downloading so the wait is explained', () => {
+    renderBanner({ state: 'downloading' })
+
+    expect(container!.textContent).toContain('Downloading')
+  })
+
+  test('shows a busy progress indicator, since Squirrel reports no percentage', () => {
+    renderBanner({ state: 'downloading' })
+
+    const progress = container!.querySelector('[role="progressbar"]')
+    expect(progress).not.toBeNull()
+    expect(progress!.getAttribute('aria-valuenow')).toBeNull()
+  })
+
+  test('offers no install action before the download finished', () => {
+    renderBanner({ state: 'downloading' })
+
+    expect(
+      container!.querySelector('[data-testid="install-update"]'),
+    ).toBeNull()
+  })
+})
+
+describe('UpdateBanner ready', () => {
+  const readyStatus: UpdateStatus = {
+    state: 'ready',
+    version: '0.9.2',
+    releaseNotesUrl:
+      'https://github.com/NilsR0711/streamwall/releases/tag/v0.9.2',
+  }
+
+  test('names the new version and the version being replaced', () => {
+    renderBanner(readyStatus, { currentVersion: '0.9.1' })
+
+    expect(container!.textContent).toContain('0.9.2')
+    expect(container!.textContent).toContain('0.9.1')
+  })
+
+  test('installs and restarts when the install action is clicked', () => {
+    const { onInstall } = renderBanner(readyStatus)
+
+    click('install-update')
+
+    expect(onInstall).toHaveBeenCalledOnce()
+  })
+
+  test('opens the release notes externally rather than navigating the control window', () => {
+    const { onOpenReleaseNotes } = renderBanner(readyStatus)
+
+    click('open-release-notes')
+
+    expect(onOpenReleaseNotes).toHaveBeenCalledWith(readyStatus.releaseNotesUrl)
+  })
+
+  test('omits the release notes action when no link is known', () => {
+    renderBanner({ ...readyStatus, releaseNotesUrl: null })
+
+    expect(
+      container!.querySelector('[data-testid="open-release-notes"]'),
+    ).toBeNull()
+  })
+
+  test('can be dismissed, keeping the notification non-intrusive', () => {
+    const { onDismiss } = renderBanner(readyStatus)
+
+    click('dismiss-update-banner')
+
+    expect(onDismiss).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/streamwall/src/renderer/UpdateBanner.tsx
+++ b/packages/streamwall/src/renderer/UpdateBanner.tsx
@@ -1,0 +1,161 @@
+import { keyframes, styled } from 'styled-components'
+import { type UpdateStatus } from '../updateStatus'
+
+const Banner = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 13px;
+`
+
+const Message = styled.div`
+  flex: 1;
+  min-width: 0;
+`
+
+const Version = styled.code`
+  font-family: var(--font-mono);
+  background: var(--surface-3);
+  border-radius: var(--r-sm);
+  padding: 1px 5px;
+`
+
+const indeterminate = keyframes`
+  from { transform: translateX(-100%); }
+  to { transform: translateX(300%); }
+`
+
+const ProgressTrack = styled.div`
+  flex-shrink: 0;
+  width: 96px;
+  height: 4px;
+  border-radius: var(--r-sm);
+  background: var(--surface-3);
+  overflow: hidden;
+`
+
+const ProgressBar = styled.div`
+  width: 33%;
+  height: 100%;
+  border-radius: var(--r-sm);
+  background: var(--accent-2);
+  animation: ${indeterminate} 1.2s ease-in-out infinite;
+`
+
+const ActionButton = styled.button`
+  flex-shrink: 0;
+  background: var(--accent-2);
+  color: var(--surface);
+  border: none;
+  border-radius: var(--r-sm);
+  padding: 6px 10px;
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+`
+
+const LinkButton = styled.button`
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--accent-2);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 6px 2px;
+`
+
+const DismissButton = styled.button`
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px;
+`
+
+export interface UpdateBannerProps {
+  status: UpdateStatus
+  currentVersion: string
+  onInstall: () => void
+  onOpenReleaseNotes: (url: string) => void
+  onDismiss: () => void
+}
+
+/**
+ * In-app update notification (#381), so users no longer have to poll the
+ * GitHub Releases page to learn a new version exists.
+ *
+ * Only the states the user can act on are rendered: `checking` is routine
+ * background noise, and a failed check (`error`) is not actionable from here -
+ * main/index.ts logs it instead of nagging.
+ *
+ * The download indicator is deliberately indeterminate: Electron's Squirrel
+ * autoUpdater emits no byte-level progress (see main/appUpdater.ts), so a
+ * percentage would have to be invented.
+ */
+export function UpdateBanner({
+  status,
+  currentVersion,
+  onInstall,
+  onOpenReleaseNotes,
+  onDismiss,
+}: UpdateBannerProps) {
+  if (status.state === 'downloading') {
+    return (
+      <Banner>
+        <Message>Downloading a new version of Streamwall...</Message>
+        <ProgressTrack role="progressbar" aria-label="Downloading update">
+          <ProgressBar />
+        </ProgressTrack>
+        <DismissButton
+          data-testid="dismiss-update-banner"
+          aria-label="Dismiss"
+          onClick={onDismiss}
+        >
+          ×
+        </DismissButton>
+      </Banner>
+    )
+  }
+
+  if (status.state !== 'ready') {
+    return null
+  }
+
+  return (
+    <Banner>
+      <Message>
+        Streamwall <Version>{status.version}</Version> is ready to install
+        (you're on <Version>{currentVersion}</Version>).
+      </Message>
+      {status.releaseNotesUrl && (
+        <LinkButton
+          data-testid="open-release-notes"
+          onClick={() => onOpenReleaseNotes(status.releaseNotesUrl!)}
+        >
+          Release notes
+        </LinkButton>
+      )}
+      <ActionButton data-testid="install-update" onClick={onInstall}>
+        Restart &amp; Install
+      </ActionButton>
+      <DismissButton
+        data-testid="dismiss-update-banner"
+        aria-label="Dismiss"
+        onClick={onDismiss}
+      >
+        ×
+      </DismissButton>
+    </Banner>
+  )
+}

--- a/packages/streamwall/src/renderer/control.tsx
+++ b/packages/streamwall/src/renderer/control.tsx
@@ -16,8 +16,10 @@ import {
   FirstRunInfo,
   StreamwallControlGlobal,
 } from '../preload/controlPreload'
+import { type UpdateStatus } from '../updateStatus'
 import { FirstRunHint } from './FirstRunHint'
 import { initRendererSentry } from './initSentry'
+import { UpdateBanner } from './UpdateBanner'
 
 const DISMISSED_STORAGE_KEY = 'streamwall:first-run-hint-dismissed'
 
@@ -119,9 +121,46 @@ function useFirstRunHint() {
   }
 }
 
+/**
+ * Tracks the main-process updater (#381). Pulls the current status once on
+ * mount (the updater may already have moved past `idle` before the renderer
+ * existed) and follows transitions from there.
+ *
+ * Dismissal is keyed on the version rather than a plain boolean, so dismissing
+ * one update does not hide the next one - and is deliberately not persisted:
+ * a downloaded update is worth re-offering after a restart.
+ */
+function useUpdateStatus() {
+  const [status, setStatus] = useState<UpdateStatus>({ state: 'idle' })
+  const [appVersion, setAppVersion] = useState('')
+  const [dismissedVersion, setDismissedVersion] = useState<string>()
+
+  useEffect(() => {
+    window.streamwallControl.getUpdateStatus().then(setStatus)
+    window.streamwallControl.getAppVersion().then(setAppVersion)
+    return window.streamwallControl.onUpdateStatus(setStatus)
+  }, [])
+
+  const dismiss = useCallback(() => {
+    setDismissedVersion(status.state === 'ready' ? status.version : 'pending')
+  }, [status])
+
+  const isDismissed =
+    status.state === 'ready'
+      ? dismissedVersion === status.version
+      : dismissedVersion === 'pending'
+
+  return {
+    status: isDismissed ? ({ state: 'idle' } as const) : status,
+    appVersion,
+    dismiss,
+  }
+}
+
 function App() {
   const connection = useStreamwallIPCConnection()
   const firstRunHint = useFirstRunHint()
+  const update = useUpdateStatus()
 
   useHotkeys('ctrl+shift+i', () => {
     window.streamwallControl.openDevTools()
@@ -130,6 +169,13 @@ function App() {
   return (
     <>
       <GlobalStyle />
+      <UpdateBanner
+        status={update.status}
+        currentVersion={update.appVersion}
+        onInstall={() => window.streamwallControl.installUpdate()}
+        onOpenReleaseNotes={() => window.streamwallControl.openReleaseNotes()}
+        onDismiss={update.dismiss}
+      />
       {firstRunHint.isVisible && (
         <FirstRunHint
           configPath={firstRunHint.configPath!}

--- a/packages/streamwall/src/updateStatus.test.ts
+++ b/packages/streamwall/src/updateStatus.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import {
+  normalizeVersion,
+  parseRepositorySlug,
+  releaseNotesUrl,
+} from './updateStatus'
+
+describe('parseRepositorySlug', () => {
+  it("parses npm's github: shorthand into an owner/name slug", () => {
+    expect(parseRepositorySlug('github:NilsR0711/streamwall')).toBe(
+      'NilsR0711/streamwall',
+    )
+  })
+
+  it('returns null for an unsupported form rather than throwing, so a bad repository field only costs the release-notes link', () => {
+    expect(parseRepositorySlug('https://example.com/repo.git')).toBeNull()
+    expect(parseRepositorySlug(undefined)).toBeNull()
+  })
+})
+
+describe('releaseNotesUrl', () => {
+  it('points at the v-prefixed tag the forge publisher creates', () => {
+    expect(releaseNotesUrl('NilsR0711/streamwall', '0.9.2')).toBe(
+      'https://github.com/NilsR0711/streamwall/releases/tag/v0.9.2',
+    )
+  })
+
+  it('does not double-prefix a release name that already carries the v', () => {
+    expect(releaseNotesUrl('NilsR0711/streamwall', 'v0.9.2')).toBe(
+      'https://github.com/NilsR0711/streamwall/releases/tag/v0.9.2',
+    )
+  })
+
+  it('yields no link when the repository is unknown', () => {
+    expect(releaseNotesUrl(null, '0.9.2')).toBeNull()
+  })
+})
+
+describe('normalizeVersion', () => {
+  it('strips the tag prefix so the banner can compare against app.getVersion()', () => {
+    expect(normalizeVersion('v0.9.2')).toBe('0.9.2')
+    expect(normalizeVersion('0.9.2')).toBe('0.9.2')
+  })
+})

--- a/packages/streamwall/src/updateStatus.ts
+++ b/packages/streamwall/src/updateStatus.ts
@@ -1,0 +1,55 @@
+/**
+ * Update lifecycle as surfaced to the control renderer, shared between the
+ * main process (which owns the updater) and the sandboxed control preload
+ * (which only forwards it), the same way sentryConfig.ts is shared.
+ *
+ * The shape deliberately mirrors what Electron's built-in `autoUpdater`
+ * (Squirrel) actually reports: it starts downloading as soon as an update is
+ * found, and emits no byte-level progress. So `downloading` carries no
+ * percentage and there is no separate user-triggered download step - see
+ * appUpdater.ts for the full rationale.
+ */
+export type UpdateStatus =
+  | { state: 'idle' }
+  | { state: 'checking' }
+  | { state: 'downloading' }
+  | { state: 'ready'; version: string; releaseNotesUrl: string | null }
+  | { state: 'error'; message: string }
+
+/**
+ * Builds the GitHub release page URL for a downloaded update.
+ *
+ * Squirrel reports the release name, which is the `v*` tag for releases cut by
+ * the forge publisher but is not guaranteed to carry the prefix, so normalize
+ * it rather than double-prefixing.
+ */
+export function releaseNotesUrl(
+  repository: string | null,
+  version: string,
+): string | null {
+  if (!repository) {
+    return null
+  }
+  const tag = version.startsWith('v') ? version : `v${version}`
+  return `https://github.com/${repository}/releases/tag/${tag}`
+}
+
+/**
+ * Turns package.json's `github:owner/name` shorthand into the `owner/name`
+ * slug release URLs need.
+ *
+ * Mirrors forge.publisher.ts's parser, but returns null instead of throwing:
+ * a missing repository only costs the release-notes link, and must not stop
+ * an otherwise installable update from being offered.
+ */
+export function parseRepositorySlug(
+  repository: string | undefined,
+): string | null {
+  const match = /^github:([^/]+)\/(.+)$/.exec(repository ?? '')
+  return match ? `${match[1]}/${match[2]}` : null
+}
+
+/** Strips the `v` prefix Squirrel may include, for display next to `app.getVersion()`. */
+export function normalizeVersion(version: string): string {
+  return version.startsWith('v') ? version.slice(1) : version
+}


### PR DESCRIPTION
## Problem

Streamwall had no visible update mechanism. `updateElectronApp()` was already wired up, but it only ever produced a native dialog — users on an old version otherwise had to manually check the GitHub Releases page to learn a newer one existed.

Closes #381

## Solution

Three layers, each independently testable:

- **`src/updateStatus.ts`** — a shared `UpdateStatus` union plus URL/version helpers, shared between main and the sandboxed control preload the same way `sentryConfig.ts` is.
- **`src/main/appUpdater.ts`** — `AppUpdater` translates Electron's `autoUpdater` events into that status and gates `quitAndInstall()` behind a downloaded update. Its backend is a constructor argument, so tests drive it with a plain `EventEmitter` and no Electron runtime.
- **`src/renderer/UpdateBanner.tsx`** — the in-app banner, following the existing `FirstRunHint` pattern.

`update-electron-app` keeps owning the feed URL and the periodic check, but now runs with `notifyUser: false` so its native dialog does not compete with the banner.

## Architecture decisions

**The release-notes IPC channel takes no URL from the renderer.** Main opens the page for the update it actually downloaded. Passing a renderer-supplied URL to `shell.openExternal` would be an open-anything gadget; there is a test asserting a spoofed URL is ignored. Install is gated in main too, so a stray IPC call cannot quit the app mid-stream.

**The renderer pulls the current status on mount** rather than only subscribing to transitions — the updater can move past `idle` before the control window exists.

**Only actionable states render.** `checking` is routine background noise. A failed check is logged, not surfaced: it usually just means the machine is offline, which the user cannot act on from a banner.

**Dismissal is keyed on the version**, not a boolean, so dismissing one update does not hide the next. It is deliberately not persisted — a downloaded update is worth re-offering after a restart.

## Deviations from the acceptance criteria

Two criteria are only partially met, both because of Squirrel, not oversight. Electron's built-in `autoUpdater`:

- emits **no download-progress event** → the banner shows an indeterminate indicator rather than a percentage;
- **downloads automatically** on discovery → there is no user-triggered download step.

Getting both requires swapping Squirrel for `electron-updater`, which needs electron-builder-style metadata Forge does not emit — a distribution-pipeline change well beyond this issue, and blocked on macOS signing anyway. Filed as #432. `AppUpdater`'s injected-backend seam is what keeps that swap contained.

Detection, in-app notification with the version, visible download feedback, and install-and-restart without leaving the app all work as specified.

## Testing

- `AppUpdater`: every status transition, version normalization, release-URL construction, missing-repository fallback, and both install guards.
- `ControlWindow`: status push, late-mount status pull, install, URL-spoofing rejection, and foreign-sender rejection on each new channel.
- `UpdateBanner`: per-state rendering, both actions, dismissal, and the absent-release-notes case.
- Full suite green (1182 tests across all packages), plus lint, typecheck, and Prettier.
- `electron-forge package` succeeds; verified in the built bundle that the repository slug inlines correctly, `notifyUser: false` reaches the call site, and the new IPC channels are present in both the main chunk and the preload.

Not exercised end-to-end against a live Squirrel feed — that needs a signed build and a published release.

## Risks

Low. The updater is inert in development and on Linux, so the change is a no-op outside packaged macOS/Windows builds. The riskiest single line is the new `package.json` import in the main process, which is why the bundle was checked directly rather than assumed.

## Follow-ups

- #432 — determinate progress and user-gated download via `electron-updater`
- #433 — Linux has no update path at all