### PR TITLE
test(control-e2e): cover security-critical browser flows

### DIFF
--- a/packages/streamwall-control-e2e/tests/custom-stream.spec.ts
+++ b/packages/streamwall-control-e2e/tests/custom-stream.spec.ts
@@ -1,0 +1,70 @@
+import type { StreamData } from 'streamwall-shared'
+import { expect, test } from './harness.ts'
+
+/**
+ * End-to-end coverage for issue #391: the Sidebar's "Custom Streams" panel
+ * (`Sidebar.tsx`'s `CustomStreamInput`/`CreateCustomStreamInput`) has no
+ * server-side unit test at all, unlike the Access panel's invite round-trip
+ * (`invite-management.spec.ts`). These drive the add and delete forms in a
+ * real browser and assert the resulting `update-custom-stream` /
+ * `delete-custom-stream` commands actually reach the Streamwall peer.
+ */
+
+const SEEDED_CUSTOM_STREAM: StreamData = {
+  _id: 'https://example.com/seeded-custom-stream',
+  _dataSource: 'custom',
+  kind: 'video',
+  link: 'https://example.com/seeded-custom-stream',
+  label: 'Seeded Custom Stream',
+}
+
+test('adding a custom stream from the sidebar forwards an update-custom-stream command to the peer', async ({
+  page,
+  harness,
+}) => {
+  await page.goto(await harness.createInviteLink())
+  await expect(
+    page.getByRole('heading', { name: 'Custom Streams' }),
+  ).toBeVisible()
+
+  const link = 'https://example.com/new-custom-stream'
+  const addForm = page
+    .locator('form')
+    .filter({ has: page.getByRole('button', { name: 'add stream' }) })
+  await addForm.getByPlaceholder('https://...').fill(link)
+  await addForm.getByPlaceholder('Label (optional)').fill('Field Cam')
+
+  const addCommandPromise = harness.waitForCommand('update-custom-stream')
+  await addForm.getByRole('button', { name: 'add stream' }).click()
+
+  const addCommand = await addCommandPromise
+  expect(addCommand).toMatchObject({
+    type: 'update-custom-stream',
+    url: link,
+    data: { link, kind: 'video', label: 'Field Cam' },
+  })
+})
+
+test('deleting an existing custom stream forwards a delete-custom-stream command to the peer', async ({
+  page,
+  harness,
+}) => {
+  // Seeded before navigation so the row (and its delete button) is already
+  // rendered when the browser connects - the harness's default state has no
+  // custom streams (see harness.ts's `DEMO_STREAMS`).
+  harness.pushState({ streams: [SEEDED_CUSTOM_STREAM] })
+  await page.goto(await harness.createInviteLink())
+
+  await expect(
+    page.getByRole('link', { name: SEEDED_CUSTOM_STREAM.link }),
+  ).toBeVisible()
+
+  const deleteCommandPromise = harness.waitForCommand('delete-custom-stream')
+  await page.getByRole('button', { name: 'x', exact: true }).click()
+
+  const deleteCommand = await deleteCommandPromise
+  expect(deleteCommand).toMatchObject({
+    type: 'delete-custom-stream',
+    url: SEEDED_CUSTOM_STREAM.link,
+  })
+})

--- a/packages/streamwall-control-e2e/tests/harness.ts
+++ b/packages/streamwall-control-e2e/tests/harness.ts
@@ -121,6 +121,15 @@ export interface Harness {
     type: T['type'],
     timeoutMs?: number,
   ): Promise<T>
+  /**
+   * Pushes an updated `StreamwallState` from the fake uplink, shallow-merged
+   * over whatever was last pushed (starting from the initial seed). Lets a
+   * test simulate the real Streamwall peer re-broadcasting a snapshot after
+   * processing a forwarded command — e.g. reflecting a `customStreams` entry
+   * back into `streams` — which the static initial seed does not do on its
+   * own.
+   */
+  pushState(patch: Partial<StreamwallState>): void
   close(): Promise<void>
 }
 
