### PR TITLE
fix(streamwall): log swallowed promise rejections on hot paths

### DIFF
--- a/packages/streamwall/src/main/data.test.ts
+++ b/packages/streamwall/src/main/data.test.ts
@@ -15,6 +15,7 @@ import {
   StreamIDGenerator,
   watchDataFile,
 } from './data'
+import log from './logger'
 import type { PresetPack } from './presets'
 
 class FakeWatcher extends EventEmitter {
@@ -663,6 +664,30 @@ describe('markDataSource', () => {
     } finally {
       await marked.return?.(undefined)
     }
+  })
+
+  test('logs a warning naming the source and propagates when it rejects', async () => {
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {})
+    const failure = new Error('source exploded')
+    const source = {
+      next: () => Promise.reject(failure),
+      return: async () => ({ done: true as const, value: undefined }),
+      [Symbol.asyncIterator]() {
+        return this
+      },
+    } as unknown as AsyncIterableIterator<StreamDataContent[]>
+
+    const marked = markDataSource(source, 'boom')
+    // The rejection must still surface to the consumer, not be silently
+    // swallowed by the logging catch.
+    await expect(marked.next()).rejects.toThrow('source exploded')
+    expect(warnSpy).toHaveBeenCalledWith(
+      'error advancing data source',
+      'boom',
+      failure,
+    )
+
+    warnSpy.mockRestore()
   })
 })
 

--- a/packages/streamwall/src/main/data.ts
+++ b/packages/streamwall/src/main/data.ts
@@ -111,6 +111,11 @@ export function watchDataFile(
         // Raced against `stop` so an early return() settles immediately
         // instead of queuing behind an event that may never fire.
         const eventP = once(watcher, 'all')
+        // Pure unhandled-rejection guard for the race loser. `once(watcher,
+        // 'all')` rejects on a watcher 'error', which is already logged by the
+        // persistent 'error' listener above (and, when this promise wins the
+        // race, by the catch below) -- so re-logging here would just duplicate
+        // an already-surfaced breadcrumb (issue #392).
         eventP.catch(() => {})
         try {
           const result = await Promise.race([eventP, stop])
@@ -158,7 +163,15 @@ export function markDataSource(
     try {
       while (true) {
         const nextP = dataSource.next()
-        nextP.catch(() => {})
+        // Guard the race loser against an unhandled rejection, and log the
+        // reason: a rejecting source (a failed watcher/generator) otherwise
+        // propagates up through combineDataSources with no breadcrumb naming
+        // which source stopped updating (issue #392). The rejection still
+        // surfaces to the awaited race below, so error propagation is
+        // unchanged.
+        nextP.catch((err) => {
+          log.warn('error advancing data source', name, err)
+        })
         const iteration = await Promise.race([nextP, stop])
         if (iteration === undefined || iteration.done) {
           return iteration?.value

--- a/packages/streamwall/src/main/viewStateMachine.test.ts
+++ b/packages/streamwall/src/main/viewStateMachine.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import log from './logger'
 
 // viewStateMachine imports electron (directly and via ./loadHTML). Stub the
 // module so the machine can be exercised without an Electron runtime; the
@@ -748,6 +749,29 @@ describe('viewStateMachine loadPage navigation', () => {
     // (see #25). It now lives in mediaPreload.ts instead, so navigate
     // should not touch executeJavaScript at all.
     expect(executeJavaScript).not.toHaveBeenCalled()
+  })
+
+  it('logs a warning when the navigation load rejects', async () => {
+    // loadURL is intentionally not awaited (see loadPage), so a rejection --
+    // e.g. a blocked navigation or network error -- would otherwise vanish
+    // with no log breadcrumb (issue #392).
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {})
+    const { actor, loadURL } = makeActorWithRealLoadPage(makeRetry())
+    const loadErr = new Error('net::ERR_CONNECTION_REFUSED')
+    loadURL.mockRejectedValue(loadErr)
+
+    actor.start()
+    display(actor)
+
+    await vi.waitFor(() =>
+      expect(warnSpy).toHaveBeenCalledWith(
+        'error loading view URL',
+        CONTENT.url,
+        loadErr,
+      ),
+    )
+
+    warnSpy.mockRestore()
   })
 })
 

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -390,9 +390,13 @@ const viewStateMachine = setup({
           // Do NOT await: the preload sends VIEW_INIT before loadURL resolves
           // (did-finish-load), so awaiting here would strand that event and hang
           // the view in waitForInit. Load failures are surfaced via the
-          // webContents 'did-fail-load' listener in StreamWindow; swallow the
-          // rejection so it isn't an unhandled promise rejection.
-          wc.loadURL(content.url).catch(() => {})
+          // webContents 'did-fail-load' listener in StreamWindow; log the
+          // rejection reason (invisible to that listener) so a blocked
+          // navigation or network error leaves a breadcrumb instead of an
+          // unhandled promise rejection (issue #392).
+          wc.loadURL(content.url).catch((err) => {
+            log.warn('error loading view URL', content.url, err)
+          })
         }
       },
     ),

--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -314,6 +314,25 @@ describe('mediaPreload pause/resume handling (issue #374)', () => {
     expect(video.paused).toBe(false)
   })
 
+  it('logs a warning when resuming playback rejects (e.g. autoplay policy)', async () => {
+    // A play() rejection (autoplay policy, media detached) previously vanished
+    // with an empty catch, hiding it during debugging (issue #392).
+    const video = await loadAcquiredVideo()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const playErr = new Error('NotAllowedError')
+    video.play = vi.fn().mockRejectedValue(playErr)
+
+    registeredHandler('resume')()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'error resuming media playback',
+      playErr,
+    )
+
+    warnSpy.mockRestore()
+  })
+
   // The bundled HLS player page (renderer/playHLS.ts) keeps its hls.js
   // instance in a closure the preload cannot reach, so pausing the <video>
   // alone leaves segment fetching to taper off on its own. These events are

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -472,8 +472,11 @@ async function main() {
     // Live streams are typically not seekable on-demand video, so resuming
     // after a pause may briefly re-buffer or land slightly behind the live
     // edge -- both cheaper than a full reload and expected to self-correct
-    // as playback continues.
-    currentMedia?.play().catch(() => {})
+    // as playback continues. A play() rejection (e.g. autoplay policy) is
+    // otherwise invisible, so log it as a breadcrumb (issue #392).
+    currentMedia?.play().catch((err) => {
+      console.warn('error resuming media playback', err)
+    })
   })
 }
 


