### PR TITLE
refactor: deduplicate collab connection logic behind a shared useCollabConnection hook

### DIFF
--- a/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.ts
+++ b/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.ts
@@ -1,216 +1,171 @@
-import { useCallback, useEffect, useRef, useState } from 'preact/hooks'
+import { useMemo, useRef } from 'preact/hooks'
 import ReconnectingWebSocket from 'reconnecting-websocket'
 import {
-  type CollabData,
-  collabDataSchema,
+  type CollabTransport,
   type StreamwallConnection,
-  useStreamwallState,
-  useYDoc,
+  useCollabConnection,
 } from 'streamwall-control-ui'
 import {
-  type ControlCommand,
-  type DisconnectReason,
   isSocketOpen,
   parseDisconnectReason,
   stateDiff,
   type StreamwallState,
 } from 'streamwall-shared'
-import * as Y from 'yjs'
+
+interface WsRef {
+  ws: ReconnectingWebSocket
+  msgId: number
+  responseMap: Map<number, (msg: object) => void>
+}
+
+/**
+ * WebSocket adapter: the transport-specific half of the collab wiring the
+ * shared `useCollabConnection` hook consumes. It owns only what is unique to
+ * the socket - the reconnect policy, the JSON message protocol (responses,
+ * `state`/`state-delta`, error reasons), and binary Yjs framing. The Yjs
+ * origin filter, doc-reset-on-disconnect, and connection-state assembly are
+ * shared and live in `useCollabConnection` (issue #396).
+ */
+function useWebsocketCollabTransport(wsEndpoint: string): CollabTransport {
+  const wsRef = useRef<WsRef>()
+
+  return useMemo<CollabTransport>(
+    () => ({
+      remoteOrigin: 'server',
+      initiallyConnected: false,
+
+      send(msg, cb) {
+        if (!wsRef.current) {
+          throw new Error('Websocket not initialized')
+        }
+        const { ws, msgId, responseMap } = wsRef.current
+        ws.send(JSON.stringify({ ...msg, id: msgId }))
+        if (cb) {
+          responseMap.set(msgId, cb)
+        }
+        wsRef.current.msgId++
+      },
+
+      sendYDocUpdate(update) {
+        const { ws } = wsRef.current ?? {}
+        if (!ws || !isSocketOpen(ws)) {
+          return
+        }
+        ws.send(update)
+      },
+
+      subscribeYDocUpdates(cb) {
+        const ws = wsRef.current?.ws
+        if (!ws) {
+          return () => {}
+        }
+        function receiveUpdate(ev: MessageEvent) {
+          if (!(ev.data instanceof ArrayBuffer)) {
+            return
+          }
+          cb(new Uint8Array(ev.data))
+        }
+        ws.addEventListener('message', receiveUpdate)
+        return () => {
+          ws.removeEventListener('message', receiveUpdate)
+        }
+      },
+
+      connect(events) {
+        let lastStateData: StreamwallState | undefined
+        const ws = new ReconnectingWebSocket(wsEndpoint, [], {
+          maxReconnectionDelay: 5000,
+          minReconnectionDelay: 1000 + Math.random() * 500,
+          reconnectionDelayGrowFactor: 1.1,
+          // The server pushes a full 'state' message (and full Yjs doc) as
+          // soon as a client (re)connects, so anything queued while
+          // disconnected is stale by the time it could be delivered. Disable
+          // the library's default unbounded queue rather than let it buffer
+          // indefinitely while the control server is unreachable.
+          maxEnqueuedMessages: 0,
+        })
+        ws.binaryType = 'arraybuffer'
+
+        function handleClose() {
+          // The shared doc-reset policy fires first (snapshot + fresh doc);
+          // then reject any command still awaiting a response - it will never
+          // hear back from this socket, so its caller must not leak in
+          // responseMap forever.
+          events.onClose()
+          const { responseMap } = wsRef.current ?? {}
+          if (responseMap) {
+            for (const responseCb of responseMap.values()) {
+              responseCb({ response: true, error: 'Connection closed' })
+            }
+            responseMap.clear()
+          }
+        }
+
+        function handleOpen() {
+          // A fresh connection attempt may still fail (e.g. an expired
+          // session); clear the previous reason optimistically so a stale
+          // "unauthorized" banner doesn't linger if this attempt instead keeps
+          // retrying for an unrelated reason. The server's next message sets
+          // it again if the same failure recurs.
+          events.onDisconnectReason(null)
+        }
+
+        function handleMessage(ev: MessageEvent) {
+          if (ev.data instanceof ArrayBuffer) {
+            return
+          }
+          const msg = JSON.parse(ev.data)
+          if (msg.response && wsRef.current != null) {
+            const { responseMap } = wsRef.current
+            const responseCb = responseMap.get(msg.id)
+            if (responseCb) {
+              responseMap.delete(msg.id)
+              responseCb(msg)
+            }
+          } else if (msg.type === 'state' || msg.type === 'state-delta') {
+            let state: StreamwallState
+            if (msg.type === 'state') {
+              state = msg.state
+              events.onConnected()
+            } else {
+              // Clone so the updated object triggers React renders
+              state = stateDiff.clone(
+                stateDiff.patch(lastStateData, msg.delta),
+              ) as StreamwallState
+            }
+            lastStateData = state
+            events.onState(state)
+          } else {
+            const reason = parseDisconnectReason(msg)
+            if (reason) {
+              events.onDisconnectReason(reason)
+            } else {
+              console.warn('unexpected ws message', msg)
+            }
+          }
+        }
+
+        ws.addEventListener('close', handleClose)
+        ws.addEventListener('open', handleOpen)
+        ws.addEventListener('message', handleMessage)
+        wsRef.current = { ws, msgId: 0, responseMap: new Map() }
+
+        return () => {
+          ws.removeEventListener('close', handleClose)
+          ws.removeEventListener('open', handleOpen)
+          ws.removeEventListener('message', handleMessage)
+          ws.close()
+          wsRef.current = undefined
+        }
+      },
+    }),
+    [wsEndpoint],
+  )
+}
 
 export function useStreamwallWebsocketConnection(
   wsEndpoint: string,
 ): StreamwallConnection {
-  const wsRef = useRef<{
-    ws: ReconnectingWebSocket
-    msgId: number
-    responseMap: Map<number, (msg: object) => void>
-  }>()
-  const [isConnected, setIsConnected] = useState(false)
-  const [disconnectReason, setDisconnectReason] =
-    useState<DisconnectReason | null>(null)
-  const {
-    docValue: sharedState,
-    doc: stateDoc,
-    setDoc: setStateDoc,
-    undoManager,
-  } = useYDoc<CollabData>(['views'], collabDataSchema, 'server')
-  const [streamwallState, setStreamwallState] = useState<StreamwallState>()
-  const appState = useStreamwallState(streamwallState)
-
-  // Kept in sync with `sharedState` on every render so `handleClose` (which
-  // runs outside React's render cycle) can always read the value from just
-  // before the disconnect - see `lastKnownSharedStateRef` below.
-  const sharedStateRef = useRef(sharedState)
-  sharedStateRef.current = sharedState
-  // `stateDoc` gets swapped for a fresh, empty doc on every disconnect (see
-  // the comment on `handleClose`), which would otherwise blank the grid's
-  // cell assignments (`sharedState.views`) for the duration of a blip. This
-  // snapshot lets the connection keep serving the pre-disconnect data for
-  // rendering while offline; it's never written back into `stateDoc`, so it
-  // can't reintroduce the divergence risk the reset avoids (issue #283).
-  const lastKnownSharedStateRef = useRef<CollabData | undefined>(undefined)
-
-  useEffect(() => {
-    let lastStateData: StreamwallState | undefined
-    const ws = new ReconnectingWebSocket(wsEndpoint, [], {
-      maxReconnectionDelay: 5000,
-      minReconnectionDelay: 1000 + Math.random() * 500,
-      reconnectionDelayGrowFactor: 1.1,
-      // The server pushes a full 'state' message (and full Yjs doc) as soon
-      // as a client (re)connects, so anything queued while disconnected is
-      // stale by the time it could be delivered. Disable the library's
-      // default unbounded queue rather than let it buffer indefinitely while
-      // the control server is unreachable.
-      maxEnqueuedMessages: 0,
-    })
-    ws.binaryType = 'arraybuffer'
-
-    // A blip only closes the *transport*: `streamwallState` (cols/rows,
-    // streams, role, ...) is left as-is so the grid and stream list keep
-    // rendering their last-known content (dimmed via `isConnected`) instead
-    // of unmounting/showing "loading..." (issue #37). `stateDoc` still gets
-    // reset, though - it's the CRDT clients write grid assignments into
-    // locally, and the server always pushes a full resync on reconnect (see
-    // the `type: 'state'` branch below), so any local-only edit made while
-    // offline would otherwise survive a Yjs merge into that resync and
-    // silently diverge from what the server (and every other client)
-    // actually has.
-    function handleClose() {
-      lastKnownSharedStateRef.current = sharedStateRef.current
-      setStateDoc(new Y.Doc())
-      setIsConnected(false)
-      // Any command awaiting a response will never hear back from this
-      // socket - reject the callers instead of leaking their callbacks in
-      // responseMap forever.
-      const { responseMap } = wsRef.current ?? {}
-      if (responseMap) {
-        for (const responseCb of responseMap.values()) {
-          responseCb({ response: true, error: 'Connection closed' })
-        }
-        responseMap.clear()
-      }
-    }
-
-    function handleOpen() {
-      // A fresh connection attempt may still fail (e.g. an expired session);
-      // clear the previous reason optimistically so a stale "unauthorized"
-      // banner doesn't linger if this attempt instead just keeps retrying for
-      // an unrelated reason. The server's next message sets it again if the
-      // same failure recurs.
-      setDisconnectReason(null)
-    }
-
-    function handleMessage(ev: MessageEvent) {
-      if (ev.data instanceof ArrayBuffer) {
-        return
-      }
-      const msg = JSON.parse(ev.data)
-      if (msg.response && wsRef.current != null) {
-        const { responseMap } = wsRef.current
-        const responseCb = responseMap.get(msg.id)
-        if (responseCb) {
-          responseMap.delete(msg.id)
-          responseCb(msg)
-        }
-      } else if (msg.type === 'state' || msg.type === 'state-delta') {
-        let state: StreamwallState
-        if (msg.type === 'state') {
-          state = msg.state
-          setIsConnected(true)
-          setDisconnectReason(null)
-        } else {
-          // Clone so updated object triggers React renders
-          state = stateDiff.clone(
-            stateDiff.patch(lastStateData, msg.delta),
-          ) as StreamwallState
-        }
-        lastStateData = state
-        setStreamwallState(state)
-      } else {
-        const reason = parseDisconnectReason(msg)
-        if (reason) {
-          setDisconnectReason(reason)
-        } else {
-          console.warn('unexpected ws message', msg)
-        }
-      }
-    }
-
-    ws.addEventListener('close', handleClose)
-    ws.addEventListener('open', handleOpen)
-    ws.addEventListener('message', handleMessage)
-    wsRef.current = { ws, msgId: 0, responseMap: new Map() }
-
-    return () => {
-      ws.removeEventListener('close', handleClose)
-      ws.removeEventListener('open', handleOpen)
-      ws.removeEventListener('message', handleMessage)
-      ws.close()
-      wsRef.current = undefined
-    }
-  }, [setStateDoc, wsEndpoint])
-
-  const send = useCallback(
-    (msg: ControlCommand, cb?: (msg: unknown) => void) => {
-      if (!wsRef.current) {
-        throw new Error('Websocket not initialized')
-      }
-      const { ws, msgId, responseMap } = wsRef.current
-      ws.send(
-        JSON.stringify({
-          ...msg,
-          id: msgId,
-        }),
-      )
-      if (cb) {
-        responseMap.set(msgId, cb)
-      }
-      wsRef.current.msgId++
-    },
-    [],
-  )
-
-  useEffect(() => {
-    if (!wsRef.current) {
-      throw new Error('Websocket not initialized')
-    }
-    const { ws } = wsRef.current
-
-    function sendUpdate(update: Uint8Array, origin: string) {
-      if (origin === 'server') {
-        return
-      }
-      const { ws } = wsRef.current ?? {}
-      if (!ws || !isSocketOpen(ws)) {
-        return
-      }
-      ws.send(update)
-    }
-
-    function receiveUpdate(ev: MessageEvent) {
-      if (!(ev.data instanceof ArrayBuffer)) {
-        return
-      }
-      Y.applyUpdate(stateDoc, new Uint8Array(ev.data), 'server')
-    }
-
-    stateDoc.on('update', sendUpdate)
-    ws.addEventListener('message', receiveUpdate)
-    return () => {
-      stateDoc.off('update', sendUpdate)
-      ws.removeEventListener('message', receiveUpdate)
-    }
-  }, [stateDoc])
-
-  return {
-    ...appState,
-    isConnected,
-    disconnectReason,
-    send,
-    sharedState: isConnected
-      ? sharedState
-      : (lastKnownSharedStateRef.current ?? sharedState),
-    stateDoc,
-    undoManager,
-  }
+  const transport = useWebsocketCollabTransport(wsEndpoint)
+  return useCollabConnection(transport)
 }

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -7,37 +7,29 @@ import '@fontsource/jetbrains-mono/500.css'
 import '@fontsource/jetbrains-mono/700.css'
 import '@fontsource/oswald/600.css'
 import '@fontsource/saira-stencil-one'