@@ -233,8 +242,14 @@ export async function startHarness(): Promise<Harness> {
   })
 
   await once(ws, 'open')
-  ws.send(JSON.stringify({ type: 'state', state: E2E_STATE }))
+  let currentState: StreamwallState = E2E_STATE
+  ws.send(JSON.stringify({ type: 'state', state: currentState }))
   ws.send(Y.encodeStateAsUpdate(peerDoc))
+
+  const pushState = (patch: Partial<StreamwallState>) => {
+    currentState = { ...currentState, ...patch }
+    ws.send(JSON.stringify({ type: 'state', state: currentState }))
+  }
 
   const redeemSessionCookie = async (role: StreamwallRole) => {
     const invite = await auth.createToken({ kind: 'invite', role, name: 'e2e' })
@@ -379,6 +394,7 @@ export async function startHarness(): Promise<Harness> {
     createInviteLink,
     waitForViewAssignment,
     waitForCommand,
+    pushState,
     close,
   }
 }

--- a/packages/streamwall-control-e2e/tests/invalid-invite.spec.ts
+++ b/packages/streamwall-control-e2e/tests/invalid-invite.spec.ts
@@ -1,0 +1,28 @@
+import { SESSION_COOKIE_NAME } from 'streamwall-control-server'
+import { expect, test } from './harness.ts'
+
+/**
+ * End-to-end coverage for issue #391: an invite link with an unknown or
+ * already-redeemed id/secret must show the invite-exchange page's error
+ * copy (`index.ts`'s `INVITE_EXCHANGE_SCRIPT`, driven by the server's plain
+ * 403) and must never set the session cookie — this is server behavior
+ * already covered by `inviteExchange.test.ts`, but only a real browser
+ * proves the client-side exchange script actually surfaces it to the user
+ * instead of, say, hanging on "Signing you in…" forever.
+ */
+
+test('visiting an invalid invite link shows an error and never grants a session', async ({
+  page,
+  harness,
+}) => {
+  await page.goto(
+    `${harness.baseURL}/invite/does-not-exist#token=not-a-real-secret`,
+  )
+
+  await expect(page.locator('p')).toHaveText(
+    'This invite is invalid or has expired.',
+  )
+
+  const cookies = await page.context().cookies()
+  expect(cookies.some((c) => c.name === SESSION_COOKIE_NAME)).toBe(false)
+})

--- a/packages/streamwall-control-e2e/tests/multi-client.spec.ts
+++ b/packages/streamwall-control-e2e/tests/multi-client.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from './harness.ts'
+
+/**
+ * End-to-end coverage for issue #391: `multiplexing.test.ts` covers the
+ * server's fan-out of a shared-doc update to every *other* connected client
+ * in isolation, but that says nothing about what two real operator browsers
+ * actually see. Each gets its own invite (and so its own session cookie) via
+ * a separate browser context, mirroring two people working the same wall at
+ * once.
+ */
+
+test('concurrent edits from two browser clients on different cells converge on both', async ({
+  browser,
+  harness,
+}) => {
+  const context1 = await browser.newContext()
+  const context2 = await browser.newContext()
+  try {
+    const page1 = await context1.newPage()
+    const page2 = await context2.newPage()
+
+    await page1.goto(await harness.createInviteLink())
+    await page2.goto(await harness.createInviteLink())
+
+    const cells1 = page1.getByTestId('grid-cell')
+    const cells2 = page2.getByTestId('grid-cell')
+    await expect(cells1).toHaveCount(harness.cols * harness.rows)
+    await expect(cells2).toHaveCount(harness.cols * harness.rows)
+
+    const [streamIdA, streamIdB] = harness.streamIds
+    const idxA = 0
+    const idxB = harness.cols * harness.rows - 1 // opposite corner: no overlap
+
+    await page1.getByTestId('grid').hover()
+    await page2.getByTestId('grid').hover()
+
+    await Promise.all([
+      (async () => {
+        await cells1.nth(idxA).fill(streamIdA)
+        await cells1.nth(idxA).blur()
+      })(),
+      (async () => {
+        await cells2.nth(idxB).fill(streamIdB)
+        await cells2.nth(idxB).blur()
+      })(),
+    ])
+
+    await Promise.all([
+      harness.waitForViewAssignment(idxA, streamIdA),
+      harness.waitForViewAssignment(idxB, streamIdB),
+    ])
+
+    // Both edits must land on both clients: a naive last-write-wins merge
+    // (or a client only reflecting its own edit) would drop one of them.
+    await expect(cells1.nth(idxA)).toHaveValue(streamIdA)
+    await expect(cells1.nth(idxB)).toHaveValue(streamIdB)
+    await expect(cells2.nth(idxA)).toHaveValue(streamIdA)
+    await expect(cells2.nth(idxB)).toHaveValue(streamIdB)
+  } finally {
+    await context1.close()
+    await context2.close()
+  }
+})

