### PR TITLE
docs: add SECURITY.md, contributor guide, and README Development section

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in the repo. GitHub auto-requests review from
+# these owners on every PR. Update as the maintainer set grows.
+* @NilsR0711

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: Bug report
+description: Report a reproducible problem in Streamwall
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. For **security** problems, do not use this
+        form — see [SECURITY.md](../blob/main/SECURITY.md) for private reporting.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal, ordered steps that trigger the bug.
+      placeholder: |
+        1. …
+        2. …
+        3. …
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Desktop app (streamwall)
+        - Control server (streamwall-control-server)
+        - Control client / UI (web)
+        - Build / release / CI
+        - Other / not sure
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Release version or commit SHA you are running.
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS / environment
+      placeholder: e.g. macOS 15.1 (Apple Silicon), Windows 11, Ubuntu 24.04
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Relevant log output or screenshots, if any. Redact secrets.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/NilsR0711/streamwall/security/advisories/new
+    about: Do not open a public issue for security problems — report privately. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature request
+description: Suggest a new capability or improvement
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do that Streamwall makes hard today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should happen? Sketch the behavior or UI you have in mind.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Desktop app (streamwall)
+        - Control server (streamwall-control-server)
+        - Control client / UI (web)
+        - Build / release / CI
+        - Other / not sure
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about, and why they fall short.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+<!--
+PR titles are validated as Conventional Commits (.github/workflows/pr-title.yml)
+and become the squash-merge commit subject on main, e.g.
+  fix(control-ui): handle empty grid
+Allowed types: feat fix docs style refactor perf test build ci chore revert
+-->
+
+## Summary
+
+<!-- What does this change do, and why? Link the issue it closes. -->
+
+Closes #
+
+## How was this tested?
+
+<!-- Commands run, scenarios exercised, or why no tests apply (docs/CI/format). -->
+
+## Checklist
+
+- [ ] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
+- [ ] New behavior is covered by tests (or this PR explains why none apply)
+- [ ] PR title follows Conventional Commits
+- [ ] No AI-tool attribution in commits, PR body, or comments

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,120 @@
 # Contributing
 
-## Quality gate
+Thanks for helping improve Streamwall. This guide covers local setup, the
+quality gate, and the conventions PRs are expected to follow.
 
-Before opening a PR, run the same checks CI runs:
+## Getting started
+
+Streamwall is an npm workspaces monorepo. Requirements:
+
+- **Node.js 22 or newer** (`engines.node` is `>=22`; a `.nvmrc` pins the major
+  so `nvm use` picks it up).
+- **npm** (ships with Node) — this repo uses npm workspaces, not pnpm or yarn.
+
+Install everything with a clean, lockfile-exact install from the repo root:
 
 ```sh
-npm run lint
-npm run format:check
-npm run typecheck
-npm test
+npm ci
 ```
