### PR TITLE
refactor(control-server): modularize the 1000-line entrypoint

### DIFF
--- a/packages/streamwall-control-server/src/bootstrap.ts
+++ b/packages/streamwall-control-server/src/bootstrap.ts
@@ -1,0 +1,165 @@
+import { inviteLink } from 'streamwall-shared'
+import type { Auth } from './auth.ts'
+import { resolveListenPort } from './config.ts'
+import { type AppOptions, initApp } from './index.ts'
+import type { StorageDB } from './storage.ts'
+import { SERVER_VERSION, type UpdateChecker } from './updateCheck.ts'
+
+/** Builds the uplink WebSocket endpoint URL, which never embeds the secret. */
+function uplinkEndpointURL(baseURL: string, tokenId: string) {
+  return `${baseURL.replace(/^http/, 'ws')}/streamwall/${tokenId}/ws`
+}
+
+export interface BootstrapResult {
+  /**
+   * The plaintext uplink secret, exposed *only* when the token was freshly
+   * minted. `null` on a restart, where the secret is unrecoverable by design.
+   */
+  uplinkSecret: string | null
+  /** The uplink WebSocket endpoint (never carries the secret). */
+  uplinkEndpoint: string
+  /** A fresh single-use admin invite link (regenerated every startup). */
+  adminInviteLink: string
+}
+
+export async function initialInviteCodes({
+  db,
+  auth,
+  baseURL,
+}: {
+  db: StorageDB
+  auth: Auth
+  baseURL: string
+}): Promise<BootstrapResult> {
+  // The uplink token is validated against its scrypt hash in `auth.tokens`,
+  // exactly like session and invite tokens. We persist only its id; the
+  // plaintext secret is shown once, at creation, and never written to disk.
+  const record = db.data.streamwallToken
+  const hasValidUplinkToken =
+    record != null && auth.tokensById.has(record.tokenId)
+
+  let uplinkSecret: string | null = null
+  let uplinkTokenId: string
+
+  if (hasValidUplinkToken) {
+    uplinkTokenId = record.tokenId
+    // Scrub any plaintext secret a pre-fix server version may have persisted
+    // alongside the id, so it stops leaking through storage.json.
+    if ((record as { secret?: string }).secret !== undefined) {
+      db.update((data) => {
+        data.streamwallToken = { tokenId: uplinkTokenId }
+      })
+    }
+  } else {
+    // Minting a fresh uplink token (first run, or a rotation triggered by
+    // clearing the stored record). Delete any superseded uplink tokens first so
+    // an old secret can never authenticate again.
+    for (const token of [...auth.tokensById.values()]) {
+      if (token.kind === 'streamwall') {
+        auth.deleteToken(token.tokenId)
+      }
+    }
+    const minted = await auth.createToken({
+      kind: 'streamwall',
+      role: 'admin',
+      name: 'Streamwall',
+    })
+    uplinkSecret = minted.secret
+    uplinkTokenId = minted.tokenId
+    db.update((data) => {
+      data.streamwallToken = { tokenId: minted.tokenId }
+    })
+  }
+
+  // Invalidate any existing admin invites and create a new one:
+  for (const adminToken of auth
+    .getState()
+    .invites.filter(({ role }) => role === 'admin')) {
+    auth.deleteToken(adminToken.tokenId)
+  }
+  const adminToken = await auth.createToken({
+    kind: 'invite',
+    role: 'admin',
+    name: 'Server admin',
+  })
+
+  return {
+    uplinkSecret,
+    uplinkEndpoint: uplinkEndpointURL(baseURL, uplinkTokenId),
+    adminInviteLink: inviteLink({
+      baseURL,
+      tokenId: adminToken.tokenId,
+      secret: adminToken.secret,
+    }),
+  }
+}
+
+/**
+ * Logs the bootstrap credentials to stdout. The uplink secret is printed only
+ * when it was just minted (shown once); on subsequent starts we print the
+ * endpoint without it and point the operator at how to rotate.
+ */
+export function logBootstrap({
+  uplinkSecret,
+  uplinkEndpoint,
+  adminInviteLink,
+}: BootstrapResult) {
+  if (uplinkSecret) {
+    console.log(
+      '🔌 Streamwall uplink (shown once — save it now):',
+      `${uplinkEndpoint}?token=${uplinkSecret}`,
+    )
+  } else {
+    console.log('🔌 Streamwall uplink endpoint:', uplinkEndpoint)
+    console.log(
+      '   (the uplink secret is shown only at creation; to rotate it, clear ' +
+        '"streamwallToken" in storage.json and restart)',
+    )
+  }
+  console.log('🔑 Admin invite:', adminInviteLink)
+}
+
+export default async function runServer({
+  port: overridePort,
+  hostname: overrideHostname,
+  baseURL,
+  clientStaticPath,
+  db: injectedDb,
+  updateChecker: injectedUpdateChecker,
+}: AppOptions & {
+  hostname?: string
+  port?: string
+  /** Test-only override so specs can exercise the real listen() path without touching disk. */
+  db?: StorageDB
+  /** Test-only override so specs can exercise the real listen() path without reaching GitHub. */
+  updateChecker?: UpdateChecker
+}) {
+  const url = new URL(baseURL)
+  const hostname = overrideHostname ?? url.hostname
+  const port = resolveListenPort(baseURL, overridePort)
+
+  console.log(`Starting streamwall-control-server ${SERVER_VERSION}`)
+  console.debug('Initializing web server:', { hostname, port })
+  const { app, db, auth, updateChecker } = await initApp({
+    baseURL,
+    clientStaticPath,
+    db: injectedDb,
+    updateChecker: injectedUpdateChecker,
+  })
+
+  const bootstrap = await initialInviteCodes({ db, auth, baseURL })
+  logBootstrap(bootstrap)
+
+  // Hooks must be registered before the instance starts listening -- Fastify 5
+  // throws FST_ERR_INSTANCE_ALREADY_LISTENING otherwise (issue #442).
+  app.addHook('onClose', async () => {
+    updateChecker.stop()
+  })
+
+  await app.listen({ port, host: hostname })
+
+  // Fire-and-forget: a slow or unreachable GitHub must never delay serving.
+  void updateChecker.start()
+
+  return { server: app.server }
+}

--- a/packages/streamwall-control-server/src/config.ts
+++ b/packages/streamwall-control-server/src/config.ts
@@ -1,0 +1,132 @@
+import process from 'node:process'
+
+import type { DocUpdateLimits } from './stateDocGuard.ts'
+
+export const SESSION_COOKIE_NAME = 's'
+// `@fastify/cookie` serializes `maxAge` into the RFC 6265 `Max-Age` attribute,
+// which is measured in SECONDS (not milliseconds). Keep this value in seconds —
+// one year — so sessions stay long-lived while remaining bounded.
+export const SESSION_COOKIE_MAX_AGE_SECONDS = 365 * 24 * 60 * 60
+export const STREAMWALL_PING_TIMEOUT_MS = 5 * 1000
+
+const DEFAULT_GLOBAL_RATE_LIMIT_MAX = 100
+const DEFAULT_AUTH_RATE_LIMIT_MAX = 10
+const DEFAULT_RATE_LIMIT_WINDOW = '1 minute'
+
+// Inbound WebSocket message limits, applied per connection as a token bucket.
+// Defaults are generous: normal collaborative editing bursts (e.g. dragging a
+// tile) stay well under them, while a flood empties the bucket and the socket
+// is closed so the client reconnects and cleanly resyncs.
+const DEFAULT_WS_MSG_RATE = 100
+const DEFAULT_WS_MSG_BURST = 1000
+
+// Bounds on inbound binary Yjs updates from untrusted clients. The shared state
+// doc only holds a grid of view assignments, so these are generous headroom
+// rather than tight fits — enough to block a single oversized update, or one
+// that balloons the doc, from corrupting shared state or exhausting memory.
+const DEFAULT_WS_UPDATE_MAX_BYTES = 512 * 1024
+const DEFAULT_WS_DOC_GROWTH_MAX_BYTES = 1024 * 1024
+
+/** Parses a positive numeric env value, falling back when unset or invalid. */
+function parsePositiveNumber(value: string | undefined, fallback: number) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+export interface RateLimitConfig {
+  globalMax: number
+  authMax: number
+  timeWindow: string
+}
+
+/**
+ * Reads the per-IP rate limit configuration from the environment. Read lazily
+ * (per `initApp` call) rather than at module load so overrides apply cleanly.
+ */
+export function getRateLimitConfig(): RateLimitConfig {
+  return {
+    globalMax: parsePositiveNumber(
+      process.env.STREAMWALL_RATE_LIMIT_MAX,
+      DEFAULT_GLOBAL_RATE_LIMIT_MAX,
+    ),
+    authMax: parsePositiveNumber(
+      process.env.STREAMWALL_AUTH_RATE_LIMIT_MAX,
+      DEFAULT_AUTH_RATE_LIMIT_MAX,
+    ),
+    timeWindow:
+      process.env.STREAMWALL_RATE_LIMIT_WINDOW ?? DEFAULT_RATE_LIMIT_WINDOW,
+  }
+}
+
+/**
+ * Parse `STREAMWALL_TRUST_PROXY` for Fastify's `trustProxy` option.
+ * Off by default so a bare internet-facing server never trusts client-supplied
+ * `X-Forwarded-For`. Behind a reverse proxy, set `true` (or an IP/CIDR list).
+ * @see https://fastify.dev/docs/latest/Reference/Server/#trustproxy
+ */
+export function parseTrustProxy(raw: string | undefined): boolean | string {
+  if (raw == null || raw.trim() === '') {
+    return false
+  }
+  const v = raw.trim().toLowerCase()
+  if (v === '1' || v === 'true' || v === 'yes' || v === 'on') {
+    return true
+  }
+  if (v === '0' || v === 'false' || v === 'no' || v === 'off') {
+    return false
+  }
+  // IP, CIDR, or comma-separated list — pass through for Fastify.
+  return raw.trim()
+}
+
+export interface WsMessageLimitConfig {
+  capacity: number
+  refillPerSec: number
+}
+
+/** Reads the inbound WebSocket message rate configuration from the env. */
+export function getWsMessageLimitConfig(): WsMessageLimitConfig {
+  return {
+    capacity: parsePositiveNumber(
+      process.env.STREAMWALL_WS_MSG_BURST,
+      DEFAULT_WS_MSG_BURST,
+    ),
+    refillPerSec: parsePositiveNumber(
+      process.env.STREAMWALL_WS_MSG_RATE,
+      DEFAULT_WS_MSG_RATE,
+    ),
+  }
+}
+
+/** Reads the binary Yjs update size limits from the environment. */
+export function getDocUpdateLimits(): DocUpdateLimits {
+  return {
+    maxUpdateBytes: parsePositiveNumber(
+      process.env.STREAMWALL_WS_UPDATE_MAX_BYTES,
+      DEFAULT_WS_UPDATE_MAX_BYTES,
+    ),
+    maxDocGrowthBytes: parsePositiveNumber(
+      process.env.STREAMWALL_WS_DOC_GROWTH_MAX_BYTES,
+      DEFAULT_WS_DOC_GROWTH_MAX_BYTES,
+    ),
+  }
+}
+
+/**
+ * Resolve the TCP listen port for the control server.
+ * `URL.port` is `""` (not undefined) when the URL has no explicit port, so
+ * `??` alone would leave an empty string and `Number('') === 0` (ephemeral bind).
+ * Prefer an explicit override, else URL port, else the scheme default.
+ */
+export function resolveListenPort(
+  baseURL: string,
+  overridePort?: string,
+): number {
+  const url = new URL(baseURL)
+  const explicit =
+    overridePort != null && String(overridePort).trim() !== ''
+      ? String(overridePort).trim()
+      : undefined
+  const fromUrl = url.port || (url.protocol === 'https:' ? '443' : '80')
+  return Number(explicit ?? fromUrl)
+}