--- a/packages/streamwall-control-e2e/tests/rate-limit.spec.ts
+++ b/packages/streamwall-control-e2e/tests/rate-limit.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test } from '@playwright/test'
+import { startHarness } from './harness.ts'
+
+/**
+ * End-to-end coverage for issue #391: the control server's per-connection
+ * inbound WebSocket message budget (`rateLimiter.ts`'s `TokenBucket`) closes
+ * the socket with a "rate limit exceeded" error once a client exceeds it.
+ * This must surface as the operator-visible rate-limited banner
+ * (`ConnectionStatusBanner`) rather than a silent drop, and the client must
+ * then reconnect and resync cleanly, same as any other transport blip
+ * (issue #37/#283).
+ *
+ * This test starts its own harness (rather than using the shared `harness`
+ * fixture from `./harness.ts`) so it can set a near-zero message budget via
+ * environment variables *before* the server boots — the config is only read
+ * once, lazily, inside `initApp`. The budget applies per-connection, so the
+ * fake uplink (which sends its own seed state + doc snapshot on connect, see
+ * `startHarness`) gets an independent bucket from the browser client under
+ * test — capacity 2 covers the uplink's two startup sends with room to
+ * spare, while still being small enough for the test to trip deliberately.
+ */
+
+test('a client that exceeds the inbound message budget sees the rate-limited banner, then resyncs', async ({
+  page,
+}) => {
+  process.env.STREAMWALL_WS_MSG_BURST = '2'
+  // Refills so slowly it may as well not refill during the test.
+  process.env.STREAMWALL_WS_MSG_RATE = '0.01'
+  const harness = await startHarness()
+  try {
+    await page.goto(await harness.createInviteLink())
+
+    const grid = page.getByTestId('grid')
+    await expect(grid).toBeVisible()
+    await expect(page.getByTestId('header-connection-status')).toContainText(
+      'connected',
+    )
+
+    const cells = page.getByTestId('grid-cell')
+    const [firstStreamId, secondStreamId, thirdStreamId] = harness.streamIds
+    await grid.hover()
+
+    // The browser client's own bucket starts fresh at capacity 2: these two
+    // edits consume it exactly, both succeeding.
+    await cells.nth(0).fill(firstStreamId)
+    await cells.nth(0).blur()
+    await harness.waitForViewAssignment(0, firstStreamId)
+
+    await cells.nth(1).fill(secondStreamId)
+    await cells.nth(1).blur()
+    await harness.waitForViewAssignment(1, secondStreamId)
+
+    // A third edit, made immediately after, exceeds the now-empty budget:
+    // the server closes the socket instead of applying it, after sending
+    // the rate-limit error the client maps to a reason.
+    await cells.nth(2).fill(thirdStreamId)
+    await cells.nth(2).blur()
+
+    await expect(page.getByTestId('connection-status-banner')).toContainText(
+      'Too many messages sent',
+    )
+    await expect(page.getByTestId('header-connection-status')).toContainText(
+      'connecting...',
+    )
+
+    // The reconnect gets a brand-new per-connection budget and a full
+    // resync: the banner clears, and both earlier (successfully applied)
+    // assignments survive the blip exactly like a plain network drop would.
+    await expect(page.getByTestId('connection-status-banner')).toHaveCount(0)
+    await expect(page.getByTestId('header-connection-status')).toContainText(
+      'connected',
+    )
+    await expect(cells.nth(0)).toHaveValue(firstStreamId)
+    await expect(cells.nth(1)).toHaveValue(secondStreamId)
+  } finally {
+    delete process.env.STREAMWALL_WS_MSG_BURST
+    delete process.env.STREAMWALL_WS_MSG_RATE
+    await harness.close()
+  }
+})