+
+Use `npm ci` rather than `npm install` — it installs the exact tree from
+`package-lock.json` and hoists shared dependencies (for example Electron) to
+the root `node_modules`, which the main-process tests rely on. A plain
+`npm install` in a fresh checkout or git worktree can leave the tree in a
+state where those tests fail to resolve their dependencies.
+
+### Workspace map
+
+Six packages live under `packages/` (see the root `package.json`
+`workspaces` array):
+
+| Package                     | Role                                                     |
+| --------------------------- | -------------------------------------------------------- |
+| `streamwall`                | The Electron desktop app (main + renderer processes).    |
+| `streamwall-shared`         | Shared schemas and types used across the other packages. |
+| `streamwall-control-server` | Self-hostable backend for remote control (WS + HTTP).    |
+| `streamwall-control-client` | Web frontend for the control server.                     |
+| `streamwall-control-ui`     | Shared control UI components (Preact).                   |
+| `streamwall-control-e2e`    | Playwright end-to-end smoke tests for the control stack. |
+
+To run the app locally: `npm run start:app`. To run the control server with
+its web client: `npm run start:server`.
+
+## Quality gate
+
+Before opening a PR, run the same checks CI runs, from the repo root:
+
+```sh
+npm run lint          # ESLint
+npm run format:check  # Prettier (also checks Markdown and YAML)
+npm run typecheck     # tsc --noEmit across all workspaces
+npm test              # full test suite (see runner note below)
+```
+
+Zero errors and no new warnings. Prettier runs on every PR — including
+documentation-only changes — so run `npm run format` to auto-fix before
+pushing.
+
+### Test runners differ per package
+
+`npm test` fans out across the workspaces, and the packages do **not** all use
+the same runner:
+
+- Most packages (`streamwall`, `streamwall-shared`, `streamwall-control-ui`,
+  `streamwall-control-client`) use **Vitest** (`vitest run`).
+- `streamwall-control-server` uses the **native Node test runner**
+  (`node --test`) via `tsx`, single-threaded.
+- Root-level workspace-metadata tests run under `node --test` too.
+
+To run a single package's tests, target its workspace, e.g.
+`npm -w streamwall-control-server test`.
+
+### End-to-end tests
+
+The E2E smoke tests need a browser that is not installed by `npm ci`. They are
+**not** part of `npm test` — CI runs them in a dedicated job. To run them
+locally:
+
+```sh
+npx playwright install --with-deps chromium
+npm -w streamwall-control-e2e run test:e2e
+```
+
+## Making changes
+
+- **Test-driven development is expected** for behavior changes: write a failing
+  test first, make it pass, then refactor. Cover happy paths, edge cases, and
+  regressions. Docs-only, CI-config, or pure-formatting changes are exempt —
+  say so in the PR when no tests are added.
+- Prefer existing patterns and abstractions over introducing new ones.
+- Do not leave TODOs, placeholders, commented-out code, or stray debug output.
+
+## Commit and PR conventions
+
+- PRs are **squash-merged**, so the **PR title becomes the commit subject on
+  `main`** and must follow
+  [Conventional Commits](https://www.conventionalcommits.org/). This is
+  enforced by `.github/workflows/pr-title.yml`. Example:
+  `fix(control-ui): handle empty grid`.
+  Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`,
+  `build`, `ci`, `chore`, `revert`.
+- Keep individual commits focused; each should compile and pass the quality
+  gate on its own.
+- **No AI-tool attribution** anywhere — not in commit messages, PR
+  descriptions, or code comments.
+
+### PR checklist
+
+- [ ] `npm run lint`, `npm run format:check`, `npm run typecheck`, and
+      `npm test` all pass locally.
+- [ ] New behavior is covered by tests (or the PR explains why none apply).
+- [ ] PR title follows Conventional Commits.
+- [ ] No AI-tool attribution in commits, PR body, or comments.
+
+## Reporting security issues
+
+Please do **not** file security problems as public issues. See
+[SECURITY.md](SECURITY.md) for the private disclosure process.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,44 @@ The overlay window has its own hotkey:
 
 - **ctrl+shift+i**: Open devtools for the overlay
 
+## Development
+
+Streamwall is an npm workspaces monorepo. You need **Node.js 22 or newer**
+(`engines.node` is `>=22`; run `nvm use` to pick up the pinned `.nvmrc`).
+
+Install dependencies from the repo root with a clean, lockfile-exact install:
+
+```sh
+npm ci
+```
+
+Use `npm ci`, not `npm install`: it hoists shared dependencies (such as
+Electron) to the root `node_modules` the way the main-process tests expect.
+
+Run the checks CI runs before pushing:
+
+```sh
+npm run lint          # ESLint
+npm run format:check  # Prettier (also checks Markdown and YAML)
+npm run typecheck     # tsc --noEmit across all workspaces
+npm test              # full test suite
+```
+
+The six workspaces under `packages/` are: `streamwall` (the Electron app),
+`streamwall-shared` (shared schemas/types), `streamwall-control-server`
+(remote-control backend), `streamwall-control-client` (its web frontend),
+`streamwall-control-ui` (shared control components), and
+`streamwall-control-e2e` (Playwright smoke tests). Start the app with
+`npm run start:app`, or the control server with its client via
+`npm run start:server`.
+
+Test runners differ per package — most use Vitest, while
+`streamwall-control-server` uses the native Node test runner. The Playwright
+E2E tests are not part of `npm test` and need a one-time browser install. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for the full setup, per-package test
+details, and commit/PR conventions, and [SECURITY.md](SECURITY.md) for how to
+report vulnerabilities.
+
 ## Building & releasing the desktop app
 
 `npm run package` / `npm run make` / `npm run publish` (in
@@ -358,5 +396,7 @@ signing are independent — provision either, both, or neither.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the local quality-gate commands
-and the license policy for workspace packages and dependencies.
+See the [Development](#development) section above for local setup, and
+[CONTRIBUTING.md](CONTRIBUTING.md) for the quality-gate commands, commit/PR
+conventions, and the license policy for workspace packages and dependencies.
+Found a security problem? Report it privately — see [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+## Supported versions
+
+Streamwall is distributed as a rolling release: only the latest published
+[GitHub Release](https://github.com/NilsR0711/streamwall/releases/latest) and
+the current `main` branch receive security fixes. There are no long-term
+support branches — please update to the newest release before reporting an
+issue you found in an older build.
+
+## Reporting a vulnerability
+
+**Do not open a public issue for security problems.** Public issues disclose
+the vulnerability to everyone before a fix exists.
+
+Instead, report privately through GitHub's built-in vulnerability reporting:
+
+1. Go to the [Security tab](https://github.com/NilsR0711/streamwall/security).
+2. Click **Report a vulnerability** to open a private advisory.
+3. Describe the issue, the affected component, and reproduction steps.
+
+This opens a private channel visible only to you and the maintainers. You will
+get an acknowledgement, and once a fix is prepared the advisory is published
+with credit to you unless you ask to stay anonymous.
+
+If you cannot use the Security tab (for example the feature is disabled for
+your account), open a regular issue that says only "security report — please
+enable a private channel" with **no technical details**, and wait for a
+maintainer to establish a private contact.
+
+## Scope
+
+Streamwall has two internet-facing surfaces worth extra scrutiny:
+
+- **Control server** (`packages/streamwall-control-server`) — WebSocket and
+  HTTP endpoints, session authentication, role-based permissions, message
+  validation, and rate limiting. This process is designed to be self-hosted
+  behind a public domain, so authentication bypass, message-validation gaps,
+  and privilege escalation between roles are in scope.
+- **Electron app** (`packages/streamwall`) — the Content Security Policy,
+  `<iframe>` sandboxing for overlay/background streams, navigation guards, and
+  the isolation between renderer content and the app's internal APIs. See
+  [Security: overlay and background streams](README.md#security-overlay-and-background-streams)
+  for the intended trust boundaries.
+
+Reports that a control operator can point an overlay tile at an arbitrary URL
+are **not** vulnerabilities — that is the documented design (overlays run in an
+opaque, script-only sandbox). Anything that lets such a page escape its
+sandbox, reach Streamwall's internal APIs, or read app cookies/storage **is** a
+vulnerability.
+
+Out of scope: findings that require an already-compromised host, physical
+access to the operator's machine, or social engineering of a control operator.


### PR DESCRIPTION
## Problem

Streamwall had solid *operator* docs but almost no *contributor* infrastructure. New developers had to reverse-engineer setup from CI workflows, and there was no security disclosure process for the internet-facing control server.

State before this PR (per #404):

- `CONTRIBUTING.md` existed but was thin (quality gate + license + release only).
- No `SECURITY.md`, no README **Development** section, no issue/PR templates, no `CODEOWNERS`.

## Solution

- **`SECURITY.md`** — supported-versions policy (rolling release), private disclosure via GitHub's *Report a vulnerability* advisory flow, and an explicit scope covering the control server (auth, WS validation, rate limiting) and the Electron app (CSP, iframe sandbox, navigation guards), including which overlay behaviors are by-design vs. in-scope.
- **`CONTRIBUTING.md`** — expanded with local setup (`npm ci`, Node 22+, worktree note), the six-package workspace map, the per-package test-runner split (Vitest vs. native `node:test`), the separate Playwright E2E step, Conventional-Commits/squash-merge PR conventions, and a PR checklist.
- **README `## Development` section** — copy-paste `npm ci` + `lint`/`format:check`/`typecheck`/`test` verify commands, workspace summary, and links to CONTRIBUTING/SECURITY. Contributing section now cross-links both.
- **Templates** — `.github/ISSUE_TEMPLATE/` (bug + feature forms, `config.yml` routing security reports to the private advisory), `.github/pull_request_template.md` (test plan + checklist), and a minimal `.github/CODEOWNERS`.

## Decisions

- **Security contact:** GitHub private vulnerability reporting rather than a published email — repo-native and requires no personal contact data. **Action needed:** enable *Settings → Advanced Security → Private vulnerability reporting* so the "Report a vulnerability" button and the issue-template contact link resolve.
- The existing `CONTRIBUTING.md` License/Release sections were kept verbatim.

## Testing

Docs/config only — no runtime behavior, so no new automated tests (per the repo's docs exemption). Full local quality gate is green: `format:check`, `lint`, `typecheck`, and `npm test` (141 node-runner tests + all Vitest suites pass). Issue-template YAML validated with `js-yaml`.

## Risks / breaking changes

None to runtime. `CODEOWNERS` starts auto-requesting review from @NilsR0711 on new PRs.

Closes #404