--- a/packages/streamwall-control-server/src/context.ts
+++ b/packages/streamwall-control-server/src/context.ts
@@ -1,0 +1,82 @@
+import WebSocket from 'ws'
+import type * as Y from 'yjs'
+
+import { type AuthTokenInfo, stateDiff } from 'streamwall-shared'
+import type { Auth, StateWrapper } from './auth.ts'
+import type { WsMessageLimitConfig } from './config.ts'
+import type { DocUpdateLimits } from './stateDocGuard.ts'
+import type { UpdateChecker } from './updateCheck.ts'
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    identity?: AuthTokenInfo
+  }
+}
+
+export interface Client {
+  clientId: string
+  ws: WebSocket
+  lastStateSent: unknown
+  identity: AuthTokenInfo
+}
+
+export interface StreamwallConnection {
+  ws: WebSocket
+  clientState: StateWrapper
+  stateDoc: Y.Doc
+}
+
+/**
+ * Shared server state and dependencies threaded through the route and
+ * WebSocket handler modules. The `currentStreamwall*` fields are reassigned as
+ * the desktop uplink connects and disconnects, so this object is always passed
+ * by reference — those fields must be read off the live context, never
+ * destructured up front.
+ */
+export interface AppContext {
+  auth: Auth
+  updateChecker: UpdateChecker
+  expectedOrigin: string
+  isSecure: boolean
+  wsMessageLimitConfig: WsMessageLimitConfig
+  docUpdateLimits: DocUpdateLimits
+  clients: Map<string, Client>
+  currentStreamwallWs: WebSocket | null
+  currentStreamwallConn: StreamwallConnection | null
+  broadcastStateDeltas: (clientState: StateWrapper) => void
+  reportCaughtError: (err: unknown) => void
+}
+
+/**
+ * Builds the state-delta broadcaster bound to a connection registry. It diffs
+ * `clientState`'s current view against what each connected client last saw and
+ * sends only the delta. Subscribed to `clientState`'s own `'state'` event (see
+ * the uplink handler) so it also runs for auth-only changes — e.g.
+ * `auth.on('state', ...)` calling `clientState.update({ auth: ... })` when an
+ * invite/session is created or deleted — not only when the desktop pushes a
+ * full state.
+ */
+export function createBroadcastStateDeltas(
+  clients: Map<string, Client>,
+  reportCaughtError: (err: unknown) => void,
+): (clientState: StateWrapper) => void {
+  return (clientState: StateWrapper) => {
+    for (const client of clients.values()) {
+      try {
+        if (client.ws.readyState !== WebSocket.OPEN) {
+          continue
+        }
+        const stateView = clientState.view(client.identity.role)
+        const delta = stateDiff.diff(client.lastStateSent, stateView)
+        if (!delta) {
+          continue
+        }
+        client.ws.send(JSON.stringify({ type: 'state-delta', delta }))
+        client.lastStateSent = stateView
+      } catch (err) {
+        console.error('failed to send client state delta', client, err)
+        reportCaughtError(err)
+      }
+    }
+  }
+}

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -1,309 +1,50 @@
 import fastifyCookie from '@fastify/cookie'
 import fastifyHelmet from '@fastify/helmet'
 import fastifyRateLimit from '@fastify/rate-limit'
-import fastifyStatic from '@fastify/static'
 import fastifyWebsocket from '@fastify/websocket'
 import * as Sentry from '@sentry/node'
 import Fastify from 'fastify'
+import path from 'node:path'
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
-import WebSocket from 'ws'
-import * as Y from 'yjs'
 
-import path from 'node:path'
+import { Auth } from './auth.ts'
+import runServer from './bootstrap.ts'
 import {
-  type AuthTokenInfo,
-  controlCommandMessageSchema,
-  controlStateMessageSchema,
-  inviteLink,
-  roleCan,
-  stateDiff,
-  type StreamwallRole,
-  streamwallStateSchema,
-} from 'streamwall-shared'
-import { Auth, StateWrapper, uniqueRand62 } from './auth.ts'
-import { TokenBucket } from './rateLimiter.ts'
+  getDocUpdateLimits,
+  getRateLimitConfig,
+  getWsMessageLimitConfig,
+  parseTrustProxy,
+} from './config.ts'
+import {
+  type AppContext,
+  type Client,
+  createBroadcastStateDeltas,
+} from './context.ts'
+import { registerInviteRoutes } from './inviteExchange/invite.ts'
 import {
   captureException,
   initSentry,
   type SentryCaptureClient,
 } from './sentry.ts'
-import {
-  applyValidatedDocUpdate,
-  type DocUpdateLimits,
-} from './stateDocGuard.ts'
 import { loadStorage, type StorageDB } from './storage.ts'
-import {
-  createUpdateChecker,
-  SERVER_VERSION,
-  type UpdateChecker,
-} from './updateCheck.ts'
+import { createUpdateChecker, type UpdateChecker } from './updateCheck.ts'
+import { registerClientRoutes } from './ws/client.ts'
+import { registerUplinkRoute } from './ws/uplink.ts'
 