-import { orderBy, range } from 'lodash-es'
+import { range } from 'lodash-es'
 import { DateTime } from 'luxon'
 import { type JSX } from 'preact'
 import { useCallback, useEffect, useMemo, useState } from 'preact/hooks'
 import { useHotkeys } from 'react-hotkeys-hook'
 import {
   clampGridDimension,
-  type ControlCommand,
-  type DataSourceHealth,
-  type DisconnectReason,
   gridWouldDropAssignments,
   hasGridAssignments,
   idColor,
   type InvitableRole,
   inviteLink,
-  type LayoutPreset,
   type LocalStreamData,
   roleCan,
   type StreamData,
   type StreamDelayStatus,
   type StreamwallRole,
-  type StreamwallState,
-  type StreamWindowConfig,
-  type ViewState,
 } from 'streamwall-shared'
 import { styled } from 'styled-components'
 import { matchesState } from 'xstate'
 import * as Y from 'yjs'
 import { AuthTokenLine, CreateInviteInput } from './AccessPanel.tsx'
 import { copyTextToClipboard } from './clipboard.ts'
-import { type CollabData } from './collabData.ts'
 import { createErrorSurfacingSend } from './commandError.ts'
 import { CommandErrorBanner } from './CommandErrorBanner.tsx'
 import { ConnectionStatusBanner } from './ConnectionStatusBanner.tsx'
