### PR TITLE
test: guard TwitchBot cleanup listener

### DIFF
--- a/packages/streamwall/src/main/TwitchBot.test.ts
+++ b/packages/streamwall/src/main/TwitchBot.test.ts
@@ -58,7 +58,8 @@ describe('TwitchBot', () => {
   })
 
   afterEach(() => {
-    process.off('unhandledRejection', onUnhandledRejection)
+    if (onUnhandledRejection)
+      process.off('unhandledRejection', onUnhandledRejection)
     vi.useRealTimers()
     vi.restoreAllMocks()
   })


### PR DESCRIPTION
## Summary
- guard the TwitchBot test cleanup before removing the unhandledRejection listener
- preserves the original beforeEach failure when setup aborts before the listener is assigned

Fixes #446

## Validation
- `npm -w packages/streamwall test -- TwitchBot.test.ts`
- `npx prettier --check packages/streamwall/src/main/TwitchBot.test.ts`
- `npm -w packages/streamwall run typecheck`
- `npm -w packages/streamwall run lint`
- `npm test`
