### PR TITLE
feat(release): automate release version bumps across workspace manifests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,3 +30,29 @@ Streamwall is distributed under the [MIT License](LICENSE).
   Distributed release binaries do not currently bundle a consolidated
   `THIRD_PARTY_NOTICES` file; each dependency's own license file remains the
   source of truth via `node_modules`.
+
+## Cutting a release
+
+electron-forge derives the packaged app's version — and the `vX.Y.Z` tag that
+triggers `.github/workflows/release.yml` — from `packages/streamwall/package.json`.
+The control server reports its own `package.json` version in the self-hosting
+update notification and compares it against release tags, so that manifest
+must always match. `packages/streamwall-control-server/src/version.test.ts`
+enforces this as a regression backstop, not as the bump mechanism itself.
+
+To bump both release-tracking manifests (and `package-lock.json`) together in
+one step:
+
+```sh
+npm run release:version -- <x.y.z>
+```
+
+No other workspace tracks the release line:
+
+- `streamwall-shared` and `streamwall-control-ui` stay pinned at `0.0.0`
+  (`"private": true`, never published or versioned independently).
+- `streamwall-control-client` and `streamwall-control-e2e` stay at a fixed
+  `1.0.0` for the same reason.
+
+None of the workspaces are published to the npm registry — only the Electron
+app itself is distributed, via GitHub Releases.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "npm run typecheck --workspaces --if-present",
-    "test": "node --test test/*.test.mjs && npm run test --workspaces --if-present"
+    "test": "node --test test/*.test.mjs && npm run test --workspaces --if-present",
+    "release:version": "node scripts/release-version.mjs"
   },
   "workspaces": [
     "packages/streamwall",

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// Bumps every manifest that tracks the release line in one step. See
+// CONTRIBUTING.md for which workspaces track the release line and why.
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+export const RELEASE_TRACKED_WORKSPACES = [
+  'packages/streamwall',
+  'packages/streamwall-control-server',
+]
+
+const SEMVER_PATTERN =
+  /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/
+
+export function parseVersionArg(argv) {
+  const version = argv[0]
+  if (!version) {
+    throw new Error(
+      'Usage: npm run release:version -- <x.y.z>\n' +
+        'Example: npm run release:version -- 0.9.2',
+    )
+  }
+  if (!SEMVER_PATTERN.test(version)) {
+    throw new Error(
+      `"${version}" is not a valid semantic version (expected e.g. "1.2.3" or "1.2.3-pre1").`,
+    )
+  }
+  return version
+}
+
+export function buildNpmVersionArgs(version) {
+  return [
+    ...RELEASE_TRACKED_WORKSPACES.flatMap((workspace) => ['-w', workspace]),
+    'version',
+    version,
+    '--no-git-tag-version',
+  ]
+}
+
+function main() {
+  let version
+  try {
+    version = parseVersionArg(process.argv.slice(2))
+  } catch (error) {
+    console.error(error.message)
+    process.exit(1)
+  }
+  const result = spawnSync('npm', buildNpmVersionArgs(version), {
+    stdio: 'inherit',
+  })
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1)
+  }
+  console.log(
+    `\nBumped ${RELEASE_TRACKED_WORKSPACES.join(' and ')} to ${version} (package-lock.json included).\n` +
+      'streamwall-shared, streamwall-control-ui, streamwall-control-client, and streamwall-control-e2e ' +
+      'do not track the release line and were left unchanged.',
+  )
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  main()
+}