### PR DESCRIPTION
## Problem

Several hot paths in the Electron main process and preload caught promise rejections with empty handlers (`() => {}`), discarding load and data-pipeline failures without logging. Operators saw stale tiles or silent data gaps with no log breadcrumb (#392).

## Solution

Replaced the swallowing catches with logging ones, using each file's established logging convention:

| Site | Change |
|------|--------|
| `viewStateMachine.ts` `loadPage` | `loadURL` rejection now logged via `log.warn('error loading view URL', url, err)`. The `did-fail-load` listener never sees the Promise rejection reason, so this is the only breadcrumb for a blocked navigation / network error. Not awaited (unchanged), so no risk of stranding `VIEW_INIT`. |
| `data.ts` `markDataSource` | The rejecting source is now logged **by name** (`log.warn('error advancing data source', name, err)`) before it propagates through `combineDataSources`. This is the race-loser guard, so it fires whether the source loses or wins the race; **error propagation is unchanged** — the awaited race still throws. |
| `mediaPreload.ts` resume handler | `play()` rejection (e.g. autoplay policy) now logged via `console.warn`, matching this file's existing `console.warn`/`console.log` usage (preload runs in a renderer context; `electron-log/main` is not available there). |

### Deliberate exception — `watchDataFile`

The issue cited `eventP.catch(() => {})` in `watchDataFile`, but that rejection is **already** surfaced: the `once(watcher, 'all')` promise only rejects on a watcher `'error'`, which is logged by the persistent `watcher.on('error', ...)` listener a few lines above (and, when the promise wins the race, by the `try/catch` around the race). Re-logging in the guard would duplicate — or triple — an already-emitted breadcrumb. Rather than add a redundant log, the empty catch is kept as a pure unhandled-rejection guard with a comment explaining why. This still satisfies the issue's goal (no undiagnosable swallow).

## Testing

TDD (red → green) for each behavior change:

- `viewStateMachine.test.ts` — drives the real `loadPage` actor with a rejecting `loadURL` and asserts the warning (message + URL + error).
- `data.test.ts` `markDataSource` — a source whose `next()` rejects logs the warning naming the source **and** still rejects to the consumer (propagation preserved).
- `mediaPreload.test.ts` — a rejecting `play()` on resume logs via `console.warn`.

Full quality gate green locally: `format:check`, `lint`, `typecheck`, full test suite (all packages).

## Risk / breaking changes

None. Purely additive logging on failure paths; control flow and error propagation are unchanged.

Closes #392