### PR TITLE
feat(streamwall): notify Linux users of available updates via GitHub Releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,10 +290,12 @@ byte-level progress, the banner shows an indeterminate indicator rather than a
 percentage. Update-check failures are logged, not surfaced — they are usually
 just an offline machine.
 
-This only runs in packaged builds, and only on macOS and Windows; on Linux the
-updater is a no-op and users install from the released packages. Note that
-macOS additionally requires the app to be **signed** (see below) before updates
-can install.
+This only runs in packaged builds, and only on macOS and Windows: Squirrel is
+a no-op on Linux. Linux builds instead poll the GitHub Releases API directly
+once a day and show a **View Release** banner when a newer version is found —
+notification only, since `.deb`/`.rpm` installs go through the OS package
+manager rather than a self-updater. Note that macOS additionally requires the
+app to be **signed** (see below) before updates can install.
 
 To produce signed, notarized builds, set these environment variables before
 running `make`/`publish` (see `packages/streamwall/forge.signing.ts`):

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -66,6 +66,7 @@ import {
   applyLayoutPreset,
   buildLayoutPreset,
 } from './layoutPresets'
+import { LinuxUpdateChecker } from './linuxUpdateChecker'
 import log, {
   LOG_LEVELS,
   initLogger,
@@ -507,31 +508,61 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     hasUserConfig,
   })
 
