### PR TITLE
refactor: address grid view commands by stable view id (#397)

### DIFF
--- a/packages/streamwall-control-server/src/multiplexing.test.ts
+++ b/packages/streamwall-control-server/src/multiplexing.test.ts
@@ -115,7 +115,7 @@ test('an operator cannot create-invite: it is dropped, logged, and never forward
         name: 'x',
       }),
     )
-    clientWs.send(JSON.stringify({ id: 2, type: 'reload-view', viewIdx: 0 }))
+    clientWs.send(JSON.stringify({ id: 2, type: 'reload-view', viewId: 0 }))
 
     const response = await client.waitFor(isResponseTo(1))
     assert.equal(response.error, 'unauthorized')
@@ -145,7 +145,7 @@ test('an operator cannot browse: it is dropped, logged, and never forwarded', as
     clientWs.send(
       JSON.stringify({ id: 3, type: 'browse', url: 'https://example.com' }),
     )
-    clientWs.send(JSON.stringify({ id: 4, type: 'reload-view', viewIdx: 0 }))
+    clientWs.send(JSON.stringify({ id: 4, type: 'reload-view', viewId: 0 }))
 
     const response = await client.waitFor(isResponseTo(3))
     assert.equal(response.error, 'unauthorized')
@@ -240,13 +240,13 @@ test('an operator can set-listening-view: it is forwarded to the Streamwall upli
   const { clientWs } = await connectClient('operator')
 
   clientWs.send(
-    JSON.stringify({ id: 9, type: 'set-listening-view', viewIdx: 0 }),
+    JSON.stringify({ id: 9, type: 'set-listening-view', viewId: 0 }),
   )
 
   const forwarded = await streamwall.waitFor(
     isCommandType('set-listening-view'),
   )
-  assert.equal(forwarded.viewIdx, 0)
+  assert.equal(forwarded.viewId, 0)
 })
 
 test("an admin's state broadcast includes auth while an operator's does not", async () => {

--- a/packages/streamwall-control-server/src/wsValidation.test.ts
+++ b/packages/streamwall-control-server/src/wsValidation.test.ts
@@ -107,16 +107,16 @@ async function connectStreamwallAndClient({
 test('does not forward an out-of-bounds command to the Streamwall uplink', async () => {
   const { clientWs, streamwall } = await connectStreamwallAndClient()
 
-  // Invalid: viewIdx is negative (outside the bounded range).
-  clientWs.send(JSON.stringify({ id: 10, type: 'reload-view', viewIdx: -5 }))
+  // Invalid: viewId is negative (outside the bounded range).
+  clientWs.send(JSON.stringify({ id: 10, type: 'reload-view', viewId: -5 }))
   // Valid: a well-formed command that must reach the uplink.
-  clientWs.send(JSON.stringify({ id: 11, type: 'reload-view', viewIdx: 2 }))
+  clientWs.send(JSON.stringify({ id: 11, type: 'reload-view', viewId: 2 }))
 
-  await streamwall.waitFor((m) => m.type === 'reload-view' && m.viewIdx === 2)
+  await streamwall.waitFor((m) => m.type === 'reload-view' && m.viewId === 2)
 
   const reloads = streamwall.messages.filter(isCommandType('reload-view'))
   assert.equal(reloads.length, 1, 'only the valid command should be forwarded')
-  assert.equal(reloads[0].viewIdx, 2)
+  assert.equal(reloads[0].viewId, 2)
 })
 
 test('does not forward an unknown command type to the Streamwall uplink', async () => {
@@ -125,9 +125,9 @@ test('does not forward an unknown command type to the Streamwall uplink', async 
   // An admin passes every roleCan check, so only schema validation can stop
   // an unrecognized command from reaching the desktop.
   clientWs.send(JSON.stringify({ id: 20, type: 'evil-command', payload: 1 }))
-  clientWs.send(JSON.stringify({ id: 21, type: 'reload-view', viewIdx: 1 }))
+  clientWs.send(JSON.stringify({ id: 21, type: 'reload-view', viewId: 1 }))
 
-  await streamwall.waitFor((m) => m.type === 'reload-view' && m.viewIdx === 1)
+  await streamwall.waitFor((m) => m.type === 'reload-view' && m.viewId === 1)
 
   assert.ok(
     // Not a real ControlCommand type: cast, since it can never actually match.
@@ -139,7 +139,7 @@ test('does not forward an unknown command type to the Streamwall uplink', async 
 test('answers an invalid command with an error response', async () => {
   const { clientWs, client } = await connectStreamwallAndClient()
 
-  clientWs.send(JSON.stringify({ id: 42, type: 'reload-view', viewIdx: -5 }))
+  clientWs.send(JSON.stringify({ id: 42, type: 'reload-view', viewId: -5 }))
 
   const response = await client.waitFor(isResponseTo(42))
   assert.equal(response.error, 'invalid message')
@@ -215,7 +215,7 @@ test('accepts an initial state payload with legitimately empty views', async () 
   // rejected by the stricter validation.
   const { clientWs, streamwall } = await connectStreamwallAndClient()
 
-  clientWs.send(JSON.stringify({ id: 1, type: 'reload-view', viewIdx: 0 }))
+  clientWs.send(JSON.stringify({ id: 1, type: 'reload-view', viewId: 0 }))
   await streamwall.waitFor((m) => m.type === 'reload-view')
 
   assert.ok(
@@ -250,13 +250,11 @@ test('drops a malformed state update on an already-connected uplink without cras
   // command from the client is still forwarded to the (still-connected)
   // uplink, proving the malformed update was cleanly dropped rather than
   // tearing down or corrupting the connection.
-  clientWs.send(JSON.stringify({ id: 99, type: 'reload-view', viewIdx: 1 }))
-  await streamwall.waitFor((m) => m.type === 'reload-view' && m.viewIdx === 1)
+  clientWs.send(JSON.stringify({ id: 99, type: 'reload-view', viewId: 1 }))
+  await streamwall.waitFor((m) => m.type === 'reload-view' && m.viewId === 1)
 
   assert.ok(
-    streamwall.messages.some(
-      (m) => m.type === 'reload-view' && m.viewIdx === 1,
-    ),
+    streamwall.messages.some((m) => m.type === 'reload-view' && m.viewId === 1),
   )
 })
 

--- a/packages/streamwall-control-ui/src/GridControls.test.tsx
+++ b/packages/streamwall-control-ui/src/GridControls.test.tsx
@@ -36,6 +36,7 @@ function renderControls(
     render(
       <GridControls
         idx={0}
+        viewId={0}
         streamId="abc"
         style={{}}
         isDisplaying={true}
@@ -80,9 +81,11 @@ describe('GridControls volume slider', () => {
     expect(box.querySelector('input[type="range"]')).toBeNull()
   })
 
-  test('sends the new volume for this tile when the slider changes', () => {
+  test('sends the new volume addressed by this tile view id when the slider changes', () => {
     const onSetVolume = vi.fn()
-    const box = renderControls({ idx: 3, volume: 1, onSetVolume })
+    // viewId deliberately differs from idx to prove the command carries the
+    // stable view id, not the grid cell index (issue #397).
+    const box = renderControls({ idx: 0, viewId: 3, volume: 1, onSetVolume })
     const slider = box.querySelector('input[type="range"]') as HTMLInputElement
 
     act(() => {
@@ -97,7 +100,7 @@ describe('GridControls volume slider', () => {
 describe('GridControls double-click to toggle fullscreen', () => {
   test('toggles fullscreen for this tile when its open area is double-clicked', () => {
     const onToggleFullscreen = vi.fn()
-    const box = renderControls({ idx: 4, onToggleFullscreen })
+    const box = renderControls({ idx: 0, viewId: 4, onToggleFullscreen })
     const controls = box.firstElementChild as HTMLElement
 
     act(() => {

--- a/packages/streamwall-control-ui/src/GridControls.tsx
+++ b/packages/streamwall-control-ui/src/GridControls.tsx
@@ -41,6 +41,7 @@ const StyledGridControlsContainer = styled.div`
 
 export function GridControls({
   idx,
+  viewId,
   streamId,
   style,
   isDisplaying,
@@ -63,7 +64,13 @@ export function GridControls({
   onPointerDown,
   onToggleFullscreen,
 }: {
+  // Grid cell index of this tile's top-left space. Used only for position-based
+  // operations (swap/drag) that intentionally target the cell, not the view.
   idx: number
+  // Stable identity of the view actor currently in this tile. View-state
+  // commands (listen/blur/volume/reload/devtools/fullscreen) address the view
+  // by this id so a concurrent grid resize can't misroute them (issue #397).
+  viewId: number
   streamId: string
   style: JSX.HTMLAttributes['style']
   isDisplaying: boolean
@@ -74,32 +81,30 @@ export function GridControls({
   isSwapping: boolean
   showDebug: boolean
   role: StreamwallRole | null
-  onSetListening: (idx: number, isListening: boolean) => void
+  onSetListening: (viewId: number, isListening: boolean) => void
   onSetBackgroundListening: (
-    idx: number,
+    viewId: number,
     isBackgroundListening: boolean,
   ) => void
-  onSetBlurred: (idx: number, isBlurred: boolean) => void
-  onSetVolume: (idx: number, volume: number) => void
-  onReloadView: (idx: number) => void
+  onSetBlurred: (viewId: number, isBlurred: boolean) => void
+  onSetVolume: (viewId: number, volume: number) => void
+  onReloadView: (viewId: number) => void
   onSwapView: (idx: number) => void
   onRotateView: (streamId: string) => void
   onBrowse: (streamId: string) => void
-  onDevTools: (idx: number) => void
+  onDevTools: (viewId: number) => void
   onPointerDown: JSX.PointerEventHandler<HTMLDivElement>
-  onToggleFullscreen: (idx: number) => void
+  onToggleFullscreen: (viewId: number) => void
 }) {
-  // TODO: Refactor callbacks to use streamID instead of idx.
-  // We should probably also switch the view-state-changing RPCs to use a view id instead of idx like they do currently.
   const handleListeningClick = useCallback<
     JSX.MouseEventHandler<HTMLButtonElement>
   >(
     (ev) =>
       ev.shiftKey || isBackgroundListening
-        ? onSetBackgroundListening(idx, !isBackgroundListening)
-        : onSetListening(idx, !isListening),
+        ? onSetBackgroundListening(viewId, !isBackgroundListening)
+        : onSetListening(viewId, !isListening),
     [
-      idx,
+      viewId,
       onSetListening,
       onSetBackgroundListening,
       isListening,
@@ -107,18 +112,18 @@ export function GridControls({
     ],
   )
   const handleBlurClick = useCallback(
-    () => onSetBlurred(idx, !isBlurred),
-    [idx, onSetBlurred, isBlurred],
+    () => onSetBlurred(viewId, !isBlurred),
+    [viewId, onSetBlurred, isBlurred],
   )
   const handleVolumeInput = useCallback<
     JSX.InputEventHandler<HTMLInputElement>
   >(
-    (ev) => onSetVolume(idx, Number(ev.currentTarget.value)),
-    [idx, onSetVolume],
+    (ev) => onSetVolume(viewId, Number(ev.currentTarget.value)),
+    [viewId, onSetVolume],
   )
   const handleReloadClick = useCallback(
-    () => onReloadView(idx),
-    [idx, onReloadView],
+    () => onReloadView(viewId),
+    [viewId, onReloadView],
   )
   const handleSwapClick = useCallback(() => onSwapView(idx), [idx, onSwapView])
   const handleRotateClick = useCallback(
@@ -130,8 +135,8 @@ export function GridControls({
     [streamId, onBrowse],
   )
   const handleDevToolsClick = useCallback(
-    () => onDevTools(idx),
-    [idx, onDevTools],
+    () => onDevTools(viewId),
+    [viewId, onDevTools],
   )
   const handleDoubleClick = useCallback<JSX.MouseEventHandler<HTMLDivElement>>(
     (ev) => {
@@ -144,9 +149,9 @@ export function GridControls({
       if (ev.target instanceof Element && ev.target.closest('button, input')) {
         return
       }
-      onToggleFullscreen(idx)
+      onToggleFullscreen(viewId)
     },
-    [role, idx, onToggleFullscreen],
+    [role, viewId, onToggleFullscreen],
   )
   return (
     <StyledGridControlsContainer

--- a/packages/streamwall-control-ui/src/gridFullscreen.test.tsx
+++ b/packages/streamwall-control-ui/src/gridFullscreen.test.tsx
@@ -59,7 +59,10 @@ function makeView(streamId: string, spaces: number[]): ViewInfo {
         },
       },
       context: {
-        id: spaces[0],
+        // Deliberately distinct from the grid cell index so tests that assert
+        // on dispatched commands prove they carry the stable view id, not the
+        // cell index (issue #397).
+        id: 1000 + spaces[0],
         content: { url: `https://example.com/${streamId}`, kind: 'video' },
         info: null,
         pos: {
@@ -153,7 +156,7 @@ describe('ControlUI double-click fullscreen', () => {
 
     expect(sent).toContainEqual({
       type: 'set-view-fullscreen',
-      viewIdx: 1,
+      viewId: 1001,
       fullscreen: true,
     })
   })
@@ -177,7 +180,7 @@ describe('ControlUI double-click fullscreen', () => {
 
     expect(sent).toContainEqual({
       type: 'set-view-fullscreen',
-      viewIdx: 0,
+      viewId: 1000,
       fullscreen: false,
     })
   })

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -336,10 +336,10 @@ export function ControlUI({
   )
 
   const handleSetListening = useCallback(
-    (idx: number, listening: boolean) => {
+    (viewId: number, listening: boolean) => {
       send({
         type: 'set-listening-view',
-        viewIdx: listening ? idx : null,
+        viewId: listening ? viewId : null,
       })
     },
     [send],
@@ -350,10 +350,10 @@ export function ControlUI({
   // back to the grid. Purely runtime state -- the persisted layout is untouched
   // (issue #362).
   const handleToggleFullscreen = useCallback(
-    (idx: number) => {
+    (viewId: number) => {
       send({
         type: 'set-view-fullscreen',
-        viewIdx: idx,
+        viewId,
         fullscreen: fullscreenViewIdx == null,
       })
     },
@@ -390,10 +390,10 @@ export function ControlUI({
   )
 
   const handleSetBackgroundListening = useCallback(
-    (viewIdx: number, listening: boolean) => {
+    (viewId: number, listening: boolean) => {
       send({
         type: 'set-view-background-listening',
-        viewIdx,
+        viewId,
         listening,
       })
     },
@@ -401,10 +401,10 @@ export function ControlUI({
   )
 
   const handleSetBlurred = useCallback(
-    (viewIdx: number, blurred: boolean) => {
+    (viewId: number, blurred: boolean) => {
       send({
         type: 'set-view-blurred',
-        viewIdx,
+        viewId,
         blurred,
       })
     },
@@ -412,10 +412,10 @@ export function ControlUI({
   )
 
   const handleSetVolume = useCallback(
-    (viewIdx: number, volume: number) => {
+    (viewId: number, volume: number) => {
       send({
         type: 'set-view-volume',
-        viewIdx,
+        viewId,
         volume,
       })
     },
@@ -423,10 +423,10 @@ export function ControlUI({
   )
 
   const handleReloadView = useCallback(
-    (viewIdx: number) => {
+    (viewId: number) => {
       send({
         type: 'reload-view',
-        viewIdx,
+        viewId,
       })
     },
     [send],
@@ -462,10 +462,10 @@ export function ControlUI({
   )
 
   const handleDevTools = useCallback(
-    (viewIdx: number) => {
+    (viewId: number) => {
       send({
         type: 'dev-tools',
-        viewIdx,
+        viewId,
       })
     },
     [send],
@@ -966,7 +966,7 @@ export function ControlUI({
                   isBlurred,
                   volume,
                 }) => {
-                  const { pos } = state.context
+                  const { id: viewId, pos } = state.context
                   if (!pos) {
                     return null
                   }
@@ -981,6 +981,7 @@ export function ControlUI({
                     <GridControls
                       key={pos.spaces[0]}
                       idx={pos.spaces[0]}
+                      viewId={viewId}
                       streamId={streamId}
                       onToggleFullscreen={handleToggleFullscreen}
                       style={{

--- a/packages/streamwall-shared/src/connectionStatus.test.ts
+++ b/packages/streamwall-shared/src/connectionStatus.test.ts
@@ -76,7 +76,7 @@ describe('parseUplinkError', () => {
 
   test('returns null for a command message', () => {
     expect(
-      parseUplinkError({ type: 'set-view-blurred', viewIdx: 0, blurred: true }),
+      parseUplinkError({ type: 'set-view-blurred', viewId: 0, blurred: true }),
     ).toBeNull()
   })
 

--- a/packages/streamwall-shared/src/schemas.test.ts
+++ b/packages/streamwall-shared/src/schemas.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import {
   type ControlCommand,
+  MAX_VIEW_IDX,
   controlCommandMessageSchema,
   controlStateMessageSchema,
   localStreamDataSchema,
@@ -152,7 +153,7 @@ describe('controlCommandMessageSchema', () => {
       controlCommandMessageSchema.safeParse({
         id: 1,
         type: 'set-view-blurred',
-        viewIdx: 0,
+        viewId: 0,
         blurred: true,
       }).success,
     ).toBe(true)
@@ -163,7 +164,7 @@ describe('controlCommandMessageSchema', () => {
       controlCommandMessageSchema.safeParse({
         id: 1,
         type: 'set-view-fullscreen',
-        viewIdx: 3,
+        viewId: 3,
         fullscreen: true,
       }).success,
     ).toBe(true)
@@ -171,7 +172,7 @@ describe('controlCommandMessageSchema', () => {
       controlCommandMessageSchema.safeParse({
         id: 1,
         type: 'set-view-fullscreen',
-        viewIdx: 0,
+        viewId: 0,
         fullscreen: false,
       }).success,
     ).toBe(true)
@@ -182,7 +183,7 @@ describe('controlCommandMessageSchema', () => {
       controlCommandMessageSchema.safeParse({
         id: 1,
         type: 'set-view-fullscreen',
-        viewIdx: 0,
+        viewId: 0,
         fullscreen: 'yes',
       }).success,
     ).toBe(false)
@@ -193,7 +194,7 @@ describe('controlCommandMessageSchema', () => {
       controlCommandMessageSchema.safeParse({
         id: 1,
         type: 'set-view-fullscreen',
-        viewIdx: 0,
+        viewId: 0,
       }).success,
     ).toBe(false)
   })
@@ -221,7 +222,7 @@ describe('controlCommandMessageSchema', () => {
       controlCommandMessageSchema.safeParse({
         id: 1,
         type: 'set-view-blurred',
-        viewIdx: 0,
+        viewId: 0,
       }).success,
     ).toBe(false)
   })
@@ -231,7 +232,7 @@ describe('controlCommandMessageSchema', () => {
       controlCommandMessageSchema.safeParse({
         id: 1,
         type: 'set-view-blurred',
-        viewIdx: 0,
+        viewId: 0,
         blurred: 'yes',
       }).success,
     ).toBe(false)
@@ -239,7 +240,7 @@ describe('controlCommandMessageSchema', () => {
 
   test('rejects a message without a numeric id', () => {
     expect(
-      controlCommandMessageSchema.safeParse({ type: 'reload-view', viewIdx: 0 })
+      controlCommandMessageSchema.safeParse({ type: 'reload-view', viewId: 0 })
         .success,
     ).toBe(false)
   })
@@ -271,21 +272,33 @@ describe('controlCommandMessageSchema', () => {
     ).toBe(false)
   })
 
-  test('bounds the view index to a non-negative integer', () => {
+  test('bounds the view id to a non-negative integer', () => {
     expect(
       controlCommandMessageSchema.safeParse({
         id: 1,
         type: 'reload-view',
-        viewIdx: -1,
+        viewId: -1,
       }).success,
     ).toBe(false)
     expect(
       controlCommandMessageSchema.safeParse({
         id: 1,
         type: 'reload-view',
-        viewIdx: 1.5,
+        viewId: 1.5,
       }).success,
     ).toBe(false)
+  })
+
+  test('accepts a view id above the max grid cell index (issue #397)', () => {
+    // A view id is the actor's stable identity, not a grid cell, so unlike a
+    // grid index it must not be capped at MAX_VIEW_IDX.
+    expect(
+      controlCommandMessageSchema.safeParse({
+        id: 1,
+        type: 'reload-view',
+        viewId: MAX_VIEW_IDX + 100,
+      }).success,
+    ).toBe(true)
   })
 
   test('rejects an out-of-range rotation on rotate-stream', () => {
@@ -304,7 +317,7 @@ describe('controlCommandMessageSchema', () => {
       controlCommandMessageSchema.safeParse({
         id: 1,
         type: 'set-listening-view',
-        viewIdx: null,
+        viewId: null,
       }).success,
     ).toBe(true)
   })
@@ -438,7 +451,7 @@ describe('controlCommandMessageSchema', () => {
       controlCommandMessageSchema.safeParse({
         id: 1,
         type: 'set-view-volume',
-        viewIdx: 0,
+        viewId: 0,
         volume: 0.5,
       }).success,
     ).toBe(true)
@@ -449,7 +462,7 @@ describe('controlCommandMessageSchema', () => {
       controlCommandMessageSchema.safeParse({
         id: 1,
         type: 'set-view-volume',
-        viewIdx: 0,
+        viewId: 0,
         volume: 1.5,
       }).success,
     ).toBe(false)
@@ -457,7 +470,7 @@ describe('controlCommandMessageSchema', () => {
       controlCommandMessageSchema.safeParse({
         id: 1,
         type: 'set-view-volume',
-        viewIdx: 0,
+        viewId: 0,
         volume: -0.1,
       }).success,
     ).toBe(false)
@@ -507,7 +520,7 @@ describe('controlCommandMessageSchema', () => {
     const result = controlCommandMessageSchema.safeParse({
       id: 7,
       type: 'reload-view',
-      viewIdx: 2,
+      viewId: 2,
     })
     expect(result.success).toBe(true)
     if (result.success) {
@@ -688,6 +701,29 @@ describe('streamwallStateSchema', () => {
   test('rejects an out-of-bounds fullscreenViewIdx', () => {
     const malformed = { ...VALID_STATE, fullscreenViewIdx: -1 }
     expect(streamwallStateSchema.safeParse(malformed).success).toBe(false)
+  })
+
+  test('accepts a view whose stable id exceeds MAX_VIEW_IDX (issue #397)', () => {
+    // A view's `context.id` is its stable actor identity (a webContents id),
+    // which grows unbounded over a session and is not a grid cell — so it must
+    // not be rejected for exceeding MAX_VIEW_IDX.
+    const state = {
+      ...VALID_STATE,
+      views: [
+        {
+          state: 'empty',
+          context: {
+            id: MAX_VIEW_IDX + 500,
+            content: null,
+            info: null,
+            pos: null,
+            error: null,
+            volume: 0,
+          },
+        },
+      ],
+    }
+    expect(streamwallStateSchema.safeParse(state).success).toBe(true)
   })
 
   test('accepts a null fullscreenViewIdx and a populated streamdelay', () => {

--- a/packages/streamwall-shared/src/schemas.ts
+++ b/packages/streamwall-shared/src/schemas.ts
@@ -42,6 +42,17 @@ const orientationSchema = z.enum(['V', 'H'])
 
 const rotationSchema = z.number().min(0).max(MAX_ROTATION)
 const viewIdxSchema = z.number().int().min(0).max(MAX_VIEW_IDX)
+
+/**
+ * A stable per-view identity, fixed when a view actor is created and preserved
+ * across grid resizes and remaps (issue #397). Unlike {@link viewIdxSchema} —
+ * a *grid cell index* that shifts whenever the layout changes — this addresses
+ * one specific running view for the lifetime of its actor, so a control command
+ * cannot race a concurrent resize into acting on the wrong tile. It is an
+ * opaque non-negative integer (the actor's creation-time `webContents.id`); it
+ * is deliberately not bounded by `MAX_VIEW_IDX`, which only limits grid cells.
+ */
+const viewIdSchema = z.number().int().nonnegative()
 const gridDimensionSchema = z.number().int().min(GRID_MIN).max(GRID_MAX)
 const volumeSchema = z.number().min(0).max(1)
 
@@ -129,21 +140,21 @@ export function parseStreamList(input: unknown): {
 export const controlCommandSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('set-listening-view'),
-    viewIdx: viewIdxSchema.nullable(),
+    viewId: viewIdSchema.nullable(),
   }),
   z.object({
     type: z.literal('set-view-background-listening'),
-    viewIdx: viewIdxSchema,
+    viewId: viewIdSchema,
     listening: z.boolean(),
   }),
   z.object({
     type: z.literal('set-view-blurred'),
-    viewIdx: viewIdxSchema,
+    viewId: viewIdSchema,
     blurred: z.boolean(),
   }),
   z.object({
     type: z.literal('set-view-volume'),
-    viewIdx: viewIdxSchema,
+    viewId: viewIdSchema,
     volume: volumeSchema,
   }),
   z.object({
@@ -162,11 +173,11 @@ export const controlCommandSchema = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal('reload-view'),
-    viewIdx: viewIdxSchema,
+    viewId: viewIdSchema,
   }),
   z.object({
     type: z.literal('set-view-fullscreen'),
-    viewIdx: viewIdxSchema,
+    viewId: viewIdSchema,
     fullscreen: z.boolean(),
   }),
   z.object({
@@ -175,7 +186,7 @@ export const controlCommandSchema = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal('dev-tools'),
-    viewIdx: viewIdxSchema,
+    viewId: viewIdSchema,
   }),
   z.object({
     type: z.literal('set-stream-censored'),
@@ -324,7 +335,9 @@ const viewStateValueSchema = z.union([
 const viewStateSchema = z.object({
   state: viewStateValueSchema,
   context: z.object({
-    id: viewIdxSchema,
+    // Stable per-view identity (issue #397). Control commands target views by
+    // this `id`, not by grid cell index, so a resize can't misroute them.
+    id: viewIdSchema,
     content: viewContentSchema.nullable(),
     info: contentViewInfoSchema.nullable(),
     pos: viewPosSchema.nullable(),

--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -90,7 +90,7 @@ describe('StreamWindow.setGridSize', () => {
 
 /**
  * A minimal stand-in for a ViewActor: enough of the `getSnapshot()`/`send()`
- * surface for setViewVolume/sendViewEvent/findViewByIdx to operate on,
+ * surface for setViewVolume/sendViewEvent/findViewById to operate on,
  * without a real XState actor or Electron WebContentsView.
  */
 function makeFakeViewActor(pos: { spaces: number[] } | null, send = vi.fn()) {
@@ -101,17 +101,17 @@ function makeFakeViewActor(pos: { spaces: number[] } | null, send = vi.fn()) {
 }
 
 describe('StreamWindow.setViewVolume', () => {
-  it('sends SET_VOLUME to the view occupying the given index', () => {
+  it('sends SET_VOLUME to the view with the given stable id', () => {
     const sw = makeStreamWindow(makeConfig())
     const send = vi.fn()
     sw.views = new Map([[1, makeFakeViewActor({ spaces: [0] }, send)]])
 
-    sw.setViewVolume(0, 0.5)
+    sw.setViewVolume(1, 0.5)
 
     expect(send).toHaveBeenCalledWith({ type: 'SET_VOLUME', volume: 0.5 })
   })
 
-  it('does nothing when no view occupies the given index', () => {
+  it('does nothing when no view has the given id', () => {
     const sw = makeStreamWindow(makeConfig())
     const send = vi.fn()
     sw.views = new Map([[1, makeFakeViewActor({ spaces: [0] }, send)]])
@@ -119,6 +119,82 @@ describe('StreamWindow.setViewVolume', () => {
     sw.setViewVolume(5, 0.5)
 
     expect(send).not.toHaveBeenCalled()
+  })
+
+  it('reaches the view by id even after a resize moved it to a new cell (issue #397)', () => {
+    // The view keeps stable id 42 but now occupies cell 7 instead of 0. A
+    // command addressed by its id must still reach it, and must not leak onto
+    // whatever view now sits at the view's old cell.
+    const sw = makeStreamWindow(makeConfig())
+    const movedSend = vi.fn()
+    const otherSend = vi.fn()
+    sw.views = new Map([
+      [42, makeFakeViewActor({ spaces: [7] }, movedSend)],
+      [9, makeFakeViewActor({ spaces: [0] }, otherSend)],
+    ])
+
+    sw.setViewVolume(42, 0.25)
+
+    expect(movedSend).toHaveBeenCalledWith({ type: 'SET_VOLUME', volume: 0.25 })
+    expect(otherSend).not.toHaveBeenCalled()
+  })
+})
+
+describe('StreamWindow.setListeningView', () => {
+  function displayingActor(send = vi.fn()) {
+    return {
+      getSnapshot: () => ({
+        matches: (query: unknown) => query === 'displaying',
+      }),
+      send,
+    } as unknown as ReturnType<typeof StreamWindow.prototype.createView>
+  }
+
+  it('unmutes the view with the given id and mutes the rest, by stable id (issue #397)', () => {
+    const sw = makeStreamWindow(makeConfig())
+    const selected = vi.fn()
+    const other = vi.fn()
+    sw.views = new Map([
+      [42, displayingActor(selected)],
+      [9, displayingActor(other)],
+    ])
+
+    sw.setListeningView(42)
+
+    expect(selected).toHaveBeenCalledWith({ type: 'UNMUTE' })
+    expect(other).toHaveBeenCalledWith({ type: 'MUTE' })
+  })
+
+  it('mutes every view when the listening id is null', () => {
+    const sw = makeStreamWindow(makeConfig())
+    const a = vi.fn()
+    const b = vi.fn()
+    sw.views = new Map([
+      [1, displayingActor(a)],
+      [2, displayingActor(b)],
+    ])
+
+    sw.setListeningView(null)
+
+    expect(a).toHaveBeenCalledWith({ type: 'MUTE' })
+    expect(b).toHaveBeenCalledWith({ type: 'MUTE' })
+  })
+})
+
+describe('StreamWindow.getViewAnchorIdx', () => {
+  it('returns the top-left cell of the view with the given id', () => {
+    const sw = makeStreamWindow(makeConfig())
+    sw.views = new Map([[42, makeFakeViewActor({ spaces: [7, 8] })]])
+
+    expect(sw.getViewAnchorIdx(42)).toBe(7)
+  })
+
+  it('returns null for an unknown id or a view without a placement', () => {
+    const sw = makeStreamWindow(makeConfig())
+    sw.views = new Map([[42, makeFakeViewActor(null)]])
+
+    expect(sw.getViewAnchorIdx(42)).toBeNull()
+    expect(sw.getViewAnchorIdx(999)).toBeNull()
   })
 })
 

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -588,57 +588,68 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
     this.emitState()
   }
 
-  setListeningView(viewIdx: number | null) {
-    const { views } = this
-    for (const view of views.values()) {
+  setListeningView(viewId: number | null) {
+    // Address the listening view by its stable id, not by grid cell, so a
+    // concurrent resize can't redirect "listen" to whatever tile now sits at
+    // an index (issue #397). `this.views` is keyed by each actor's stable
+    // `context.id`, so the map key is that id.
+    for (const [id, view] of this.views) {
       const snapshot = view.getSnapshot()
       if (!snapshot.matches('displaying')) {
         continue
       }
-      const { context } = snapshot
-      const isSelectedView =
-        viewIdx != null
-          ? (context.pos?.spaces.includes(viewIdx) ?? false)
-          : false
+      const isSelectedView = viewId != null && id === viewId
       view.send({ type: isSelectedView ? 'UNMUTE' : 'MUTE' })
     }
   }
 
-  findViewByIdx(viewIdx: number) {
-    for (const view of this.views.values()) {
-      if (view.getSnapshot().context.pos?.spaces?.includes?.(viewIdx)) {
-        return view
-      }
-    }
+  findViewById(viewId: number) {
+    // O(1) lookup by stable id: `this.views` is keyed by each actor's
+    // creation-time `context.id`, which survives grid resizes and remaps
+    // (issue #397), unlike a grid cell index.
+    return this.views.get(viewId)
   }
 
-  sendViewEvent(viewIdx: number, event: EventFrom<typeof viewStateMachine>) {
-    const view = this.findViewByIdx(viewIdx)
+  sendViewEvent(viewId: number, event: EventFrom<typeof viewStateMachine>) {
+    const view = this.findViewById(viewId)
     if (view) {
       view.send(event)
     }
   }
 
-  setViewBackgroundListening(viewIdx: number, listening: boolean) {
-    this.sendViewEvent(viewIdx, {
+  /**
+   * The top-left grid cell the view with `viewId` currently occupies, or null
+   * when it has no placement or no such view exists. Translates a stable view
+   * id into the cell-based `fullscreenViewIdx` the layout state still keys on
+   * (issue #397), resolved against the live layout so a resize racing the
+   * command can't select the wrong cell.
+   */
+  getViewAnchorIdx(viewId: number): number | null {
+    return (
+      this.findViewById(viewId)?.getSnapshot().context.pos?.spaces[0] ?? null
+    )
+  }
+
+  setViewBackgroundListening(viewId: number, listening: boolean) {
+    this.sendViewEvent(viewId, {
       type: listening ? 'BACKGROUND' : 'UNBACKGROUND',
     })
   }
 
-  setViewBlurred(viewIdx: number, blurred: boolean) {
-    this.sendViewEvent(viewIdx, { type: blurred ? 'BLUR' : 'UNBLUR' })
+  setViewBlurred(viewId: number, blurred: boolean) {
+    this.sendViewEvent(viewId, { type: blurred ? 'BLUR' : 'UNBLUR' })
   }
 
-  setViewVolume(viewIdx: number, volume: number) {
-    this.sendViewEvent(viewIdx, { type: 'SET_VOLUME', volume })
+  setViewVolume(viewId: number, volume: number) {
+    this.sendViewEvent(viewId, { type: 'SET_VOLUME', volume })
   }
 
-  reloadView(viewIdx: number) {
-    this.sendViewEvent(viewIdx, { type: 'RELOAD' })
+  reloadView(viewId: number) {
+    this.sendViewEvent(viewId, { type: 'RELOAD' })
   }
 
-  openDevTools(viewIdx: number, inWebContents: WebContents) {
-    this.sendViewEvent(viewIdx, { type: 'DEVTOOLS', inWebContents })
+  openDevTools(viewId: number, inWebContents: WebContents) {
+    this.sendViewEvent(viewId, { type: 'DEVTOOLS', inWebContents })
   }
 
   onState(state: StreamwallState) {

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -717,21 +717,17 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     }
 
     if (msg.type === 'set-listening-view') {
-      log.debug('Setting listening view:', msg.viewIdx)
-      streamWindow.setListeningView(msg.viewIdx)
+      log.debug('Setting listening view:', msg.viewId)
+      streamWindow.setListeningView(msg.viewId)
     } else if (msg.type === 'set-view-background-listening') {
-      log.debug(
-        'Setting view background listening:',
-        msg.viewIdx,
-        msg.listening,
-      )
-      streamWindow.setViewBackgroundListening(msg.viewIdx, msg.listening)
+      log.debug('Setting view background listening:', msg.viewId, msg.listening)
+      streamWindow.setViewBackgroundListening(msg.viewId, msg.listening)
     } else if (msg.type === 'set-view-blurred') {
-      log.debug('Setting view blurred:', msg.viewIdx, msg.blurred)
-      streamWindow.setViewBlurred(msg.viewIdx, msg.blurred)
+      log.debug('Setting view blurred:', msg.viewId, msg.blurred)
+      streamWindow.setViewBlurred(msg.viewId, msg.blurred)
     } else if (msg.type === 'set-view-volume') {
-      log.debug('Setting view volume:', msg.viewIdx, msg.volume)
-      streamWindow.setViewVolume(msg.viewIdx, msg.volume)
+      log.debug('Setting view volume:', msg.viewId, msg.volume)
+      streamWindow.setViewVolume(msg.viewId, msg.volume)
     } else if (msg.type === 'rotate-stream') {
       log.debug('Rotating stream:', msg.url, msg.rotation)
       overlayStreamData.update(msg.url, {
@@ -744,14 +740,25 @@ async function main(argv: ReturnType<typeof parseArgs>) {
       log.debug('Deleting custom stream:', msg.url)
       localStreamData.delete(msg.url)
     } else if (msg.type === 'reload-view') {
-      log.debug('Reloading view:', msg.viewIdx)
-      streamWindow.reloadView(msg.viewIdx)
+      log.debug('Reloading view:', msg.viewId)
+      streamWindow.reloadView(msg.viewId)
     } else if (msg.type === 'set-view-fullscreen') {
       // Runtime-only wall zoom (issue #362): remember which view fills the
       // wall (or null) and re-derive the layout. Broadcast the new value first
       // so clients render the expansion consistently, then re-lay-out the wall.
-      log.debug('Setting view fullscreen:', msg.viewIdx, msg.fullscreen)
-      updateState({ fullscreenViewIdx: msg.fullscreen ? msg.viewIdx : null })
+      //
+      // The command carries a stable view id (issue #397); resolve it to the
+      // cell that view currently occupies so the cell-based `fullscreenViewIdx`
+      // (which the layout state and clients still key on) reflects the view the
+      // operator actually double-clicked, even if a resize just moved it. If
+      // the view has no placement, `getViewAnchorIdx` returns null and no
+      // expansion happens.
+      log.debug('Setting view fullscreen:', msg.viewId, msg.fullscreen)
+      updateState({
+        fullscreenViewIdx: msg.fullscreen
+          ? streamWindow.getViewAnchorIdx(msg.viewId)
+          : null,
+      })
       updateViewsFromStateDoc()
     } else if (msg.type === 'browse' || msg.type === 'dev-tools') {
       if (browseWindow && !browseWindow.isDestroyed()) {
@@ -788,8 +795,8 @@ async function main(argv: ReturnType<typeof parseArgs>) {
           return { error: 'invalid url' }
         }
       } else if (msg.type === 'dev-tools') {
-        log.debug('Opening DevTools for view:', msg.viewIdx)
-        streamWindow.openDevTools(msg.viewIdx, browseWindow.webContents)
+        log.debug('Opening DevTools for view:', msg.viewId)
+        streamWindow.openDevTools(msg.viewId, browseWindow.webContents)
       }
     } else if (msg.type === 'set-stream-censored' && streamdelayClient) {
       log.debug('Setting stream censored:', msg.isCensored)

--- a/packages/streamwall/src/main/uplinkCommandGate.test.ts
+++ b/packages/streamwall/src/main/uplinkCommandGate.test.ts
@@ -14,7 +14,7 @@ describe('checkUplinkCommandGate', () => {
   it('allows an uplink command on the remote allowlist', () => {
     expect(
       checkUplinkCommandGate(
-        { type: 'set-listening-view', viewIdx: 0 },
+        { type: 'set-listening-view', viewId: 0 },
         'uplink',
       ),
     ).toEqual({ allowed: true })

--- a/packages/streamwall/src/main/uplinkMessageRouting.test.ts
+++ b/packages/streamwall/src/main/uplinkMessageRouting.test.ts
@@ -21,11 +21,11 @@ describe('routeUplinkWsMessage', () => {
   it('routes a valid uplink command as a command message', () => {
     expect(
       routeUplinkWsMessage(
-        JSON.stringify({ type: 'set-view-blurred', viewIdx: 0, blurred: true }),
+        JSON.stringify({ type: 'set-view-blurred', viewId: 0, blurred: true }),
       ),
     ).toEqual({
       kind: 'command',
-      message: { type: 'set-view-blurred', viewIdx: 0, blurred: true },
+      message: { type: 'set-view-blurred', viewId: 0, blurred: true },
     })
   })
 


### PR DESCRIPTION
## Problem

Grid view-state commands — listen, background-listen, blur, volume, reload, dev-tools, fullscreen — identified their target view by **numeric grid cell index** (`viewIdx`). Cell indices shift whenever the grid is resized or views are remapped, so a command could race a concurrent resize and act on whichever tile happened to occupy that cell (e.g. an operator clicks *reload* mid-resize and the wrong view reloads). This was a long-standing `TODO` in `GridControls.tsx`.

Closes #397

## Solution

Migrate those commands from a grid cell index to a **stable per-view id** (`viewId`).

Each view actor already carries a creation-time `context.id` that survives resizes/remaps, and `StreamWindow.views` is already keyed by it — so the fix reuses the existing stable identity rather than inventing a second one:

- **`streamwall-shared`** — the seven view commands now carry `viewId` instead of `viewIdx`. A new `viewIdSchema` validates it and `viewStateSchema.context.id`; unlike `viewIdxSchema` it is **not** capped at `MAX_VIEW_IDX`, because a view id is an actor identity (a `webContents.id`) that can exceed the max grid-cell index over a session — the old bound could reject otherwise-valid broadcast state.
- **`streamwall` main** — the fragile `findViewByIdx` (scans views by `pos.spaces`) becomes `findViewById`, an O(1) lookup on the id-keyed `views` map; `setListeningView` compares by id. Fullscreen still keys its layout/broadcast state on a cell (`fullscreenViewIdx`), so the command's `viewId` is resolved to the view's **current anchor cell** at handling time via the new `getViewAnchorIdx` — race-free against the live layout.
- **`streamwall-control-ui`** — `GridControls` gains a `viewId` prop; view-state callbacks address the view by id, while position-only operations (swap/drag) keep using the cell index. The `TODO` is removed.

## Architecture decisions

- **Reuse the existing stable `context.id` instead of minting a UUID.** The actor's creation-time id is already stable across remaps and is already the key of `StreamWindow.views`, giving an O(1) lookup and a single source of view identity. This also let me fix the latent `MAX_VIEW_IDX` over-tight bound on `context.id` in the same change.
- **Command vs. position semantics kept separate.** Operations that target a *running view* (the seven above) now use `viewId`. Operations that target a *grid cell/position* — swap, drag-move (Yjs `views` map), layout presets — are intentionally left index-keyed; they act synchronously on the current snapshot and are not subject to the in-flight-resize race.

## Schema / state migration

**No saved-state or Yjs document migration is required.** The persisted Yjs `views` map, layout presets, and the broadcast `fullscreenViewIdx` field all remain grid-index keyed and unchanged on the wire. Only the *command* payloads changed (`viewIdx` → `viewId`); the desktop, control-server, and control-client ship and upgrade together, so no deprecation alias is carried.

## Testing

- **shared** — command schema round-trips `viewId`; a view id above `MAX_VIEW_IDX` is accepted for both a command and a broadcast view slot (regression for the old bound).
- **main** — `setViewVolume`/`setListeningView` route by stable id; new regression proves a command still reaches a view **after a resize moved it to a different cell**, and does not leak onto the view now at the old cell; `getViewAnchorIdx` resolves the anchor cell / null.
- **control-ui** — `GridControls` and the double-click fullscreen flow dispatch commands carrying the view id (fixtures use an id deliberately distinct from the cell index to prove decoupling).
- **control-server** — WebSocket forwarding/validation of the renamed field end-to-end.
- Full quality gate green locally: `format:check`, `lint`, `typecheck`, all workspace test suites, `control-client` build.

## Risks / breaking changes

- The control command protocol field `viewIdx` → `viewId` is a breaking wire change for the seven listed commands. Impact is contained: all three components (desktop/server/client) are released together, and no persisted state changes.