### PR TITLE
test(control-server): cover Access Panel token revocation

### DIFF
--- a/packages/streamwall-control-e2e/tests/invite-management.spec.ts
+++ b/packages/streamwall-control-e2e/tests/invite-management.spec.ts
@@ -34,3 +34,33 @@ test('creating an invite from the Access panel renders the resulting link and li
   // ...and the token now shows up live in the persistent Invites list.
   await expect(page.getByText('field-crew: operator')).toBeVisible()
 })
+
+/**
+ * Coverage for issue #438: the Access panel's "revoke" button (`AuthTokenLine`'s
+ * `onDelete`) had no E2E coverage at all. Revokes a freshly created invite -
+ * never the browser's own admin session, which the harness names "e2e" and
+ * which revoking would immediately close this very socket (a distinct
+ * scenario from the one under test here).
+ */
+test('revoking an invite from the Access panel removes it from the Invites list', async ({
+  page,
+  harness,
+}) => {
+  await page.goto(await harness.createInviteLink())
+
+  const createInviteForm = page
+    .locator('form')
+    .filter({ has: page.getByRole('button', { name: 'create invite' }) })
+  await createInviteForm
+    .getByPlaceholder('Name', { exact: true })
+    .fill('to-revoke')
+  await createInviteForm.getByRole('combobox').selectOption('operator')
+  await createInviteForm.getByRole('button', { name: 'create invite' }).click()
+
+  await expect(page.getByText('to-revoke: operator')).toBeVisible()
+
+  const inviteRow = page.getByText('to-revoke', { exact: true }).locator('..')
+  await inviteRow.getByRole('button', { name: 'revoke' }).click()
+
+  await expect(page.getByText('to-revoke: operator')).not.toBeVisible()
+})

--- a/packages/streamwall-control-server/src/multiplexing.test.ts
+++ b/packages/streamwall-control-server/src/multiplexing.test.ts
@@ -408,3 +408,60 @@ test('deleting a token live-pushes a state-delta to an already-connected admin c
     'the revoked invite must disappear via a live delta, without waiting for an unrelated desktop state push',
   )
 })
+
+test("an admin's delete-token command revokes the token and live-pushes the removal to other connected clients", async () => {
+  const { auth, connectClient } = await bootServerWithUplink()
+  const { clientWs: actingAdminWs } = await connectClient('admin')
+  // A second admin client (only admins are ever sent `auth` state, see
+  // `StateWrapper.view`) proves the removal is broadcast, not just reflected
+  // back to the client that sent the command.
+  const { client: otherAdminClient } = await connectClient('admin')
+  let state = (await otherAdminClient.waitFor(isStateMessage)).state
+
+  const invite = await auth.createToken({
+    kind: 'invite',
+    role: 'operator',
+    name: 'to revoke',
+  })
+  const createDelta = await otherAdminClient.waitFor(isStateDelta)
+  state = applyDelta(state, createDelta.delta)
+  assert.ok(state.auth?.invites.some((i) => i.tokenId === invite.tokenId))
+
+  actingAdminWs.send(
+    JSON.stringify({ id: 20, type: 'delete-token', tokenId: invite.tokenId }),
+  )
+
+  const deleteDelta = await otherAdminClient.waitFor(
+    (m): m is ClientStateDeltaMessage => isStateDelta(m) && m !== createDelta,
+  )
+  state = applyDelta(state, deleteDelta.delta)
+  assert.ok(
+    !state.auth?.invites.some((i) => i.tokenId === invite.tokenId),
+    'the revoked invite must disappear via a live delta pushed to another connected client, not just the actor',
+  )
+  assert.ok(
+    !auth.getStoredData().tokens.some((t) => t.tokenId === invite.tokenId),
+    'the delete-token command must remove the token from storage',
+  )
+})
+
+test('an admin revoking their own session via delete-token closes their own socket', async () => {
+  const { connectClient } = await bootServerWithUplink()
+  const { clientWs: adminWs, client: adminClient } =
+    await connectClient('admin')
+
+  const state = (await adminClient.waitFor(isStateMessage)).state
+  const ownTokenId = state.auth?.sessions[0]?.tokenId
+  assert.ok(
+    ownTokenId,
+    'the initial state pushed on connect must include the just-redeemed session',
+  )
+
+  const closed = once(adminWs, 'close', { signal: AbortSignal.timeout(3000) })
+  adminWs.send(
+    JSON.stringify({ id: 21, type: 'delete-token', tokenId: ownTokenId }),
+  )
+
+  await closed
+  assert.equal(adminWs.readyState, WebSocket.CLOSED)
+})


### PR DESCRIPTION
## Problem

Issue #391's gap analysis flagged the Access Panel's token-revocation flow ("revoke" button on an invite/session row, `AuthTokenLine`'s `onDelete` → `delete-token` command) as having no test coverage at all - neither a server unit test nor an E2E spec. Unlike the other gaps in that table, this one was intentionally left out of #391's "Proposed specs" list and out of #437 to keep that PR scoped.

| Scenario | Server unit test | E2E |
|----------|------------------|-----|
| Token revocation in Access Panel | ❌ | ❌ |

This is the one action in the Access panel with zero regression coverage, and it has real security weight: `delete-token` is literally how an admin locks someone out, and revoking your own session immediately disconnects you.

## Solution

- **`multiplexing.test.ts`** (control-server): two new tests drive the actual `delete-token` WS command (not `auth.deleteToken()` directly, as the existing adjacent test does):
  - an admin's `delete-token` command removes the token from `auth.getStoredData()` and live-pushes the removal to *another* already-connected admin client (not just the actor) via a `state-delta`.
  - an admin revoking their own session's token closes their own socket, covering the security-relevant self-lockout behavior called out in the issue.
- **`invite-management.spec.ts`** (control-e2e): a new spec creates an invite from the Access panel, clicks "revoke" on it, and asserts the entry disappears from the Invites list - careful to revoke a token distinct from the browser's own session (named `"e2e"` by the harness), since revoking your own session would close that very socket.

## Architecture decisions

- The two server unit tests use two independent admin client connections rather than admin + operator, since `StateWrapper.view()` only includes `auth` state for the `admin` role — an operator would never observe the delta and the test would hang waiting for one.
- Kept the E2E addition in the existing `invite-management.spec.ts` rather than a new file, since it extends the same Access-panel invite round-trip already covered there.

## Testing performed

- `node --import tsx --test src/multiplexing.test.ts` (control-server) — new and existing tests pass.
- `npm -w streamwall-control-client run build && NODE_OPTIONS="--import tsx" npx playwright test tests/invite-management.spec.ts` (control-e2e) — both specs pass.
- `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (all workspaces) — all clean.
- `npm -w streamwall-control-client run build` (the only workspace with a build step) — succeeds.

## Risks / breaking changes

None — test-only change, no production code touched.

Closes #438