--- a/test/release-version.test.mjs
+++ b/test/release-version.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import {
+  buildNpmVersionArgs,
+  parseVersionArg,
+  RELEASE_TRACKED_WORKSPACES,
+} from '../scripts/release-version.mjs'
+
+test('parseVersionArg accepts a plain semantic version', () => {
+  assert.equal(parseVersionArg(['0.9.2']), '0.9.2')
+})
+
+test('parseVersionArg accepts a prerelease version', () => {
+  assert.equal(parseVersionArg(['2.0.0-pre4']), '2.0.0-pre4')
+})
+
+test('parseVersionArg accepts a version with build metadata', () => {
+  assert.equal(parseVersionArg(['1.2.3+build.7']), '1.2.3+build.7')
+})
+
+test('parseVersionArg rejects a missing argument', () => {
+  assert.throws(() => parseVersionArg([]), /Usage: npm run release:version/)
+})
+
+test('parseVersionArg rejects a version with a leading "v"', () => {
+  assert.throws(
+    () => parseVersionArg(['v0.9.2']),
+    /not a valid semantic version/,
+  )
+})
+
+test('parseVersionArg rejects a non-semver string', () => {
+  assert.throws(
+    () => parseVersionArg(['latest']),
+    /not a valid semantic version/,
+  )
+})
+
+test('parseVersionArg rejects a partial version', () => {
+  assert.throws(() => parseVersionArg(['0.9']), /not a valid semantic version/)
+})
+
+test('RELEASE_TRACKED_WORKSPACES lists exactly the manifests pinned by the version-sync test', () => {
+  assert.deepEqual(RELEASE_TRACKED_WORKSPACES, [
+    'packages/streamwall',
+    'packages/streamwall-control-server',
+  ])
+})
+
+test('buildNpmVersionArgs bumps every release-tracked workspace without tagging', () => {
+  assert.deepEqual(buildNpmVersionArgs('0.9.2'), [
+    '-w',
+    'packages/streamwall',
+    '-w',
+    'packages/streamwall-control-server',
+    'version',
+    '0.9.2',
+    '--no-git-tag-version',
+  ])
+})


### PR DESCRIPTION
## Problem

Cutting a release meant hand-editing package versions before tagging. Since #430, two manifests must move together:

- `packages/streamwall/package.json` — what electron-forge publishes, and what the `vX.Y.Z` tag reflects.
- `packages/streamwall-control-server/package.json` — what the server reports as its running version and compares against release tags.

`packages/streamwall-control-server/src/version.test.ts` catches drift between the two, but only after someone has already forgotten, and only in CI. The remaining manifests (`streamwall-shared`, `streamwall-control-ui` at `0.0.0`, `streamwall-control-client`, `streamwall-control-e2e` at `1.0.0`) carry no meaningful version, and it was undocumented which packages are supposed to track the release line.

## Solution

Adds `npm run release:version -- <x.y.z>`, a thin wrapper around `npm version` scoped to the two release-tracking workspaces:

```
npm -w packages/streamwall -w packages/streamwall-control-server version <x.y.z> --no-git-tag-version
```

This bumps both `package.json` files and `package-lock.json` in a single command, so the two manifests can no longer drift apart during a manual release. The script validates the version argument is well-formed semver (matching the plain and prerelease tags already used in this repo, e.g. `v0.9.1`, `v2.0.0-pre1`) before shelling out, and reports a clear usage error otherwise.

`CONTRIBUTING.md` now documents which manifests track the release line and which deliberately don't (and why) — the version-sync test is a backstop, not the specification, as suggested in the issue.

## Testing

- Added `test/release-version.test.mjs` (`node:test`, matching this repo's existing root-level test style) covering: valid plain/prerelease/build-metadata versions, a missing argument, a version with a leading `v`, a non-semver string, and a partial version — plus that the workspace list and generated `npm version` args are exactly right.
- Manually ran `npm run release:version -- 9.9.9` end-to-end and confirmed both manifests and `package-lock.json` bump correctly, then reverted (no version was actually released).
- Manually exercised both CLI error paths (missing arg, invalid semver) and confirmed no files change and the process exits non-zero.
- Full quality gate: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` (all workspaces), and `npm -w streamwall run package` (the same packaging smoke build CI runs) — all green.

## Risks / breaking changes

None. This only adds a new opt-in script and documentation; no existing behavior changes. The two manifests are currently already in sync (`0.9.1`), so nothing in this PR itself needs a version bump.

Closes #435