-  const appUpdater = new AppUpdater(
-    autoUpdater,
-    parseRepositorySlug(packageJson.repository),
-  )
-  appUpdater.on('status', (status) => {
-    if (status.state === 'error') {
-      // Not surfaced in the UI: a failed update check is routine (offline,
-      // rate limit) and not actionable by the user.
-      log.warn('Update check failed:', status.message)
-    } else {
+  // Squirrel's autoUpdater (and update-electron-app, below) is a no-op on
+  // Linux, so it never notifies users there. LinuxUpdateChecker polls GitHub
+  // Releases directly instead, and only ever offers a link since .deb/.rpm
+  // installs go through the OS package manager, not a self-updater (#433).
+  if (process.platform === 'linux') {
+    const linuxUpdateChecker = new LinuxUpdateChecker({
+      currentVersion: app.getVersion(),
+      repository: parseRepositorySlug(packageJson.repository),
+    })
+    linuxUpdateChecker.on('status', (status) => {
       log.debug('Update status:', status.state)
-    }
-    controlWindow.onUpdateStatus(status)
-  })
-  controlWindow.setUpdateHandlers({
-    getAppVersion: () => app.getVersion(),
-    getStatus: () => appUpdater.getStatus(),
-    install: () => appUpdater.install(),
-    openReleaseNotes: () => {
-      const status = appUpdater.getStatus()
-      if (status.state === 'ready' && status.releaseNotesUrl) {
-        shell.openExternal(status.releaseNotesUrl)
+      controlWindow.onUpdateStatus(status)
+    })
+    controlWindow.setUpdateHandlers({
+      getAppVersion: () => app.getVersion(),
+      getStatus: () => linuxUpdateChecker.getStatus(),
+      install: () => {
+        // Never reachable from the banner (no install action is offered for
+        // `available`), but the handler bundle requires one.
+      },
+      openReleaseNotes: () => {
+        const status = linuxUpdateChecker.getStatus()
+        if (status.state === 'available') {
+          shell.openExternal(status.releaseUrl)
+        }
+      },
+    })
+    linuxUpdateChecker.start()
+  } else {
+    const appUpdater = new AppUpdater(
+      autoUpdater,
+      parseRepositorySlug(packageJson.repository),
+    )
+    appUpdater.on('status', (status) => {
+      if (status.state === 'error') {
+        // Not surfaced in the UI: a failed update check is routine (offline,
+        // rate limit) and not actionable by the user.
+        log.warn('Update check failed:', status.message)
+      } else {
+        log.debug('Update status:', status.state)
       }
-    },
-  })
+      controlWindow.onUpdateStatus(status)
+    })
+    controlWindow.setUpdateHandlers({
+      getAppVersion: () => app.getVersion(),
+      getStatus: () => appUpdater.getStatus(),
+      install: () => appUpdater.install(),
+      openReleaseNotes: () => {
+        const status = appUpdater.getStatus()
+        if (status.state === 'ready' && status.releaseNotesUrl) {
+          shell.openExternal(status.releaseNotesUrl)
+        }
+      },
+    })
+  }
 
   let browseWindow: BrowserWindow | null = null
   let streamdelayClient: StreamdelayClient | null = null

--- a/packages/streamwall/src/main/linuxUpdateChecker.test.ts
+++ b/packages/streamwall/src/main/linuxUpdateChecker.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it, vi } from 'vitest'
+import { LinuxUpdateChecker, isNewerVersion } from './linuxUpdateChecker'
+
+/** A `fetch`-shaped stub resolving to a JSON body with the given status. */
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    json: async () => body,
+  }
+}
+
+function createChecker(
+  overrides: Partial<ConstructorParameters<typeof LinuxUpdateChecker>[0]> = {},
+) {
+  const checker = new LinuxUpdateChecker({
+    currentVersion: '0.9.1',
+    repository: 'NilsR0711/streamwall',
+    fetchImpl: async () =>
+      jsonResponse({
+        tag_name: 'v0.9.1',
+        html_url: 'https://github.com/NilsR0711/streamwall/releases/tag/v0.9.1',
+      }),
+    ...overrides,
+  })
+  const statuses: unknown[] = []
+  checker.on('status', (status) => statuses.push(status))
+  return { checker, statuses }
+}
+
+describe('isNewerVersion', () => {
+  it('detects a newer major/minor/patch release', () => {
+    expect(isNewerVersion('1.0.0', '0.9.1')).toBe(true)
+    expect(isNewerVersion('0.10.0', '0.9.1')).toBe(true)
+    expect(isNewerVersion('0.9.2', '0.9.1')).toBe(true)
+  })
+
+  it('ignores an equal or older release', () => {
+    expect(isNewerVersion('0.9.1', '0.9.1')).toBe(false)
+    expect(isNewerVersion('0.9.0', '0.9.1')).toBe(false)
+  })
+
+  it('tolerates a leading "v" on either side (release tags carry one)', () => {
+    expect(isNewerVersion('v1.0.0', '0.9.1')).toBe(true)
+  })
+
+  it('treats an unparsable version as "no update" rather than throwing', () => {
+    expect(isNewerVersion('not-a-version', '0.9.1')).toBe(false)
+  })
+})
+
+describe('LinuxUpdateChecker.checkNow', () => {
+  it('starts idle so the renderer renders no banner before a check has run', () => {
+    const { checker } = createChecker()
+
+    expect(checker.getStatus()).toEqual({ state: 'idle' })
+  })
+
+  it('reports an available update with a release page URL, never install semantics', async () => {
+    const { checker, statuses } = createChecker({
+      fetchImpl: async () =>
+        jsonResponse({
+          tag_name: 'v1.0.0',
+          html_url:
+            'https://github.com/NilsR0711/streamwall/releases/tag/v1.0.0',
+        }),
+    })
+
+    const status = await checker.checkNow()
+
+    expect(status).toEqual({
+      state: 'available',
+      version: '1.0.0',
+      releaseUrl: 'https://github.com/NilsR0711/streamwall/releases/tag/v1.0.0',
+    })
+    expect(statuses).toEqual([status])
+  })
+
+  it('stays idle when the latest release is not newer than the running version', async () => {
+    const { checker } = createChecker({
+      fetchImpl: async () =>
+        jsonResponse({
+          tag_name: 'v0.9.1',
+          html_url: 'https://example.test/r',
+        }),
+    })
+
+    const status = await checker.checkNow()
+
+    expect(status).toEqual({ state: 'idle' })
+  })
+
+  it('queries the GitHub releases API for the configured repository', async () => {
+    const requestedUrls: string[] = []
+    const { checker } = createChecker({
+      fetchImpl: async (url: string) => {
+        requestedUrls.push(url)
+        return jsonResponse({
+          tag_name: 'v0.9.1',
+          html_url: 'https://example.test',
+        })
+      },
+    })
+
+    await checker.checkNow()
+
+    expect(requestedUrls).toEqual([
+      'https://api.github.com/repos/NilsR0711/streamwall/releases/latest',
+    ])
+  })
+
+  it('never performs a request when the repository is unknown', async () => {
+    let calls = 0
+    const { checker } = createChecker({
+      repository: null,
+      fetchImpl: async () => {
+        calls++
+        return jsonResponse({})
+      },
+    })
+
+    const status = await checker.checkNow()
+
+    expect(calls).toBe(0)
+    expect(status).toEqual({ state: 'idle' })
+  })
+
+  it('keeps the last known available status when a later check fails, so a transient network hiccup does not hide a real update', async () => {
+    let fail = false
+    const { checker } = createChecker({
+      fetchImpl: async () => {
+        if (fail) {
+          throw new Error('network down')
+        }
+        return jsonResponse({
+          tag_name: 'v1.0.0',
+          html_url: 'https://example.test/releases/v1.0.0',
+        })
+      },
+    })
+
+    const first = await checker.checkNow()
+    fail = true
+    const second = await checker.checkNow()
+
+    expect(second).toEqual(first)
+  })
+
+  it('skips draft and prerelease entries, treating them as no update', async () => {
+    const { checker } = createChecker({
+      fetchImpl: async () =>
+        jsonResponse({
+          tag_name: 'v1.0.0',
+          html_url: 'https://example.test/r',
+          draft: true,
+        }),
+    })
+
+    const status = await checker.checkNow()
+
+    expect(status).toEqual({ state: 'idle' })
+  })
+
+  it('does not emit a status event when a check changes nothing', async () => {
+    const { checker, statuses } = createChecker({
+      fetchImpl: async () =>
+        jsonResponse({ tag_name: 'v0.9.1', html_url: 'https://example.test' }),
+    })
+
+    await checker.checkNow()
+    await checker.checkNow()
+
+    expect(statuses).toEqual([])
+  })
+})
+
+describe('LinuxUpdateChecker.start/stop', () => {
+  it('start() runs an immediate check and schedules periodic ones; stop() clears them', async () => {
+    let calls = 0
+    const timers: { fn: () => void; ms: number }[] = []
+    const { checker } = createChecker({
+      intervalMs: 1000,
+      fetchImpl: async () => {
+        calls++
+        return jsonResponse({
+          tag_name: 'v0.9.1',
+          html_url: 'https://example.test',
+        })
+      },
+      setIntervalImpl: (fn: () => void, ms: number) => {
+        timers.push({ fn, ms })
+        return timers.length
+      },
+      clearIntervalImpl: (handle: unknown) => {
+        timers.splice(Number(handle) - 1, 1)
+      },
+    })
+
+    checker.start()
+    await vi.waitFor(() => expect(calls).toBe(1))
+
+    expect(timers).toEqual([{ fn: timers[0]?.fn, ms: 1000 }])
+
+    checker.stop()
+    expect(timers.length).toBe(0)
+  })
+
+  it('start() is idempotent (no duplicate intervals)', () => {
+    const timers: unknown[] = []
+    const { checker } = createChecker({
+      setIntervalImpl: () => {
+        timers.push({})
+        return timers.length
+      },
+      clearIntervalImpl: () => {
+        timers.pop()
+      },
+    })
+
+    checker.start()
+    checker.start()
+
+    expect(timers.length).toBe(1)
+    checker.stop()
+  })
+})

