### PR TITLE
feat(control-ui): surface control-server version and update notice for admins

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -169,6 +169,11 @@ STREAMWALL_UPDATE_CHECK=false
 `updateAvailable` then stays `false` and `checkEnabled` reports `false`, so
 the endpoint still tells you the running version.
 
+A signed-in admin also sees this in the web control UI itself — the running
+version next to the connection status, and a dismissible notice when an
+update is available — so checking no longer requires shelling into the host
+or querying `/admin/status` by hand. Every other role sees neither.
+
 ## Updating
 
 ```sh

--- a/packages/streamwall-control-server/README.md
+++ b/packages/streamwall-control-server/README.md
@@ -66,7 +66,9 @@ The Content-Security-Policy is kept compatible with the served control client.
 The server logs its version at startup and, once a day, checks the GitHub
 Releases API for a newer release. It only ever notifies — it never updates
 itself. A signed-in **admin** can read the same state from
-`GET /admin/status` (`403` for every other role and for anonymous requests):
+`GET /admin/status` (`403` for every other role and for anonymous requests),
+which the web control UI also surfaces directly (running version plus a
+dismissible update notice) for admins signed in there:
 
 ```json
 {

--- a/packages/streamwall-control-ui/src/ServerUpdateBanner.test.tsx
+++ b/packages/streamwall-control-ui/src/ServerUpdateBanner.test.tsx
@@ -1,0 +1,111 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { ServerUpdateBanner } from './ServerUpdateBanner.tsx'
+import { type ServerStatus } from './useServerStatus.ts'
+
+let container: HTMLDivElement | undefined
+
+const AVAILABLE_STATUS: ServerStatus = {
+  version: '0.9.1',
+  latestVersion: '1.0.0',
+  updateAvailable: true,
+  releaseUrl: 'https://github.com/NilsR0711/streamwall/releases/tag/v1.0.0',
+  lastCheckedAt: '2026-07-20T09:00:00.000Z',
+  checkEnabled: true,
+}
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+  localStorage.clear()
+})
+
+function renderBanner(status: ServerStatus | null): HTMLDivElement {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    render(<ServerUpdateBanner status={status} />, container!)
+  })
+  return container
+}
+
+describe('ServerUpdateBanner', () => {
+  test('renders nothing when there is no status', () => {
+    const el = renderBanner(null)
+    expect(el.querySelector('.server-update-banner')).toBeNull()
+  })
+
+  test('renders nothing when no update is available', () => {
+    const el = renderBanner({ ...AVAILABLE_STATUS, updateAvailable: false })
+    expect(el.querySelector('.server-update-banner')).toBeNull()
+  })
+
+  test('renders nothing when the update check is disabled, even if the stale flag is set', () => {
+    const el = renderBanner({
+      ...AVAILABLE_STATUS,
+      checkEnabled: false,
+    })
+    expect(el.querySelector('.server-update-banner')).toBeNull()
+  })
+
+  test('shows a notice linking to the release when an update is available', () => {
+    const el = renderBanner(AVAILABLE_STATUS)
+    const banner = el.querySelector('.server-update-banner')
+    expect(banner?.textContent).toContain('1.0.0')
+    expect(banner?.textContent).toContain('0.9.1')
+    const link = banner?.querySelector('a') as HTMLAnchorElement
+    expect(link.href).toBe(AVAILABLE_STATUS.releaseUrl)
+  })
+
+  test('renders English copy', () => {
+    const el = renderBanner(AVAILABLE_STATUS)
+    const text = el.querySelector('.server-update-banner')?.textContent
+    expect(text).toContain('update')
+    expect(text).not.toMatch(/aktualisierung|verfügbar/i)
+  })
+
+  test('dismissing the notice hides it', () => {
+    const el = renderBanner(AVAILABLE_STATUS)
+    const dismissButton = el.querySelector(
+      '.server-update-banner button',
+    ) as HTMLButtonElement
+    act(() => {
+      dismissButton.click()
+    })
+    expect(el.querySelector('.server-update-banner')).toBeNull()
+  })
+
+  test('a dismissal persists across remounts for the same release', () => {
+    let el = renderBanner(AVAILABLE_STATUS)
+    const dismissButton = el.querySelector(
+      '.server-update-banner button',
+    ) as HTMLButtonElement
+    act(() => {
+      dismissButton.click()
+    })
+    act(() => render(null, container!))
+    el = renderBanner(AVAILABLE_STATUS)
+    expect(el.querySelector('.server-update-banner')).toBeNull()
+  })
+
+  test('a newer release re-shows the notice after a prior dismissal', () => {
+    let el = renderBanner(AVAILABLE_STATUS)
+    const dismissButton = el.querySelector(
+      '.server-update-banner button',
+    ) as HTMLButtonElement
+    act(() => {
+      dismissButton.click()
+    })
+    act(() => render(null, container!))
+    el = renderBanner({ ...AVAILABLE_STATUS, latestVersion: '1.1.0' })
+    expect(el.querySelector('.server-update-banner')).not.toBeNull()
+  })
+})

