### PR TITLE
fix(control-ui): announce command and data-source banners to assistive tech

### DIFF
--- a/packages/streamwall-control-ui/src/CommandErrorBanner.test.tsx
+++ b/packages/streamwall-control-ui/src/CommandErrorBanner.test.tsx
@@ -67,4 +67,13 @@ describe('CommandErrorBanner', () => {
     })
     expect(onDismiss).toHaveBeenCalledOnce()
   })
+
+  // A command failure is an urgent, user-triggered outcome, so it is
+  // announced assertively to assistive technology (WCAG 4.1.3, issue #398).
+  test('announces the failure assertively to assistive technology', () => {
+    const el = renderBanner('unauthorized')
+    const banner = el.querySelector('.command-error-banner')
+    expect(banner?.getAttribute('role')).toBe('alert')
+    expect(banner?.getAttribute('aria-live')).toBe('assertive')
+  })
 })

--- a/packages/streamwall-control-ui/src/CommandErrorBanner.tsx
+++ b/packages/streamwall-control-ui/src/CommandErrorBanner.tsx
@@ -36,7 +36,11 @@ export function CommandErrorBanner({
   }
 
   return (
-    <StyledCommandErrorBanner className="command-error-banner">
+    <StyledCommandErrorBanner
+      className="command-error-banner"
+      role="alert"
+      aria-live="assertive"
+    >
       <FaExclamationTriangle />
       <span>Action failed: {error}</span>
       <button type="button" onClick={onDismiss}>

--- a/packages/streamwall-control-ui/src/DataSourceHealthBanner.test.tsx
+++ b/packages/streamwall-control-ui/src/DataSourceHealthBanner.test.tsx
@@ -106,4 +106,22 @@ describe('DataSourceHealthBanner', () => {
     expect(warnings.join(' ')).toContain('https://b.example/streams.json')
     expect(warnings.join(' ')).toContain('/tmp/streams.toml')
   })
+
+  // A data-source outage is recoverable and not user-triggered, so it is
+  // announced politely rather than interrupting the operator (WCAG 4.1.3,
+  // issue #398).
+  test('announces failing sources politely to assistive technology', () => {
+    const el = renderBanner([
+      {
+        id: 'https://dead.example/streams.json',
+        type: 'json-url',
+        status: 'error',
+        message: 'fetch failed',
+        updatedAt: 1000,
+      },
+    ])
+    const banner = el.querySelector('[role="status"]')
+    expect(banner).not.toBeNull()
+    expect(banner?.getAttribute('aria-live')).toBe('polite')
+  })
 })

--- a/packages/streamwall-control-ui/src/DataSourceHealthBanner.tsx
+++ b/packages/streamwall-control-ui/src/DataSourceHealthBanner.tsx
@@ -38,7 +38,7 @@ export function DataSourceHealthBanner({
   }
 
   return (
-    <StyledDataSourceHealthBanner>
+    <StyledDataSourceHealthBanner role="status" aria-live="polite">
       {failing.map((health) => (
         <span
           className="data-source-health-warning"


### PR DESCRIPTION
## Problem

`ConnectionStatusBanner` exposes connection state to assistive technology via `role="status"`, but `CommandErrorBanner` and `DataSourceHealthBanner` did not. Command failures (unauthorized, rate-limited, invalid payload) and data-source outages rendered visually only, so screen-reader users got no announcement when an action they triggered failed or a configured data file went missing/stale.

## Solution

- **`CommandErrorBanner`** → `role="alert"` + `aria-live="assertive"`. A command failure is an urgent, user-triggered outcome, so it interrupts the AT queue.
- **`DataSourceHealthBanner`** → `role="status"` + `aria-live="polite"`. An outage is recoverable and not directly user-triggered, so it is announced without interrupting.

Both follow the established pattern already used by `ConnectionStatusBanner` in the same UI.

## Architecture decisions

- Matched the assertive/polite split to urgency (WCAG-recommended): user-triggered failure = assertive, ambient health change = polite.
- Kept the live-region role on the existing banner wrapper (consistent with `ConnectionStatusBanner`, which returns `null` while healthy and mounts the region on state change). No structural/markup changes, so no visual regression.

## Testing

- Added tests to `CommandErrorBanner.test.tsx` and `DataSourceHealthBanner.test.tsx` asserting the `role`/`aria-live` attributes, mirroring the `ConnectionStatusBanner` accessibility tests.
- Full `streamwall-control-ui` suite: 280 passed. Root quality gate green: format, lint, typecheck, full test suite.

## Risks / breaking changes

None. Purely additive ARIA attributes; no visual or behavioral change for sighted users.

## Acceptance criteria

- [x] `CommandErrorBanner` announces errors to AT
- [x] `DataSourceHealthBanner` announces health changes
- [x] Tests assert ARIA attributes
- [x] No visual regression

Closes #398