--- a/packages/streamwall/src/main/linuxUpdateChecker.ts
+++ b/packages/streamwall/src/main/linuxUpdateChecker.ts
@@ -1,0 +1,265 @@
+import fetch from 'node-fetch'
+import EventEmitter from 'node:events'
+import { type UpdateStatus } from '../updateStatus'
+
+/**
+ * Linux update notifications (#433).
+ *
+ * Electron's built-in `autoUpdater` (Squirrel) and `update-electron-app` are
+ * both no-ops on Linux, so main/index.ts never touches `appUpdater.ts` there.
+ * This polls the GitHub Releases API directly instead, and is deliberately
+ * notify-only: it never downloads or installs anything, since `.deb`/`.rpm`
+ * users expect their package manager to handle installs, matching platform
+ * convention (see the issue). The `available` state it produces has no install
+ * action - main/index.ts wires it to open the release page instead.
+ */
+
+/** Once a day: releases are rare, and this keeps the GitHub API load trivial. */
+const DEFAULT_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000
+
+const DEFAULT_FETCH_TIMEOUT_MS = 10_000
+
+interface ParsedVersion {
+  core: number[]
+  prerelease: string[]
+}
+
+/**
+ * Parses the `MAJOR.MINOR.PATCH[-prerelease]` subset of semver the project
+ * actually publishes (`v0.9.1`, `v2.0.0-pre3`). Build metadata is ignored, and
+ * anything that does not match returns null so callers can degrade to "no
+ * update".
+ */
+function parseVersion(raw: string): ParsedVersion | null {
+  const match =
+    /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[\w.-]+)?$/.exec(
+      raw.trim(),
+    )
+  if (!match) {
+    return null
+  }
+  return {
+    core: [Number(match[1]), Number(match[2]), Number(match[3])],
+    prerelease: match[4] ? match[4].split('.') : [],
+  }
+}
+
+/** Semver precedence for prerelease identifiers: numeric < alphanumeric. */
+function comparePrerelease(a: string[], b: string[]): number {
+  if (a.length === 0 || b.length === 0) {
+    return a.length === b.length ? 0 : a.length === 0 ? 1 : -1
+  }
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const left = a[i]
+    const right = b[i]
+    if (left === undefined) {
+      return -1
+    }
+    if (right === undefined) {
+      return 1
+    }
+    const leftNumeric = /^\d+$/.test(left)
+    const rightNumeric = /^\d+$/.test(right)
+    if (leftNumeric && rightNumeric) {
+      if (Number(left) !== Number(right)) {
+        return Number(left) < Number(right) ? -1 : 1
+      }
+      continue
+    }
+    if (leftNumeric !== rightNumeric) {
+      return leftNumeric ? -1 : 1
+    }
+    if (left !== right) {
+      return left < right ? -1 : 1
+    }
+  }
+  return 0
+}
+
+/**
+ * True when `candidate` is strictly newer than `current`. Unparsable input on
+ * either side yields false: a version we cannot reason about must never
+ * produce a bogus "update available" notice.
+ */
+export function isNewerVersion(candidate: string, current: string): boolean {
+  const a = parseVersion(candidate)
+  const b = parseVersion(current)
+  if (!a || !b) {
+    return false
+  }
+  for (let i = 0; i < 3; i++) {
+    if (a.core[i] !== b.core[i]) {
+      return a.core[i] > b.core[i]
+    }
+  }
+  return comparePrerelease(a.prerelease, b.prerelease) > 0
+}
+
+interface LatestRelease {
+  version: string
+  url: string
+}
+
+type FetchResponse = {
+  ok: boolean
+  json(): Promise<unknown>
+}
+
+type FetchImpl = (
+  url: string,
+  init?: { signal?: AbortSignal; headers?: Record<string, string> },
+) => Promise<FetchResponse>
+
+/**
+ * Fetches the latest published (non-draft, non-prerelease) release. Every
+ * failure mode - offline host, rate limit, malformed body, hung connection -
+ * resolves to null: an update notice must never come from data that could not
+ * be fully verified.
+ */
+async function fetchLatestRelease(
+  repository: string,
+  fetchImpl: FetchImpl,
+  timeoutMs: number,
+): Promise<LatestRelease | null> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await fetchImpl(
+      `https://api.github.com/repos/${repository}/releases/latest`,
+      {
+        signal: controller.signal,
+        headers: { accept: 'application/vnd.github+json' },
+      },
+    )
+    if (!response.ok) {
+      return null
+    }
+    const body = (await response.json()) as {
+      tag_name?: unknown
+      html_url?: unknown
+      draft?: unknown
+      prerelease?: unknown
+    }
+    if (body.draft === true || body.prerelease === true) {
+      return null
+    }
+    if (
+      typeof body.tag_name !== 'string' ||
+      typeof body.html_url !== 'string'
+    ) {
+      return null
+    }
+    return {
+      version: body.tag_name.replace(/^v/, ''),
+      url: body.html_url,
+    }
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export interface LinuxUpdateCheckerEventMap {
+  status: [UpdateStatus]
+}
+
+export interface LinuxUpdateCheckerOptions {
+  currentVersion: string
+  /** `owner/name` slug; a check is a no-op when this is unknown. */
+  repository: string | null
+  fetchImpl?: FetchImpl
+  intervalMs?: number
+  timeoutMs?: number
+  setIntervalImpl?: (fn: () => void, ms: number) => unknown
+  clearIntervalImpl?: (handle: unknown) => void
+}
+
+/** Node's `setInterval` handle keeps the event loop alive; unref'ing it means a pending check never delays app shutdown. */
+function defaultSetInterval(fn: () => void, ms: number): unknown {
+  const handle = setInterval(fn, ms)
+  handle.unref?.()
+  return handle
+}
+
+/** Polls GitHub Releases for a newer version, since Squirrel cannot on Linux (#433). */
+export class LinuxUpdateChecker extends EventEmitter<LinuxUpdateCheckerEventMap> {
+  private status: UpdateStatus = { state: 'idle' }
+  private timer: unknown = null
+
+  constructor(private readonly options: LinuxUpdateCheckerOptions) {
+    super()
+  }
+
+  getStatus(): UpdateStatus {
+    return this.status
+  }
+
+  /**
+   * Runs a single check. On any failure the previous status is kept as-is: a
+   * transient network hiccup (offline machine, rate limit) must not hide an
+   * update notice the user has already seen, matching
+   * streamwall-control-server's updateCheck.ts.
+   */
+  async checkNow(): Promise<UpdateStatus> {
+    const { repository, currentVersion } = this.options
+    if (!repository) {
+      return this.status
+    }
+    const release = await fetchLatestRelease(
+      repository,
+      this.options.fetchImpl ?? (fetch as unknown as FetchImpl),
+      this.options.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS,
+    )
+    if (!release) {
+      return this.status
+    }
+    const nextStatus: UpdateStatus = isNewerVersion(
+      release.version,
+      currentVersion,
+    )
+      ? {
+          state: 'available',
+          version: release.version,
+          releaseUrl: release.url,
+        }
+      : { state: 'idle' }
+    this.setStatus(nextStatus)
+    return this.status
+  }
+
+  /** Runs an initial check and schedules periodic ones. Idempotent. */
+  start() {
+    if (this.timer !== null) {
+      return
+    }
+    void this.checkNow()
+    const setIntervalImpl = this.options.setIntervalImpl ?? defaultSetInterval
+    this.timer = setIntervalImpl(() => {
+      void this.checkNow()
+    }, this.options.intervalMs ?? DEFAULT_CHECK_INTERVAL_MS)
+  }
+
+  stop() {
+    if (this.timer !== null) {
+      const clearIntervalImpl =
+        this.options.clearIntervalImpl ??
+        ((handle: unknown) => clearInterval(handle as NodeJS.Timeout))
+      clearIntervalImpl(this.timer)
+      this.timer = null
+    }
+  }
+
+  /** Only emits when the status actually changed, so a no-op daily poll does not repeat IPC pushes/logs forever. */
+  private setStatus(status: UpdateStatus) {
+    if (statusEquals(this.status, status)) {
+      return
+    }
+    this.status = status
+    this.emit('status', status)
+  }
+}
+
+function statusEquals(a: UpdateStatus, b: UpdateStatus): boolean {
+  return JSON.stringify(a) === JSON.stringify(b)
+}