### PR DESCRIPTION
## Problem

The Playwright E2E suite covered happy-path multiplayer smoke scenarios but did not exercise several failure modes that are security- and UX-critical in production, even though the equivalent server-side behavior was already unit-tested:

| Scenario | Server unit test | E2E (before) |
|----------|------------------|----|
| HTTP/WS rate limit → user-visible feedback | `rateLimiter.test.ts` | ❌ |
| Invalid/expired invite link in browser | `inviteExchange.test.ts` | ❌ |
| Two simultaneous browser clients editing grid | `multiplexing.test.ts` | ❌ |
| Custom stream add/delete roundtrip | — | ❌ |

## Solution

Added four new Playwright specs to `streamwall-control-e2e`, following the existing harness/fixture conventions:

- **`rate-limit.spec.ts`** — drives a client past the per-connection inbound WebSocket message budget (`STREAMWALL_WS_MSG_BURST`/`_RATE`, set to a tiny value for this test only) and asserts the rate-limited banner appears, then that the client cleanly reconnects and resyncs (same recovery path as the existing reconnect regression test).
- **`invalid-invite.spec.ts`** — visits an invite link with an unknown id/secret and asserts the exchange page's error copy renders and no session cookie is ever set.
- **`multi-client.spec.ts`** — opens two separate browser contexts (two independent sessions), has both edit different grid cells concurrently, and asserts both edits converge on both clients.
- **`custom-stream.spec.ts`** — drives the sidebar's add/delete custom-stream forms and asserts the resulting `update-custom-stream`/`delete-custom-stream` commands reach the Streamwall peer with the expected shape.

`harness.ts` gained a small `pushState` helper so a test can simulate the Streamwall peer re-broadcasting a state snapshot after processing a forwarded command (used to seed an existing custom stream before the delete test) without touching the shared default state every other spec relies on.

## Architecture decisions

- `rate-limit.spec.ts` starts its own harness via the exported `startHarness()` (rather than the shared `harness` fixture) so it can set the message-budget env vars *before* the server boots. The budget applies per-connection, so the fake uplink's own two startup sends (state + doc snapshot) get an independent bucket from the browser client under test — capacity 2 covers both cleanly while still being small enough to trip deliberately with a 3rd edit.
- `multi-client.spec.ts` uses two separate `BrowserContext`s (not two pages in one context) so each gets its own session cookie, matching how two real operators would actually connect.
- Kept scope to the issue's four proposed specs. Token revocation in the Access Panel is a real gap too (flagged in the issue's gap table but not one of its proposed specs) — filed as a separate follow-up issue rather than expanding scope here.

## Testing performed

- `npm -w streamwall-control-e2e run test:e2e` — all 15 specs pass (10 pre-existing + 5 new).
- `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (all workspaces) — all clean.
- `npm run build` (streamwall-control-client, the only workspace with a build step) — succeeds.

## Risks / breaking changes

None — test-only change, no production code touched.

Closes #391