--- a/packages/streamwall-control-ui/src/ServerUpdateBanner.tsx
+++ b/packages/streamwall-control-ui/src/ServerUpdateBanner.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'preact/hooks'
+import { styled } from 'styled-components'
+import { type ServerStatus } from './useServerStatus.ts'
+
+const StyledServerUpdateBanner = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-dim);
+
+  a {
+    color: inherit;
+  }
+
+  button {
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    font-size: 12px;
+    padding: 0;
+    text-decoration: underline;
+  }
+`
+
+const DISMISSED_STORAGE_KEY = 'streamwall:update-notice-dismissed-release'
+
+function readDismissedKey(): string | null {
+  try {
+    return localStorage.getItem(DISMISSED_STORAGE_KEY)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Dismissible "a newer release is available" notice for admins, sourced
+ * from `GET /admin/status` (#436). Dismissal is keyed on `latestVersion` so
+ * dismissing one release doesn't hide the next one.
+ */
+export function ServerUpdateBanner({
+  status,
+}: {
+  status: ServerStatus | null
+}) {
+  const releaseKey = status?.latestVersion ?? status?.version ?? null
+  const [dismissedKey, setDismissedKey] = useState(readDismissedKey)
+
+  if (
+    status == null ||
+    !status.checkEnabled ||
+    !status.updateAvailable ||
+    releaseKey == null ||
+    dismissedKey === releaseKey
+  ) {
+    return null
+  }
+  // Reassign into a freshly-typed `const` (`string`, not `string | null`):
+  // TypeScript doesn't carry the `releaseKey == null` narrowing above into
+  // the nested `handleDismiss` closure.
+  const confirmedReleaseKey: string = releaseKey
+
+  function handleDismiss() {
+    setDismissedKey(confirmedReleaseKey)
+    try {
+      localStorage.setItem(DISMISSED_STORAGE_KEY, confirmedReleaseKey)
+    } catch {
+      // ignore (e.g. storage disabled)
+    }
+  }
+
+  return (
+    <StyledServerUpdateBanner className="server-update-banner">
+      <span>
+        A Streamwall update is available: {status.latestVersion} (you're on{' '}
+        {status.version}).
+      </span>
+      {status.releaseUrl && (
+        <a href={status.releaseUrl} target="_blank" rel="noreferrer">
+          Release notes
+        </a>
+      )}
+      <button type="button" onClick={handleDismiss}>
+        Dismiss
+      </button>
+    </StyledServerUpdateBanner>
+  )
+}

--- a/packages/streamwall-control-ui/src/ServerVersionLabel.test.tsx
+++ b/packages/streamwall-control-ui/src/ServerVersionLabel.test.tsx
@@ -1,0 +1,37 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { afterEach, describe, expect, test } from 'vitest'
+import { ServerVersionLabel } from './ServerVersionLabel.tsx'
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+function renderLabel(version: string | null): HTMLDivElement {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    render(<ServerVersionLabel version={version} />, container!)
+  })
+  return container
+}
+
+describe('ServerVersionLabel', () => {
+  test('renders nothing when there is no version to show', () => {
+    const el = renderLabel(null)
+    expect(el.querySelector('.server-version-label')).toBeNull()
+  })
+
+  test('shows the running server version', () => {
+    const el = renderLabel('0.9.1')
+    expect(el.querySelector('.server-version-label')?.textContent).toContain(
+      '0.9.1',
+    )
+  })
+})

--- a/packages/streamwall-control-ui/src/ServerVersionLabel.tsx
+++ b/packages/streamwall-control-ui/src/ServerVersionLabel.tsx
@@ -1,0 +1,23 @@
+import { styled } from 'styled-components'
+
+const StyledServerVersionLabel = styled.span`
+  font-size: 12px;
+  color: var(--text-dim);
+`
+
+/**
+ * Unobtrusive running-server-version line for admins (#436), so checking it
+ * no longer requires shelling into the host or hand-crafting an
+ * `/admin/status` request.
+ */
+export function ServerVersionLabel({ version }: { version: string | null }) {
+  if (version == null) {
+    return null
+  }
+
+  return (
+    <StyledServerVersionLabel className="server-version-label">
+      &nbsp;· v{version}
+    </StyledServerVersionLabel>
+  )
+}

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -57,12 +57,15 @@ import './index.css'
 import { type Invite, parseInviteResponse } from './invite.ts'
 import { LayoutPresetControls } from './LayoutPresetControls.tsx'
 import { ResizeHandles } from './ResizeHandles.tsx'
+import { ServerUpdateBanner } from './ServerUpdateBanner.tsx'
+import { ServerVersionLabel } from './ServerVersionLabel.tsx'
 import {
   CreateCustomStreamInput,
   CustomStreamInput,
   StreamList,
 } from './Sidebar.tsx'
 import { StyledButton, StyledDataContainer } from './StyledButton.tsx'
+import { useServerStatus } from './useServerStatus.ts'
 import { useTileDrag } from './useTileDrag.ts'
 import { useTileResize } from './useTileResize.ts'
 import {
@@ -272,6 +275,13 @@ export function ControlUI({
     width: windowWidth,
     height: windowHeight,
   } = config ?? { cols: null, rows: null, width: null, height: null }
+
+  // `local` is the desktop app's own IPC role, which has no `/admin/status`
+  // HTTP endpoint to fetch (issue #436) - the Electron app surfaces its own
+  // update state separately (issue #382).
+  const serverStatus = useServerStatus(
+    role !== 'local' && roleCan(role, 'view-server-status'),
+  )
 
   // Surfaces `{ error }` command responses that would otherwise be dropped
   // silently by the many call sites below that don't pass their own
@@ -777,6 +787,7 @@ export function ControlUI({
             <div className="status" data-testid="header-connection-status">
               <span className={`dot ${isConnected ? 'on' : 'off'}`} />
               {isConnected ? 'connected' : 'connecting...'} · {role}
+              <ServerVersionLabel version={serverStatus?.version ?? null} />
             </div>
           )}
           <ThemeToggle />
@@ -786,6 +797,7 @@ export function ControlUI({
           reason={disconnectReason}
         />
         <DataSourceHealthBanner dataSourceHealth={dataSourceHealth} />
+        <ServerUpdateBanner status={serverStatus} />
         <CommandErrorBanner
           error={commandError}
           onDismiss={() => setCommandError(null)}

--- a/packages/streamwall-control-ui/src/serverStatusGating.test.tsx
+++ b/packages/streamwall-control-ui/src/serverStatusGating.test.tsx
@@ -1,0 +1,134 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import type { StreamwallRole } from 'streamwall-shared'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import * as Y from 'yjs'
+import type { StreamwallConnection } from './index.tsx'
+import { ControlUI } from './index.tsx'
+import { type ServerStatus } from './useServerStatus.ts'
+
+// react-icons renders through preact/compat's Context.Consumer, which
+// currently crashes under this package's happy-dom test environment
+// (unrelated to the server status under test here) - stub the icons out so
+// the component can render.
+vi.mock('react-icons/fa', () => ({
+  FaExchangeAlt: () => null,
+  FaExclamationTriangle: () => null,
+  FaRedoAlt: () => null,
+  FaRegLifeRing: () => null,
+  FaRegWindowMaximize: () => null,
+  FaSyncAlt: () => null,
+  FaVideoSlash: () => null,
+  FaVolumeUp: () => null,
+}))
+vi.mock('react-icons/md', () => ({
+  MdOutlineStayCurrentLandscape: () => null,
+  MdOutlineStayCurrentPortrait: () => null,
+}))
+// react-hotkeys-hook calls into React internals that don't cooperate with
+// this package's Preact/compat test environment (unrelated to the server
+// status under test here) - stub it out so the component can render.
+vi.mock('react-hotkeys-hook', () => ({
+  useHotkeys: () => {},
+}))
+
+let container: HTMLDivElement | undefined
+let fetchMock: ReturnType<typeof vi.fn>
+
+const ADMIN_STATUS: ServerStatus = {
+  version: '0.9.1',
+  latestVersion: '1.0.0',
+  updateAvailable: true,
+  releaseUrl: 'https://github.com/NilsR0711/streamwall/releases/tag/v1.0.0',
+  lastCheckedAt: '2026-07-20T09:00:00.000Z',
+  checkEnabled: true,
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+  vi.unstubAllGlobals()
+})
+
+async function renderControlUI(role: StreamwallRole): Promise<HTMLDivElement> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+
+  const connection: StreamwallConnection = {
+    isConnected: true,
+    role,
+    send: () => {},
+    sharedState: { views: {} },
+    stateDoc: new Y.Doc(),
+    config: undefined,
+    streams: [],
+    customStreams: [],
+    views: [],
+    fullscreenViewIdx: null,
+    stateIdxMap: new Map(),
+    delayState: null,
+    authState: undefined,
+    layoutPresets: [],
+    favorites: [],
+    dataSourceHealth: [],
+  }
+
+  await act(async () => {
+    render(<ControlUI connection={connection} />, container!)
+  })
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+  return container
+}
+
+describe('server status gating (#436)', () => {
+  test('an admin sees the running version and an available update', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(ADMIN_STATUS),
+    })
+    const el = await renderControlUI('admin')
+    expect(fetchMock).toHaveBeenCalledWith('/admin/status', {
+      credentials: 'same-origin',
+    })
+    expect(el.querySelector('.server-version-label')?.textContent).toContain(
+      '0.9.1',
+    )
+    expect(el.querySelector('.server-update-banner')).not.toBeNull()
+  })
+
+  test('a non-admin role never requests /admin/status', async () => {
+    const el = await renderControlUI('operator')
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(el.querySelector('.server-version-label')).toBeNull()
+    expect(el.querySelector('.server-update-banner')).toBeNull()
+  })
+
+  test('the desktop app (role "local") never requests /admin/status', async () => {
+    const el = await renderControlUI('local')
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(el.querySelector('.server-version-label')).toBeNull()
+    expect(el.querySelector('.server-update-banner')).toBeNull()
+  })
+
+  test('a 403 response (session lost admin) shows neither version nor banner', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: () => Promise.resolve(null),
+    })
+    const el = await renderControlUI('admin')
+    expect(el.querySelector('.server-version-label')).toBeNull()
+    expect(el.querySelector('.server-update-banner')).toBeNull()
+  })
+})

--- a/packages/streamwall-control-ui/src/useServerStatus.test.tsx
+++ b/packages/streamwall-control-ui/src/useServerStatus.test.tsx
@@ -1,0 +1,93 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { type ServerStatus, useServerStatus } from './useServerStatus.ts'
+
+let container: HTMLDivElement | undefined
+let fetchMock: ReturnType<typeof vi.fn>
+
+const SAMPLE_STATUS: ServerStatus = {
+  version: '0.9.1',
+  latestVersion: '1.0.0',
+  updateAvailable: true,
+  releaseUrl: 'https://github.com/NilsR0711/streamwall/releases/tag/v1.0.0',
+  lastCheckedAt: '2026-07-20T09:00:00.000Z',
+  checkEnabled: true,
+}
+
+function jsonResponse(body: unknown, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response
+}
+
+function Probe({ enabled }: { enabled: boolean }) {
+  const status = useServerStatus(enabled)
+  return <div data-testid="probe">{JSON.stringify(status)}</div>
+}
+
+async function renderProbe(enabled: boolean) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  await act(async () => {
+    render(<Probe enabled={enabled} />, container!)
+  })
+  // Flush the fetch promise chain.
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+  return container
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+  vi.unstubAllGlobals()
+})
+
+describe('useServerStatus', () => {
+  test('does not fetch while disabled', async () => {
+    const el = await renderProbe(false)
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(el.querySelector('[data-testid="probe"]')?.textContent).toBe('null')
+  })
+
+  test('fetches /admin/status with same-origin credentials when enabled', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(SAMPLE_STATUS))
+    await renderProbe(true)
+    expect(fetchMock).toHaveBeenCalledWith('/admin/status', {
+      credentials: 'same-origin',
+    })
+  })
+
+  test('exposes the parsed status on success', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(SAMPLE_STATUS))
+    const el = await renderProbe(true)
+    expect(
+      JSON.parse(el.querySelector('[data-testid="probe"]')!.textContent!),
+    ).toEqual(SAMPLE_STATUS)
+  })
+
+  test('treats a 403 (non-admin) as no status rather than an error', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(null, false, 403))
+    const el = await renderProbe(true)
+    expect(el.querySelector('[data-testid="probe"]')?.textContent).toBe('null')
+  })
+
+  test('treats a network failure as no status', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'))
+    const el = await renderProbe(true)
+    expect(el.querySelector('[data-testid="probe"]')?.textContent).toBe('null')
+  })
+})

--- a/packages/streamwall-control-ui/src/useServerStatus.ts
+++ b/packages/streamwall-control-ui/src/useServerStatus.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'preact/hooks'
+
+export interface ServerStatus {
+  version: string
+  latestVersion: string | null
+  updateAvailable: boolean
+  releaseUrl: string | null
+  lastCheckedAt: string | null
+  checkEnabled: boolean
+}
+
+/**
+ * Fetches `GET /admin/status` (#430) while `enabled`. The endpoint is
+ * admin-only and returns a bare 403 for every other role/anonymous request;
+ * that's treated the same as any other failure (no status), since callers
+ * are expected to only set `enabled` once they already know the role can
+ * see it (#436) - a 403 here just means that check raced a role change.
+ */
+export function useServerStatus(enabled: boolean): ServerStatus | null {
+  const [status, setStatus] = useState<ServerStatus | null>(null)
+
+  useEffect(() => {
+    if (!enabled) {
+      setStatus(null)
+      return
+    }
+
+    let cancelled = false
+    fetch('/admin/status', { credentials: 'same-origin' })
+      .then((res) => (res.ok ? (res.json() as Promise<ServerStatus>) : null))
+      .then((data) => {
+        if (!cancelled) {
+          setStatus(data)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setStatus(null)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [enabled])
+
+  return status
+}


### PR DESCRIPTION
## Problem

`GET /admin/status` (#430) gives self-hosters the running control-server version and an "a newer release is available" signal, but only through a container log line and the raw endpoint. An admin signed in to the web control UI on a phone — the primary self-hosting use case — had to shell into the host or hand-craft a request to see either.

## Solution

- Added `useServerStatus(enabled)`, a hook that fetches `GET /admin/status` while `enabled`, treating a `403` (or any other failure) the same as "nothing to show" rather than an error.
- Added `ServerVersionLabel`, an unobtrusive `· v0.9.1` line next to the existing header connection-status text.
- Added `ServerUpdateBanner`, a dismissible notice ("A Streamwall update is available: …") linking to `releaseUrl` when `updateAvailable` is true. Dismissal is keyed on `latestVersion` and persisted in `localStorage`, so dismissing one release doesn't hide the next.
- Wired both into `ControlUI`, gated on `role !== 'local' && roleCan(role, 'view-server-status')`:
  - `role !== 'local'` excludes the Electron desktop app, which has no HTTP endpoint to fetch this from and already shows its own update state separately (#382/#434).
  - `roleCan(role, 'view-server-status')` restricts it to admins, matching the endpoint's own `403` gate.
- `checkEnabled: false` (operator disabled the check via `STREAMWALL_UPDATE_CHECK`) still shows the version but never the update banner — no stale or implied "you are up to date".
- Notify-only, per the decision already recorded in #382 — no update action in the UI.

Cross-referenced the new UI surface from the existing `/admin/status` docs in `docs/self-hosting.md` and `packages/streamwall-control-server/README.md`.

## Architecture decisions

- The fetch is a plain relative `fetch('/admin/status', { credentials: 'same-origin' })` rather than plumbing a base URL through `StreamwallConnection`: the control UI is always served by the control-server itself at the same origin (confirmed via `fastifyStatic` in `packages/streamwall-control-server/src/index.ts`), and the existing session cookie (`SESSION_COOKIE_NAME`) is sent automatically. This avoids adding a new prop to every connection implementation for a single admin-only fetch.
- The `ServerStatus` type is defined locally in `streamwall-control-ui` rather than imported from `streamwall-control-server`, to avoid adding a new cross-package dependency in the wrong direction (the repo already has 3 flagged circular dependencies — see `CLAUDE.md`).

## Testing

- `useServerStatus.test.tsx`: fetch gating (disabled ⇒ no request), success parsing, 403-as-no-status, network-failure-as-no-status, exact request shape (`/admin/status`, `same-origin`).
- `ServerVersionLabel.test.tsx`: renders nothing without a version; shows the version when present.
- `ServerUpdateBanner.test.tsx`: renders nothing without a status / when no update is available / when the check is disabled; shows the notice with a working release link; dismiss hides it; dismissal persists across remounts for the same release; a newer release re-shows the notice after a prior dismissal; English-only copy.
- `serverStatusGating.test.tsx`: integration test rendering the real `ControlUI` — an admin with a mocked `updateAvailable` response sees both the version and the banner; `operator` and `local` roles never even call `fetch`; a 403 response shows neither.
- Manually verified against a real running `control-server` (invite exchange → session cookie → `GET /admin/status`) via `curl`: `200` with the real version/update payload for the admin session, `403` empty-body for an anonymous request.

All new/changed code is covered — no untested behavior change.

## Risks / breaking changes

None. Additive UI surface, gated so it's invisible to non-admins and to the desktop app; the underlying endpoint (#430) is unchanged.

## Follow-up issues

- #442 — **unrelated pre-existing bug found while manually verifying this change**: `streamwall-control-server` crashes on every real startup (`FST_ERR_INSTANCE_ALREADY_LISTENING`) because `runServer` calls `app.addHook('onClose', ...)` after `await app.listen(...)` (introduced in #430). Not touched here to stay in scope for #436; filed as a release-blocking follow-up.

Closes #436