--- a/packages/streamwall/src/renderer/UpdateBanner.test.tsx
+++ b/packages/streamwall/src/renderer/UpdateBanner.test.tsx
@@ -90,6 +90,45 @@ describe('UpdateBanner downloading', () => {
   })
 })
 
+describe('UpdateBanner available', () => {
+  const availableStatus: UpdateStatus = {
+    state: 'available',
+    version: '0.9.2',
+    releaseUrl: 'https://github.com/NilsR0711/streamwall/releases/tag/v0.9.2',
+  }
+
+  test('names the new version and the version being replaced', () => {
+    renderBanner(availableStatus, { currentVersion: '0.9.1' })
+
+    expect(container!.textContent).toContain('0.9.2')
+    expect(container!.textContent).toContain('0.9.1')
+  })
+
+  test('offers no install action, since Linux updates go through the package manager', () => {
+    renderBanner(availableStatus)
+
+    expect(
+      container!.querySelector('[data-testid="install-update"]'),
+    ).toBeNull()
+  })
+
+  test('opens the release page externally rather than navigating the control window', () => {
+    const { onOpenReleaseNotes } = renderBanner(availableStatus)
+
+    click('view-release')
+
+    expect(onOpenReleaseNotes).toHaveBeenCalledWith(availableStatus.releaseUrl)
+  })
+
+  test('can be dismissed, keeping the notification non-intrusive', () => {
+    const { onDismiss } = renderBanner(availableStatus)
+
+    click('dismiss-update-banner')
+
+    expect(onDismiss).toHaveBeenCalledOnce()
+  })
+})
+
 describe('UpdateBanner ready', () => {
   const readyStatus: UpdateStatus = {
     state: 'ready',

--- a/packages/streamwall/src/renderer/UpdateBanner.tsx
+++ b/packages/streamwall/src/renderer/UpdateBanner.tsx
@@ -102,6 +102,10 @@ export interface UpdateBannerProps {
  * The download indicator is deliberately indeterminate: Electron's Squirrel
  * autoUpdater emits no byte-level progress (see main/appUpdater.ts), so a
  * percentage would have to be invented.
+ *
+ * `available` (#433) is Linux's notify-only counterpart to `ready`: Squirrel
+ * cannot download or install there, so the only action offered is opening the
+ * release page - see main/linuxUpdateChecker.ts.
  */
 export function UpdateBanner({
   status,
@@ -117,6 +121,31 @@ export function UpdateBanner({
         <ProgressTrack role="progressbar" aria-label="Downloading update">
           <ProgressBar />
         </ProgressTrack>
+        <DismissButton
+          data-testid="dismiss-update-banner"
+          aria-label="Dismiss"
+          onClick={onDismiss}
+        >
+          ×
+        </DismissButton>
+      </Banner>
+    )
+  }
+
+  if (status.state === 'available') {
+    return (
+      <Banner>
+        <Message>
+          Streamwall <Version>{status.version}</Version> is available (you're on{' '}
+          <Version>{currentVersion}</Version>). Update via your package manager,
+          or view the release.
+        </Message>
+        <ActionButton
+          data-testid="view-release"
+          onClick={() => onOpenReleaseNotes(status.releaseUrl)}
+        >
+          View Release
+        </ActionButton>
         <DismissButton
           data-testid="dismiss-update-banner"
           aria-label="Dismiss"

--- a/packages/streamwall/src/renderer/control.tsx
+++ b/packages/streamwall/src/renderer/control.tsx
@@ -142,11 +142,15 @@ function useUpdateStatus() {
   }, [])
 
   const dismiss = useCallback(() => {
-    setDismissedVersion(status.state === 'ready' ? status.version : 'pending')
+    setDismissedVersion(
+      status.state === 'ready' || status.state === 'available'
+        ? status.version
+        : 'pending',
+    )
   }, [status])
 
   const isDismissed =
-    status.state === 'ready'
+    status.state === 'ready' || status.state === 'available'
       ? dismissedVersion === status.version
       : dismissedVersion === 'pending'
 

--- a/packages/streamwall/src/updateStatus.ts
+++ b/packages/streamwall/src/updateStatus.ts
@@ -8,11 +8,16 @@
  * found, and emits no byte-level progress. So `downloading` carries no
  * percentage and there is no separate user-triggered download step - see
  * appUpdater.ts for the full rationale.
+ *
+ * `available` is a separate state (rather than reusing `ready`) for Linux
+ * (#433), where Squirrel is a no-op: linuxUpdateChecker.ts polls GitHub
+ * Releases directly and can only ever offer a link, never an install action.
  */
 export type UpdateStatus =
   | { state: 'idle' }
   | { state: 'checking' }
   | { state: 'downloading' }
+  | { state: 'available'; version: string; releaseUrl: string }
   | { state: 'ready'; version: string; releaseNotesUrl: string | null }
   | { state: 'error'; message: string }
 


### PR DESCRIPTION
## Problem

The in-app update notification added in #381/#434 covers macOS and Windows only. Electron's built-in `autoUpdater` (Squirrel) and `update-electron-app` are both no-ops on Linux, so a Linux user never learns a new version exists — the same awareness gap #381 fixed for the other two platforms.

## Solution

Implements option 1 from the issue (notify only):

- **`LinuxUpdateChecker`** (`packages/streamwall/src/main/linuxUpdateChecker.ts`) polls the GitHub Releases API once a day, compares the latest published (non-draft, non-prerelease) tag against `app.getVersion()`, and reports a new `available` `UpdateStatus` state. Every fetch failure (offline, rate limit, malformed body, timeout) leaves the previous status untouched instead of resetting to idle, so a transient network hiccup does not hide an update the user has already seen. The version-compare/fetch shape mirrors `streamwall-control-server/src/updateCheck.ts`.
- **`UpdateBanner`** gets a new `available` branch: names the new version, and offers a **View Release** button (opens the GitHub release page) with no install action, since `.deb`/`.rpm` installs go through the OS package manager rather than a self-updater.
- **`main/index.ts`** branches on `process.platform === 'linux'`: Linux gets `LinuxUpdateChecker` wired the same way `AppUpdater` already is on macOS/Windows (status pushed to the control window, `openReleaseNotes` gated in main so the renderer cannot spoof the target URL). `install` is a no-op there since it's never reachable from the banner.
- `useUpdateStatus`'s per-version dismissal now also covers `available`, matching the existing `ready` handling.
- README's "In-app updates" section documents the new Linux behavior.

## Architecture decisions

- **New `available` state instead of reusing `ready`**: `ready` means "downloaded and installable"; Linux never downloads or installs anything, so overloading `ready` would have been misleading and would have required threading a platform flag through the banner.
- **Duplicated version-compare/fetch logic rather than sharing it with `streamwall-control-server`**: the two packages already have separate, independently-tested copies of this shape (control-server's is Node-only, doesn't share `streamwall-shared`, and has no `repository` field to derive from). Consolidating them is a real but separate cleanup — filed as a follow-up issue (see below) rather than folded into this change.
- **No new IPC channel**: the existing `openReleaseNotes` channel (gated in main, no URL param from the renderer) already does exactly what the Linux "View Release" action needs.

## Testing

- `packages/streamwall/src/main/linuxUpdateChecker.test.ts` (new): version comparison, GitHub API URL construction, available/idle transitions, draft/prerelease skipping, failure resilience (keeps last known status), start/stop interval scheduling.
- `packages/streamwall/src/renderer/UpdateBanner.test.tsx`: new `available` branch coverage (version display, no install button, View Release click, dismiss).
- Full quality gate run locally: `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm test` (all packages, 0 failures), plus `npm -w streamwall-control-client run build` and `npm -w streamwall run package` (Electron Forge packaging smoke test) — all green.

## Risks / breaking changes

None expected. macOS/Windows update flow is untouched (same `AppUpdater`/`update-electron-app` path, unchanged behavior). The Linux path is new and additive; `install` is a no-op there so a stray IPC call cannot do anything.

Closes #433
