### PR TITLE
docs: add CHANGELOG and wire it to the release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to Streamwall are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Only the Electron app is distributed (via [GitHub Releases](https://github.com/NilsR0711/streamwall/releases));
+no workspace is published to npm. The release line is driven by
+`packages/streamwall/package.json` — see
+[CONTRIBUTING.md](CONTRIBUTING.md#cutting-a-release) for how versions and this
+changelog are kept in step.
+
+## [Unreleased]
+
+### Added
+
+- Consent-gated update downloads with a determinate progress indicator (#454).
+- In-app update notification with an install-and-restart flow (#434).
+- Update notifications for Linux users via GitHub Releases (#443).
+- Control server reports its own version and surfaces new releases (#430); the
+  control UI shows the server version and an update notice to admins (#444).
+- Stop HLS segment loading for parked views to save bandwidth (#424).
+
+### Changed
+
+- Release version bumps are automated across the release-tracking workspace
+  manifests via `npm run release:version` (#448).
+
+### Fixed
+
+- Control server registers its `onClose` hook before `app.listen()` so shutdown
+  cleanup runs reliably (#449).
+- IPC command errors are returned to the `CommandErrorBanner` instead of being
+  swallowed (#417).
+- Uplink state payloads are validated against a strict schema (#416).
+
+## [0.9.1] - 2026-07-15
+
+### Added
+
+- Double-click a grid stream to expand it to fullscreen (#368).
+- Optionally pause parked views during a fullscreen expansion (#383).
+
+### Changed
+
+- GitHub releases are published as non-prerelease builds (#361).
+
+### Fixed
+
+- Non-focused streams stay alive across a fullscreen expand/collapse (#373).
+- Unresolved playlist URLs are retried when stream data updates (#365).
+- The control server defaults its listen port when the URL has no port (#378).
+- `trustProxy` is opt-in so per-client rate limits work behind a reverse proxy
+  (#379).
+
+## [0.9.0] - 2026-07-15
+
+Initial public release: the first GitHub Release of the Streamwall Electron app,
+with unsigned pre-release builds for macOS, Windows, and Linux.
+
+[Unreleased]: https://github.com/NilsR0711/streamwall/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/NilsR0711/streamwall/compare/v0.9.0...v0.9.1
+[0.9.0]: https://github.com/NilsR0711/streamwall/releases/tag/v0.9.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,3 +56,23 @@ No other workspace tracks the release line:
 
 None of the workspaces are published to the npm registry — only the Electron
 app itself is distributed, via GitHub Releases.
+
+### Changelog
+
+Notable changes are tracked in [`CHANGELOG.md`](CHANGELOG.md), in
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. Because PRs are
+squash-merged with a Conventional Commits title, each merged PR should add a
+line to the `## [Unreleased]` section (grouped under `Added`, `Changed`,
+`Fixed`, etc.).
+
+When cutting a release, alongside the `release:version` bump:
+
+1. Rename `## [Unreleased]` to `## [x.y.z] - YYYY-MM-DD` and start a fresh empty
+   `## [Unreleased]` section above it.
+2. Update the compare links at the bottom of the file so `[Unreleased]` points
+   at `vx.y.z...HEAD` and a new `[x.y.z]` link is added.
+
+`test/changelog.test.mjs` runs as part of `npm test` and fails if `CHANGELOG.md`
+is missing an `## [Unreleased]` section or a heading for the version currently
+in `packages/streamwall/package.json`, so a version bump without a matching
+changelog entry is caught before release.

--- a/test/changelog.test.mjs
+++ b/test/changelog.test.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)))
+
+function readRootFile(relativePath) {
+  return readFileSync(join(rootDir, relativePath), 'utf8')
+}
+
+// The release line is driven by packages/streamwall/package.json (see the
+// "Cutting a release" section in CONTRIBUTING.md). Tie the changelog to that
+// same manifest so a version bump without a matching CHANGELOG entry fails
+// here, giving contributors the feedback loop the commit convention promises.
+function readReleaseVersion() {
+  const manifest = JSON.parse(readRootFile('packages/streamwall/package.json'))
+  return manifest.version
+}
+
+test('CHANGELOG.md keeps an Unreleased section', () => {
+  const changelog = readRootFile('CHANGELOG.md')
+  assert.match(
+    changelog,
+    /^## \[Unreleased\]/m,
+    'CHANGELOG.md must keep an "## [Unreleased]" section for pending changes',
+  )
+})
+
+test('CHANGELOG.md documents the current release version', () => {
+  const changelog = readRootFile('CHANGELOG.md')
+  const version = readReleaseVersion()
+  const heading = new RegExp(
+    `^## \\[${version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\]`,
+    'm',
+  )
+  assert.match(
+    changelog,
+    heading,
+    `CHANGELOG.md must document the current release version ${version} ` +
+      `(bumped in packages/streamwall/package.json). Add a "## [${version}]" section.`,
+  )
+})


### PR DESCRIPTION
## Problem

The project enforces Conventional Commits PR titles (`.github/workflows/pr-title.yml`) because squash merges use the PR title as the commit subject — but there was **no CHANGELOG** consuming that convention. GitHub Releases published Forge artifacts without a structured "what changed", users couldn't skim version-to-version differences, and contributors got no feedback loop from their commit discipline.

Closes #405.

## Solution

- **`CHANGELOG.md`** in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format with a baseline for the two shipped releases (`0.9.0`, `0.9.1`) plus an `## [Unreleased]` section capturing what's on `main` since `v0.9.1`. Compare links at the bottom point at the `vX.Y.Z...` diffs.
- **`CONTRIBUTING.md`** — extended the existing "Cutting a release" section with a *Changelog* subsection documenting per-PR upkeep and the release-cut steps (rename `[Unreleased]` → `[x.y.z]`, refresh compare links), right next to `npm run release:version`.
- **`test/changelog.test.mjs`** — regression backstop (runs under `npm test`, alongside the existing `version.test.ts` manifest guard). It fails if `CHANGELOG.md` is missing an `## [Unreleased]` section or a heading for the version currently in `packages/streamwall/package.json`, so a version bump without a matching changelog entry is caught before release.

## Architecture decisions

- Scope kept to the issue's **minimum (manual)** path. The **automated** option (release-please) is deliberately out of scope and tracked as a follow-up (see below).
- The changelog is tied to `packages/streamwall/package.json`, the same manifest that already drives the release line and the `vX.Y.Z` tag — keeping the single source of truth consistent with `version.test.ts`.

## Testing

- `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm test` all green locally (full suite; `test/changelog.test.mjs` red before `CHANGELOG.md` existed, green after).
- No production/runtime code changed, so no Electron package smoke was run locally — CI's change-scaled pipeline covers that.

## Risks / breaking changes

None. Docs plus one new test file; no runtime code touched.

## Follow-ups

- #457 — automate changelog/release notes generation (release-please or similar).