### PR TITLE
fix(control-server): register onClose hook before app.listen()

### DIFF
--- a/packages/streamwall-control-server/src/index.test.ts
+++ b/packages/streamwall-control-server/src/index.test.ts
@@ -2,8 +2,13 @@ import { Low, Memory } from 'lowdb'
 import assert from 'node:assert/strict'
 import { after, describe, test } from 'node:test'
 
-import { initApp, resolveListenPort, SESSION_COOKIE_NAME } from './index.ts'
+import runServer, {
+  initApp,
+  resolveListenPort,
+  SESSION_COOKIE_NAME,
+} from './index.ts'
 import type { StoredData } from './storage.ts'
+import type { UpdateChecker, UpdateStatus } from './updateCheck.ts'
 
 const ONE_YEAR_IN_SECONDS = 365 * 24 * 60 * 60
 
@@ -12,6 +17,24 @@ function inMemoryDb(): Low<StoredData> {
     auth: { salt: null, tokens: [] },
     streamwallToken: null,
   })
+}
+
+/** Stub `UpdateChecker` so specs never reach GitHub. */
+function fakeUpdateChecker(): UpdateChecker {
+  const status: UpdateStatus = {
+    version: 'test',
+    latestVersion: null,
+    updateAvailable: false,
+    releaseUrl: null,
+    lastCheckedAt: null,
+    checkEnabled: false,
+  }
+  return {
+    getStatus: () => status,
+    checkNow: async () => status,
+    start: async () => {},
+    stop: () => {},
+  }
 }
 
 /**
@@ -100,6 +123,29 @@ describe('session cookie security attributes', () => {
 
     assert.equal(response.statusCode, 403)
     assert.equal(response.headers['set-cookie'], undefined)
+  })
+})
+
+describe('runServer', () => {
+  test('starts for real via app.listen() without throwing (issue #442)', async () => {
+    // Regression test: `fastify.inject()` (used by every other spec in this
+    // file) drives the app *before* it ever listens, so a hook registered
+    // after `app.listen()` slips past the whole suite. Only a real
+    // `app.listen()` call reproduces FST_ERR_INSTANCE_ALREADY_LISTENING.
+    const { server } = await runServer({
+      baseURL: 'http://127.0.0.1:0',
+      clientStaticPath: import.meta.dirname,
+      db: inMemoryDb(),
+      updateChecker: fakeUpdateChecker(),
+    })
+    after(() => {
+      server.close()
+    })
+
+    assert.ok(
+      server.listening,
+      'server should be listening after runServer resolves',
+    )
   })
 })
 

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -1031,7 +1031,16 @@ export default async function runServer({
   hostname: overrideHostname,
   baseURL,
   clientStaticPath,
-}: AppOptions & { hostname?: string; port?: string }) {
+  db: injectedDb,
+  updateChecker: injectedUpdateChecker,
+}: AppOptions & {
+  hostname?: string
+  port?: string
+  /** Test-only override so specs can exercise the real listen() path without touching disk. */
+  db?: StorageDB
+  /** Test-only override so specs can exercise the real listen() path without reaching GitHub. */
+  updateChecker?: UpdateChecker
+}) {
   const url = new URL(baseURL)
   const hostname = overrideHostname ?? url.hostname
   const port = resolveListenPort(baseURL, overridePort)
@@ -1041,18 +1050,23 @@ export default async function runServer({
   const { app, db, auth, updateChecker } = await initApp({
     baseURL,
     clientStaticPath,
+    db: injectedDb,
+    updateChecker: injectedUpdateChecker,
   })
 
   const bootstrap = await initialInviteCodes({ db, auth, baseURL })
   logBootstrap(bootstrap)
 
+  // Hooks must be registered before the instance starts listening -- Fastify 5
+  // throws FST_ERR_INSTANCE_ALREADY_LISTENING otherwise (issue #442).
+  app.addHook('onClose', async () => {
+    updateChecker.stop()
+  })
+
   await app.listen({ port, host: hostname })
 
   // Fire-and-forget: a slow or unreachable GitHub must never delay serving.
   void updateChecker.start()
-  app.addHook('onClose', async () => {
-    updateChecker.stop()
-  })
 
   return { server: app.server }
 }


### PR DESCRIPTION
## Problem

`streamwall-control-server` crashed on every real startup (not caught by any test) since #430. `runServer` in `packages/streamwall-control-server/src/index.ts` called `app.addHook('onClose', ...)` *after* `await app.listen(...)`. Fastify 5 forbids registering hooks once the instance has started listening:

```
FastifyError: Fastify instance is already listening. Cannot call "addHook"!
  code: 'FST_ERR_INSTANCE_ALREADY_LISTENING'
```

Every self-hosted deployment on `main` failed to start (`node packages/streamwall-control-server/src/index.ts`, `npm run start:server`). The existing suite never caught this because every spec drives the app via `fastify.inject()` against the pre-listening instance and never exercises the real `app.listen()` path.

## Solution

- Moved `app.addHook('onClose', ...)` before `await app.listen(...)` — hooks can be registered any time before the instance starts.
- Extended `runServer`'s options with the same test-only `db`/`updateChecker` overrides `initApp` already supports, so specs can drive the real `runServer` end-to-end without touching real disk storage or reaching GitHub.
- Added a regression test that calls `runServer()` for real (binding an ephemeral port) and asserts the returned server is listening, so a future hook/plugin registered after `listen()` fails CI instead of only failing in production.

## Testing performed

- New regression test reproduces `FST_ERR_INSTANCE_ALREADY_LISTENING` against the pre-fix code, passes after the fix.
- `npm run format:check`, `npm run lint`, `npm run typecheck` — all clean.
- `npm test` — all workspaces green (streamwall 543, shared 305, control-client 16, control-server 153, control-ui 278 tests).
- `npm -w streamwall-control-client run build` — succeeds.
- Manually reproduced the crash with the real `runServer` path before the fix, confirmed it disappears after.
- Full PR CI green (static checks, ubuntu/macos/windows test matrix, build, package smoke, E2E smoke, CodeQL).

## Risks / breaking changes

None. This restores the intended startup behavior; no API or config surface changes. The `db`/`updateChecker` overrides added to `runServer` are optional test-only parameters, matching the existing pattern on `initApp`.

## Follow-up

Filed #451 (low priority) for a small pre-existing duplication noticed while touching `index.test.ts`'s imports.

Closes #442