@@ -64,6 +56,7 @@ import {
   CustomStreamInput,
   StreamList,
 } from './Sidebar.tsx'
+import { type StreamwallConnection } from './streamwallState.tsx'
 import { StyledButton, StyledDataContainer } from './StyledButton.tsx'
 import { useServerStatus } from './useServerStatus.ts'
 import { useTileDrag } from './useTileDrag.ts'
@@ -78,15 +71,6 @@ import {
 // which mount it alongside `<ControlUI>` — its implementation now lives in
 // `./globalStyle.tsx` alongside the theme tokens it applies.
 export { GlobalStyle } from './globalStyle.tsx'
-
-export interface ViewInfo {
-  state: ViewState
-  isListening: boolean
-  isBackgroundListening: boolean
-  isBlurred: boolean
-  volume: number
-  spaces: number[]
-}
 
 const normalStreamKinds = new Set(['video', 'audio', 'web'])
 function filterStreams(
@@ -127,122 +111,17 @@ function filterStreams(
 }
 
 export { collabDataSchema, type CollabData } from './collabData.ts'
+export {
+  useStreamwallState,
+  type StreamwallConnection,
+  type ViewInfo,
+} from './streamwallState.tsx'
+export {
+  useCollabConnection,
+  type CollabTransport,
+  type CollabTransportEvents,
+} from './useCollabConnection.ts'
 export { useYDoc } from './useYDoc.ts'
-
-export interface StreamwallConnection {
-  isConnected: boolean
-  /**
-   * Why the websocket is currently closed, when the server said so before
-   * closing it. `undefined`/`null` while connected, or while disconnected
-   * for an unexplained reason (network blip, generic retry).
-   */
-  disconnectReason?: DisconnectReason | null
-  role: StreamwallRole | null
-  send: (msg: ControlCommand, cb?: (msg: unknown) => void) => void
-  sharedState: CollabData | undefined
-  stateDoc: Y.Doc
-  undoManager?: Y.UndoManager
-  config: StreamWindowConfig | undefined
-  streams: StreamData[]
-  customStreams: StreamData[]
-  views: ViewInfo[]
-  /**
-   * Anchor cell index of the view currently expanded to fill the whole wall,
-   * or `null` for the normal grid layout (issue #362).
-   */
-  fullscreenViewIdx: number | null
-  stateIdxMap: Map<number, ViewInfo>
-  delayState: StreamDelayStatus | null | undefined
-  authState?: StreamwallState['auth']
-  layoutPresets: LayoutPreset[]
-  favorites: string[]
-  dataSourceHealth: DataSourceHealth[]
-}
-
-export function useStreamwallState(state: StreamwallState | undefined) {
-  return useMemo(() => {
-    if (state === undefined) {
-      return {
-        role: null,
-        config: undefined,
-        streams: [],
-        customStreams: [],
-        views: [],
-        fullscreenViewIdx: null,
-        stateIdxMap: new Map(),
-        delayState: undefined,
-        authState: undefined,
-        layoutPresets: [],
-        favorites: [],
-        dataSourceHealth: [],
-      }
-    }
-
-    const {
-      identity: { role },
-      auth,
-      config,
-      streams: stateStreams,
-      views: stateViews,
-      fullscreenViewIdx,
-      streamdelay,
-      layoutPresets,
-      favorites,
-      dataSourceHealth,
-    } = state
-    const stateIdxMap = new Map()
-    const views = []
-    for (const viewState of stateViews) {
-      const { pos } = viewState.context
-      const isListening = matchesState(
-        'displaying.running.audio.listening',
-        viewState.state,
-      )
-      const isBackgroundListening = matchesState(
-        'displaying.running.audio.background',
-        viewState.state,
-      )
-      const isBlurred = matchesState(
-        'displaying.running.video.blurred',
-        viewState.state,
-      )
-      const spaces = pos?.spaces ?? []
-      const viewInfo = {
-        state: viewState,
-        isListening,
-        isBackgroundListening,
-        isBlurred,
-        volume: viewState.context.volume,
-        spaces,
-      }
-      views.push(viewInfo)
-      for (const space of spaces) {
-        if (!stateIdxMap.has(space)) {
-          stateIdxMap.set(space, {})
-        }
-        Object.assign(stateIdxMap.get(space), viewInfo)
-      }
-    }
-
-    const streams = orderBy(stateStreams, ['addedDate', '_id'], ['desc', 'asc'])
-    const customStreams = stateStreams.filter((s) => s._dataSource === 'custom')
-
-    return {
-      role,
-      authState: auth,
-      delayState: streamdelay,
-      views,
-      fullscreenViewIdx,
-      config,
-      streams,
-      customStreams,
-      stateIdxMap,
-      layoutPresets,
-      favorites,
-      dataSourceHealth,
-    }
-  }, [state])
-}
 
 export function ControlUI({
   connection,

--- a/packages/streamwall-control-ui/src/streamwallState.tsx
+++ b/packages/streamwall-control-ui/src/streamwallState.tsx
@@ -1,0 +1,148 @@
+import { orderBy } from 'lodash-es'
+import { useMemo } from 'preact/hooks'
+import {
+  type ControlCommand,
+  type DataSourceHealth,
+  type DisconnectReason,
+  type LayoutPreset,
+  type StreamData,
+  type StreamDelayStatus,
+  type StreamwallRole,
+  type StreamwallState,
+  type StreamWindowConfig,
+  type ViewState,
+} from 'streamwall-shared'
+import { matchesState } from 'xstate'
+import * as Y from 'yjs'
+import { type CollabData } from './collabData.ts'
+
+export interface ViewInfo {
+  state: ViewState
+  isListening: boolean
+  isBackgroundListening: boolean
+  isBlurred: boolean
+  volume: number
+  spaces: number[]
+}
+
+/**
+ * The transport-agnostic view of a live control connection consumed by
+ * `<ControlUI>`. Both the Electron IPC renderer and the standalone WebSocket
+ * client produce one of these via `useCollabConnection` (see
+ * `./useCollabConnection.ts`); the shared hook owns the Yjs origin rules and
+ * doc-reset policy so the two paths cannot drift (issue #396).
+ */
+export interface StreamwallConnection {
+  isConnected: boolean
+  /**
+   * Why the websocket is currently closed, when the server said so before
+   * closing it. `undefined`/`null` while connected, or while disconnected
+   * for an unexplained reason (network blip, generic retry).
+   */
+  disconnectReason?: DisconnectReason | null
+  role: StreamwallRole | null
+  send: (msg: ControlCommand, cb?: (msg: unknown) => void) => void
+  sharedState: CollabData | undefined
+  stateDoc: Y.Doc
+  undoManager?: Y.UndoManager
+  config: StreamWindowConfig | undefined
+  streams: StreamData[]
+  customStreams: StreamData[]
+  views: ViewInfo[]
+  /**
+   * Anchor cell index of the view currently expanded to fill the whole wall,
+   * or `null` for the normal grid layout (issue #362).
+   */
+  fullscreenViewIdx: number | null
+  stateIdxMap: Map<number, ViewInfo>
+  delayState: StreamDelayStatus | null | undefined
+  authState?: StreamwallState['auth']
+  layoutPresets: LayoutPreset[]
+  favorites: string[]
+  dataSourceHealth: DataSourceHealth[]
+}
+
+export function useStreamwallState(state: StreamwallState | undefined) {
+  return useMemo(() => {
+    if (state === undefined) {
+      return {
+        role: null,
+        config: undefined,
+        streams: [],
+        customStreams: [],
+        views: [],
+        fullscreenViewIdx: null,
+        stateIdxMap: new Map(),
+        delayState: undefined,
+        authState: undefined,
+        layoutPresets: [],
+        favorites: [],
+        dataSourceHealth: [],
+      }
+    }
+
+    const {
+      identity: { role },
+      auth,
+      config,
+      streams: stateStreams,
+      views: stateViews,
+      fullscreenViewIdx,
+      streamdelay,
+      layoutPresets,
+      favorites,
+      dataSourceHealth,
+    } = state
+    const stateIdxMap = new Map()
+    const views = []
+    for (const viewState of stateViews) {
+      const { pos } = viewState.context
+      const isListening = matchesState(
+        'displaying.running.audio.listening',
+        viewState.state,
+      )
+      const isBackgroundListening = matchesState(
+        'displaying.running.audio.background',
+        viewState.state,
+      )
+      const isBlurred = matchesState(
+        'displaying.running.video.blurred',
+        viewState.state,
+      )
+      const spaces = pos?.spaces ?? []
+      const viewInfo = {
+        state: viewState,
+        isListening,
+        isBackgroundListening,
+        isBlurred,
+        volume: viewState.context.volume,
+        spaces,
+      }
+      views.push(viewInfo)
+      for (const space of spaces) {
+        if (!stateIdxMap.has(space)) {
+          stateIdxMap.set(space, {})
+        }
+        Object.assign(stateIdxMap.get(space), viewInfo)
+      }
+    }
+
+    const streams = orderBy(stateStreams, ['addedDate', '_id'], ['desc', 'asc'])
+    const customStreams = stateStreams.filter((s) => s._dataSource === 'custom')
+
+    return {
+      role,
+      authState: auth,
+      delayState: streamdelay,
+      views,
+      fullscreenViewIdx,
+      config,
+      streams,
+      customStreams,
+      stateIdxMap,
+      layoutPresets,
+      favorites,
+      dataSourceHealth,
+    }
+  }, [state])
+}

--- a/packages/streamwall-control-ui/src/useCollabConnection.test.tsx
+++ b/packages/streamwall-control-ui/src/useCollabConnection.test.tsx
@@ -1,0 +1,342 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import type { ControlCommand, StreamwallState } from 'streamwall-shared'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import * as Y from 'yjs'
+import { type StreamwallConnection } from './streamwallState.tsx'
+import {
+  type CollabTransport,
+  type CollabTransportEvents,
+  useCollabConnection,
+} from './useCollabConnection.ts'
+
+const minimalState: StreamwallState = {
+  identity: { role: 'admin' },
+  config: {
+    cols: 1,
+    rows: 1,
+    width: 100,
+    height: 100,
+    frameless: false,
+    fullscreen: false,
+    activeColor: '#fff',
+    backgroundColor: '#000',
+  },
+  streams: [],
+  customStreams: [],
+  views: [],
+  fullscreenViewIdx: null,
+  streamdelay: null,
+  layoutPresets: [],
+  favorites: [],
+  dataSourceHealth: [],
+}
+
+/**
+ * A hand-driven transport: the test plays the peer by invoking the captured
+ * `events`, pushing remote Yjs updates, and inspecting what the shared hook
+ * forwarded. Deliberately dumb so every assertion pins the *shared* policy,
+ * not transport plumbing.
+ */
+function createFakeTransport(overrides: Partial<CollabTransport> = {}) {
+  const sentUpdates: Uint8Array[] = []
+  const sentCommands: ControlCommand[] = []
+  let events: CollabTransportEvents | undefined
+  let ydocCb: ((update: Uint8Array) => void) | undefined
+  const teardown = vi.fn()
+
+  const transport: CollabTransport = {
+    remoteOrigin: 'server',
+    initiallyConnected: false,
+    send: (msg) => {
+      sentCommands.push(msg)
+    },
+    sendYDocUpdate: (update) => {
+      sentUpdates.push(update)
+    },
+    subscribeYDocUpdates: (cb) => {
+      ydocCb = cb
+      return () => {
+        ydocCb = undefined
+      }
+    },
+    connect: (e) => {
+      events = e
+      return teardown
+    },
+    ...overrides,
+  }
+
+  return {
+    transport,
+    sentUpdates,
+    sentCommands,
+    teardown,
+    getEvents: () => events!,
+    pushRemote: (update: Uint8Array) => ydocCb!(update),
+    isYDocSubscribed: () => ydocCb !== undefined,
+  }
+}
+
+function cellAssignmentUpdate(idx: string, streamId: string): Uint8Array {
+  const doc = new Y.Doc()
+  const cell = new Y.Map<string | undefined>()
+  cell.set('streamId', streamId)
+  doc.getMap<Y.Map<string | undefined>>('views').set(idx, cell)
+  return Y.encodeStateAsUpdate(doc)
+}
+
+let container: HTMLDivElement | undefined
+
+function Harness({
+  transport,
+  onConnection,
+}: {
+  transport: CollabTransport
+  onConnection: (connection: StreamwallConnection) => void
+}) {
+  const connection = useCollabConnection(transport)
+  onConnection(connection)
+  return null
+}
+
+function mount(transport: CollabTransport) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  let connection!: StreamwallConnection
+  act(() => {
+    render(
+      <Harness
+        transport={transport}
+        onConnection={(c) => {
+          connection = c
+        }}
+      />,
+      container!,
+    )
+  })
+  return {
+    getConnection: () => connection,
+    unmount: () => act(() => render(null, container!)),
+  }
+}
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+describe('useCollabConnection', () => {
+  describe('Yjs origin filtering', () => {
+    it('forwards a local doc edit to the transport', () => {
+      const fake = createFakeTransport()
+      const { getConnection } = mount(fake.transport)
+
+      act(() => {
+        getConnection()
+          .stateDoc.getMap<Y.Map<string | undefined>>('views')
+          .set('0', new Y.Map<string | undefined>())
+      })
+
+      expect(fake.sentUpdates).toHaveLength(1)
+    })
+
+    it('does not echo a peer-origin update back to the transport', () => {
+      const fake = createFakeTransport()
+      const { getConnection } = mount(fake.transport)
+
+      act(() => {
+        Y.applyUpdate(
+          getConnection().stateDoc,
+          cellAssignmentUpdate('0', 'abc'),
+          'server',
+        )
+      })
+
+      expect(fake.sentUpdates).toHaveLength(0)
+    })
+
+    it('applies a remote update into the shared doc without re-forwarding it', () => {
+      const fake = createFakeTransport()
+      const { getConnection } = mount(fake.transport)
+
+      act(() => {
+        fake.pushRemote(cellAssignmentUpdate('0', 'abc'))
+      })
+
+      expect(getConnection().sharedState?.views['0']?.streamId).toBe('abc')
+      expect(fake.sentUpdates).toHaveLength(0)
+    })
+  })
+
+  describe('connection state', () => {
+    it('starts disconnected by default and connects on onConnected', () => {
+      const fake = createFakeTransport()
+      const { getConnection } = mount(fake.transport)
+      expect(getConnection().isConnected).toBe(false)
+
+      act(() => {
+        fake.getEvents().onConnected()
+      })
+
+      expect(getConnection().isConnected).toBe(true)
+    })
+
+    it('honors an initiallyConnected transport from mount', () => {
+      const fake = createFakeTransport({ initiallyConnected: true })
+      const { getConnection } = mount(fake.transport)
+      expect(getConnection().isConnected).toBe(true)
+    })
+
+    it('surfaces the state pushed via onState', () => {
+      const fake = createFakeTransport()
+      const { getConnection } = mount(fake.transport)
+
+      act(() => {
+        fake.getEvents().onState(minimalState)
+      })
+
+      expect(getConnection().role).toBe('admin')
+      expect(getConnection().config).toEqual(minimalState.config)
+    })
+
+    it('sets and clears the disconnect reason', () => {
+      const fake = createFakeTransport()
+      const { getConnection } = mount(fake.transport)
+      expect(getConnection().disconnectReason).toBeNull()
+
+      act(() => {
+        fake.getEvents().onDisconnectReason('unauthorized')
+      })
+      expect(getConnection().disconnectReason).toBe('unauthorized')
+
+      act(() => {
+        fake.getEvents().onDisconnectReason(null)
+      })
+      expect(getConnection().disconnectReason).toBeNull()
+    })
+
+    it('clears the disconnect reason on onConnected', () => {
+      const fake = createFakeTransport()
+      const { getConnection } = mount(fake.transport)
+
+      act(() => {
+        fake.getEvents().onDisconnectReason('unauthorized')
+      })
+      act(() => {
+        fake.getEvents().onConnected()
+      })
+
+      expect(getConnection().disconnectReason).toBeNull()
+    })
+
+    it('delegates send to the transport', () => {
+      const fake = createFakeTransport()
+      const { getConnection } = mount(fake.transport)
+      const command: ControlCommand = {
+        type: 'create-invite',
+        name: 'x',
+        role: 'operator',
+      }
+
+      act(() => {
+        getConnection().send(command)
+      })
+
+      expect(fake.sentCommands).toEqual([command])
+    })
+  })
+
+  describe('doc-reset policy on close (issues #37 / #283)', () => {
+    it('swaps in a fresh Yjs doc on close', () => {
+      const fake = createFakeTransport()
+      const { getConnection } = mount(fake.transport)
+      const docBeforeClose = getConnection().stateDoc
+
+      act(() => {
+        fake.getEvents().onClose()
+      })
+
+      expect(getConnection().stateDoc).not.toBe(docBeforeClose)
+      expect(getConnection().isConnected).toBe(false)
+    })
+
+    it('keeps serving the last-known shared state while the fresh doc is empty', () => {
+      const fake = createFakeTransport()
+      const { getConnection } = mount(fake.transport)
+
+      act(() => {
+        fake.pushRemote(cellAssignmentUpdate('0', 'abc'))
+      })
+      expect(getConnection().sharedState?.views['0']?.streamId).toBe('abc')
+
+      act(() => {
+        fake.getEvents().onClose()
+      })
+
+      expect(getConnection().sharedState?.views['0']?.streamId).toBe('abc')
+      // ...but the fresh doc itself is empty, so a local-only offline edit
+      // cannot survive into the next resync.
+      const freshViews = getConnection().stateDoc.getMap('views')
+      expect(freshViews.size).toBe(0)
+    })
+
+    it('switches back to the live shared state once reconnected', () => {
+      const fake = createFakeTransport()
+      const { getConnection } = mount(fake.transport)
+
+      act(() => {
+        fake.pushRemote(cellAssignmentUpdate('0', 'abc'))
+      })
+      act(() => {
+        fake.getEvents().onClose()
+      })
+      expect(getConnection().sharedState?.views['0']?.streamId).toBe('abc')
+
+      act(() => {
+        fake.pushRemote(cellAssignmentUpdate('0', 'fresh'))
+      })
+      act(() => {
+        fake.getEvents().onConnected()
+        fake.getEvents().onState(minimalState)
+      })
+
+      expect(getConnection().isConnected).toBe(true)
+      expect(getConnection().sharedState?.views['0']?.streamId).toBe('fresh')
+    })
+
+    it('re-wires Yjs forwarding to the fresh doc after a close', () => {
+      const fake = createFakeTransport()
+      const { getConnection } = mount(fake.transport)
+
+      act(() => {
+        fake.getEvents().onClose()
+      })
+      expect(fake.sentUpdates).toHaveLength(0)
+
+      // A local edit on the *fresh* post-close doc must still be forwarded,
+      // proving the origin-filtered update listener re-attached to it.
+      act(() => {
+        getConnection()
+          .stateDoc.getMap<Y.Map<string | undefined>>('views')
+          .set('1', new Y.Map<string | undefined>())
+      })
+
+      expect(fake.sentUpdates).toHaveLength(1)
+    })
+  })
+
+  it('runs the transport teardown on unmount', () => {
+    const fake = createFakeTransport()
+    const { unmount } = mount(fake.transport)
+    expect(fake.teardown).not.toHaveBeenCalled()
+
+    unmount()
+
+    expect(fake.teardown).toHaveBeenCalledTimes(1)
+    expect(fake.isYDocSubscribed()).toBe(false)
+  })
+})

--- a/packages/streamwall-control-ui/src/useCollabConnection.ts
+++ b/packages/streamwall-control-ui/src/useCollabConnection.ts
@@ -1,0 +1,173 @@
+import { useEffect, useRef, useState } from 'preact/hooks'
+import { type DisconnectReason, type StreamwallState } from 'streamwall-shared'
+import * as Y from 'yjs'
+import { type CollabData, collabDataSchema } from './collabData.ts'
+import {
+  type StreamwallConnection,
+  useStreamwallState,
+} from './streamwallState.tsx'
+import { useYDoc } from './useYDoc.ts'
+
+/**
+ * Lifecycle callbacks a `CollabTransport` invokes to drive the shared
+ * connection state. Each maps to exactly one policy the shared hook owns, so
+ * every transport gets identical reconnect and origin behaviour (issue #396).
+ */
+export interface CollabTransportEvents {
+  /** A full state snapshot pushed by the peer (initial load or resync). */
+  onState(state: StreamwallState): void
+  /**
+   * The collab link is live and carrying a fresh full state. Marks the
+   * connection connected and clears any lingering disconnect reason.
+   */
+  onConnected(): void
+  /**
+   * The collab link dropped. Triggers the shared doc-reset policy: snapshot
+   * the last-known shared state for offline rendering, then swap in a fresh
+   * Yjs doc so a local-only offline edit cannot merge into the next resync
+   * (issues #37 / #283).
+   */
+  onClose(): void
+  /**
+   * The peer stated why it is (or is about to be) disconnected, without a
+   * full close - e.g. an `unauthorized` error, or clearing the reason
+   * (`null`) on a fresh connection attempt.
+   */
+  onDisconnectReason(reason: DisconnectReason | null): void
+}
+
+/**
+ * A thin, transport-specific adapter consumed by {@link useCollabConnection}.
+ * It owns only what differs between transports (how bytes move); the shared
+ * hook owns the Yjs origin rules, doc-reset policy, and connection-state
+ * assembly. Implement one of these to add a new client (e.g. Tauri, an
+ * embedded webview) without reimplementing the collab wiring.
+ */
+export interface CollabTransport {
+  /**
+   * Origin tag for Yjs updates that arrived from the peer. Local edits carry
+   * any other origin and get forwarded back to the peer; peer-origin updates
+   * are applied with this tag and never echoed, breaking the update loop.
+   */
+  remoteOrigin: string
+  /**
+   * Whether the transport is connected before any peer message arrives. `true`
+   * for an always-on transport (Electron IPC); `false` for one that must first
+   * establish a link (WebSocket).
+   */
+  initiallyConnected?: boolean
+  /** Send a control command to the peer, optionally awaiting its response. */
+  send: StreamwallConnection['send']
+  /** Forward a local Yjs update to the peer. */
+  sendYDocUpdate(update: Uint8Array): void
+  /** Subscribe to Yjs updates arriving from the peer; returns an unsubscribe. */
+  subscribeYDocUpdates(cb: (update: Uint8Array) => void): () => void
+  /**
+   * Establish the connection and wire peer messages to `events`. Returns a
+   * teardown run on unmount. Called once per transport instance and never
+   * re-run on a doc reset, so the transport outlives reconnect blips.
+   */
+  connect(events: CollabTransportEvents): () => void
+}
+
+/**
+ * Turns a {@link CollabTransport} into a `StreamwallConnection` for
+ * `<ControlUI>`. This is the single home for the collab wiring both the
+ * Electron IPC renderer and the standalone WebSocket client used to
+ * reimplement independently (issue #396): the Yjs origin filter, the
+ * doc-reset-on-disconnect policy with last-known-state fallback, and the
+ * connection-state assembly all live here.
+ */
+export function useCollabConnection(
+  transport: CollabTransport,
+): StreamwallConnection {
+  const { remoteOrigin } = transport
+  const {
+    docValue: sharedState,
+    doc: stateDoc,
+    setDoc: setStateDoc,
+    undoManager,
+  } = useYDoc<CollabData>(['views'], collabDataSchema, remoteOrigin)
+  const [streamwallState, setStreamwallState] = useState<StreamwallState>()
+  const [isConnected, setIsConnected] = useState(
+    transport.initiallyConnected ?? false,
+  )
+  const [disconnectReason, setDisconnectReason] =
+    useState<DisconnectReason | null>(null)
+  const appState = useStreamwallState(streamwallState)
+
+  // Kept in sync with `sharedState` on every render so `onClose` (which fires
+  // from the transport, outside React's render cycle) can always read the
+  // value from just before the disconnect.
+  const sharedStateRef = useRef(sharedState)
+  sharedStateRef.current = sharedState
+  // `stateDoc` is swapped for a fresh, empty doc on every disconnect, which
+  // would otherwise blank the grid's cell assignments (`sharedState.views`)
+  // for the duration of a blip. This snapshot lets the connection keep serving
+  // the pre-disconnect data for rendering while offline; it's never written
+  // back into `stateDoc`, so it can't reintroduce the divergence the reset
+  // avoids (issue #283).
+  const lastKnownSharedStateRef = useRef<CollabData | undefined>(undefined)
+
+  // Connection lifecycle. Deliberately not keyed on `stateDoc`: a reconnect
+  // resets the doc, but the transport itself must survive that so the socket
+  // is not torn down and recreated on every blip.
+  useEffect(() => {
+    const events: CollabTransportEvents = {
+      onState(state) {
+        setStreamwallState(state)
+      },
+      onConnected() {
+        setIsConnected(true)
+        setDisconnectReason(null)
+      },
+      onClose() {
+        lastKnownSharedStateRef.current = sharedStateRef.current
+        setStateDoc(new Y.Doc())
+        setIsConnected(false)
+      },
+      onDisconnectReason(reason) {
+        setDisconnectReason(reason)
+      },
+    }
+    return transport.connect(events)
+    // The setters and `setStateDoc` are stable; `transport` is stable per
+    // adapter (recreated only when its identity - e.g. the ws endpoint -
+    // changes). Reruns only on a genuine transport swap.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [transport])
+
+  // Yjs sync, re-subscribed per doc so a fresh post-disconnect doc is wired up
+  // too. Single home for the origin rule shared by all transports: never echo
+  // a peer-origin update back, and tag incoming peer updates with
+  // `remoteOrigin` so they don't loop.
+  useEffect(() => {
+    function sendUpdate(update: Uint8Array, origin: unknown) {
+      if (origin === remoteOrigin) {
+        return
+      }
+      transport.sendYDocUpdate(update)
+    }
+
+    stateDoc.on('update', sendUpdate)
+    const unsubscribe = transport.subscribeYDocUpdates((update) => {
+      Y.applyUpdate(stateDoc, update, remoteOrigin)
+    })
+    return () => {
+      stateDoc.off('update', sendUpdate)
+      unsubscribe()
+    }
+  }, [stateDoc, transport, remoteOrigin])
+
+  return {
+    ...appState,
+    isConnected,
+    disconnectReason,
+    send: transport.send,
+    sharedState: isConnected
+      ? sharedState
+      : (lastKnownSharedStateRef.current ?? sharedState),
+    stateDoc,
+    undoManager,
+  }
+}

--- a/packages/streamwall/src/renderer/control.tsx
+++ b/packages/streamwall/src/renderer/control.tsx
@@ -1,17 +1,12 @@
 import { render } from 'preact'
-import { useCallback, useEffect, useState } from 'preact/hooks'
+import { useCallback, useEffect, useMemo, useState } from 'preact/hooks'
 import { useHotkeys } from 'react-hotkeys-hook'
 import {
-  CollabData,
-  collabDataSchema,
   ControlUI,
   GlobalStyle,
   StreamwallConnection,
-  useStreamwallState,
-  useYDoc,
+  useCollabConnection,
 } from 'streamwall-control-ui'
-import { ControlCommand, StreamwallState } from 'streamwall-shared'
-import * as Y from 'yjs'
 import {
   FirstRunInfo,
   StreamwallControlGlobal,
@@ -19,6 +14,7 @@ import {
 import { type UpdateStatus } from '../updateStatus'
 import { FirstRunHint } from './FirstRunHint'
 import { initRendererSentry } from './initSentry'
+import { createIpcCollabTransport } from './ipcCollabTransport'
 import { UpdateBanner } from './UpdateBanner'
 
 const DISMISSED_STORAGE_KEY = 'streamwall:first-run-hint-dismissed'
@@ -32,63 +28,11 @@ declare global {
 initRendererSentry()
 
 function useStreamwallIPCConnection(): StreamwallConnection {
-  const {
-    docValue: sharedState,
-    doc: stateDoc,
-    undoManager,
-  } = useYDoc<CollabData>(['views'], collabDataSchema, 'app')
-
-  const [streamwallState, setStreamwallState] = useState<StreamwallState>()
-  const appState = useStreamwallState(streamwallState)
-
-  useEffect(() => {
-    // TODO: improve typing (Zod?)
-    function handleState(state: StreamwallState) {
-      setStreamwallState(state)
-    }
-    return window.streamwallControl.onState(handleState)
-  }, [])
-
-  const send = useCallback(
-    async (msg: ControlCommand, cb?: (msg: unknown) => void) => {
-      const resp = await window.streamwallControl.invokeCommand(msg)
-      cb?.(resp)
-    },
+  const transport = useMemo(
+    () => createIpcCollabTransport(window.streamwallControl),
     [],
   )
-
-  useEffect(() => {
-    function sendUpdate(update: Uint8Array, origin: string) {
-      if (origin === 'app') {
-        return
-      }
-      window.streamwallControl.updateYDoc(update)
-    }
-
-    function handleUpdate(update: Uint8Array) {
-      Y.applyUpdate(stateDoc, update, 'app')
-    }
-
-    stateDoc.on('update', sendUpdate)
-    const unsubscribeUpdate = window.streamwallControl.onYDoc(handleUpdate)
-    return () => {
-      stateDoc.off('update', sendUpdate)
-      unsubscribeUpdate()
-    }
-  }, [stateDoc])
-
-  useEffect(() => {
-    window.streamwallControl.load()
-  }, [])
-
-  return {
-    ...appState,
-    isConnected: true,
-    send,
-    sharedState,
-    stateDoc,
-    undoManager,
-  }
+  return useCollabConnection(transport)
 }
 
 /**

--- a/packages/streamwall/src/renderer/ipcCollabTransport.test.ts
+++ b/packages/streamwall/src/renderer/ipcCollabTransport.test.ts
@@ -1,0 +1,130 @@
+import { type CollabTransportEvents } from 'streamwall-control-ui'
+import { describe, expect, it, vi } from 'vitest'
+import { type StreamwallControlGlobal } from '../preload/controlPreload'
+import { createIpcCollabTransport } from './ipcCollabTransport'
+
+function createMockControl() {
+  const onStateUnsubscribe = vi.fn()
+  const onYDocUnsubscribe = vi.fn()
+  const control = {
+    invokeCommand: vi.fn().mockResolvedValue({ response: true, ok: 1 }),
+    updateYDoc: vi.fn(),
+    onState: vi.fn().mockReturnValue(onStateUnsubscribe),
+    onYDoc: vi.fn().mockReturnValue(onYDocUnsubscribe),
+    load: vi.fn(),
+  }
+  return {
+    control: control as unknown as StreamwallControlGlobal,
+    mocks: control,
+    onStateUnsubscribe,
+    onYDocUnsubscribe,
+  }
+}
+
+function noopEvents(
+  overrides: Partial<CollabTransportEvents> = {},
+): CollabTransportEvents {
+  return {
+    onState: vi.fn(),
+    onConnected: vi.fn(),
+    onClose: vi.fn(),
+    onDisconnectReason: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('createIpcCollabTransport', () => {
+  it('reports an always-on link: app origin, initially connected', () => {
+    const { control } = createMockControl()
+    const transport = createIpcCollabTransport(control)
+
+    expect(transport.remoteOrigin).toBe('app')
+    expect(transport.initiallyConnected).toBe(true)
+  })
+
+  it('sends a command over IPC and forwards the response to the callback', async () => {
+    const { control, mocks } = createMockControl()
+    const transport = createIpcCollabTransport(control)
+    const cb = vi.fn()
+    const command = { type: 'create-invite', name: 'x', role: 'operator' }
+
+    await transport.send(command as never, cb)
+
+    expect(mocks.invokeCommand).toHaveBeenCalledWith(command)
+    expect(cb).toHaveBeenCalledWith({ response: true, ok: 1 })
+  })
+
+  it('tolerates a command sent without a callback', async () => {
+    const { control, mocks } = createMockControl()
+    const transport = createIpcCollabTransport(control)
+
+    await expect(
+      transport.send({ type: 'reload-view', viewIdx: 0 } as never),
+    ).resolves.toBeUndefined()
+    expect(mocks.invokeCommand).toHaveBeenCalledTimes(1)
+  })
+
+  it('forwards local Yjs updates to the main process', () => {
+    const { control, mocks } = createMockControl()
+    const transport = createIpcCollabTransport(control)
+    const update = new Uint8Array([1, 2, 3])
+
+    transport.sendYDocUpdate(update)
+
+    expect(mocks.updateYDoc).toHaveBeenCalledWith(update)
+  })
+
+  it('subscribes to Yjs updates via onYDoc and returns its unsubscribe', () => {
+    const { control, mocks, onYDocUnsubscribe } = createMockControl()
+    const transport = createIpcCollabTransport(control)
+    const cb = vi.fn()
+
+    const unsubscribe = transport.subscribeYDocUpdates(cb)
+
+    expect(mocks.onYDoc).toHaveBeenCalledWith(cb)
+    expect(onYDocUnsubscribe).not.toHaveBeenCalled()
+    unsubscribe()
+    expect(onYDocUnsubscribe).toHaveBeenCalledTimes(1)
+  })
+
+  describe('connect', () => {
+    it('wires onState, marks connected, then requests the initial load', () => {
+      const { control, mocks } = createMockControl()
+      const transport = createIpcCollabTransport(control)
+      const events = noopEvents()
+
+      transport.connect(events)
+
+      expect(mocks.onState).toHaveBeenCalledWith(events.onState)
+      expect(events.onConnected).toHaveBeenCalledTimes(1)
+      expect(mocks.load).toHaveBeenCalledTimes(1)
+      // The listener must be attached before load() so the pushed state and
+      // Yjs snapshot are not missed.
+      const onStateOrder = mocks.onState.mock.invocationCallOrder[0]!
+      const loadOrder = mocks.load.mock.invocationCallOrder[0]!
+      expect(onStateOrder).toBeLessThan(loadOrder)
+    })
+
+    it('never closes the connection (main process is always up)', () => {
+      const { control } = createMockControl()
+      const transport = createIpcCollabTransport(control)
+      const events = noopEvents()
+
+      transport.connect(events)
+
+      expect(events.onClose).not.toHaveBeenCalled()
+      expect(events.onDisconnectReason).not.toHaveBeenCalled()
+    })
+
+    it('returns the onState unsubscribe as its teardown', () => {
+      const { control, onStateUnsubscribe } = createMockControl()
+      const transport = createIpcCollabTransport(control)
+
+      const teardown = transport.connect(noopEvents())
+      expect(onStateUnsubscribe).not.toHaveBeenCalled()
+
+      teardown()
+      expect(onStateUnsubscribe).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/packages/streamwall/src/renderer/ipcCollabTransport.ts
+++ b/packages/streamwall/src/renderer/ipcCollabTransport.ts
@@ -1,0 +1,40 @@
+import { type CollabTransport } from 'streamwall-control-ui'
+import { type StreamwallControlGlobal } from '../preload/controlPreload'
+
+/**
+ * Electron IPC adapter: the transport-specific half of the collab wiring the
+ * shared `useCollabConnection` hook consumes. The main process is always
+ * reachable, so this transport is trivially "connected" and never closes -
+ * the shared hook's reconnect/doc-reset policy simply no-ops for it. The Yjs
+ * origin filter and connection-state assembly are shared and live in
+ * `useCollabConnection` (issue #396).
+ */
+export function createIpcCollabTransport(
+  control: StreamwallControlGlobal,
+): CollabTransport {
+  return {
+    remoteOrigin: 'app',
+    // The main process is in-process and always up: there is no link to
+    // establish, so the connection is live from the first render (no
+    // "connecting" flash), and `onClose` never fires.
+    initiallyConnected: true,
+
+    send: async (msg, cb) => {
+      const resp = await control.invokeCommand(msg)
+      cb?.(resp)
+    },
+
+    sendYDocUpdate: (update) => control.updateYDoc(update),
+
+    subscribeYDocUpdates: (cb) => control.onYDoc(cb),
+
+    connect: (events) => {
+      const unsubscribe = control.onState(events.onState)
+      events.onConnected()
+      // Ask the main process for the initial state + Yjs snapshot now that the
+      // listeners are wired.
+      control.load()
+      return unsubscribe
+    },
+  }
+}


### PR DESCRIPTION
## Problem

The control UI is embedded in two transports — Electron IPC (`packages/streamwall/src/renderer/control.tsx`) and the standalone web client (`packages/streamwall-control-client/src/useStreamwallWebsocketConnection.ts`) — and each independently reimplemented the same **Yjs sync + command send + state subscription** wiring. Bugfixes in one path had to be manually ported to the other; the reconnect snapshot handling (#283) and the IPC/Web error-surfacing parity gap (#388) are the canonical examples.

## Solution

Extract a single shared hook `useCollabConnection(transport)` in `streamwall-control-ui` that owns the collab policy both paths used to duplicate:

- **Yjs origin filtering** — never echo a peer-origin update back; tag incoming peer updates with `remoteOrigin` so they don't loop. One implementation.
- **Doc-reset-on-disconnect policy** — snapshot the last-known shared state for offline rendering, then swap in a fresh Yjs doc so a local-only offline edit can't merge into the next resync (issues #37 / #283). One implementation; the always-connected IPC transport simply never triggers it.
- **Connection-state assembly** — `isConnected` / `disconnectReason` / `sharedState` fallback.

Each transport now implements a small `CollabTransport` interface for the parts that genuinely differ (how bytes move), driving the shared hook through a `CollabTransportEvents` callback set.

### Architecture decisions

- `StreamwallConnection`, `ViewInfo`, and `useStreamwallState` moved from the `index.tsx` barrel into `streamwallState.tsx` so the new hook can consume them **without introducing an import cycle** with the barrel (the repo already carries 3 circular deps — deliberately not adding a 4th). The barrel keeps re-exporting them, so no external consumer changes.
- The connection-lifecycle effect is deliberately **not** keyed on the Yjs doc: a reconnect resets the doc, but the transport itself must survive that (the socket is not recreated on every blip). Yjs sync is a separate, per-doc effect so a fresh post-disconnect doc gets re-wired.
- The WebSocket adapter keeps the pre-existing message routing, response map, and reconnect options verbatim — only the shared collab wiring was removed — so behavior is byte-for-byte preserved.

## Transport interface (for future clients)

`CollabTransport` / `CollabTransportEvents` are fully documented via JSDoc next to their definitions in `useCollabConnection.ts`. A new client (Tauri, embedded webview, …) implements `remoteOrigin`, `send`, `sendYDocUpdate`, `subscribeYDocUpdates`, and `connect(events)` and gets the origin rules + reconnect policy for free.

## Acceptance criteria

- [x] Single implementation of Yjs origin filtering and doc-reset policy (`useCollabConnection.ts`)
- [x] Electron reduced to a thin transport adapter (IPC hook ~6 lines + `createIpcCollabTransport` ~40 lines)
- [x] Web client reduced to a transport adapter — the shared collab wiring is gone; what remains is only genuinely WebSocket-specific protocol (reconnect opts, JSON message routing, response map, binary framing), which was never the duplicated part
- [x] Existing tests in both packages stay green (WebSocket connection: 16/16; full suite green)
- [x] Transport interface documented for future clients

> Note on the "<80 lines each" target: the IPC adapter meets it easily. The WebSocket adapter is larger, but only because the WebSocket wire protocol is irreducibly WS-specific — all of the *shared* duplication the issue called out is now single-sourced.

## Testing

- New `useCollabConnection.test.tsx` (13 tests) pins the shared policy via a hand-driven fake transport: origin filtering, remote-apply, connection state, disconnect reasons, and the full doc-reset / last-known-state / reconnect flow.
- New `ipcCollabTransport.test.ts` (8 tests) covers the IPC adapter's command/response, Yjs, and connect wiring, including listener-before-`load()` ordering.
- Existing `useStreamwallWebsocketConnection.test.tsx` (16 tests) unchanged and green — it exercises the refactored path through the unchanged public hook.
- Quality gate green locally: `format`, `lint`, `typecheck` (all workspaces), full `test` suite, `control-client` build, and the Electron `package` smoke build.

## Risks / breaking changes

None to the public API: `useStreamwallWebsocketConnection` and the `streamwall-control-ui` barrel exports are unchanged. The refactor touches reconnect-sensitive code (a prior-defect hotspot), which is why the shared policy is covered by dedicated behavioral tests in addition to the preserved WebSocket suite.

Closes #396