### PR TITLE
fix(streamwall): main-process tests depend on electron being hoisted to the root node_modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "streamwall",
+      "license": "MIT",
       "workspaces": [
         "packages/streamwall",
         "packages/streamwall-shared",
@@ -7371,25 +7372,6 @@
         "node": ">=0.12.18"
       }
     },
-    "node_modules/electron": {
-      "version": "43.1.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-43.1.0.tgz",
-      "integrity": "sha512-DPfxpQLd4NL3BJ8DBxYAfmLUKKesF5Rx9dQx5FyczAP8bhOPScjHE48GArVeXu68LlAainuwkmQTQvdZwpIIAQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@electron-internal/extract-zip": "^1.0.1",
-        "@electron/get": "^5.0.0",
-        "@types/node": "^24.9.0"
-      },
-      "bin": {
-        "electron": "cli.js",
-        "install-electron": "install.js"
-      },
-      "engines": {
-        "node": ">= 22.12.0"
-      }
-    },
     "node_modules/electron-installer-common": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/electron-installer-common/-/electron-installer-common-0.10.3.tgz",
@@ -7873,53 +7855,6 @@
       "optional": true,
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/electron/node_modules/@electron/get": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
-      "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "env-paths": "^3.0.0",
-        "graceful-fs": "^4.2.11",
-        "progress": "^2.0.3",
-        "semver": "^7.6.3",
-        "sumchecker": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=22.12.0"
-      },
-      "optionalDependencies": {
-        "undici": "^7.24.4"
-      }
-    },
-    "node_modules/electron/node_modules/env-paths": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
-      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/electron/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/emoji-regex": {
@@ -15215,7 +15150,7 @@
         "@types/lodash-es": "^4.17.12",
         "@types/ws": "^8.18.1",
         "@types/yargs": "^17.0.35",
-        "electron": "^43.1.0",
+        "electron": "^43.1.1",
         "happy-dom": "^20.11.0",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.3",
@@ -15547,6 +15482,7 @@
     },
     "packages/streamwall-control-ui": {
       "version": "0.0.0",
+      "license": "MIT",
       "dependencies": {
         "@fontsource/ibm-plex-sans": "^5.3.0",
         "@fontsource/jetbrains-mono": "^5.3.0",
@@ -15654,6 +15590,7 @@
     },
     "packages/streamwall-shared": {
       "version": "0.0.0",
+      "license": "MIT",
       "dependencies": {
         "color": "^5.0.3",
         "jsondiffpatch": "^0.7.6",
@@ -15723,6 +15660,27 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "packages/streamwall/node_modules/@electron/get": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
+      "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
+        "progress": "^2.0.3",
+        "semver": "^7.6.3",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "optionalDependencies": {
+        "undici": "^7.24.4"
       }
     },
     "packages/streamwall/node_modules/@preact/preset-vite": {
@@ -15930,6 +15888,25 @@
         "node": ">=18"
       }
     },
+    "packages/streamwall/node_modules/electron": {
+      "version": "43.1.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.1.1.tgz",
+      "integrity": "sha512-I5c5vfuVvaXpWx3IZdwvXgxQW44+e7OP1wXGVQkogLeSFSkUZ6sLCcWV05AdEcs65AO5tAIJJwbp7ixw+LdarA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
+      },
+      "bin": {
+        "electron": "cli.js",
+        "install-electron": "install.js"
+      },
+      "engines": {
+        "node": ">= 22.12.0"
+      }
+    },
     "packages/streamwall/node_modules/entities": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
