### PR TITLE
ci(release): align release quality gate with PR CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,33 +16,95 @@ concurrency:
   group: release-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+# The quality gate mirrors the PR `ci-ok` inputs (format, cross-OS tests,
+# control-client build, Electron package smoke, E2E) so a tag can never ship
+# code that would have failed a PR. Unlike CI there are no docs-only path
+# filters: a release always builds and ships binaries, so every check runs
+# unconditionally. `publish` fans out only after all of them pass.
 jobs:
-  quality-gate:
-    name: Quality gate
+  # Prettier (also Markdown/YAML), ESLint and tsc — the CI `checks` job.
+  checks:
+    name: Static checks
     runs-on: ubuntu-latest
-    # Raised from 15 to cover the added packaging step.
-    timeout-minutes: 25
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
-      - name: Lint
+      - name: Format (Prettier)
+        run: npm run format:check
+      - name: Lint (ESLint)
+        if: ${{ !cancelled() }}
         run: npm run lint
-      - name: Typecheck
+      - name: Typecheck (tsc)
+        if: ${{ !cancelled() }}
         run: npm run typecheck
-      - name: Test
-        run: npm test
-      # Packaging smoke test before the three-OS publish matrix fans out: a
-      # Vite/Forge misconfiguration or a native-module unpacking failure
-      # fails here once (~45 seconds) instead of three times in parallel,
-      # each after a full Electron download.
-      - name: Package smoke build
-        run: npm -w streamwall run package
+
+  # Cross-OS unit tests. A release ships binaries for all three platforms, so
+  # the gate runs the full matrix rather than trusting a Linux-only leg.
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - run: npm test
+
+  build:
+    name: Build (web control client)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - run: npm -w streamwall-control-client run build
+
+  # Packaging smoke test before the three-OS publish matrix fans out: a
+  # Vite/Forge misconfiguration or a native-module unpacking failure fails
+  # here once (~45 seconds) instead of three times in parallel, each after a
+  # full Electron download. `package` only, not `make` — the maker-specific
+  # installer steps are the publish job's concern.
+  package:
+    name: Package smoke (Electron app)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - run: npm -w streamwall run package
+
+  # End-to-end smoke tests: the control client in a real Chromium browser
+  # against a real control server + fake Streamwall uplink. Linux-only (the
+  # Playwright browser install with system deps is Linux-only).
+  e2e:
+    name: E2E smoke (control client)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+      - name: Run E2E smoke tests
+        run: npm -w streamwall-control-e2e run test:e2e
 
   publish:
     name: Publish (${{ matrix.platform.name }})
-    needs: quality-gate
+    needs: [checks, test, build, package, e2e]
     runs-on: ${{ matrix.platform.os }}
     timeout-minutes: 30
     permissions:

--- a/README.md
+++ b/README.md
@@ -332,11 +332,24 @@ or by right-clicking the app and choosing "Open" instead of double-clicking.
 ### CI releases
 
 Pushing a `v*` tag (or running the workflow manually) triggers
-`.github/workflows/release.yml`, which runs the quality gate (lint, typecheck,
-test) and then builds and publishes a GitHub release for Linux, Windows, and
-macOS via `electron-forge publish`. Signing in CI is opt-in, matching the
-local `make`/`publish` behavior above: builds stay unsigned until these
-repository secrets are set.
+`.github/workflows/release.yml`. Its quality gate mirrors the same checks a
+pull request must pass (`CI OK`), so a tag can never ship code that would have
+failed a PR:
+
+- **Format** — `prettier --check` (also Markdown and YAML)
+- **Lint + typecheck** — ESLint and `tsc` across all workspaces
+- **Tests** — the full unit suite on Ubuntu, Windows, and macOS
+- **Control-client build** — `streamwall-control-client` production build
+- **Package smoke** — an Electron `package` of the desktop app
+- **E2E smoke** — the control client in a real browser against a live server
+
+Cross-OS tests run in the gate itself (not merely trusted from `main` CI):
+a release ships binaries for all three platforms, so all three are verified
+before publishing. Only once every check passes does the workflow build and
+publish a GitHub release for Linux, Windows, and macOS via
+`electron-forge publish`. Signing in CI is opt-in, matching the local
+`make`/`publish` behavior above: builds stay unsigned until these repository
+secrets are set.
 
 | Secret                         | Purpose                                                       |
 | ------------------------------ | ------------------------------------------------------------- |


### PR DESCRIPTION
## Problem

Tagged releases could ship code that a PR would have rejected. The release
workflow's quality gate was a strict subset of PR CI (`ci-ok`): it ran only
lint, typecheck, **Ubuntu-only** tests and an Electron package smoke. Missing
relative to a PR: `prettier --check`, cross-OS tests (Windows/macOS), the
control-client build, and the Playwright E2E smoke. A maintainer could tag
immediately after merging a formatting failure, a platform-specific test
regression, a broken control-client build, or an E2E breakage.

Resolves the gap documented in #402.

## Solution — Option A (strict)

Restructure the release quality gate into parallel jobs that mirror the
`ci-ok` inputs, and gate `publish` on all of them:

| Check | Before | After |
|-------|--------|-------|
| `prettier --check` | ❌ | ✅ |
| ESLint + tsc | ✅ | ✅ |
| Unit tests | Ubuntu only | ✅ Ubuntu + Windows + macOS |
| Control-client build | ❌ | ✅ |
| Electron package smoke | ✅ | ✅ |
| Playwright E2E | ❌ | ✅ |

`publish` now `needs: [checks, test, build, package, e2e]` and only fans out
across the three publish platforms once every check passes.

## Architecture decisions

- **No path filters.** Unlike CI, the release gate runs every check
  unconditionally — a release always ships binaries, so there is no docs-only
  fast path.
- **Cross-OS tests run *in* the gate**, not merely trusted from `main` CI: a
  release ships binaries for all three platforms, so all three are verified
  immediately before publishing (the cross-OS decision the issue asked to
  document).
- Job structure, pinned action SHAs, `persist-credentials: false`, and the
  shared `./.github/actions/setup` composite all match `ci.yml` so the two
  workflows stay in lockstep.
- The `publish` job (signing, matrix, permissions) is unchanged.

## Testing

- `npm run format:check` — clean
- `npm run lint` — clean (after `npm ci`; the worktree had stale
  `node_modules` missing `electron-updater`)
- `npm run typecheck` — clean
- `actionlint .github/workflows/release.yml` — clean

No unit tests were added: this change is workflow configuration and
documentation with no runtime behavior to cover. The workflow steps reuse the
exact commands already exercised green by `ci.yml` on `main`; `actionlint`
(itself part of CI) validates the workflow syntax.

## Risks / breaking changes

None for consumers. Releases will take longer and cost more runner minutes
(the added Windows/macOS test legs and E2E run before publish), which is the
intended trade-off of Option A. The `publish` job and signing flow are
untouched.

Closes #402