### PR TITLE
feat(control-ui): add accessible names to AccessPanel and Sidebar controls

### DIFF
--- a/packages/streamwall-control-e2e/tests/custom-stream.spec.ts
+++ b/packages/streamwall-control-e2e/tests/custom-stream.spec.ts
@@ -60,7 +60,11 @@ test('deleting an existing custom stream forwards a delete-custom-stream command
   ).toBeVisible()
 
   const deleteCommandPromise = harness.waitForCommand('delete-custom-stream')
-  await page.getByRole('button', { name: 'x', exact: true }).click()
+  await page
+    .getByRole('button', {
+      name: `Delete custom stream ${SEEDED_CUSTOM_STREAM.label}`,
+    })
+    .click()
 
   const deleteCommand = await deleteCommandPromise
   expect(deleteCommand).toMatchObject({

--- a/packages/streamwall-control-ui/src/AccessPanel.test.tsx
+++ b/packages/streamwall-control-ui/src/AccessPanel.test.tsx
@@ -119,6 +119,23 @@ describe('CreateInviteInput', () => {
   })
 })
 
+describe('CreateInviteInput accessible names', () => {
+  test('gives the name field and role select programmatic names', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      render(<CreateInviteInput onCreateInvite={() => {}} />, container!)
+    })
+
+    expect(
+      container.querySelector('input[aria-label="Invite name"]'),
+    ).not.toBeNull()
+    expect(
+      container.querySelector('select[aria-label="Invite role"]'),
+    ).not.toBeNull()
+  })
+})
+
 describe('AuthTokenLine', () => {
   test('shows the token name and role', () => {
     container = document.createElement('div')

--- a/packages/streamwall-control-ui/src/AccessPanel.tsx
+++ b/packages/streamwall-control-ui/src/AccessPanel.tsx
@@ -44,11 +44,16 @@ export function CreateInviteInput({
     <div>
       <form onSubmit={handleSubmit}>
         <input
+          aria-label="Invite name"
           onChange={handleChangeName}
           placeholder="Name"
           value={inviteName}
         />
-        <select onChange={handleChangeRole} value={inviteRole}>
+        <select
+          aria-label="Invite role"
+          onChange={handleChangeRole}
+          value={inviteRole}
+        >
           {invitableRoles.map((role) => (
             <option key={role} value={role}>
               {role}

--- a/packages/streamwall-control-ui/src/Sidebar.test.tsx
+++ b/packages/streamwall-control-ui/src/Sidebar.test.tsx
@@ -147,6 +147,28 @@ describe('StreamList', () => {
   })
 })
 
+describe('StreamList accessible names', () => {
+  test('gives the id/drag handle a descriptive accessible name', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      render(
+        <StreamList
+          rows={[baseRow({ _id: 'xyz' })]}
+          disabled={false}
+          onClickId={() => {}}
+          favorites={new Set()}
+        />,
+        container!,
+      )
+    })
+
+    expect(
+      container.querySelector('[aria-label="Add stream xyz to the wall"]'),
+    ).not.toBeNull()
+  })
+})
+
 describe('StreamList favorites', () => {
   test('renders a filled star for a favorited row and an empty star for a non-favorited one', () => {
     container = document.createElement('div')
@@ -281,7 +303,76 @@ describe('CustomStreamInput', () => {
   })
 })
 
+describe('CustomStreamInput accessible names', () => {
+  test('labels the editable label field and the delete button by the stream name', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      render(
+        <CustomStreamInput
+          link="https://example.com/a"
+          kind="video"
+          label="Corner cam"
+          onChange={() => {}}
+          onDelete={() => {}}
+        />,
+        container!,
+      )
+    })
+
+    expect(
+      container.querySelector('input[aria-label="Custom stream label"]'),
+    ).not.toBeNull()
+    expect(
+      container.querySelector(
+        'button[aria-label="Delete custom stream Corner cam"]',
+      ),
+    ).not.toBeNull()
+  })
+
+  test('falls back to the link when the stream has no label', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      render(
+        <CustomStreamInput
+          link="https://example.com/a"
+          kind="video"
+          label=""
+          onChange={() => {}}
+          onDelete={() => {}}
+        />,
+        container!,
+      )
+    })
+
+    expect(
+      container.querySelector(
+        'button[aria-label="Delete custom stream https://example.com/a"]',
+      ),
+    ).not.toBeNull()
+  })
+})
+
 describe('CreateCustomStreamInput', () => {
+  test('gives the url, type and label fields programmatic names', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      render(<CreateCustomStreamInput onCreate={() => {}} />, container!)
+    })
+
+    expect(
+      container.querySelector('input[aria-label="Stream URL"]'),
+    ).not.toBeNull()
+    expect(
+      container.querySelector('select[aria-label="Stream type"]'),
+    ).not.toBeNull()
+    expect(
+      container.querySelector('input[aria-label="Stream label"]'),
+    ).not.toBeNull()
+  })
+
   test('creates a stream from the form fields and resets them', () => {
     const onCreate = vi.fn()
     container = document.createElement('div')

--- a/packages/streamwall-control-ui/src/Sidebar.tsx
+++ b/packages/streamwall-control-ui/src/Sidebar.tsx
@@ -102,6 +102,7 @@ function StreamLine({
         $disabled={disabled}
         onMouseDown={disabled ? undefined : handleMouseDownId}
         $color={idColor(id)}
+        aria-label={`Add stream ${id} to the wall`}
       >
         {id}
       </StyledId>
@@ -184,12 +185,18 @@ export function CustomStreamInput({
   return (
     <div>
       <LazyChangeInput
+        aria-label="Custom stream label"
         value={props.label ?? ''}
         onChange={handleChangeLabel}
         placeholder="Label (optional)"
       />{' '}
       <a href={props.link}>{props.link}</a> <span>({props.kind})</span>{' '}
-      <button onClick={handleDeleteClick}>x</button>
+      <button
+        aria-label={`Delete custom stream ${props.label || props.link}`}
+        onClick={handleDeleteClick}
+      >
+        x
+      </button>
     </div>
   )
 }
@@ -215,11 +222,13 @@ export function CreateCustomStreamInput({
   return (
     <form onSubmit={handleSubmit}>
       <input
+        aria-label="Stream URL"
         value={link}
         onChange={(ev) => setLink(ev.currentTarget.value)}
         placeholder="https://..."
       />
       <select
+        aria-label="Stream type"
         onChange={(ev) => setKind(ev.currentTarget.value as ContentKind)}
         value={kind}
       >
@@ -230,6 +239,7 @@ export function CreateCustomStreamInput({
         <option value="background">background</option>
       </select>
       <input
+        aria-label="Stream label"
         value={label}
         onChange={(ev) => setLabel(ev.currentTarget.value)}
         placeholder="Label (optional)"


### PR DESCRIPTION
## Problem

Several interactive control-UI elements relied on placeholder text or icon/text-only buttons with no associated label. Screen readers announced them as a bare `button` or `times` with no context, and could not distinguish the invite name field from the role field (WCAG 1.3.1 Info and Relationships, 4.1.2 Name, Role, Value).

## Solution

Added programmatic accessible names, following the `aria-label` pattern already established in `GridControls.tsx`/`GridControls.test.tsx`:

**`AccessPanel.tsx` — `CreateInviteInput`**
- Invite name input → `aria-label="Invite name"`
- Invite role select → `aria-label="Invite role"`

**`Sidebar.tsx`**
- `CustomStreamInput`: editable label → `aria-label="Custom stream label"`; delete button (`x`) → `aria-label="Delete custom stream {name}"`, falling back to the link when there is no label.
- `CreateCustomStreamInput`: URL / type / label fields → `aria-label` each.
- `StreamLine` id/drag handle (`StyledId`) → interim `aria-label="Add stream {id} to the wall"`.

Placeholders are kept as-is for sighted users; the `aria-label`s add the missing programmatic names without any visual change.

## Architecture decisions

- Chose `aria-label` over visually-hidden `<label>` elements for consistency with the existing accessible-name approach in this package and to avoid layout churn. `LazyChangeInput` already spreads `...props`, so the label passes straight through to the underlying `<input>`.
- The drag handle keeps its mouse-only `mousedown` behaviour. A keyboard-operable path is out of scope here and tracked in #460 (WCAG 2.1.1); this PR only adds the interim accessible name the original issue asked for.

## Testing

- New accessible-name assertions in `AccessPanel.test.tsx` and `Sidebar.test.tsx` (mirroring `GridControls.test.tsx`).
- Full quality gate green locally: format, lint, typecheck, full test suite (control-server 141, control-ui 283), and `streamwall-control-client` build.

## Risks / breaking changes

None. Additive `aria-label` attributes only; no behavioural or visual changes.

## Follow-ups

- #460 — keyboard path for the Sidebar drag handle.

Closes #399