@@ -15941,6 +15918,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "packages/streamwall/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/streamwall/node_modules/happy-dom": {
@@ -16034,6 +16024,19 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/streamwall/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "packages/streamwall/node_modules/utf-8-validate": {

--- a/packages/streamwall/package.json
+++ b/packages/streamwall/package.json
@@ -34,7 +34,7 @@
     "@types/lodash-es": "^4.17.12",
     "@types/ws": "^8.18.1",
     "@types/yargs": "^17.0.35",
-    "electron": "^43.1.0",
+    "electron": "^43.1.1",
     "happy-dom": "^20.11.0",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3",

--- a/packages/streamwall/vitest.config.ts
+++ b/packages/streamwall/vitest.config.ts
@@ -19,6 +19,19 @@ import { defineConfig } from 'vitest/config'
 // (see issue #182); it was replaced with a first-party inlined component
 // (see OverlayViewTile.tsx's TailSpin import) rather than extending this fix
 // to a third dependency.
+//
+// `logger.ts` imports `electron-log/main`, whose entry point is CJS-only (no
+// ESM/browser build to route through the fix above) and does a bare
+// `require('electron')` at module scope. That require is real Node
+// resolution rooted at electron-log's own install location, not this
+// package's - so it only finds `electron` when npm happens to hoist both to
+// the same node_modules directory, and throws "Cannot find module 'electron'"
+// whenever npm nests `electron` under this package instead (see issue #439).
+// electron-log also ships `electron-log/node`, a Node-only build with the
+// same Logger API (transports, log levels) that never touches `electron` at
+// all - main-process code under test never runs inside a real Electron
+// process anyway, so redirecting to it here sidesteps the hoisting-dependent
+// require entirely instead of trying to make it resolve reliably.
 export default defineConfig({
   esbuild: {
     jsx: 'automatic',
@@ -29,6 +42,7 @@ export default defineConfig({
     alias: {
       react: 'preact/compat',
       'react-dom': 'preact/compat',
+      'electron-log/main': 'electron-log/node',
     },
   },
   test: {


### PR DESCRIPTION
## Problem

`electron-log` is a dependency of `packages/streamwall`, but npm hoists it to the root `node_modules`. Its entry point resolves Electron with a bare `require('electron')`, which only succeeds because `electron` also happens to be hoisted to the root today. The dependency tree layout is not something we control, and npm changes it on a version bump — in #422, bumping `electron` 43.1.0 → 43.1.1 made npm place `electron` at `packages/streamwall/node_modules/electron` instead of the root, and the hoisted `electron-log` could no longer resolve it, failing 15 main-process test files to load on all three CI platforms. The electron bump was deferred out of #422 to unblock it.

## Technical solution

`packages/streamwall/src/main/logger.ts` imports `electron-log/main`. That entry point is CJS-only (no ESM/browser build), and does a bare `require('electron')` at module scope. Under Vitest, electron-log is loaded as an opaque external CJS module, so that require runs through real Node resolution rooted at electron-log's own install location — not this package's — which is why it depends on npm's hoisting choice.

I initially tried the same fix `vitest.config.ts` already uses for `react-icons`/`styled-components` (alias `electron` to a resolved path + `deps.inline` to route electron-log through Vite's resolver). That's the wrong fix here and CI caught it: unlike `react-icons`/`styled-components`, electron-log ships no ESM/browser build, so inlining a pure-CJS module doesn't rewrite its internal `require()` calls — they still go through raw Node resolution regardless of the alias, and CI still failed with the exact same `Cannot find module 'electron'` error.

The actual fix: electron-log also ships `electron-log/node`, a Node-only build with the same Logger API (`transports`, log levels, `initialize()`) that never touches `electron` anywhere in its dependency chain (verified: no `require('electron')` in its source tree at all). Main-process code under test never runs inside a real Electron process anyway, so `vitest.config.ts` now aliases `electron-log/main` → `electron-log/node` for tests, sidestepping the hoisting-dependent require entirely instead of trying to make it resolve reliably.

The deferred `electron` 43.1.0 → 43.1.1 bump from #422 is applied in a separate commit.

## Testing performed

- Full quality gate (`format:check`, `lint`, `typecheck`, `npm test` across all workspaces, `streamwall-control-client` build, `streamwall` Electron package smoke test) passes locally.
- As the issue notes, this failure mode is hoisting-layout-dependent and not reliably reproducible on a local tree. I got a genuine, non-contrived reproduction anyway: a plain `npm install` in this environment happened to place `electron` under `packages/streamwall/node_modules` instead of the root (the same "nested" layout #422 hit on CI) — I confirmed the *previous* (incorrect) alias/inline fix still failed with `Cannot find module 'electron'` under that real layout, and confirmed the current fix passes the full suite (50 files / 525 tests) under that same layout.
- No new test file was added: `logger.test.ts` already imports `electron-log/main` (indirectly, via `./logger`) unmocked, so it already serves as the regression guard for this resolution path.

## Risks / breaking changes

None expected. This is test-tooling configuration only, plus a routine patch-level `electron` bump (bugfix release, no breaking changes per Electron's release notes). `electron-log/node` omits only the Electron IPC-forwarding behavior (irrelevant outside a real Electron process) and uses OS/package.json-derived paths instead of `electron.app.getPath()` for its default log directory — neither is exercised by any test (file logging is disabled in tests via `log.transports.file.level = false`).

Closes #439