-export const SESSION_COOKIE_NAME = 's'
-// `@fastify/cookie` serializes `maxAge` into the RFC 6265 `Max-Age` attribute,
-// which is measured in SECONDS (not milliseconds). Keep this value in seconds —
-// one year — so sessions stay long-lived while remaining bounded.
-export const SESSION_COOKIE_MAX_AGE_SECONDS = 365 * 24 * 60 * 60
-const STREAMWALL_PING_TIMEOUT_MS = 5 * 1000
-
-const DEFAULT_GLOBAL_RATE_LIMIT_MAX = 100
-const DEFAULT_AUTH_RATE_LIMIT_MAX = 10
-const DEFAULT_RATE_LIMIT_WINDOW = '1 minute'
-
-// Inbound WebSocket message limits, applied per connection as a token bucket.
-// Defaults are generous: normal collaborative editing bursts (e.g. dragging a
-// tile) stay well under them, while a flood empties the bucket and the socket
-// is closed so the client reconnects and cleanly resyncs.
-const DEFAULT_WS_MSG_RATE = 100
-const DEFAULT_WS_MSG_BURST = 1000
-
-// Served at `/invite/:id`. It carries no secret and no inline script (so it
-// satisfies the strict `script-src 'self'` CSP); the loaded script reads the
-// invite secret from the URL fragment and POSTs it to redeem the invite.
-const INVITE_EXCHANGE_HTML = `<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Streamwall — joining…</title>
-  </head>
-  <body>
-    <p>Signing you in…</p>
-    <script src="/invite-exchange.js"></script>
-  </body>
-</html>
-`
-
-// Reads the invite secret from `location.hash` (which the browser never sends
-// to the server), scrubs it from the address bar, and exchanges it for a
-// session cookie via POST. On success it navigates to the app.
-const INVITE_EXCHANGE_SCRIPT = `(function () {
-  var status = document.querySelector('p')
-  var token = new URLSearchParams(window.location.hash.slice(1)).get('token')
-  window.history.replaceState(null, '', window.location.pathname)
-  if (!token) {
-    if (status) status.textContent = 'This invite link is missing its token.'
-    return
-  }
-  fetch(window.location.pathname, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ token: token }),
-  })
-    .then(function (res) {
-      if (res.ok) {
-        window.location.replace('/')
-      } else if (status) {
-        status.textContent = 'This invite is invalid or has expired.'
-      }
-    })
-    .catch(function () {
-      if (status) {
-        status.textContent = 'Could not reach the server. Please try again.'
-      }
-    })
-})()
-`
-
-// Bounds on inbound binary Yjs updates from untrusted clients. The shared state
-// doc only holds a grid of view assignments, so these are generous headroom
-// rather than tight fits — enough to block a single oversized update, or one
-// that balloons the doc, from corrupting shared state or exhausting memory.
-const DEFAULT_WS_UPDATE_MAX_BYTES = 512 * 1024
-const DEFAULT_WS_DOC_GROWTH_MAX_BYTES = 1024 * 1024
-
-/** Parses a positive numeric env value, falling back when unset or invalid. */
-function parsePositiveNumber(value: string | undefined, fallback: number) {
-  const parsed = Number(value)
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
-}
-
-/**
- * Extracts a Bearer token from an `Authorization` header. Uplink credentials
- * travel in this header rather than the URL query string so the secret never
- * lands in server or proxy access logs. The scheme name is matched
- * case-insensitively per RFC 7235.
- */
-function bearerToken(authorization: string | undefined): string | null {
-  if (!authorization) {
-    return null
-  }
-  const match = /^Bearer[ ]+(.+)$/i.exec(authorization)
-  return match ? match[1] : null
-}
-
-interface RateLimitConfig {
-  globalMax: number
-  authMax: number
-  timeWindow: string
-}
-
-/**
- * Reads the per-IP rate limit configuration from the environment. Read lazily
- * (per `initApp` call) rather than at module load so overrides apply cleanly.
- */
-function getRateLimitConfig(): RateLimitConfig {
-  return {
-    globalMax: parsePositiveNumber(
-      process.env.STREAMWALL_RATE_LIMIT_MAX,
-      DEFAULT_GLOBAL_RATE_LIMIT_MAX,
-    ),
-    authMax: parsePositiveNumber(
-      process.env.STREAMWALL_AUTH_RATE_LIMIT_MAX,
-      DEFAULT_AUTH_RATE_LIMIT_MAX,
-    ),
-    timeWindow:
-      process.env.STREAMWALL_RATE_LIMIT_WINDOW ?? DEFAULT_RATE_LIMIT_WINDOW,
-  }
-}
-
-/**
- * Parse `STREAMWALL_TRUST_PROXY` for Fastify's `trustProxy` option.
- * Off by default so a bare internet-facing server never trusts client-supplied
- * `X-Forwarded-For`. Behind a reverse proxy, set `true` (or an IP/CIDR list).
- * @see https://fastify.dev/docs/latest/Reference/Server/#trustproxy
- */
-export function parseTrustProxy(raw: string | undefined): boolean | string {
-  if (raw == null || raw.trim() === '') {
-    return false
-  }
-  const v = raw.trim().toLowerCase()
-  if (v === '1' || v === 'true' || v === 'yes' || v === 'on') {
-    return true
-  }
-  if (v === '0' || v === 'false' || v === 'no' || v === 'off') {
-    return false
-  }
-  // IP, CIDR, or comma-separated list — pass through for Fastify.
-  return raw.trim()
-}
-
-interface WsMessageLimitConfig {
-  capacity: number
-  refillPerSec: number
-}
-
-/** Reads the inbound WebSocket message rate configuration from the env. */
-function getWsMessageLimitConfig(): WsMessageLimitConfig {
-  return {
-    capacity: parsePositiveNumber(
-      process.env.STREAMWALL_WS_MSG_BURST,
-      DEFAULT_WS_MSG_BURST,
-    ),
-    refillPerSec: parsePositiveNumber(
-      process.env.STREAMWALL_WS_MSG_RATE,
-      DEFAULT_WS_MSG_RATE,
-    ),
-  }
-}
-
-/** Reads the binary Yjs update size limits from the environment. */
-function getDocUpdateLimits(): DocUpdateLimits {
-  return {
-    maxUpdateBytes: parsePositiveNumber(
-      process.env.STREAMWALL_WS_UPDATE_MAX_BYTES,
-      DEFAULT_WS_UPDATE_MAX_BYTES,
-    ),
-    maxDocGrowthBytes: parsePositiveNumber(
-      process.env.STREAMWALL_WS_DOC_GROWTH_MAX_BYTES,
-      DEFAULT_WS_DOC_GROWTH_MAX_BYTES,
-    ),
-  }
-}
-
-/**
- * Wraps a socket with a per-connection inbound message rate limiter. Returns a
- * guard to invoke for each received message: it returns true when the message
- * may be processed, or closes the socket (once) and returns false when the
- * connection has exceeded its message budget.
- */
-function createWsMessageGuard(
-  ws: WebSocket,
-  config: WsMessageLimitConfig,
-  label: string,
-): () => boolean {
-  const bucket = new TokenBucket({
-    capacity: config.capacity,
-    refillPerSec: config.refillPerSec,
-  })
-  let closed = false
-  return () => {
-    if (closed) {
-      return false
-    }
-    if (bucket.tryConsume()) {
-      return true
-    }
-    closed = true
-    console.warn(`WebSocket message rate limit exceeded, closing ${label}`)
-    try {
-      ws.send(JSON.stringify({ error: 'rate limit exceeded' }))
-    } catch {
-      // The socket is being closed anyway; ignore send failures.
-    }
-    ws.close(1008, 'rate limit exceeded')
-    return false
-  }
-}
-
-interface Client {
-  clientId: string
-  ws: WebSocket
-  lastStateSent: unknown
-  identity: AuthTokenInfo
-}
-
-interface StreamwallConnection {
-  ws: WebSocket
-  clientState: StateWrapper
-  stateDoc: Y.Doc
-}
+// Re-exported so existing importers (and the test suite) keep a single stable
+// entry point even though these now live in focused modules.
+export { initialInviteCodes, type BootstrapResult } from './bootstrap.ts'
+export {
+  parseTrustProxy,
+  resolveListenPort,
+  SESSION_COOKIE_NAME,
+} from './config.ts'
+export { queueWebSocketMessages } from './wsSupport.ts'
 
 export interface AppOptions {
   baseURL: string
   clientStaticPath: string
-}
-
-declare module 'fastify' {
-  interface FastifyRequest {
-    identity?: AuthTokenInfo
-  }
-}
-
-/**
- * Helper to immediately watch for and queue incoming websocket messages.
- * This is useful for async validation of the connection before handling messages,
- * because awaiting before adding a message event listener can drop messages.
- */
-export function queueWebSocketMessages(ws: WebSocket) {
-  let queue: WebSocket.Data[] = []
-  let messageHandler: ((rawData: WebSocket.Data) => void) | null = null
-
-  const processQueue = () => {
-    if (messageHandler !== null) {
-      let queuedData
-      while ((queuedData = queue.shift())) {
-        messageHandler(queuedData)
-      }
-    }
-  }
-
-  const setMessageHandler = (handler: typeof messageHandler) => {
-    messageHandler = handler
-    processQueue()
-  }
-
-  ws.on('message', (rawData) => {
-    queue.push(rawData)
-    processQueue()
-  })
-
-  ws.on('close', () => {
-    queue = []
-    messageHandler = null
-  })
-
-  return setMessageHandler
 }
 
 export async function initApp({
@@ -326,11 +67,7 @@ export async function initApp({
   updateChecker?: UpdateChecker
 }) {
   const expectedOrigin = new URL(baseURL).origin
-  const clients = new Map<string, Client>()
   const isSecure = baseURL.startsWith('https')
-
-  let currentStreamwallWs: WebSocket | null = null
-  let currentStreamwallConn: StreamwallConnection | null = null
 
   const db = injectedDb ?? (await loadStorage())
   const auth = new Auth(db.data.auth)
@@ -347,43 +84,36 @@ export async function initApp({
     Sentry.setupFastifyErrorHandler(app)
   }
 
-  // WebSocket message handling and doc-update delivery below run outside
-  // Fastify's request lifecycle, so `setupFastifyErrorHandler` never sees
-  // their errors — they are caught locally instead. All of those catch sites
-  // report here. This includes the ones that wrap a bare `ws.send()`: `ws`
-  // does not throw for the routine case of sending to an already-closing
-  // socket (it silently buffers via its internal `sendAfterClose` path), so a
-  // throw out of `send()` here signals a genuine anomaly (e.g. a payload
-  // serialization failure), not ordinary client churn.
+  // WebSocket message handling and doc-update delivery run outside Fastify's
+  // request lifecycle, so `setupFastifyErrorHandler` never sees their errors —
+  // they are caught locally and reported through here instead. This includes
+  // the sites that wrap a bare `ws.send()`: `ws` does not throw for the routine
+  // case of sending to an already-closing socket (it silently buffers via its
+  // internal `sendAfterClose` path), so a throw out of `send()` signals a
+  // genuine anomaly (e.g. a payload serialization failure), not client churn.
   const reportCaughtError = (err: unknown) =>
     captureException(err, sentryEnabled, sentryClient)
 
-  /**
-   * Diffs `clientState`'s current view against what each connected client last
-   * saw and sends only the delta. Subscribed to `clientState`'s own `'state'`
-   * event (see the Streamwall connection handler below) so it also runs for
-   * auth-only changes — e.g. `auth.on('state', ...)` calling
-   * `clientState.update({ auth: ... })` when an invite/session is
-   * created or deleted — not only when the desktop pushes a full state.
-   */
-  const broadcastStateDeltas = (clientState: StateWrapper) => {
-    for (const client of clients.values()) {
-      try {
-        if (client.ws.readyState !== WebSocket.OPEN) {
-          continue
-        }
-        const stateView = clientState.view(client.identity.role)
-        const delta = stateDiff.diff(client.lastStateSent, stateView)
-        if (!delta) {
-          continue
-        }
-        client.ws.send(JSON.stringify({ type: 'state-delta', delta }))
-        client.lastStateSent = stateView
-      } catch (err) {
-        console.error('failed to send client state delta', client, err)
-        reportCaughtError(err)
-      }
-    }
+  const clients = new Map<string, Client>()
+  const broadcastStateDeltas = createBroadcastStateDeltas(
+    clients,
+    reportCaughtError,
+  )
+
+  const rateLimitConfig = getRateLimitConfig()
+
+  const ctx: AppContext = {
+    auth,
+    updateChecker,
+    expectedOrigin,
+    isSecure,
+    wsMessageLimitConfig: getWsMessageLimitConfig(),
+    docUpdateLimits: getDocUpdateLimits(),
+    clients,
+    currentStreamwallWs: null,
+    currentStreamwallConn: null,
+    broadcastStateDeltas,
+    reportCaughtError,
   }
 
   await app.register(fastifyCookie)
@@ -410,15 +140,11 @@ export async function initApp({
   // Per-IP rate limiting. Auth-bearing routes run an expensive scrypt
   // derivation per request, so they get a much stricter budget than the
   // global default to blunt scrypt-amplification DoS and credential stuffing.
-  const rateLimitConfig = getRateLimitConfig()
   await app.register(fastifyRateLimit, {
     global: true,
     max: rateLimitConfig.globalMax,
     timeWindow: rateLimitConfig.timeWindow,
   })
-
-  const wsMessageLimitConfig = getWsMessageLimitConfig()
-  const docUpdateLimits = getDocUpdateLimits()
 
   await app.register(fastifyWebsocket, {
     errorHandler: (err) => {
@@ -426,454 +152,16 @@ export async function initApp({
     },
   })
 
-  // The invite page never receives the secret — it lives in the URL fragment,
-  // which the browser does not send — so this bare GET only serves the exchange
-  // page and needs no auth rate limit.
-  app.get<{ Params: { id: string } }>(
-    '/invite/:id',
-    async (_request, reply) => {
-      return reply.type('text/html').send(INVITE_EXCHANGE_HTML)
+  await registerInviteRoutes(app, {
+    auth,
+    isSecure,
+    authRateLimit: {
+      max: rateLimitConfig.authMax,
+      timeWindow: rateLimitConfig.timeWindow,
     },
-  )
-
-  app.get('/invite-exchange.js', async (_request, reply) => {
-    return reply
-      .type('application/javascript')
-      .header('cache-control', 'no-store')
-      .send(INVITE_EXCHANGE_SCRIPT)
   })
-
-  // Redeems an invite. The secret arrives in the request body (not the URL),
-  // and this route runs the expensive scrypt verification, so it carries the
-  // strict auth rate limit.
-  app.post<{ Params: { id: string }; Body: { token?: string } }>(
-    '/invite/:id',
-    {
-      config: {
-        rateLimit: {
-          max: rateLimitConfig.authMax,
-          timeWindow: rateLimitConfig.timeWindow,
-        },
-      },
-    },
-    async (request, reply) => {
-      const { id } = request.params
-      const token = request.body?.token
-
-      if (!token || typeof token !== 'string') {
-        return reply.code(403).send()
-      }
-
-      const tokenInfo = await auth.validateToken(id, token)
-      if (!tokenInfo || tokenInfo.kind !== 'invite') {
-        return reply.code(403).send()
-      }
-
-      const sessionToken = await auth.createToken({
-        kind: 'session',
-        name: tokenInfo.name,
-        role: tokenInfo.role,
-      })
-
-      reply.setCookie(
-        SESSION_COOKIE_NAME,
-        `${sessionToken.tokenId}:${sessionToken.secret}`,
-        {
-          path: '/',
-          httpOnly: true,
-          secure: isSecure,
-          sameSite: 'strict',
-          maxAge: SESSION_COOKIE_MAX_AGE_SECONDS,
-        },
-      )
-
-      await auth.deleteToken(tokenInfo.tokenId)
-      return reply.code(204).send()
-    },
-  )
-
-  app.get<{ Params: { id: string } }>(
-    '/streamwall/:id/ws',
-    { websocket: true },
-    async (ws, request) => {
-      ws.binaryType = 'arraybuffer'
-      const handleMessage = queueWebSocketMessages(ws)
-
-      const { id } = request.params
-      const token = bearerToken(request.headers.authorization)
-
-      if (!token) {
-        ws.send(JSON.stringify({ error: 'unauthorized' }))
-        ws.close()
-        return
-      }
-
-      const tokenInfo = await auth.validateToken(id, token)
-      if (!tokenInfo || tokenInfo.kind !== 'streamwall') {
-        ws.send(JSON.stringify({ error: 'unauthorized' }))
-        ws.close()
-        return
-      }
-
-      if (currentStreamwallWs != null) {
-        console.warn(
-          'Rejecting Streamwall connection (already connected) from',
-          request.ip,
-          tokenInfo,
-        )
-        ws.send(JSON.stringify({ error: 'streamwall already connected' }))
-        ws.close()
-        return
-      }
-
-      currentStreamwallWs = ws
-
-      const pingInterval = setInterval(() => {
-        ws.ping()
-        const pongTimeout = setTimeout(() => {
-          if (ws.readyState === ws.OPEN) {
-            console.warn(
-              `Streamwall timeout: no pong within ${STREAMWALL_PING_TIMEOUT_MS}ms. Closing connection.`,
-            )
-            ws.terminate()
-          }
-        }, STREAMWALL_PING_TIMEOUT_MS)
-        ws.once('pong', () => {
-          clearTimeout(pongTimeout)
-        })
-      }, STREAMWALL_PING_TIMEOUT_MS)
-
-      ws.on('close', () => {
-        console.log('Streamwall disconnected')
-        currentStreamwallWs = null
-        currentStreamwallConn = null
-        clearInterval(pingInterval)
-
-        for (const client of clients.values()) {
-          client.ws.close()
-        }
-      })
-
-      let clientState: StateWrapper | null = null
-      const stateDoc = new Y.Doc()
-
-      console.log('Streamwall connecting from', request.ip, tokenInfo)
-
-      const allowMessage = createWsMessageGuard(
-        ws,
-        wsMessageLimitConfig,
-        `streamwall connection from ${request.ip}`,
-      )
-
-      handleMessage((rawData) => {
-        if (!allowMessage()) {
-          return
-        }
-        if (rawData instanceof ArrayBuffer) {
-          // The uplink is the trusted authority for the shared doc and streams
-          // the full state snapshot on connect, so it bypasses the size/shape
-          // guard applied to untrusted client updates (which would otherwise
-          // reject a legitimately large snapshot and silently break sync).
-          Y.applyUpdate(stateDoc, new Uint8Array(rawData))
-          return
-        }
-
-        let raw: unknown
-        try {
-          raw = JSON.parse(rawData.toString())
-        } catch (err) {
-          console.warn('Received unexpected ws data: ', rawData.length, 'bytes')
-          return
-        }
-
-        // The desktop only ever sends `state` messages over this channel.
-        // Validate structurally so a malformed payload can never wrap the
-        // shared StateWrapper around garbage (which crashed clients on view()).
-        const parsed = controlStateMessageSchema.safeParse(raw)
-        if (!parsed.success) {
-          console.warn(
-            'Rejected invalid Streamwall state message:',
-            parsed.error.issues[0]?.message,
-          )
-          return
-        }
-
-        // The envelope check above only guarantees "an object". Validate the
-        // full snapshot itself so a malformed or adversarial desktop build can
-        // never seed StateWrapper with garbage that crashes clients on
-        // view() or corrupts the role-scoped projection (issue #387).
-        const stateResult = streamwallStateSchema.safeParse(parsed.data.state)
-        if (!stateResult.success) {
-          console.warn(
-            'Rejected invalid Streamwall state payload:',
-            stateResult.error.issues[0]?.message,
-          )
-          return
-        }
-        const state = stateResult.data
-
-        try {
-          if (clientState === null) {
-            const newClientState = new StateWrapper(state)
-            // Broadcasting on every `'state'` event (rather than only here)
-            // is what makes auth-only changes — invite/session created or
-            // deleted while the desktop pushes no new state — reach already
-            // connected clients; see `auth.on('state', ...)` below.
-            newClientState.on('state', () =>
-              broadcastStateDeltas(newClientState),
-            )
-            clientState = newClientState
-            clientState.update({ auth: auth.getState() })
-            currentStreamwallConn = {
-              ws,
-              clientState,
-              stateDoc,
-            }
-
-            console.log('Streamwall connected from', request.ip, tokenInfo)
-          } else {
-            clientState.update(state)
-          }
-        } catch (err) {
-          console.error('Failed to handle ws message:', rawData, err)
-          reportCaughtError(err)
-        }
-      })
-
-      stateDoc.on('update', (update, origin) => {
-        try {
-          ws.send(update)
-        } catch (err) {
-          console.error('Failed to send Streamwall doc update', err)
-          reportCaughtError(err)
-        }
-        for (const client of clients.values()) {
-          if (client.clientId === origin) {
-            continue
-          }
-          try {
-            client.ws.send(update)
-          } catch (err) {
-            console.error('Failed to send client doc update:', client, err)
-            reportCaughtError(err)
-          }
-        }
-      })
-    },
-  )
-
-  // Authenticated client routes
-  app.register(async function (fastify) {
-    fastify.addHook('preHandler', async (request) => {
-      const sessionCookie = request.cookies[SESSION_COOKIE_NAME]
-      if (sessionCookie) {
-        const [tokenId, tokenSecret] = sessionCookie.split(':', 2)
-        const tokenInfo = await auth.validateToken(tokenId, tokenSecret)
-        if (tokenInfo && tokenInfo.kind === 'session') {
-          request.identity = tokenInfo
-        }
-      }
-    })
-
-    // Deployment status for self-hosters (issue #382): the running version
-    // plus whether a newer release exists. Admin-only — the version of a
-    // publicly reachable server is exactly the kind of detail that helps
-    // someone shop for a known vulnerability, so it stays behind auth.
-    fastify.get('/admin/status', async (request, reply) => {
-      if (!roleCan(request.identity?.role ?? null, 'view-server-status')) {
-        return reply.code(403).send()
-      }
-      return reply
-        .header('cache-control', 'no-store')
-        .send(updateChecker.getStatus())
-    })
-
-    // Serve frontend assets
-    await fastify.register(fastifyStatic, {
-      root: clientStaticPath,
-    })
-
-    // Client WebSocket connection
-    fastify.get('/client/ws', { websocket: true }, async (ws, request) => {
-      ws.binaryType = 'arraybuffer'
-      const handleMessage = queueWebSocketMessages(ws)
-
-      const { identity } = request
-
-      if (request.headers.origin !== expectedOrigin || !identity) {
-        ws.send(JSON.stringify({ error: 'unauthorized' }))
-        ws.close()
-        return
-      }
-
-      const streamwallConn = currentStreamwallConn
-      if (!streamwallConn) {
-        ws.send(JSON.stringify({ error: 'streamwall disconnected' }))
-        ws.close()
-        return
-      }
-
-      const clientId = uniqueRand62(8, clients)
-      const client: Client = {
-        clientId,
-        ws,
-        lastStateSent: null,
-        identity,
-      }
-      clients.set(clientId, client)
-
-      const pingInterval = setInterval(() => {
-        ws.ping()
-      }, 20 * 1000)
-
-      ws.on('close', () => {
-        clients.delete(clientId)
-        clearInterval(pingInterval)
-
-        console.log(
-          'Client',
-          clientId,
-          'disconnected from',
-          request.ip,
-          client.identity,
-        )
-      })
-
-      console.log(
-        'Client',
-        clientId,
-        'connected from',
-        request.ip,
-        client.identity,
-      )
-
-      const allowMessage = createWsMessageGuard(
-        ws,
-        wsMessageLimitConfig,
-        `client ${clientId} from ${request.ip}`,
-      )
-
-      handleMessage(async (rawData) => {
-        if (!allowMessage()) {
-          return
-        }
-        let messageId: number | undefined
-        const respond = (responseData: Record<string, unknown>) => {
-          if (ws.readyState !== WebSocket.OPEN) {
-            return
-          }
-          ws.send(
-            JSON.stringify({
-              ...responseData,
-              response: true,
-              id: messageId,
-            }),
-          )
-        }
-
-        if (!currentStreamwallConn) {
-          respond({ error: 'streamwall disconnected' })
-          return
-        }
-
-        if (rawData instanceof ArrayBuffer) {
-          if (!roleCan(identity.role, 'mutate-state-doc')) {
-            console.warn(
-              `Unauthorized attempt to edit state doc by "${identity.name}"`,
-            )
-            respond({ error: 'unauthorized' })
-            return
-          }
-          if (
-            !applyValidatedDocUpdate(
-              streamwallConn.stateDoc,
-              new Uint8Array(rawData),
-              docUpdateLimits,
-              clientId,
-            )
-          ) {
-            // The client already applied this edit to its local doc. Dropping
-            // it server-side would leave the operator UI out of sync with the
-            // shared doc, so close the socket (like a rate-limit violation) to
-            // force a clean reconnect and resync.
-            console.warn(
-              `Rejected invalid state doc update from client ${clientId}, closing to force resync`,
-            )
-            ws.close(1008, 'invalid state update')
-          }
-          return
-        }
-
-        let raw: unknown
-        try {
-          raw = JSON.parse(rawData.toString())
-        } catch (err) {
-          console.warn('Received unexpected ws data: ', rawData.length, 'bytes')
-          return
-        }
-
-        // Preserve the client-supplied id (when present) so an error response
-        // can still be correlated even if the message is otherwise invalid.
-        if (
-          typeof raw === 'object' &&
-          raw !== null &&
-          typeof (raw as { id?: unknown }).id === 'number'
-        ) {
-          messageId = (raw as { id: number }).id
-        }
-
-        // Every command is validated against the shared schema before it is
-        // authorized or dispatched: an admin passes every roleCan check, so
-        // this is the only barrier stopping a malformed or unknown command
-        // from being forwarded to — and executed on — the desktop.
-        const parsed = controlCommandMessageSchema.safeParse(raw)
-        if (!parsed.success) {
-          console.warn(
-            `Rejected invalid control message from client ${clientId}:`,
-            parsed.error.issues[0]?.message,
-          )
-          respond({ error: 'invalid message' })
-          return
-        }
-        const msg = parsed.data
-
-        try {
-          if (!roleCan(identity.role, msg.type)) {
-            console.warn(
-              `Unauthorized attempt to "${msg.type}" by "${identity.name}"`,
-            )
-            respond({ error: 'unauthorized' })
-            return
-          }
-
-          if (msg.type === 'create-invite') {
-            console.debug('Creating invite for role:', msg.role)
-            const { tokenId, secret } = await auth.createToken({
-              kind: 'invite',
-              role: msg.role as StreamwallRole,
-              name: msg.name,
-            })
-            respond({ name: msg.name, secret, tokenId })
-          } else if (msg.type === 'delete-token') {
-            console.debug('Deleting token:', msg.tokenId)
-            auth.deleteToken(msg.tokenId)
-          } else {
-            streamwallConn.ws.send(
-              JSON.stringify({ ...msg, clientId: identity.tokenId }),
-            )
-          }
-        } catch (err) {
-          console.error('Failed to handle ws message:', rawData, err)
-          reportCaughtError(err)
-        }
-      })
-
-      const state = streamwallConn.clientState.view(identity.role)
-      ws.send(JSON.stringify({ type: 'state', state }))
-      ws.send(Y.encodeStateAsUpdate(streamwallConn.stateDoc))
-      client.lastStateSent = state
-    })
-  })
+  registerUplinkRoute(app, ctx)
+  registerClientRoutes(app, ctx, { clientStaticPath })
 
   auth.on('state', (state) => {
     db.update((data) => {
@@ -887,189 +175,15 @@ export async function initApp({
       }
     }
 
-    currentStreamwallConn?.clientState.update({ auth: auth.getState() })
+    ctx.currentStreamwallConn?.clientState.update({ auth: auth.getState() })
   })
 
   return { app, db, auth, updateChecker }
 }
 
-/** Builds the uplink WebSocket endpoint URL, which never embeds the secret. */
-function uplinkEndpointURL(baseURL: string, tokenId: string) {
-  return `${baseURL.replace(/^http/, 'ws')}/streamwall/${tokenId}/ws`
-}
-
-export interface BootstrapResult {
-  /**
-   * The plaintext uplink secret, exposed *only* when the token was freshly
-   * minted. `null` on a restart, where the secret is unrecoverable by design.
-   */
-  uplinkSecret: string | null
-  /** The uplink WebSocket endpoint (never carries the secret). */
-  uplinkEndpoint: string
-  /** A fresh single-use admin invite link (regenerated every startup). */
-  adminInviteLink: string
-}
-
-export async function initialInviteCodes({
-  db,
-  auth,
-  baseURL,
-}: {
-  db: StorageDB
-  auth: Auth
-  baseURL: string
-}): Promise<BootstrapResult> {
-  // The uplink token is validated against its scrypt hash in `auth.tokens`,
-  // exactly like session and invite tokens. We persist only its id; the
-  // plaintext secret is shown once, at creation, and never written to disk.
-  const record = db.data.streamwallToken
-  const hasValidUplinkToken =
-    record != null && auth.tokensById.has(record.tokenId)
-
-  let uplinkSecret: string | null = null
-  let uplinkTokenId: string
-
-  if (hasValidUplinkToken) {
-    uplinkTokenId = record.tokenId
-    // Scrub any plaintext secret a pre-fix server version may have persisted
-    // alongside the id, so it stops leaking through storage.json.
-    if ((record as { secret?: string }).secret !== undefined) {
-      db.update((data) => {
-        data.streamwallToken = { tokenId: uplinkTokenId }
-      })
-    }
-  } else {
-    // Minting a fresh uplink token (first run, or a rotation triggered by
-    // clearing the stored record). Delete any superseded uplink tokens first so
-    // an old secret can never authenticate again.
-    for (const token of [...auth.tokensById.values()]) {
-      if (token.kind === 'streamwall') {
-        auth.deleteToken(token.tokenId)
-      }
-    }
-    const minted = await auth.createToken({
-      kind: 'streamwall',
-      role: 'admin',
-      name: 'Streamwall',
-    })
-    uplinkSecret = minted.secret
-    uplinkTokenId = minted.tokenId
-    db.update((data) => {
-      data.streamwallToken = { tokenId: minted.tokenId }
-    })
-  }
-
-  // Invalidate any existing admin invites and create a new one:
-  for (const adminToken of auth
-    .getState()
-    .invites.filter(({ role }) => role === 'admin')) {
-    auth.deleteToken(adminToken.tokenId)
-  }
-  const adminToken = await auth.createToken({
-    kind: 'invite',
-    role: 'admin',
-    name: 'Server admin',
-  })
-
-  return {
-    uplinkSecret,
-    uplinkEndpoint: uplinkEndpointURL(baseURL, uplinkTokenId),
-    adminInviteLink: inviteLink({
-      baseURL,
-      tokenId: adminToken.tokenId,
-      secret: adminToken.secret,
-    }),
-  }
-}
-
-/**
- * Logs the bootstrap credentials to stdout. The uplink secret is printed only
- * when it was just minted (shown once); on subsequent starts we print the
- * endpoint without it and point the operator at how to rotate.
- */
-function logBootstrap({
-  uplinkSecret,
-  uplinkEndpoint,
-  adminInviteLink,
-}: BootstrapResult) {
-  if (uplinkSecret) {
-    console.log(
-      '🔌 Streamwall uplink (shown once — save it now):',
-      `${uplinkEndpoint}?token=${uplinkSecret}`,
-    )
-  } else {
-    console.log('🔌 Streamwall uplink endpoint:', uplinkEndpoint)
-    console.log(
-      '   (the uplink secret is shown only at creation; to rotate it, clear ' +
-        '"streamwallToken" in storage.json and restart)',
-    )
-  }
-  console.log('🔑 Admin invite:', adminInviteLink)
-}
-
-/**
- * Resolve the TCP listen port for the control server.
- * `URL.port` is `""` (not undefined) when the URL has no explicit port, so
- * `??` alone would leave an empty string and `Number('') === 0` (ephemeral bind).
- * Prefer an explicit override, else URL port, else the scheme default.
- */
-export function resolveListenPort(
-  baseURL: string,
-  overridePort?: string,
-): number {
-  const url = new URL(baseURL)
-  const explicit =
-    overridePort != null && String(overridePort).trim() !== ''
-      ? String(overridePort).trim()
-      : undefined
-  const fromUrl = url.port || (url.protocol === 'https:' ? '443' : '80')
-  return Number(explicit ?? fromUrl)
-}
-
-export default async function runServer({
-  port: overridePort,
-  hostname: overrideHostname,
-  baseURL,
-  clientStaticPath,
-  db: injectedDb,
-  updateChecker: injectedUpdateChecker,
-}: AppOptions & {
-  hostname?: string
-  port?: string
-  /** Test-only override so specs can exercise the real listen() path without touching disk. */
-  db?: StorageDB
-  /** Test-only override so specs can exercise the real listen() path without reaching GitHub. */
-  updateChecker?: UpdateChecker
-}) {
-  const url = new URL(baseURL)
-  const hostname = overrideHostname ?? url.hostname
-  const port = resolveListenPort(baseURL, overridePort)
-
-  console.log(`Starting streamwall-control-server ${SERVER_VERSION}`)
-  console.debug('Initializing web server:', { hostname, port })
-  const { app, db, auth, updateChecker } = await initApp({
-    baseURL,
-    clientStaticPath,
-    db: injectedDb,
-    updateChecker: injectedUpdateChecker,
-  })
-
-  const bootstrap = await initialInviteCodes({ db, auth, baseURL })
-  logBootstrap(bootstrap)
-
-  // Hooks must be registered before the instance starts listening -- Fastify 5
-  // throws FST_ERR_INSTANCE_ALREADY_LISTENING otherwise (issue #442).
-  app.addHook('onClose', async () => {
-    updateChecker.stop()
-  })
-
-  await app.listen({ port, host: hostname })
-
-  // Fire-and-forget: a slow or unreachable GitHub must never delay serving.
-  void updateChecker.start()
-
-  return { server: app.server }
-}
+// `runServer` and the bootstrap helpers live in `./bootstrap.ts`; re-exported
+// here so `./index.ts` stays the process entry point and stable public module.
+export { default } from './bootstrap.ts'
 
 const isMainModule =
   !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href

--- a/packages/streamwall-control-server/src/inviteExchange/exchange.d.ts
+++ b/packages/streamwall-control-server/src/inviteExchange/exchange.d.ts
@@ -1,0 +1,31 @@
+// Type contract for the browser-served `exchange.js`. It is authored as plain
+// JS (so it can be served verbatim and executed by the browser), so this
+// declaration types its testable entry point without pulling the DOM lib into
+// the server's TypeScript program.
+
+export interface InviteExchangeDeps {
+  location: {
+    hash: string
+    pathname: string
+    replace(url: string): void
+  }
+  history: {
+    replaceState(data: unknown, unused: string, url: string): void
+  }
+  fetch: (
+    url: string,
+    init: {
+      method: string
+      headers: Record<string, string>
+      body: string
+    },
+  ) => Promise<{ ok: boolean }>
+  setStatus: (text: string) => void
+}
+
+/**
+ * Reads the invite token from `location.hash`, scrubs it from the address bar,
+ * and exchanges it for a session cookie via POST. Resolves once the attempt
+ * settles.
+ */
+export function runInviteExchange(deps: InviteExchangeDeps): Promise<void>

--- a/packages/streamwall-control-server/src/inviteExchange/exchange.js
+++ b/packages/streamwall-control-server/src/inviteExchange/exchange.js
@@ -1,0 +1,65 @@
+// Client-side invite redemption. Served at `/invite-exchange.js` and loaded by
+// `page.html` as a module script (which satisfies the strict
+// `script-src 'self'` CSP). The invite secret lives in `location.hash`, which
+// the browser never sends to the server, so this script reads it client-side,
+// scrubs it from the address bar, and POSTs it to redeem the invite for a
+// session cookie.
+//
+// The core logic is factored into `runInviteExchange` with its browser
+// dependencies injected, so fragment parsing and the fetch success/error paths
+// can be unit-tested under `node:test` without a DOM.
+
+/**
+ * Reads the invite token from `location.hash`, scrubs it from the address bar,
+ * and exchanges it for a session cookie via POST. On success it navigates to
+ * the app; otherwise it reports the failure through `setStatus`.
+ *
+ * @param {object} deps
+ * @param {Location} deps.location - the page location (hash carries the token).
+ * @param {History} deps.history - used to scrub the token from the URL.
+ * @param {typeof fetch} deps.fetch - performs the redemption request.
+ * @param {(text: string) => void} deps.setStatus - surfaces status/errors.
+ * @returns {Promise<void>} resolves once the exchange attempt settles.
+ */
+export function runInviteExchange({ location, history, fetch, setStatus }) {
+  const token = new URLSearchParams(location.hash.slice(1)).get('token')
+  // Scrub the token from the address bar before doing anything else, so it
+  // never lingers in history or a shared screen — even if it is missing.
+  history.replaceState(null, '', location.pathname)
+  if (!token) {
+    setStatus('This invite link is missing its token.')
+    return Promise.resolve()
+  }
+  return fetch(location.pathname, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ token: token }),
+  })
+    .then(function (res) {
+      if (res.ok) {
+        location.replace('/')
+      } else {
+        setStatus('This invite is invalid or has expired.')
+      }
+    })
+    .catch(function () {
+      setStatus('Could not reach the server. Please try again.')
+    })
+}
+
+// Auto-run in the browser only. The guard keeps importing this module under
+// `node:test` (to exercise `runInviteExchange`) from touching `window` or
+// `document`.
+if (typeof document !== 'undefined' && typeof window !== 'undefined') {
+  const statusEl = document.querySelector('p')
+  runInviteExchange({
+    location: window.location,
+    history: window.history,
+    fetch: window.fetch.bind(window),
+    setStatus: (text) => {
+      if (statusEl) {
+        statusEl.textContent = text
+      }
+    },
+  })
+}

--- a/packages/streamwall-control-server/src/inviteExchange/exchange.test.ts
+++ b/packages/streamwall-control-server/src/inviteExchange/exchange.test.ts
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+
+import { runInviteExchange } from './exchange.js'
+
+/**
+ * Builds the injected browser dependencies for `runInviteExchange`, recording
+ * every side effect so tests can assert on them without a real DOM.
+ */
+function harness({
+  hash = '',
+  pathname = '/invite/tok123',
+  fetchImpl,
+}: {
+  hash?: string
+  pathname?: string
+  fetchImpl?: (url: string, init: unknown) => Promise<{ ok: boolean }>
+} = {}) {
+  const calls = {
+    replaceState: [] as Array<[unknown, string, string]>,
+    replaced: [] as string[],
+    status: [] as string[],
+    fetch: [] as Array<{ url: string; init: unknown }>,
+  }
+  const location = {
+    hash,
+    pathname,
+    replace(url: string) {
+      calls.replaced.push(url)
+    },
+  }
+  const history = {
+    replaceState(state: unknown, unused: string, url: string) {
+      calls.replaceState.push([state, unused, url])
+    },
+  }
+  const fetch = (url: string, init: unknown) => {
+    calls.fetch.push({ url, init })
+    return (fetchImpl ?? (async () => ({ ok: true })))(url, init)
+  }
+  const setStatus = (text: string) => {
+    calls.status.push(text)
+  }
+  return { calls, deps: { location, history, fetch, setStatus } }
+}
+
+describe('runInviteExchange fragment parsing', () => {
+  test('scrubs the token from the address bar before anything else', async () => {
+    const { calls, deps } = harness({
+      hash: '#token=secret-abc',
+      pathname: '/invite/tok123',
+    })
+
+    await runInviteExchange(deps)
+
+    assert.deepEqual(calls.replaceState[0], [null, '', '/invite/tok123'])
+  })
+
+  test('extracts the token from among other fragment params', async () => {
+    const { calls, deps } = harness({
+      hash: '#foo=1&token=secret-xyz&bar=2',
+    })
+
+    await runInviteExchange(deps)
+
+    assert.equal(calls.fetch.length, 1)
+    assert.deepEqual(
+      JSON.parse(String((calls.fetch[0].init as { body: string }).body)),
+      {
+        token: 'secret-xyz',
+      },
+    )
+  })
+
+  test('reports and skips the request when the fragment carries no token', async () => {
+    const { calls, deps } = harness({ hash: '#nope=1' })
+
+    await runInviteExchange(deps)
+
+    assert.deepEqual(calls.status, ['This invite link is missing its token.'])
+    assert.equal(calls.fetch.length, 0, 'no redemption request without a token')
+    // The address bar is still scrubbed even on the no-token path.
+    assert.equal(calls.replaceState.length, 1)
+  })
+})
+
+describe('runInviteExchange redemption paths', () => {
+  test('POSTs the token to the invite path and navigates home on success', async () => {
+    const { calls, deps } = harness({
+      hash: '#token=good',
+      pathname: '/invite/tok123',
+      fetchImpl: async () => ({ ok: true }),
+    })
+
+    await runInviteExchange(deps)
+
+    assert.equal(calls.fetch[0].url, '/invite/tok123')
+    const init = calls.fetch[0].init as {
+      method: string
+      headers: Record<string, string>
+      body: string
+    }
+    assert.equal(init.method, 'POST')
+    assert.equal(init.headers['content-type'], 'application/json')
+    assert.deepEqual(JSON.parse(init.body), { token: 'good' })
+    assert.deepEqual(calls.replaced, ['/'], 'navigates to the app on success')
+    assert.deepEqual(calls.status, [], 'no error surfaced on success')
+  })
+
+  test('surfaces an invalid/expired message when the server rejects', async () => {
+    const { calls, deps } = harness({
+      hash: '#token=stale',
+      fetchImpl: async () => ({ ok: false }),
+    })
+
+    await runInviteExchange(deps)
+
+    assert.deepEqual(calls.status, ['This invite is invalid or has expired.'])
+    assert.deepEqual(
+      calls.replaced,
+      [],
+      'does not navigate on a rejected invite',
+    )
+  })
+
+  test('surfaces a connectivity message when the request itself fails', async () => {
+    const { calls, deps } = harness({
+      hash: '#token=whatever',
+      fetchImpl: async () => {
+        throw new Error('network down')
+      },
+    })
+
+    await runInviteExchange(deps)
+
+    assert.deepEqual(calls.status, [
+      'Could not reach the server. Please try again.',
+    ])
+    assert.deepEqual(calls.replaced, [])
+  })
+})

--- a/packages/streamwall-control-server/src/inviteExchange/invite.ts
+++ b/packages/streamwall-control-server/src/inviteExchange/invite.ts
@@ -1,0 +1,119 @@
+import type { FastifyInstance } from 'fastify'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import type { Auth } from '../auth.ts'
+import {
+  SESSION_COOKIE_MAX_AGE_SECONDS,
+  SESSION_COOKIE_NAME,
+} from '../config.ts'
+
+// The invite exchange page and its client script are shipped as static assets
+// alongside this module (rather than inline strings) so the script can be
+// linted and unit-tested on its own. They are read once and cached; the whole
+// `src/` tree is copied into the runtime image, so these resolve both under
+// `tsx`/native-TS dev and in the container.
+const ASSET_DIR = import.meta.dirname
+let pageHtmlCache: string | null = null
+let exchangeScriptCache: string | null = null
+
+async function invitePageHtml(): Promise<string> {
+  pageHtmlCache ??= await readFile(path.join(ASSET_DIR, 'page.html'), 'utf8')
+  return pageHtmlCache
+}
+
+async function inviteExchangeScript(): Promise<string> {
+  exchangeScriptCache ??= await readFile(
+    path.join(ASSET_DIR, 'exchange.js'),
+    'utf8',
+  )
+  return exchangeScriptCache
+}
+
+export interface InviteRouteOptions {
+  auth: Auth
+  /** Whether the server is reached over TLS, gating the `Secure` cookie flag. */
+  isSecure: boolean
+  /** Per-IP budget for the scrypt-bearing redemption route. */
+  authRateLimit: { max: number; timeWindow: string }
+}
+
+/**
+ * Registers the invite exchange endpoints:
+ * - `GET /invite/:id` serves the exchange page (carries no secret).
+ * - `GET /invite-exchange.js` serves the client redemption script.
+ * - `POST /invite/:id` redeems the secret (from the body) for a session cookie.
+ */
+export async function registerInviteRoutes(
+  app: FastifyInstance,
+  { auth, isSecure, authRateLimit }: InviteRouteOptions,
+): Promise<void> {
+  const pageHtml = await invitePageHtml()
+  const exchangeScript = await inviteExchangeScript()
+
+  // The invite page never receives the secret — it lives in the URL fragment,
+  // which the browser does not send — so this bare GET only serves the exchange
+  // page and needs no auth rate limit.
+  app.get<{ Params: { id: string } }>(
+    '/invite/:id',
+    async (_request, reply) => {
+      return reply.type('text/html').send(pageHtml)
+    },
+  )
+
+  app.get('/invite-exchange.js', async (_request, reply) => {
+    return reply
+      .type('application/javascript')
+      .header('cache-control', 'no-store')
+      .send(exchangeScript)
+  })
+
+  // Redeems an invite. The secret arrives in the request body (not the URL),
+  // and this route runs the expensive scrypt verification, so it carries the
+  // strict auth rate limit.
+  app.post<{ Params: { id: string }; Body: { token?: string } }>(
+    '/invite/:id',
+    {
+      config: {
+        rateLimit: {
+          max: authRateLimit.max,
+          timeWindow: authRateLimit.timeWindow,
+        },
+      },
+    },
+    async (request, reply) => {
+      const { id } = request.params
+      const token = request.body?.token
+
+      if (!token || typeof token !== 'string') {
+        return reply.code(403).send()
+      }
+
+      const tokenInfo = await auth.validateToken(id, token)
+      if (!tokenInfo || tokenInfo.kind !== 'invite') {
+        return reply.code(403).send()
+      }
+
+      const sessionToken = await auth.createToken({
+        kind: 'session',
+        name: tokenInfo.name,
+        role: tokenInfo.role,
+      })
+
+      reply.setCookie(
+        SESSION_COOKIE_NAME,
+        `${sessionToken.tokenId}:${sessionToken.secret}`,
+        {
+          path: '/',
+          httpOnly: true,
+          secure: isSecure,
+          sameSite: 'strict',
+          maxAge: SESSION_COOKIE_MAX_AGE_SECONDS,
+        },
+      )
+
+      await auth.deleteToken(tokenInfo.tokenId)
+      return reply.code(204).send()
+    },
+  )
+}

--- a/packages/streamwall-control-server/src/inviteExchange/page.html
+++ b/packages/streamwall-control-server/src/inviteExchange/page.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Streamwall — joining…</title>
+  </head>
+  <body>
+    <p>Signing you in…</p>
+    <script type="module" src="/invite-exchange.js"></script>
+  </body>
+</html>

--- a/packages/streamwall-control-server/src/ws/client.ts
+++ b/packages/streamwall-control-server/src/ws/client.ts
@@ -1,0 +1,243 @@
+import fastifyStatic from '@fastify/static'
+import type { FastifyInstance } from 'fastify'
+import WebSocket from 'ws'
+import * as Y from 'yjs'
+
+import {
+  controlCommandMessageSchema,
+  roleCan,
+  type StreamwallRole,
+} from 'streamwall-shared'
+import { uniqueRand62 } from '../auth.ts'
+import { SESSION_COOKIE_NAME } from '../config.ts'
+import { type AppContext, type Client } from '../context.ts'
+import { applyValidatedDocUpdate } from '../stateDocGuard.ts'
+import { createWsMessageGuard, queueWebSocketMessages } from '../wsSupport.ts'
+
+export interface ClientRouteOptions {
+  /** Filesystem root of the built control client served at `/`. */
+  clientStaticPath: string
+}
+
+/**
+ * Registers the authenticated surface as an encapsulated Fastify plugin: a
+ * session-cookie auth `preHandler`, the admin-only `/admin/status` endpoint,
+ * the static control client, and the browser control WebSocket at `/client/ws`.
+ */
+export function registerClientRoutes(
+  app: FastifyInstance,
+  ctx: AppContext,
+  { clientStaticPath }: ClientRouteOptions,
+): void {
+  app.register(async function (fastify) {
+    fastify.addHook('preHandler', async (request) => {
+      const sessionCookie = request.cookies[SESSION_COOKIE_NAME]
+      if (sessionCookie) {
+        const [tokenId, tokenSecret] = sessionCookie.split(':', 2)
+        const tokenInfo = await ctx.auth.validateToken(tokenId, tokenSecret)
+        if (tokenInfo && tokenInfo.kind === 'session') {
+          request.identity = tokenInfo
+        }
+      }
+    })
+
+    // Deployment status for self-hosters (issue #382): the running version
+    // plus whether a newer release exists. Admin-only — the version of a
+    // publicly reachable server is exactly the kind of detail that helps
+    // someone shop for a known vulnerability, so it stays behind auth.
+    fastify.get('/admin/status', async (request, reply) => {
+      if (!roleCan(request.identity?.role ?? null, 'view-server-status')) {
+        return reply.code(403).send()
+      }
+      return reply
+        .header('cache-control', 'no-store')
+        .send(ctx.updateChecker.getStatus())
+    })
+
+    // Serve frontend assets
+    await fastify.register(fastifyStatic, {
+      root: clientStaticPath,
+    })
+
+    // Client WebSocket connection
+    fastify.get('/client/ws', { websocket: true }, async (ws, request) => {
+      ws.binaryType = 'arraybuffer'
+      const handleMessage = queueWebSocketMessages(ws)
+
+      const { identity } = request
+
+      if (request.headers.origin !== ctx.expectedOrigin || !identity) {
+        ws.send(JSON.stringify({ error: 'unauthorized' }))
+        ws.close()
+        return
+      }
+
+      const streamwallConn = ctx.currentStreamwallConn
+      if (!streamwallConn) {
+        ws.send(JSON.stringify({ error: 'streamwall disconnected' }))
+        ws.close()
+        return
+      }
+
+      const clientId = uniqueRand62(8, ctx.clients)
+      const client: Client = {
+        clientId,
+        ws,
+        lastStateSent: null,
+        identity,
+      }
+      ctx.clients.set(clientId, client)
+
+      const pingInterval = setInterval(() => {
+        ws.ping()
+      }, 20 * 1000)
+
+      ws.on('close', () => {
+        ctx.clients.delete(clientId)
+        clearInterval(pingInterval)
+
+        console.log(
+          'Client',
+          clientId,
+          'disconnected from',
+          request.ip,
+          client.identity,
+        )
+      })
+
+      console.log(
+        'Client',
+        clientId,
+        'connected from',
+        request.ip,
+        client.identity,
+      )
+
+      const allowMessage = createWsMessageGuard(
+        ws,
+        ctx.wsMessageLimitConfig,
+        `client ${clientId} from ${request.ip}`,
+      )
+
+      handleMessage(async (rawData) => {
+        if (!allowMessage()) {
+          return
+        }
+        let messageId: number | undefined
+        const respond = (responseData: Record<string, unknown>) => {
+          if (ws.readyState !== WebSocket.OPEN) {
+            return
+          }
+          ws.send(
+            JSON.stringify({
+              ...responseData,
+              response: true,
+              id: messageId,
+            }),
+          )
+        }
+
+        if (!ctx.currentStreamwallConn) {
+          respond({ error: 'streamwall disconnected' })
+          return
+        }
+
+        if (rawData instanceof ArrayBuffer) {
+          if (!roleCan(identity.role, 'mutate-state-doc')) {
+            console.warn(
+              `Unauthorized attempt to edit state doc by "${identity.name}"`,
+            )
+            respond({ error: 'unauthorized' })
+            return
+          }
+          if (
+            !applyValidatedDocUpdate(
+              streamwallConn.stateDoc,
+              new Uint8Array(rawData),
+              ctx.docUpdateLimits,
+              clientId,
+            )
+          ) {
+            // The client already applied this edit to its local doc. Dropping
+            // it server-side would leave the operator UI out of sync with the
+            // shared doc, so close the socket (like a rate-limit violation) to
+            // force a clean reconnect and resync.
+            console.warn(
+              `Rejected invalid state doc update from client ${clientId}, closing to force resync`,
+            )
+            ws.close(1008, 'invalid state update')
+          }
+          return
+        }
+
+        let raw: unknown
+        try {
+          raw = JSON.parse(rawData.toString())
+        } catch (err) {
+          console.warn('Received unexpected ws data: ', rawData.length, 'bytes')
+          return
+        }
+
+        // Preserve the client-supplied id (when present) so an error response
+        // can still be correlated even if the message is otherwise invalid.
+        if (
+          typeof raw === 'object' &&
+          raw !== null &&
+          typeof (raw as { id?: unknown }).id === 'number'
+        ) {
+          messageId = (raw as { id: number }).id
+        }
+
+        // Every command is validated against the shared schema before it is
+        // authorized or dispatched: an admin passes every roleCan check, so
+        // this is the only barrier stopping a malformed or unknown command
+        // from being forwarded to — and executed on — the desktop.
+        const parsed = controlCommandMessageSchema.safeParse(raw)
+        if (!parsed.success) {
+          console.warn(
+            `Rejected invalid control message from client ${clientId}:`,
+            parsed.error.issues[0]?.message,
+          )
+          respond({ error: 'invalid message' })
+          return
+        }
+        const msg = parsed.data
+
+        try {
+          if (!roleCan(identity.role, msg.type)) {
+            console.warn(
+              `Unauthorized attempt to "${msg.type}" by "${identity.name}"`,
+            )
+            respond({ error: 'unauthorized' })
+            return
+          }
+
+          if (msg.type === 'create-invite') {
+            console.debug('Creating invite for role:', msg.role)
+            const { tokenId, secret } = await ctx.auth.createToken({
+              kind: 'invite',
+              role: msg.role as StreamwallRole,
+              name: msg.name,
+            })
+            respond({ name: msg.name, secret, tokenId })
+          } else if (msg.type === 'delete-token') {
+            console.debug('Deleting token:', msg.tokenId)
+            ctx.auth.deleteToken(msg.tokenId)
+          } else {
+            streamwallConn.ws.send(
+              JSON.stringify({ ...msg, clientId: identity.tokenId }),
+            )
+          }
+        } catch (err) {
+          console.error('Failed to handle ws message:', rawData, err)
+          ctx.reportCaughtError(err)
+        }
+      })
+
+      const state = streamwallConn.clientState.view(identity.role)
+      ws.send(JSON.stringify({ type: 'state', state }))
+      ws.send(Y.encodeStateAsUpdate(streamwallConn.stateDoc))
+      client.lastStateSent = state
+    })
+  })
+}

--- a/packages/streamwall-control-server/src/ws/uplink.ts
+++ b/packages/streamwall-control-server/src/ws/uplink.ts
@@ -1,0 +1,196 @@
+import type { FastifyInstance } from 'fastify'
+import * as Y from 'yjs'
+
+import {
+  controlStateMessageSchema,
+  streamwallStateSchema,
+} from 'streamwall-shared'
+import { StateWrapper } from '../auth.ts'
+import { STREAMWALL_PING_TIMEOUT_MS } from '../config.ts'
+import type { AppContext } from '../context.ts'
+import {
+  bearerToken,
+  createWsMessageGuard,
+  queueWebSocketMessages,
+} from '../wsSupport.ts'
+
+/**
+ * Registers the desktop uplink endpoint `GET /streamwall/:id/ws`. The uplink is
+ * the trusted authority for the shared Yjs doc: it streams the full state
+ * snapshot on connect and relays doc updates to every browser client. Only one
+ * uplink may be connected at a time; a second is rejected.
+ */
+export function registerUplinkRoute(
+  app: FastifyInstance,
+  ctx: AppContext,
+): void {
+  app.get<{ Params: { id: string } }>(
+    '/streamwall/:id/ws',
+    { websocket: true },
+    async (ws, request) => {
+      ws.binaryType = 'arraybuffer'
+      const handleMessage = queueWebSocketMessages(ws)
+
+      const { id } = request.params
+      const token = bearerToken(request.headers.authorization)
+
+      if (!token) {
+        ws.send(JSON.stringify({ error: 'unauthorized' }))
+        ws.close()
+        return
+      }
+
+      const tokenInfo = await ctx.auth.validateToken(id, token)
+      if (!tokenInfo || tokenInfo.kind !== 'streamwall') {
+        ws.send(JSON.stringify({ error: 'unauthorized' }))
+        ws.close()
+        return
+      }
+
+      if (ctx.currentStreamwallWs != null) {
+        console.warn(
+          'Rejecting Streamwall connection (already connected) from',
+          request.ip,
+          tokenInfo,
+        )
+        ws.send(JSON.stringify({ error: 'streamwall already connected' }))
+        ws.close()
+        return
+      }
+
+      ctx.currentStreamwallWs = ws
+
+      const pingInterval = setInterval(() => {
+        ws.ping()
+        const pongTimeout = setTimeout(() => {
+          if (ws.readyState === ws.OPEN) {
+            console.warn(
+              `Streamwall timeout: no pong within ${STREAMWALL_PING_TIMEOUT_MS}ms. Closing connection.`,
+            )
+            ws.terminate()
+          }
+        }, STREAMWALL_PING_TIMEOUT_MS)
+        ws.once('pong', () => {
+          clearTimeout(pongTimeout)
+        })
+      }, STREAMWALL_PING_TIMEOUT_MS)
+
+      ws.on('close', () => {
+        console.log('Streamwall disconnected')
+        ctx.currentStreamwallWs = null
+        ctx.currentStreamwallConn = null
+        clearInterval(pingInterval)
+
+        for (const client of ctx.clients.values()) {
+          client.ws.close()
+        }
+      })
+
+      let clientState: StateWrapper | null = null
+      const stateDoc = new Y.Doc()
+
+      console.log('Streamwall connecting from', request.ip, tokenInfo)
+
+      const allowMessage = createWsMessageGuard(
+        ws,
+        ctx.wsMessageLimitConfig,
+        `streamwall connection from ${request.ip}`,
+      )
+
+      handleMessage((rawData) => {
+        if (!allowMessage()) {
+          return
+        }
+        if (rawData instanceof ArrayBuffer) {
+          // The uplink is the trusted authority for the shared doc and streams
+          // the full state snapshot on connect, so it bypasses the size/shape
+          // guard applied to untrusted client updates (which would otherwise
+          // reject a legitimately large snapshot and silently break sync).
+          Y.applyUpdate(stateDoc, new Uint8Array(rawData))
+          return
+        }
+
+        let raw: unknown
+        try {
+          raw = JSON.parse(rawData.toString())
+        } catch (err) {
+          console.warn('Received unexpected ws data: ', rawData.length, 'bytes')
+          return
+        }
+
+        // The desktop only ever sends `state` messages over this channel.
+        // Validate structurally so a malformed payload can never wrap the
+        // shared StateWrapper around garbage (which crashed clients on view()).
+        const parsed = controlStateMessageSchema.safeParse(raw)
+        if (!parsed.success) {
+          console.warn(
+            'Rejected invalid Streamwall state message:',
+            parsed.error.issues[0]?.message,
+          )
+          return
+        }
+
+        // The envelope check above only guarantees "an object". Validate the
+        // full snapshot itself so a malformed or adversarial desktop build can
+        // never seed StateWrapper with garbage that crashes clients on
+        // view() or corrupts the role-scoped projection (issue #387).
+        const stateResult = streamwallStateSchema.safeParse(parsed.data.state)
+        if (!stateResult.success) {
+          console.warn(
+            'Rejected invalid Streamwall state payload:',
+            stateResult.error.issues[0]?.message,
+          )
+          return
+        }
+        const state = stateResult.data
+
+        try {
+          if (clientState === null) {
+            const newClientState = new StateWrapper(state)
+            // Broadcasting on every `'state'` event (rather than only here)
+            // is what makes auth-only changes — invite/session created or
+            // deleted while the desktop pushes no new state — reach already
+            // connected clients; see `auth.on('state', ...)` in initApp.
+            newClientState.on('state', () =>
+              ctx.broadcastStateDeltas(newClientState),
+            )
+            clientState = newClientState
+            clientState.update({ auth: ctx.auth.getState() })
+            ctx.currentStreamwallConn = {
+              ws,
+              clientState,
+              stateDoc,
+            }
+
+            console.log('Streamwall connected from', request.ip, tokenInfo)
+          } else {
+            clientState.update(state)
+          }
+        } catch (err) {
+          console.error('Failed to handle ws message:', rawData, err)
+          ctx.reportCaughtError(err)
+        }
+      })
+
+      stateDoc.on('update', (update, origin) => {
+        try {
+          ws.send(update)
+        } catch (err) {
+          console.error('Failed to send Streamwall doc update', err)
+          ctx.reportCaughtError(err)
+        }
+        for (const client of ctx.clients.values()) {
+          if (client.clientId === origin) {
+            continue
+          }
+          try {
+            client.ws.send(update)
+          } catch (err) {
+            console.error('Failed to send client doc update:', client, err)
+            ctx.reportCaughtError(err)
+          }
+        }
+      })
+    },
+  )
+}

--- a/packages/streamwall-control-server/src/wsSupport.ts
+++ b/packages/streamwall-control-server/src/wsSupport.ts
@@ -1,0 +1,89 @@
+import WebSocket from 'ws'
+
+import type { WsMessageLimitConfig } from './config.ts'
+import { TokenBucket } from './rateLimiter.ts'
+
+/**
+ * Extracts a Bearer token from an `Authorization` header. Uplink credentials
+ * travel in this header rather than the URL query string so the secret never
+ * lands in server or proxy access logs. The scheme name is matched
+ * case-insensitively per RFC 7235.
+ */
+export function bearerToken(authorization: string | undefined): string | null {
+  if (!authorization) {
+    return null
+  }
+  const match = /^Bearer[ ]+(.+)$/i.exec(authorization)
+  return match ? match[1] : null
+}
+
+/**
+ * Helper to immediately watch for and queue incoming websocket messages.
+ * This is useful for async validation of the connection before handling messages,
+ * because awaiting before adding a message event listener can drop messages.
+ */
+export function queueWebSocketMessages(ws: WebSocket) {
+  let queue: WebSocket.Data[] = []
+  let messageHandler: ((rawData: WebSocket.Data) => void) | null = null
+
+  const processQueue = () => {
+    if (messageHandler !== null) {
+      let queuedData
+      while ((queuedData = queue.shift())) {
+        messageHandler(queuedData)
+      }
+    }
+  }
+
+  const setMessageHandler = (handler: typeof messageHandler) => {
+    messageHandler = handler
+    processQueue()
+  }
+
+  ws.on('message', (rawData) => {
+    queue.push(rawData)
+    processQueue()
+  })
+
+  ws.on('close', () => {
+    queue = []
+    messageHandler = null
+  })
+
+  return setMessageHandler
+}
+
+/**
+ * Wraps a socket with a per-connection inbound message rate limiter. Returns a
+ * guard to invoke for each received message: it returns true when the message
+ * may be processed, or closes the socket (once) and returns false when the
+ * connection has exceeded its message budget.
+ */
+export function createWsMessageGuard(
+  ws: WebSocket,
+  config: WsMessageLimitConfig,
+  label: string,
+): () => boolean {
+  const bucket = new TokenBucket({
+    capacity: config.capacity,
+    refillPerSec: config.refillPerSec,
+  })
+  let closed = false
+  return () => {
+    if (closed) {
+      return false
+    }
+    if (bucket.tryConsume()) {
+      return true
+    }
+    closed = true
+    console.warn(`WebSocket message rate limit exceeded, closing ${label}`)
+    try {
+      ws.send(JSON.stringify({ error: 'rate limit exceeded' }))
+    } catch {
+      // The socket is being closed anyway; ignore send failures.
+    }
+    ws.close(1008, 'rate limit exceeded')
+    return false
+  }
+}


### PR DESCRIPTION
## Problem

`packages/streamwall-control-server/src/index.ts` had grown to ~1030 lines,
combining Fastify bootstrap, authentication, two WebSocket protocols (desktop
uplink + browser clients), inline invite-exchange HTML/JS, Yjs state broadcast,
and startup logging in a single file. Protocol wiring changes meant editing the
monolith, and the inline invite-exchange script could neither be linted nor
unit-tested on its own.

Closes #395

## Solution

Split the entrypoint into cohesive modules. Shared mutable connection state and
dependencies are threaded through an `AppContext` object passed **by reference**,
so the uplink/client handlers can reassign `currentStreamwall*` as the desktop
connects and disconnects:

| Module | Responsibility |
| --- | --- |
| `config.ts` | env parsing, constants, `resolveListenPort`, `parseTrustProxy` |
| `context.ts` | `Client` / `StreamwallConnection` / `AppContext` types + `broadcastStateDeltas` factory + the `fastify` `identity` augmentation |
| `wsSupport.ts` | `bearerToken`, `queueWebSocketMessages`, per-connection message-rate guard |
| `inviteExchange/page.html` + `exchange.js` | the exchange page and its client script, served from disk |
| `inviteExchange/invite.ts` | `GET`/`POST /invite/:id`, `GET /invite-exchange.js` |
| `ws/uplink.ts` | desktop Streamwall uplink handler |
| `ws/client.ts` | authenticated plugin: auth `preHandler`, `/admin/status`, static, `/client/ws` |
| `bootstrap.ts` | `initialInviteCodes`, `logBootstrap`, `runServer` |

`index.ts` is now ~200 lines: `initApp` app-assembly plus the process entry
guard. It re-exports the public surface (`initApp`, `initialInviteCodes`,
`parseTrustProxy`, `resolveListenPort`, `SESSION_COOKIE_NAME`,
`queueWebSocketMessages`, default `runServer`) so existing importers and the
test suite keep a single stable entry point.

### Invite-exchange script

The inline `INVITE_EXCHANGE_SCRIPT` string becomes a real ES module
(`inviteExchange/exchange.js`) with its core logic factored into
`runInviteExchange(deps)`, its browser dependencies injected. `page.html` loads
it via `<script type="module" src="/invite-exchange.js">` — still same-origin,
so it satisfies the strict `script-src 'self'` CSP. A colocated `exchange.d.ts`
types the module boundary without pulling the DOM lib into the server's TS
program.

## Architecture decisions

- **Served from disk, not inline.** The server runs directly from `src/` (no
  compile step) and the Dockerfile copies the whole `src/` tree, so
  `page.html`/`exchange.js` resolve via `import.meta.dirname` both under
  `tsx`/native-TS dev and in the container. They are read once and cached.
- **`AppContext` by reference.** The uplink connection is single-flight and its
  handler mutates `currentStreamwall*`; passing the context object (rather than
  destructured values) keeps every handler reading the live connection.

## Testing

- All existing server tests stay green (**141 → 147**, +6 new).
- New `inviteExchange/exchange.test.ts` covers `runInviteExchange` in isolation
  (no DOM): fragment token parsing, address-bar scrubbing on token/no-token
  paths, POST request shape, and the success / rejected / network-failure
  branches.
- `format:check`, `eslint .`, and `tsc --noEmit` across all workspaces are green.

## Risks / breaking changes

None intended — no protocol or HTTP behavior changes. The only observable
difference is the invite page's `<script>` gaining `type="module"` (same
origin, same CSP). The public module surface of `./index.ts` is preserved via
re-exports.