### PR TITLE
refactor(control-ui): split monolithic ControlUI into composable hooks and components

### DIFF
--- a/packages/streamwall-control-ui/src/components/ControlBanners.tsx
+++ b/packages/streamwall-control-ui/src/components/ControlBanners.tsx
@@ -1,0 +1,39 @@
+import { type DataSourceHealth, type DisconnectReason } from 'streamwall-shared'
+import { CommandErrorBanner } from '../CommandErrorBanner.tsx'
+import { ConnectionStatusBanner } from '../ConnectionStatusBanner.tsx'
+import { DataSourceHealthBanner } from '../DataSourceHealthBanner.tsx'
+import { ServerUpdateBanner } from '../ServerUpdateBanner.tsx'
+import { type ServerStatus } from '../useServerStatus.ts'
+
+/**
+ * The stack of transient status banners shown above the wall: connection
+ * state, data-source health, an available server update, and surfaced command
+ * errors. Grouped from ControlUI's composition root unchanged (issue #393).
+ */
+export function ControlBanners({
+  isConnected,
+  disconnectReason,
+  dataSourceHealth,
+  serverStatus,
+  commandError,
+  onDismissError,
+}: {
+  isConnected: boolean
+  disconnectReason: DisconnectReason | null | undefined
+  dataSourceHealth: DataSourceHealth[]
+  serverStatus: ServerStatus | null
+  commandError: string | null
+  onDismissError: () => void
+}) {
+  return (
+    <>
+      <ConnectionStatusBanner
+        isConnected={isConnected}
+        reason={disconnectReason}
+      />
+      <DataSourceHealthBanner dataSourceHealth={dataSourceHealth} />
+      <ServerUpdateBanner status={serverStatus} />
+      <CommandErrorBanner error={commandError} onDismiss={onDismissError} />
+    </>
+  )
+}

--- a/packages/streamwall-control-ui/src/components/ControlGrid.tsx
+++ b/packages/streamwall-control-ui/src/components/ControlGrid.tsx
@@ -1,0 +1,322 @@
+import { range } from 'lodash-es'
+import {
+  idColor,
+  type StreamData,
+  type StreamwallRole,
+} from 'streamwall-shared'
+import { styled } from 'styled-components'
+import { matchesState } from 'xstate'
+import { type CollabData } from '../collabData.ts'
+import { GridControls } from '../GridControls.tsx'
+import { GridInput } from '../GridInput.tsx'
+import { isIdxInResizeBox } from '../gridInteractions'
+import { GridPreviewBox } from '../GridPreviewBox.tsx'
+import { ResizeHandles } from '../ResizeHandles.tsx'
+import { type ViewInfo } from '../streamwallState.tsx'
+import { type useTileDrag } from '../useTileDrag.ts'
+import { type useTileResize } from '../useTileResize.ts'
+import { resolveAnchorIdx } from '../viewPlacement.ts'
+
+/**
+ * The interactive wall grid: the invisible per-cell placement inputs, resize
+ * handles, live preview boxes, and per-view control overlays. The tile drag and
+ * resize interaction state arrive as the whole hook-return objects so their
+ * shapes stay in sync with `useTileDrag`/`useTileResize`. Extracted from
+ * ControlUI's composition root unchanged (issue #393).
+ */
+export function ControlGrid({
+  cols,
+  rows,
+  windowWidth,
+  windowHeight,
+  role,
+  showDebug,
+  sharedState,
+  views,
+  stateIdxMap,
+  streams,
+  fullscreenViewIdx,
+  tileDrag,
+  tileResize,
+  onSetView,
+  onFocusInput,
+  onBlurInput,
+  onToggleFullscreen,
+  onSetListening,
+  onSetBackgroundListening,
+  onSetBlurred,
+  onSetVolume,
+  onReloadView,
+  onRotateView,
+  onBrowse,
+  onDevTools,
+}: {
+  cols: number
+  rows: number
+  windowWidth: number
+  windowHeight: number
+  role: StreamwallRole | null
+  showDebug: boolean
+  sharedState: CollabData | undefined
+  views: ViewInfo[]
+  stateIdxMap: Map<number, ViewInfo>
+  streams: StreamData[]
+  fullscreenViewIdx: number | null
+  tileDrag: ReturnType<typeof useTileDrag>
+  tileResize: ReturnType<typeof useTileResize>
+  onSetView: (idx: number, streamId: string) => void
+  onFocusInput: (idx: number) => void
+  onBlurInput: () => void
+  onToggleFullscreen: (viewId: number) => void
+  onSetListening: (viewId: number, listening: boolean) => void
+  onSetBackgroundListening: (viewId: number, listening: boolean) => void
+  onSetBlurred: (viewId: number, blurred: boolean) => void
+  onSetVolume: (viewId: number, volume: number) => void
+  onReloadView: (viewId: number) => void
+  onRotateView: (streamId: string) => void
+  onBrowse: (streamId: string) => void
+  onDevTools: (viewId: number) => void
+}) {
+  const {
+    hoveringIdx,
+    swapStartIdx,
+    moveStart,
+    moveTargetIdx,
+    updateHoveringIdx,
+    clearHoveringIdx,
+    handleSwapView,
+    handleGridPointerDown,
+  } = tileDrag
+  const { resize, handleResizeStart, handleResizeKeyDown } = tileResize
+
+  return (
+    <StyledGridContainer
+      className="grid"
+      data-testid="grid"
+      onPointerMove={updateHoveringIdx}
+      onPointerLeave={clearHoveringIdx}
+      $windowWidth={windowWidth}
+      $windowHeight={windowHeight}
+    >
+      <StyledGridInputs>
+        {range(0, rows).map((y) =>
+          range(0, cols).map((x) => {
+            const idx = cols * y + x
+            const { streamId } = sharedState?.views?.[idx] ?? {}
+            const isMoveHighlight =
+              moveStart != null &&
+              moveTargetIdx != null &&
+              moveStart.idx !== moveTargetIdx &&
+              (
+                stateIdxMap.get(moveTargetIdx)?.spaces ?? [moveTargetIdx]
+              ).includes(idx)
+            const isResizeHighlight =
+              resize != null &&
+              hoveringIdx != null &&
+              isIdxInResizeBox(
+                cols,
+                resize.anchorIdx,
+                hoveringIdx,
+                resize.handle,
+                resize.originalSpaces,
+                idx,
+              )
+            const isHighlighted = isMoveHighlight || isResizeHighlight
+            return (
+              <GridInput
+                key={idx}
+                style={{
+                  width: `${100 / cols}%`,
+                  height: `${100 / rows}%`,
+                  left: `${(100 * x) / cols}%`,
+                  top: `${(100 * y) / rows}%`,
+                }}
+                idx={idx}
+                spaceValue={streamId ?? ''}
+                onChangeSpace={onSetView}
+                isHighlighted={isHighlighted}
+                role={role}
+                onPointerDown={handleGridPointerDown}
+                onFocus={onFocusInput}
+                onBlur={onBlurInput}
+              />
+            )
+          }),
+        )}
+      </StyledGridInputs>
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          pointerEvents: 'none',
+        }}
+      >
+        {views.map(({ state }) => {
+          const { pos } = state.context
+          if (pos == null) {
+            return null
+          }
+          const anchorIdx = Math.min(...pos.spaces)
+          return (
+            <div
+              key={`rh-${anchorIdx}`}
+              style={{
+                position: 'absolute',
+                left: `${(100 * pos.x) / windowWidth}%`,
+                top: `${(100 * pos.y) / windowHeight}%`,
+                width: `${(100 * pos.width) / windowWidth}%`,
+                height: `${(100 * pos.height) / windowHeight}%`,
+                pointerEvents: 'none',
+              }}
+            >
+              <ResizeHandles
+                anchorIdx={anchorIdx}
+                originalSpaces={pos.spaces}
+                role={role}
+                onResizeStart={handleResizeStart}
+                onResizeKeyDown={handleResizeKeyDown}
+              />
+            </div>
+          )
+        })}
+      </div>
+      <StyledGridPreview>
+        {views.map(({ state, isListening }) => {
+          const { pos } = state.context
+          if (pos == null) {
+            return null
+          }
+
+          const { streamId } =
+            sharedState?.views[
+              resolveAnchorIdx(pos.spaces, fullscreenViewIdx)
+            ] ?? {}
+          const data = streams.find((d) => d._id === streamId)
+          if (streamId == null || data == null) {
+            return null
+          }
+
+          const isSmall = pos.height < 200
+          const isError = matchesState('displaying.error', state.state)
+          const errorReason = state.context.error
+          return (
+            <GridPreviewBox
+              key={pos.spaces[0]}
+              streamId={streamId}
+              color={idColor(streamId)}
+              style={{
+                left: `${(100 * pos.x) / windowWidth}%`,
+                top: `${(100 * pos.y) / windowHeight}%`,
+                width: `${(100 * pos.width) / windowWidth}%`,
+                height: `${(100 * pos.height) / windowHeight}%`,
+              }}
+              pos={pos}
+              windowWidth={windowWidth}
+              windowHeight={windowHeight}
+              isListening={isListening}
+              isSmall={isSmall}
+              isError={isError}
+              errorReason={errorReason}
+              orientation={data?.orientation ?? null}
+              source={data?.source}
+              city={data?.city}
+              state={data?.state}
+            />
+          )
+        })}
+      </StyledGridPreview>
+      {views.map(
+        ({ state, isListening, isBackgroundListening, isBlurred, volume }) => {
+          const { id: viewId, pos } = state.context
+          if (!pos) {
+            return null
+          }
+          const { streamId } =
+            sharedState?.views[
+              resolveAnchorIdx(pos.spaces, fullscreenViewIdx)
+            ] ?? {}
+          if (!streamId) {
+            return null
+          }
+          return (
+            <GridControls
+              key={pos.spaces[0]}
+              idx={pos.spaces[0]}
+              viewId={viewId}
+              streamId={streamId}
+              onToggleFullscreen={onToggleFullscreen}
+              style={{
+                left: `${(100 * pos.x) / windowWidth}%`,
+                top: `${(100 * pos.y) / windowHeight}%`,
+                width: `${(100 * pos.width) / windowWidth}%`,
+                height: `${(100 * pos.height) / windowHeight}%`,
+              }}
+              isDisplaying={matchesState('displaying', state.state)}
+              isListening={isListening}
+              isBackgroundListening={isBackgroundListening}
+              isBlurred={isBlurred}
+              volume={volume}
+              isSwapping={
+                swapStartIdx != null && pos.spaces.includes(swapStartIdx)
+              }
+              showDebug={showDebug}
+              role={role}
+              onSetListening={onSetListening}
+              onSetBackgroundListening={onSetBackgroundListening}
+              onSetBlurred={onSetBlurred}
+              onSetVolume={onSetVolume}
+              onReloadView={onReloadView}
+              onSwapView={handleSwapView}
+              onRotateView={onRotateView}
+              onBrowse={onBrowse}
+              onDevTools={onDevTools}
+              onPointerDown={handleGridPointerDown}
+            />
+          )
+        },
+      )}
+    </StyledGridContainer>
+  )
+}
+
+const StyledGridPreview = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`
+
+const StyledGridInputs = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  transition: opacity 100ms ease-out;
+  overflow: hidden;
+  z-index: 100;
+`
+
+const StyledGridContainer = styled.div<{
+  $windowWidth: number
+  $windowHeight: number
+}>`
+  position: relative;
+  /* Responsive: keep the wall's aspect ratio but fit the available space
+     instead of a hard-coded pixel size, so the layout never overflows. */
+  aspect-ratio: ${({ $windowWidth, $windowHeight }) =>
+    `${$windowWidth} / ${$windowHeight}`};
+  width: 100%;
+  max-height: 100%;
+  margin: 0 auto;
+  border: 1px solid var(--border-2);
+  border-radius: var(--r-md);
+  background: var(--cell-bg);
+  overflow: hidden;
+
+  &:hover ${StyledGridInputs} {
+    opacity: 0.35;
+  }
+`

--- a/packages/streamwall-control-ui/src/components/ControlHeader.tsx
+++ b/packages/streamwall-control-ui/src/components/ControlHeader.tsx
@@ -1,0 +1,167 @@
+import { type LayoutPreset, type StreamwallRole } from 'streamwall-shared'
+import { styled } from 'styled-components'
+import { ThemeToggle } from '../globalStyle.tsx'
+import { GridSizeControls } from '../GridSizeControls.tsx'
+import { NARROW_BREAKPOINT } from '../layout.tsx'
+import { LayoutPresetControls } from '../LayoutPresetControls.tsx'
+import { ServerVersionLabel } from '../ServerVersionLabel.tsx'
+
+/**
+ * The wall's masthead: brand mark, grid-size breadcrumb + controls, layout
+ * presets, live-count badge, connection/role status, and the theme toggle.
+ * Extracted from ControlUI's composition root unchanged (issue #393).
+ */
+export function ControlHeader({
+  cols,
+  rows,
+  role,
+  onSetGridSize,
+  presets,
+  onSavePreset,
+  onLoadPreset,
+  onDeletePreset,
+  liveCount,
+  isConnected,
+  serverVersion,
+}: {
+  cols: number | null
+  rows: number | null
+  role: StreamwallRole | null
+  onSetGridSize: (cols: number, rows: number) => void
+  presets: LayoutPreset[]
+  onSavePreset: (name: string) => void
+  onLoadPreset: (presetId: string) => void
+  onDeletePreset: (presetId: string) => void
+  liveCount: number
+  isConnected: boolean
+  serverVersion: string | null
+}) {
+  return (
+    <StyledHeader>
+      <div className="wm">
+        STREAM<span>·</span>WALL
+      </div>
+      <div className="crumbs">
+        //&nbsp; <b>Multiview</b> &nbsp;·&nbsp; {cols}×{rows}
+      </div>
+      {cols != null && rows != null && (
+        <GridSizeControls
+          cols={cols}
+          rows={rows}
+          role={role}
+          onSetGridSize={onSetGridSize}
+        />
+      )}
+      <LayoutPresetControls
+        presets={presets}
+        role={role}
+        onSavePreset={onSavePreset}
+        onLoadPreset={onLoadPreset}
+        onDeletePreset={onDeletePreset}
+      />
+      <div className="spacer" />
+      {liveCount > 0 && <div className="livecount">● {liveCount} On Air</div>}
+      {role !== 'local' && (
+        <div className="status" data-testid="header-connection-status">
+          <span className={`dot ${isConnected ? 'on' : 'off'}`} />
+          {isConnected ? 'connected' : 'connecting...'} · {role}
+          <ServerVersionLabel version={serverVersion} />
+        </div>
+      )}
+      <ThemeToggle />
+    </StyledHeader>
+  )
+}
+
+const StyledHeader = styled.header`
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex: 0 0 auto;
+  position: relative;
+  padding: 4px 2px 14px;
+  margin-bottom: 14px;
+
+  /* Stencil-editorial anchor: a red rule that runs out into the border line. */
+  &::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 2px;
+    background: linear-gradient(
+      90deg,
+      var(--accent) 0 132px,
+      var(--border) 132px
+    );
+  }
+
+  .wm {
+    font-family: var(--font-display);
+    font-size: 27px;
+    line-height: 1;
+    letter-spacing: 0.03em;
+    color: var(--text);
+    white-space: nowrap;
+  }
+  .wm span {
+    color: var(--accent);
+  }
+
+  .crumbs {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    letter-spacing: 0.04em;
+    color: var(--text-faint);
+  }
+  .crumbs b {
+    color: var(--text-dim);
+    font-weight: 500;
+  }
+
+  .spacer {
+    flex: 1;
+  }
+
+  .livecount {
+    font-family: 'Oswald', var(--font-ui);
+    text-transform: uppercase;
+    font-weight: 600;
+    font-size: 13px;
+    letter-spacing: 0.12em;
+    color: var(--accent);
+    border: 1px solid var(--accent);
+    background: var(--accent-soft);
+    padding: 5px 11px;
+  }
+
+  .status {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.02em;
+    color: var(--text-dim);
+    text-transform: uppercase;
+  }
+  .status .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+  }
+  .status .dot.on {
+    background: var(--ok);
+  }
+  .status .dot.off {
+    background: var(--text-faint);
+  }
+
+  /* On narrow screens the header controls no longer fit on one line - let them
+     wrap instead of overflowing the viewport (see #81). */
+  @media (max-width: ${NARROW_BREAKPOINT}px) {
+    flex-wrap: wrap;
+    gap: 10px 14px;
+  }
+`

--- a/packages/streamwall-control-ui/src/components/ControlSidebar.tsx
+++ b/packages/streamwall-control-ui/src/components/ControlSidebar.tsx
@@ -1,0 +1,222 @@
+import { type JSX } from 'preact'
+import { useCallback } from 'preact/hooks'
+import {
+  type InvitableRole,
+  inviteLink,
+  type LocalStreamData,
+  roleCan,
+  type StreamData,
+  type StreamwallRole,
+  type StreamwallState,
+} from 'streamwall-shared'
+import { styled } from 'styled-components'
+import { AuthTokenLine, CreateInviteInput } from '../AccessPanel.tsx'
+import { type Invite } from '../invite.ts'
+import { Stack } from '../layout.tsx'
+import {
+  CreateCustomStreamInput,
+  CustomStreamInput,
+  StreamList,
+} from '../Sidebar.tsx'
+import { StyledDataContainer } from '../StyledButton.tsx'
+
+/**
+ * The right-hand stream list column: the filter box, the four categorized
+ * stream lists (favorites/viewing/live/offline), custom-stream management, and
+ * the access/invite panel. Extracted from ControlUI's composition root
+ * unchanged (issue #393).
+ */
+export function ControlSidebar({
+  role,
+  isConnected,
+  streamFilter,
+  onStreamFilterChange,
+  favoriteStreams,
+  wallStreams,
+  liveStreams,
+  otherStreams,
+  favoritesSet,
+  onClickId,
+  onToggleFavorite,
+  customStreams,
+  onChangeCustomStream,
+  onDeleteCustomStream,
+  authState,
+  newInvite,
+  onCreateInvite,
+  onDeleteToken,
+}: {
+  role: StreamwallRole | null
+  isConnected: boolean
+  streamFilter: string
+  onStreamFilterChange: JSX.InputEventHandler<HTMLInputElement>
+  favoriteStreams: StreamData[]
+  wallStreams: StreamData[]
+  liveStreams: StreamData[]
+  otherStreams: StreamData[]
+  favoritesSet: ReadonlySet<string>
+  onClickId: (streamId: string) => void
+  onToggleFavorite: (url: string) => void
+  customStreams: StreamData[]
+  onChangeCustomStream: (url: string, customStream: LocalStreamData) => void
+  onDeleteCustomStream: (url: string) => void
+  authState: StreamwallState['auth'] | undefined
+  newInvite: Invite | undefined
+  onCreateInvite: (args: { name: string; role: InvitableRole }) => void
+  onDeleteToken: (tokenId: string) => void
+}) {
+  const preventLinkClick = useCallback((ev: Event) => {
+    ev.preventDefault()
+  }, [])
+
+  // Favoriting is hidden entirely for roles that can't add favorites, matching
+  // the previous inline gating in ControlUI.
+  const toggleFavoriteHandler = roleCan(role, 'add-favorite')
+    ? onToggleFavorite
+    : undefined
+
+  return (
+    <Stack className="stream-list" $scroll={true} $minHeight={200}>
+      {
+        // Keyed on `role` (persists across a reconnect, see
+        // `StreamwallConnection`) rather than `isConnected`, so a brief
+        // disconnect dims the last-known list instead of replacing it with
+        // "loading..." (issue #37). Only the very first load, before any
+        // state has ever arrived, shows the loading placeholder.
+      }
+      <StyledDataContainer $isConnected={isConnected}>
+        {role != null ? (
+          <div>
+            <input
+              className="filter-input"
+              onChange={onStreamFilterChange}
+              value={streamFilter}
+              placeholder="Filter streams…"
+            />
+            <h3>
+              Favorites <span className="ct">{favoriteStreams.length}</span>
+            </h3>
+            <StreamList
+              rows={favoriteStreams}
+              disabled={!roleCan(role, 'mutate-state-doc')}
+              onClickId={onClickId}
+              favorites={favoritesSet}
+              onToggleFavorite={toggleFavoriteHandler}
+            />
+            <h3>
+              Viewing <span className="ct">{wallStreams.length}</span>
+            </h3>
+            <StreamList
+              rows={wallStreams}
+              disabled={!roleCan(role, 'mutate-state-doc')}
+              onClickId={onClickId}
+              favorites={favoritesSet}
+              onToggleFavorite={toggleFavoriteHandler}
+            />
+            <h3>
+              Live <span className="ct">{liveStreams.length}</span>
+            </h3>
+            <StreamList
+              rows={liveStreams}
+              disabled={!roleCan(role, 'mutate-state-doc')}
+              onClickId={onClickId}
+              favorites={favoritesSet}
+              onToggleFavorite={toggleFavoriteHandler}
+            />
+            <h3>
+              Offline / Unknown{' '}
+              <span className="ct">{otherStreams.length}</span>
+            </h3>
+            <StreamList
+              rows={otherStreams}
+              disabled={!roleCan(role, 'mutate-state-doc')}
+              onClickId={onClickId}
+              favorites={favoritesSet}
+              onToggleFavorite={toggleFavoriteHandler}
+            />
+          </div>
+        ) : (
+          <div>loading...</div>
+        )}
+        {roleCan(role, 'update-custom-stream') &&
+          roleCan(role, 'delete-custom-stream') && (
+            <>
+              <h2>Custom Streams</h2>
+              <div>
+                {/*
+                  Keyed by `link` (each custom stream's stable id) rather
+                  than array index, so deleting an earlier entry doesn't
+                  shift later entries onto a different DOM node mid-edit.
+                */}
+                {customStreams.map(({ link, label, kind }) => (
+                  <CustomStreamInput
+                    key={link}
+                    link={link}
+                    label={label}
+                    kind={kind}
+                    onChange={onChangeCustomStream}
+                    onDelete={onDeleteCustomStream}
+                  />
+                ))}
+                <CreateCustomStreamInput onCreate={onChangeCustomStream} />
+              </div>
+            </>
+          )}
+        {(roleCan(role, 'create-invite') || roleCan(role, 'delete-token')) &&
+          authState && (
+            <>
+              <h2>Access</h2>
+              <div>
+                <CreateInviteInput onCreateInvite={onCreateInvite} />
+                <h3>Invites</h3>
+                {newInvite && (
+                  <StyledNewInviteBox>
+                    Invite link created:{' '}
+                    <a
+                      href={inviteLink({
+                        tokenId: newInvite.tokenId,
+                        secret: newInvite.secret,
+                      })}
+                      onClick={preventLinkClick}
+                    >
+                      "{newInvite.name}"
+                    </a>
+                  </StyledNewInviteBox>
+                )}
+                {authState.invites.map(({ tokenId, name, role }) => (
+                  <AuthTokenLine
+                    key={tokenId}
+                    id={tokenId}
+                    name={name}
+                    role={role}
+                    onDelete={onDeleteToken}
+                  />
+                ))}
+                <h3>Sessions</h3>
+                {authState.sessions.map(({ tokenId, name, role }) => (
+                  <AuthTokenLine
+                    key={tokenId}
+                    id={tokenId}
+                    name={name}
+                    role={role}
+                    onDelete={onDeleteToken}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+      </StyledDataContainer>
+    </Stack>
+  )
+}
+
+const StyledNewInviteBox = styled.div`
+  display: block;
+  padding: 10px 12px;
+  margin: 8px 0;
+  border-radius: var(--r-md);
+  background: color-mix(in srgb, var(--ok) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ok) 45%, transparent);
+  color: var(--text);
+  font-size: 13px;
+`

--- a/packages/streamwall-control-ui/src/components/ControlStatusBar.tsx
+++ b/packages/streamwall-control-ui/src/components/ControlStatusBar.tsx
@@ -1,0 +1,84 @@
+import { type JSX } from 'preact'
+import { useCallback } from 'preact/hooks'
+import { roleCan, type StreamwallRole } from 'streamwall-shared'
+import { styled } from 'styled-components'
+
+/**
+ * The wall column's footer bar: the debug-tools toggle (shown only to roles
+ * that can use it) and the source/live counts. Extracted from ControlUI's
+ * composition root unchanged (issue #393).
+ */
+export function ControlStatusBar({
+  role,
+  showDebug,
+  onSetShowDebug,
+  sourceCount,
+  liveCount,
+}: {
+  role: StreamwallRole | null
+  showDebug: boolean
+  onSetShowDebug: (showDebug: boolean) => void
+  sourceCount: number
+  liveCount: number
+}) {
+  const handleChangeShowDebug = useCallback<
+    JSX.InputEventHandler<HTMLInputElement>
+  >(
+    (ev) => {
+      onSetShowDebug(ev.currentTarget.checked)
+    },
+    [onSetShowDebug],
+  )
+  return (
+    <StyledStatusBar>
+      {(roleCan(role, 'dev-tools') || roleCan(role, 'browse')) && (
+        <label className="dbg">
+          <input
+            type="checkbox"
+            checked={showDebug}
+            onChange={handleChangeShowDebug}
+          />
+          Debug-Tools
+        </label>
+      )}
+      <span className="spacer" />
+      <span className="meta">
+        {sourceCount} sources · {liveCount} live
+      </span>
+    </StyledStatusBar>
+  )
+}
+
+const StyledStatusBar = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex: 0 0 auto;
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-dim);
+
+  .spacer {
+    flex: 1;
+  }
+
+  .meta {
+    color: var(--text-faint);
+  }
+
+  label.dbg {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  label.dbg input {
+    accent-color: var(--accent);
+  }
+`

--- a/packages/streamwall-control-ui/src/components/StreamDelayBox.tsx
+++ b/packages/streamwall-control-ui/src/components/StreamDelayBox.tsx
@@ -1,0 +1,103 @@
+import { DateTime } from 'luxon'
+import { useCallback, useEffect, useState } from 'preact/hooks'
+import {
+  roleCan,
+  type StreamDelayStatus,
+  type StreamwallRole,
+} from 'streamwall-shared'
+import { styled } from 'styled-components'
+import { matchesState } from 'xstate'
+import { StyledButton } from '../StyledButton.tsx'
+
+function StreamDurationClock({ startTime }: { startTime: number }) {
+  const [now, setNow] = useState(() => DateTime.now())
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setNow(DateTime.now())
+    }, 500)
+    return () => {
+      clearInterval(interval)
+    }
+  }, [startTime])
+  return (
+    <span>{now.diff(DateTime.fromMillis(startTime)).toFormat('hh:mm:ss')}</span>
+  )
+}
+
+/**
+ * The Streamdelay control strip: shows connection/running state and the delay
+ * duration, and (role permitting) the censor and start/stop-stream buttons.
+ * Extracted from ControlUI's composition root unchanged (issue #393).
+ */
+export function StreamDelayBox({
+  role,
+  delayState,
+  setStreamCensored,
+  setStreamRunning,
+}: {
+  role: StreamwallRole | null
+  delayState: StreamDelayStatus
+  setStreamCensored: (isCensored: boolean) => void
+  setStreamRunning: (isStreamRunning: boolean) => void
+}) {
+  const handleToggleStreamCensored = useCallback(() => {
+    setStreamCensored(!delayState.isCensored)
+  }, [delayState.isCensored, setStreamCensored])
+  const handleToggleStreamRunning = useCallback(() => {
+    if (!delayState.isStreamRunning || confirm('End stream?')) {
+      setStreamRunning(!delayState.isStreamRunning)
+    }
+  }, [delayState.isStreamRunning, setStreamRunning])
+  let buttonText
+  if (delayState.isConnected) {
+    if (matchesState('censorship.censored.deactivating', delayState.state)) {
+      buttonText = 'Deactivating...'
+    } else if (delayState.isCensored) {
+      buttonText = 'Uncensor stream'
+    } else {
+      buttonText = 'Censor stream'
+    }
+  }
+  return (
+    <div>
+      <StyledStreamDelayBox>
+        <strong>Streamdelay</strong>
+        {!delayState.isConnected && <span>connecting...</span>}
+        {!delayState.isStreamRunning && <span>stream stopped</span>}
+        {delayState.isConnected && (
+          <>
+            {delayState.startTime !== null && (
+              <StreamDurationClock startTime={delayState.startTime} />
+            )}
+            <span>delay: {delayState.delaySeconds}s</span>
+            {delayState.isStreamRunning && (
+              <StyledButton
+                $isActive={delayState.isCensored}
+                onClick={handleToggleStreamCensored}
+              >
+                {buttonText}
+              </StyledButton>
+            )}
+            {roleCan(role, 'set-stream-running') && (
+              <StyledButton onClick={handleToggleStreamRunning}>
+                {delayState.isStreamRunning ? 'End stream' : 'Start stream'}
+              </StyledButton>
+            )}
+          </>
+        )}
+      </StyledStreamDelayBox>
+    </div>
+  )
+}
+
+const StyledStreamDelayBox = styled.div`
+  display: inline-flex;
+  align-items: center;
+  margin: 5px 0;
+  padding: 10px 12px;
+  gap: 1em;
+  border-radius: var(--r-md);
+  background: var(--accent-soft);
+  border: 1px solid var(--accent);
+  color: var(--text);
+`

--- a/packages/streamwall-control-ui/src/hooks/useControlHotkeys.ts
+++ b/packages/streamwall-control-ui/src/hooks/useControlHotkeys.ts
@@ -1,0 +1,143 @@
+import { useCallback } from 'preact/hooks'
+import { useHotkeys } from 'react-hotkeys-hook'
+import { roleCan, type StreamwallRole } from 'streamwall-shared'
+import type * as Y from 'yjs'
+import {
+  blurHotkeyLayerBindings,
+  hotkeyLayerBindings,
+  hotkeyTriggers,
+} from '../hotkeyLabel.ts'
+import { type ViewInfo } from '../streamwallState.tsx'
+
+/**
+ * Registers ControlUI's global keyboard shortcuts: the two-layer alt-key
+ * audio-listen and blur toggles, the censor shortcuts, the focused-cell swap
+ * (role-gated), and undo/redo on the shared views doc. Extracted from the
+ * composition root so the shortcut wiring lives in one place (issue #393);
+ * behavior — including the `enableOnFormTags` options and role gating — is
+ * unchanged.
+ */
+export function useControlHotkeys({
+  stateIdxMap,
+  focusedInputIdx,
+  role,
+  handleSetListening,
+  handleSetBlurred,
+  setStreamCensored,
+  handleSwapView,
+  undoManager,
+}: {
+  stateIdxMap: Map<number, ViewInfo>
+  focusedInputIdx: number | undefined
+  role: StreamwallRole | null
+  handleSetListening: (idx: number, listening: boolean) => void
+  handleSetBlurred: (idx: number, blurred: boolean) => void
+  setStreamCensored: (isCensored: boolean) => void
+  handleSwapView: (idx: number) => void
+  undoManager: Y.UndoManager | undefined
+}) {
+  const toggleListening = useCallback(
+    (idx: number) => {
+      const isListening = stateIdxMap.get(idx)?.isListening ?? false
+      handleSetListening(idx, !isListening)
+    },
+    [stateIdxMap, handleSetListening],
+  )
+  // Audio-listen toggle, layer 0: alt+<key> -> cells 0-19. `enableOnFormTags`
+  // keeps the hotkey live while a grid input is focused.
+  useHotkeys(
+    hotkeyLayerBindings[0],
+    (ev, { hotkey }) => {
+      ev.preventDefault()
+      toggleListening(hotkeyTriggers.indexOf(hotkey[hotkey.length - 1]))
+    },
+    { enableOnFormTags: true },
+    [toggleListening],
+  )
+  // Audio-listen toggle, layer 1: alt+ctrl+<key> -> cells 20-39 (see
+  // `hotkeyLayers`). Same trigger keys, offset by one layer of 20 cells.
+  useHotkeys(
+    hotkeyLayerBindings[1],
+    (ev, { hotkey }) => {
+      ev.preventDefault()
+      toggleListening(
+        hotkeyTriggers.length +
+          hotkeyTriggers.indexOf(hotkey[hotkey.length - 1]),
+      )
+    },
+    { enableOnFormTags: true },
+    [toggleListening],
+  )
+  const toggleBlurred = useCallback(
+    (idx: number) => {
+      const isBlurred = stateIdxMap.get(idx)?.isBlurred ?? false
+      handleSetBlurred(idx, !isBlurred)
+    },
+    [stateIdxMap, handleSetBlurred],
+  )
+  // Blur toggle, layer 0: alt+shift+<key> -> cells 0-19.
+  useHotkeys(
+    blurHotkeyLayerBindings[0],
+    (ev, { hotkey }) => {
+      ev.preventDefault()
+      toggleBlurred(hotkeyTriggers.indexOf(hotkey[hotkey.length - 1]))
+    },
+    [toggleBlurred],
+  )
+  // Blur toggle, layer 1: alt+ctrl+shift+<key> -> cells 20-39 (see
+  // `blurHotkeyLayers`). Same trigger keys, offset by one layer of 20 cells.
+  useHotkeys(
+    blurHotkeyLayerBindings[1],
+    (ev, { hotkey }) => {
+      ev.preventDefault()
+      toggleBlurred(
+        hotkeyTriggers.length +
+          hotkeyTriggers.indexOf(hotkey[hotkey.length - 1]),
+      )
+    },
+    [toggleBlurred],
+  )
+  useHotkeys(
+    `alt+c`,
+    () => {
+      setStreamCensored(true)
+    },
+    [setStreamCensored],
+  )
+  useHotkeys(
+    `alt+shift+c`,
+    () => {
+      setStreamCensored(false)
+    },
+    [setStreamCensored],
+  )
+  useHotkeys(
+    `alt+s`,
+    () => {
+      if (focusedInputIdx != null && roleCan(role, 'mutate-state-doc')) {
+        handleSwapView(focusedInputIdx)
+      }
+    },
+    [handleSwapView, focusedInputIdx, role],
+  )
+  // Undo/redo edits to the shared views doc (drag-move, swap, and destructive
+  // grid-shrink remaps alike - see `useYDoc`'s `remoteOrigin` wiring).
+  // `enableOnFormTags` defaults to false so this doesn't hijack native
+  // undo/redo while a text input (e.g. a grid-size field) is focused.
+  useHotkeys(
+    'mod+z',
+    (ev) => {
+      ev.preventDefault()
+      undoManager?.undo()
+    },
+    [undoManager],
+  )
+  useHotkeys(
+    'mod+shift+z',
+    (ev) => {
+      ev.preventDefault()
+      undoManager?.redo()
+    },
+    [undoManager],
+  )
+}

--- a/packages/streamwall-control-ui/src/hooks/useGridCommands.test.tsx
+++ b/packages/streamwall-control-ui/src/hooks/useGridCommands.test.tsx
@@ -1,0 +1,243 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import type { ControlCommand, StreamData } from 'streamwall-shared'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import * as Y from 'yjs'
+import { type CollabData } from '../collabData.ts'
+import { type Invite } from '../invite.ts'
+import { useGridCommands } from './useGridCommands.ts'
+
+type Commands = ReturnType<typeof useGridCommands>
+
+function makeStream(
+  id: string,
+  overrides: Partial<StreamData> = {},
+): StreamData {
+  return {
+    _id: id,
+    _dataSource: 'test',
+    kind: 'video',
+    link: `https://example.com/${id}`,
+    ...overrides,
+  }
+}
+
+interface Overrides {
+  streams?: StreamData[]
+  sharedState?: CollabData | undefined
+  stateDoc?: Y.Doc
+  cols?: number | null
+  rows?: number | null
+  fullscreenViewIdx?: number | null
+  focusedInputIdx?: number | undefined
+  favoritesSet?: ReadonlySet<string>
+  onInvite?: (invite: Invite) => void
+  onError?: (message: string) => void
+}
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+/** happy-dom does not implement window.confirm, so install a mock for it. */
+function stubConfirm(returnValue: boolean) {
+  const mock = vi.fn().mockReturnValue(returnValue)
+  vi.stubGlobal('confirm', mock)
+  return mock
+}
+
+/**
+ * Render the hook and return its command bag plus the mock `send`. `send`
+ * records the last response callback so invite-flow tests can drive the
+ * server reply.
+ */
+function renderCommands(overrides: Overrides = {}) {
+  const send =
+    vi.fn<(msg: ControlCommand, cb?: (msg: unknown) => void) => void>()
+  let commands: Commands | undefined
+  function Probe() {
+    commands = useGridCommands({
+      send,
+      streams: overrides.streams ?? [],
+      sharedState: overrides.sharedState,
+      stateDoc: overrides.stateDoc ?? new Y.Doc(),
+      cols: overrides.cols ?? 2,
+      rows: overrides.rows ?? 2,
+      fullscreenViewIdx: overrides.fullscreenViewIdx ?? null,
+      focusedInputIdx: overrides.focusedInputIdx,
+      favoritesSet: overrides.favoritesSet ?? new Set(),
+      onInvite: overrides.onInvite ?? (() => {}),
+      onError: overrides.onError ?? (() => {}),
+    })
+    return null
+  }
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    render(<Probe />, container!)
+  })
+  return { commands: commands!, send }
+}
+
+describe('useGridCommands', () => {
+  test('dispatches view commands through send', () => {
+    const { commands, send } = renderCommands()
+    act(() => commands.handleSetListening(3, true))
+    expect(send).toHaveBeenLastCalledWith({
+      type: 'set-listening-view',
+      viewId: 3,
+    })
+    act(() => commands.handleSetListening(3, false))
+    expect(send).toHaveBeenLastCalledWith({
+      type: 'set-listening-view',
+      viewId: null,
+    })
+    act(() => commands.handleSetVolume(1, 0.5))
+    expect(send).toHaveBeenLastCalledWith({
+      type: 'set-view-volume',
+      viewId: 1,
+      volume: 0.5,
+    })
+    act(() => commands.handleReloadView(2))
+    expect(send).toHaveBeenLastCalledWith({ type: 'reload-view', viewId: 2 })
+  })
+
+  test('derives the fullscreen flag from the current fullscreen index', () => {
+    const notFull = renderCommands({ fullscreenViewIdx: null })
+    act(() => notFull.commands.handleToggleFullscreen(0))
+    expect(notFull.send).toHaveBeenLastCalledWith({
+      type: 'set-view-fullscreen',
+      viewId: 0,
+      fullscreen: true,
+    })
+
+    const full = renderCommands({ fullscreenViewIdx: 0 })
+    act(() => full.commands.handleToggleFullscreen(0))
+    expect(full.send).toHaveBeenLastCalledWith({
+      type: 'set-view-fullscreen',
+      viewId: 0,
+      fullscreen: false,
+    })
+  })
+
+  test('resolves browse/rotate by stream id and no-ops for unknown ids', () => {
+    const stream = makeStream('a', { link: 'https://x/a', rotation: 90 })
+    const { commands, send } = renderCommands({ streams: [stream] })
+    act(() => commands.handleBrowse('a'))
+    expect(send).toHaveBeenLastCalledWith({
+      type: 'browse',
+      url: 'https://x/a',
+    })
+    act(() => commands.handleRotateStream('a'))
+    expect(send).toHaveBeenLastCalledWith({
+      type: 'rotate-stream',
+      url: 'https://x/a',
+      rotation: 180,
+    })
+    send.mockClear()
+    act(() => commands.handleBrowse('missing'))
+    act(() => commands.handleRotateStream('missing'))
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  test('clamps grid size and confirms before a destructive shrink', () => {
+    const sharedState = {
+      views: { 0: { streamId: 'a' }, 3: { streamId: 'b' } },
+    } as unknown as CollabData
+    const confirmMock = stubConfirm(false)
+    const { commands, send } = renderCommands({ cols: 2, sharedState })
+
+    // Shrinking 2x2 -> 1x1 would drop the occupied cell at index 3; a declined
+    // confirm cancels the command.
+    act(() => commands.handleSetGridSize(1, 1))
+    expect(confirmMock).toHaveBeenCalledTimes(1)
+    expect(send).not.toHaveBeenCalled()
+
+    // Accepting the confirm lets it through.
+    confirmMock.mockReturnValue(true)
+    act(() => commands.handleSetGridSize(1, 1))
+    expect(send).toHaveBeenLastCalledWith({
+      type: 'set-grid-size',
+      cols: 1,
+      rows: 1,
+    })
+  })
+
+  test('confirms before loading a preset over a populated layout', () => {
+    const sharedState = {
+      views: { 0: { streamId: 'a' } },
+    } as unknown as CollabData
+    const confirmMock = stubConfirm(false)
+    const { commands, send } = renderCommands({ sharedState })
+    act(() => commands.handleLoadLayoutPreset('p1'))
+    expect(confirmMock).toHaveBeenCalledTimes(1)
+    expect(send).not.toHaveBeenCalled()
+
+    confirmMock.mockReturnValue(true)
+    act(() => commands.handleLoadLayoutPreset('p1'))
+    expect(send).toHaveBeenLastCalledWith({
+      type: 'load-layout-preset',
+      presetId: 'p1',
+    })
+  })
+
+  test('toggles favorites based on the current favorites set', () => {
+    const { commands, send } = renderCommands({
+      favoritesSet: new Set(['https://fav/x']),
+    })
+    act(() => commands.handleToggleFavorite('https://fav/x'))
+    expect(send).toHaveBeenLastCalledWith({
+      type: 'remove-favorite',
+      url: 'https://fav/x',
+    })
+    act(() => commands.handleToggleFavorite('https://new/y'))
+    expect(send).toHaveBeenLastCalledWith({
+      type: 'add-favorite',
+      url: 'https://new/y',
+    })
+  })
+
+  test('surfaces a valid invite response and reports a malformed one', () => {
+    const onInvite = vi.fn()
+    const onError = vi.fn()
+    const { commands, send } = renderCommands({ onInvite, onError })
+
+    act(() => commands.handleCreateInvite({ name: 'Guest', role: 'operator' }))
+    const cb = send.mock.calls.at(-1)?.[1]
+    expect(cb).toBeTypeOf('function')
+
+    act(() => cb!({ tokenId: 't1', name: 'Guest', secret: 's1' }))
+    expect(onInvite).toHaveBeenCalledWith({
+      tokenId: 't1',
+      name: 'Guest',
+      secret: 's1',
+    })
+    expect(onError).not.toHaveBeenCalled()
+
+    act(() => cb!({ bogus: true }))
+    expect(onError).toHaveBeenCalledWith(
+      'Received a malformed invite response from the server',
+    )
+  })
+
+  test('writes the resolved stream id into the shared views doc', () => {
+    const stateDoc = new Y.Doc()
+    const views = stateDoc.getMap<Y.Map<string | undefined>>('views')
+    const cell = new Y.Map<string | undefined>()
+    views.set('0', cell)
+    const { commands } = renderCommands({
+      stateDoc,
+      streams: [makeStream('a')],
+    })
+    act(() => commands.handleSetView(0, 'a'))
+    expect(cell.get('streamId')).toBe('a')
+  })
+})

--- a/packages/streamwall-control-ui/src/hooks/useGridCommands.ts
+++ b/packages/streamwall-control-ui/src/hooks/useGridCommands.ts
@@ -1,0 +1,374 @@
+import { useCallback } from 'preact/hooks'
+import {
+  clampGridDimension,
+  type ControlCommand,
+  gridWouldDropAssignments,
+  hasGridAssignments,
+  type InvitableRole,
+  type LocalStreamData,
+  type StreamData,
+} from 'streamwall-shared'
+import * as Y from 'yjs'
+import { copyTextToClipboard } from '../clipboard.ts'
+import { type CollabData } from '../collabData.ts'
+import { type Invite, parseInviteResponse } from '../invite.ts'
+import {
+  resolveEagerWriteStreamId,
+  resolveTargetViewIdx,
+} from '../viewPlacement.ts'
+
+/**
+ * The imperative command layer for ControlUI: every wrapper that dispatches a
+ * `ControlCommand` through `send` or mutates the shared views doc. Grouping
+ * them here keeps the composition root free of dispatch logic and makes the
+ * command handlers unit-testable in isolation with a mock `send` (issue #393).
+ *
+ * The two grid-shrinking guards (`handleSetGridSize`, `handleLoadLayoutPreset`)
+ * intentionally still call `window.confirm` before a destructive change, and
+ * `handleClickId`/`handleCreateInvite` reach out to the clipboard and invite
+ * parser exactly as they did inline — behavior is unchanged.
+ */
+export function useGridCommands({
+  send,
+  streams,
+  sharedState,
+  stateDoc,
+  cols,
+  rows,
+  fullscreenViewIdx,
+  focusedInputIdx,
+  favoritesSet,
+  onInvite,
+  onError,
+}: {
+  send: (msg: ControlCommand, cb?: (msg: unknown) => void) => void
+  streams: StreamData[]
+  sharedState: CollabData | undefined
+  stateDoc: Y.Doc
+  cols: number | null
+  rows: number | null
+  fullscreenViewIdx: number | null
+  focusedInputIdx: number | undefined
+  favoritesSet: ReadonlySet<string>
+  onInvite: (invite: Invite) => void
+  onError: (message: string) => void
+}) {
+  const handleSetView = useCallback(
+    (idx: number, streamId: string) => {
+      const resolved = resolveEagerWriteStreamId(streams, streamId)
+      if (resolved === undefined) {
+        return
+      }
+      stateDoc
+        .getMap<Y.Map<string | undefined>>('views')
+        .get(String(idx))
+        ?.set('streamId', resolved)
+    },
+    [stateDoc, streams],
+  )
+
+  const handleSetListening = useCallback(
+    (viewId: number, listening: boolean) => {
+      send({
+        type: 'set-listening-view',
+        viewId: listening ? viewId : null,
+      })
+    },
+    [send],
+  )
+
+  // Double-clicking a stream tile expands it to fill the whole wall; double-
+  // clicking again (any tile, since only the expanded one is shown) collapses
+  // back to the grid. Purely runtime state -- the persisted layout is untouched
+  // (issue #362).
+  const handleToggleFullscreen = useCallback(
+    (viewId: number) => {
+      send({
+        type: 'set-view-fullscreen',
+        viewId,
+        fullscreen: fullscreenViewIdx == null,
+      })
+    },
+    [send, fullscreenViewIdx],
+  )
+
+  const handleSetGridSize = useCallback(
+    (nextCols: number, nextRows: number) => {
+      const targetCols = clampGridDimension(nextCols)
+      const targetRows = clampGridDimension(nextRows)
+      // Shrinking the grid permanently drops any placement whose (x, y) no
+      // longer fits. Warn before that happens so it is never silent.
+      if (cols != null && sharedState) {
+        const assignments = new Map<number, string | undefined>()
+        for (const [idx, view] of Object.entries(sharedState.views)) {
+          assignments.set(Number(idx), view.streamId)
+        }
+        if (
+          gridWouldDropAssignments(cols, targetCols, targetRows, assignments) &&
+          !window.confirm(
+            'The new grid is smaller and will permanently remove occupied tiles. Continue?',
+          )
+        ) {
+          return
+        }
+      }
+      send({
+        type: 'set-grid-size',
+        cols: targetCols,
+        rows: targetRows,
+      })
+    },
+    [send, cols, sharedState],
+  )
+
+  const handleSetBackgroundListening = useCallback(
+    (viewId: number, listening: boolean) => {
+      send({
+        type: 'set-view-background-listening',
+        viewId,
+        listening,
+      })
+    },
+    [send],
+  )
+
+  const handleSetBlurred = useCallback(
+    (viewId: number, blurred: boolean) => {
+      send({
+        type: 'set-view-blurred',
+        viewId,
+        blurred,
+      })
+    },
+    [send],
+  )
+
+  const handleSetVolume = useCallback(
+    (viewId: number, volume: number) => {
+      send({
+        type: 'set-view-volume',
+        viewId,
+        volume,
+      })
+    },
+    [send],
+  )
+
+  const handleReloadView = useCallback(
+    (viewId: number) => {
+      send({
+        type: 'reload-view',
+        viewId,
+      })
+    },
+    [send],
+  )
+
+  const handleRotateStream = useCallback(
+    (streamId: string) => {
+      const stream = streams.find((d) => d._id === streamId)
+      if (!stream) {
+        return
+      }
+      send({
+        type: 'rotate-stream',
+        url: stream.link,
+        rotation: ((stream.rotation || 0) + 90) % 360,
+      })
+    },
+    [streams, send],
+  )
+
+  const handleBrowse = useCallback(
+    (streamId: string) => {
+      const stream = streams.find((d) => d._id === streamId)
+      if (!stream) {
+        return
+      }
+      send({
+        type: 'browse',
+        url: stream.link,
+      })
+    },
+    [streams, send],
+  )
+
+  const handleDevTools = useCallback(
+    (viewId: number) => {
+      send({
+        type: 'dev-tools',
+        viewId,
+      })
+    },
+    [send],
+  )
+
+  const handleClickId = useCallback(
+    (streamId: string) => {
+      if (cols == null || rows == null || sharedState == null) {
+        return
+      }
+
+      copyTextToClipboard(streamId)
+
+      const targetIdx = resolveTargetViewIdx({
+        views: sharedState.views,
+        cellCount: cols * rows,
+        focusedInputIdx,
+      })
+      if (targetIdx === undefined) {
+        return
+      }
+      handleSetView(targetIdx, streamId)
+    },
+    [cols, rows, sharedState, focusedInputIdx, handleSetView],
+  )
+
+  const handleChangeCustomStream = useCallback(
+    (url: string, customStream: LocalStreamData) => {
+      send({
+        type: 'update-custom-stream',
+        url,
+        data: customStream,
+      })
+    },
+    [send],
+  )
+
+  const handleDeleteCustomStream = useCallback(
+    (url: string) => {
+      send({
+        type: 'delete-custom-stream',
+        url,
+      })
+      return
+    },
+    [send],
+  )
+
+  const setStreamCensored = useCallback(
+    (isCensored: boolean) => {
+      send({
+        type: 'set-stream-censored',
+        isCensored,
+      })
+    },
+    [send],
+  )
+
+  const setStreamRunning = useCallback(
+    (isStreamRunning: boolean) => {
+      send({
+        type: 'set-stream-running',
+        isStreamRunning,
+      })
+    },
+    [send],
+  )
+
+  const handleCreateInvite = useCallback(
+    ({ name, role }: { name: string; role: InvitableRole }) => {
+      send(
+        {
+          type: 'create-invite',
+          name,
+          role,
+        },
+        (msg) => {
+          const invite = parseInviteResponse(msg)
+          if (!invite) {
+            onError('Received a malformed invite response from the server')
+            return
+          }
+          onInvite(invite)
+        },
+      )
+    },
+    [send, onError, onInvite],
+  )
+
+  const handleDeleteToken = useCallback(
+    (tokenId: string) => {
+      send({
+        type: 'delete-token',
+        tokenId,
+      })
+    },
+    [send],
+  )
+
+  const handleSaveLayoutPreset = useCallback(
+    (name: string) => {
+      send({ type: 'save-layout-preset', name })
+    },
+    [send],
+  )
+
+  const handleLoadLayoutPreset = useCallback(
+    (presetId: string) => {
+      // Loading a preset unconditionally replaces every cell (see
+      // applyLayoutPreset), unlike a grid resize which only drops cells that
+      // fall outside the new bounds. So warn whenever the current layout has
+      // any live assignment, mirroring handleSetGridSize's confirm above.
+      if (sharedState) {
+        const assignments = new Map<number, string | undefined>()
+        for (const [idx, view] of Object.entries(sharedState.views)) {
+          assignments.set(Number(idx), view.streamId)
+        }
+        if (
+          hasGridAssignments(assignments) &&
+          !window.confirm(
+            'Loading this preset will replace the current layout. Save it as a preset first if you want to keep it. Continue?',
+          )
+        ) {
+          return
+        }
+      }
+      send({ type: 'load-layout-preset', presetId })
+    },
+    [send, sharedState],
+  )
+
+  const handleDeleteLayoutPreset = useCallback(
+    (presetId: string) => {
+      send({ type: 'delete-layout-preset', presetId })
+    },
+    [send],
+  )
+
+  const handleToggleFavorite = useCallback(
+    (url: string) => {
+      if (favoritesSet.has(url)) {
+        send({ type: 'remove-favorite', url })
+      } else {
+        send({ type: 'add-favorite', url })
+      }
+    },
+    [send, favoritesSet],
+  )
+
+  return {
+    handleSetView,
+    handleSetListening,
+    handleToggleFullscreen,
+    handleSetGridSize,
+    handleSetBackgroundListening,
+    handleSetBlurred,
+    handleSetVolume,
+    handleReloadView,
+    handleRotateStream,
+    handleBrowse,
+    handleDevTools,
+    handleClickId,
+    handleChangeCustomStream,
+    handleDeleteCustomStream,
+    setStreamCensored,
+    setStreamRunning,
+    handleCreateInvite,
+    handleDeleteToken,
+    handleSaveLayoutPreset,
+    handleLoadLayoutPreset,
+    handleDeleteLayoutPreset,
+    handleToggleFavorite,
+  }
+}

--- a/packages/streamwall-control-ui/src/hooks/useStreamFilters.test.tsx
+++ b/packages/streamwall-control-ui/src/hooks/useStreamFilters.test.tsx
@@ -1,0 +1,156 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import type { StreamData } from 'streamwall-shared'
+import { afterEach, describe, expect, test } from 'vitest'
+import { type CollabData } from '../collabData.ts'
+import { filterStreams, useStreamFilters } from './useStreamFilters.ts'
+
+function makeStream(
+  id: string,
+  overrides: Partial<StreamData> = {},
+): StreamData {
+  return {
+    _id: id,
+    _dataSource: 'test',
+    kind: 'video',
+    link: `https://example.com/${id}`,
+    ...overrides,
+  }
+}
+
+describe('filterStreams', () => {
+  test('places streams assigned to the wall in the wall bucket', () => {
+    const onWall = makeStream('a')
+    const offWall = makeStream('b')
+    const [wall, live, other] = filterStreams(
+      [onWall, offWall],
+      new Set(['a']),
+      new Set(),
+      '',
+    )
+    expect(wall).toEqual([onWall])
+    expect(live).toEqual([])
+    expect(other).toEqual([offWall])
+  })
+
+  test('treats non-video kinds and Live video as live streams', () => {
+    const audio = makeStream('a', { kind: 'audio' })
+    const web = makeStream('b', { kind: 'web' })
+    const liveVideo = makeStream('c', { kind: 'video', status: 'Live' })
+    const idleVideo = makeStream('d', { kind: 'video' })
+    const [, live, other] = filterStreams(
+      [audio, web, liveVideo, idleVideo],
+      new Set(),
+      new Set(),
+      '',
+    )
+    expect(live).toEqual([audio, web, liveVideo])
+    expect(other).toEqual([idleVideo])
+  })
+
+  test('drops kinds outside the normal video/audio/web set entirely', () => {
+    const overlay = makeStream('a', {
+      kind: 'background' as StreamData['kind'],
+    })
+    const video = makeStream('b')
+    const [wall, live, other, favorites] = filterStreams(
+      [overlay, video],
+      new Set(),
+      new Set(),
+      '',
+    )
+    expect([...wall, ...live, ...other, ...favorites]).toEqual([video])
+  })
+
+  test('collects favorites by link independently of the primary bucket', () => {
+    const fav = makeStream('a', { link: 'https://fav.example/x' })
+    const notFav = makeStream('b')
+    const [, , , favorites] = filterStreams(
+      [fav, notFav],
+      new Set(),
+      new Set(['https://fav.example/x']),
+      '',
+    )
+    expect(favorites).toEqual([fav])
+  })
+
+  test('matches the filter case-insensitively across label/source/state/city', () => {
+    const match = makeStream('a', { city: 'Portland' })
+    const miss = makeStream('b', { city: 'Seattle' })
+    const [, , other] = filterStreams(
+      [match, miss],
+      new Set(),
+      new Set(),
+      'portl',
+    )
+    expect(other).toEqual([match])
+  })
+
+  test('an empty filter keeps every stream', () => {
+    const streams = [makeStream('a'), makeStream('b', { kind: 'audio' })]
+    const [, live, other] = filterStreams(streams, new Set(), new Set(), '')
+    expect(live.length + other.length).toBe(2)
+  })
+})
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+function Probe({
+  streams,
+  sharedState,
+  favorites,
+}: {
+  streams: StreamData[]
+  sharedState: CollabData | undefined
+  favorites: string[]
+}) {
+  const { favoritesSet, wallStreams, liveStreams, otherStreams } =
+    useStreamFilters({ streams, sharedState, favorites })
+  return (
+    <div
+      data-testid="probe"
+      data-wall={wallStreams.map((s) => s._id).join(',')}
+      data-live={liveStreams.map((s) => s._id).join(',')}
+      data-other={otherStreams.map((s) => s._id).join(',')}
+      data-favset={[...favoritesSet].join(',')}
+    />
+  )
+}
+
+describe('useStreamFilters', () => {
+  test('derives wall placement from sharedState and exposes the favorites set', () => {
+    const streams = [
+      makeStream('a'),
+      makeStream('b', { kind: 'audio' }),
+      makeStream('c'),
+    ]
+    const sharedState = {
+      views: { 0: { streamId: 'a' } },
+    } as unknown as CollabData
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      render(
+        <Probe
+          streams={streams}
+          sharedState={sharedState}
+          favorites={['https://example.com/c']}
+        />,
+        container!,
+      )
+    })
+    const probe = container.querySelector('[data-testid="probe"]')!
+    expect(probe.getAttribute('data-wall')).toBe('a')
+    expect(probe.getAttribute('data-live')).toBe('b')
+    expect(probe.getAttribute('data-other')).toBe('c')
+    expect(probe.getAttribute('data-favset')).toBe('https://example.com/c')
+  })
+})

--- a/packages/streamwall-control-ui/src/hooks/useStreamFilters.ts
+++ b/packages/streamwall-control-ui/src/hooks/useStreamFilters.ts
@@ -1,0 +1,98 @@
+import { type JSX } from 'preact'
+import { useCallback, useMemo, useState } from 'preact/hooks'
+import { type StreamData } from 'streamwall-shared'
+import { type CollabData } from '../collabData.ts'
+
+const normalStreamKinds = new Set(['video', 'audio', 'web'])
+
+/**
+ * Partition the visible streams into the four sidebar buckets — streams placed
+ * on the wall, live streams, everything else, and (independently) favorites.
+ * `filter` matches case-insensitively against the label/source/state/city text.
+ * Exported for unit testing; `useStreamFilters` is the component-facing wrapper.
+ */
+export function filterStreams(
+  streams: StreamData[],
+  wallStreamIds: Set<string>,
+  favoriteLinks: ReadonlySet<string>,
+  filter: string,
+): [StreamData[], StreamData[], StreamData[], StreamData[]] {
+  const wallStreams = []
+  const liveStreams = []
+  const otherStreams = []
+  const favoriteStreams = []
+  for (const stream of streams) {
+    const { _id, kind, status, label, source, state, city, link } = stream
+    if (kind && !normalStreamKinds.has(kind)) {
+      continue
+    }
+    if (
+      filter !== '' &&
+      !`${label}${source}${state}${city}`
+        .toLowerCase()
+        .includes(filter.toLowerCase())
+    ) {
+      continue
+    }
+    if (favoriteLinks.has(link)) {
+      favoriteStreams.push(stream)
+    }
+    if (wallStreamIds.has(_id)) {
+      wallStreams.push(stream)
+    } else if ((kind && kind !== 'video') || status === 'Live') {
+      liveStreams.push(stream)
+    } else {
+      otherStreams.push(stream)
+    }
+  }
+  return [wallStreams, liveStreams, otherStreams, favoriteStreams]
+}
+
+/**
+ * Owns the sidebar's stream-filter text box and derives the memoized favorites
+ * set, the set of stream ids currently placed on the wall, and the four
+ * partitioned stream buckets the sidebar renders (issue #393).
+ */
+export function useStreamFilters({
+  streams,
+  sharedState,
+  favorites,
+}: {
+  streams: StreamData[]
+  sharedState: CollabData | undefined
+  favorites: string[]
+}) {
+  const [streamFilter, setStreamFilter] = useState('')
+  const handleStreamFilterChange = useCallback<
+    JSX.InputEventHandler<HTMLInputElement>
+  >((ev) => {
+    setStreamFilter(ev.currentTarget?.value)
+  }, [])
+
+  const favoritesSet = useMemo(() => new Set(favorites), [favorites])
+
+  const wallStreamIds = useMemo(
+    () =>
+      new Set(
+        Object.values(sharedState?.views ?? {})
+          .map(({ streamId }) => streamId)
+          .filter((x) => x !== undefined),
+      ),
+    [sharedState],
+  )
+
+  const [wallStreams, liveStreams, otherStreams, favoriteStreams] = useMemo(
+    () => filterStreams(streams, wallStreamIds, favoritesSet, streamFilter),
+    [streams, wallStreamIds, favoritesSet, streamFilter],
+  )
+
+  return {
+    streamFilter,
+    handleStreamFilterChange,
+    favoritesSet,
+    wallStreams,
+    liveStreams,
+    otherStreams,
+    favoriteStreams,
+  }
+}

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -7,108 +7,31 @@ import '@fontsource/jetbrains-mono/500.css'
 import '@fontsource/jetbrains-mono/700.css'
 import '@fontsource/oswald/600.css'
 import '@fontsource/saira-stencil-one'
-import { range } from 'lodash-es'
-import { DateTime } from 'luxon'
-import { type JSX } from 'preact'
-import { useCallback, useEffect, useMemo, useState } from 'preact/hooks'
-import { useHotkeys } from 'react-hotkeys-hook'
-import {
-  clampGridDimension,
-  gridWouldDropAssignments,
-  hasGridAssignments,
-  idColor,
-  type InvitableRole,
-  inviteLink,
-  type LocalStreamData,
-  roleCan,
-  type StreamData,
-  type StreamDelayStatus,
-  type StreamwallRole,
-} from 'streamwall-shared'
-import { styled } from 'styled-components'
-import { matchesState } from 'xstate'
-import * as Y from 'yjs'
-import { AuthTokenLine, CreateInviteInput } from './AccessPanel.tsx'
-import { copyTextToClipboard } from './clipboard.ts'
+import { useCallback, useMemo, useState } from 'preact/hooks'
+import { roleCan } from 'streamwall-shared'
 import { createErrorSurfacingSend } from './commandError.ts'
-import { CommandErrorBanner } from './CommandErrorBanner.tsx'
-import { ConnectionStatusBanner } from './ConnectionStatusBanner.tsx'
-import { DataSourceHealthBanner } from './DataSourceHealthBanner.tsx'
-import { ThemeToggle } from './globalStyle.tsx'
-import { GridControls } from './GridControls.tsx'
-import { GridInput } from './GridInput.tsx'
-import { isIdxInResizeBox } from './gridInteractions'
-import { GridPreviewBox } from './GridPreviewBox.tsx'
-import { GridSizeControls } from './GridSizeControls.tsx'
-import {
-  blurHotkeyLayerBindings,
-  hotkeyLayerBindings,
-  hotkeyTriggers,
-} from './hotkeyLabel.ts'
+import { ControlBanners } from './components/ControlBanners.tsx'
+import { ControlGrid } from './components/ControlGrid.tsx'
+import { ControlHeader } from './components/ControlHeader.tsx'
+import { ControlSidebar } from './components/ControlSidebar.tsx'
+import { ControlStatusBar } from './components/ControlStatusBar.tsx'
+import { StreamDelayBox } from './components/StreamDelayBox.tsx'
+import { useControlHotkeys } from './hooks/useControlHotkeys.ts'
+import { useGridCommands } from './hooks/useGridCommands.ts'
+import { useStreamFilters } from './hooks/useStreamFilters.ts'
 import './index.css'
-import { type Invite, parseInviteResponse } from './invite.ts'
-import { LayoutPresetControls } from './LayoutPresetControls.tsx'
-import { ResizeHandles } from './ResizeHandles.tsx'
-import { ServerUpdateBanner } from './ServerUpdateBanner.tsx'
-import { ServerVersionLabel } from './ServerVersionLabel.tsx'
-import {
-  CreateCustomStreamInput,
-  CustomStreamInput,
-  StreamList,
-} from './Sidebar.tsx'
+import { type Invite } from './invite.ts'
+import { AppShell, Stack } from './layout.tsx'
 import { type StreamwallConnection } from './streamwallState.tsx'
-import { StyledButton, StyledDataContainer } from './StyledButton.tsx'
+import { StyledDataContainer } from './StyledButton.tsx'
 import { useServerStatus } from './useServerStatus.ts'
 import { useTileDrag } from './useTileDrag.ts'
 import { useTileResize } from './useTileResize.ts'
-import {
-  resolveAnchorIdx,
-  resolveEagerWriteStreamId,
-  resolveTargetViewIdx,
-} from './viewPlacement.ts'
 
 // Re-exported for `streamwall-control-client` and `streamwall`'s renderer,
 // which mount it alongside `<ControlUI>` — its implementation now lives in
 // `./globalStyle.tsx` alongside the theme tokens it applies.
 export { GlobalStyle } from './globalStyle.tsx'
-
-const normalStreamKinds = new Set(['video', 'audio', 'web'])
-function filterStreams(
-  streams: StreamData[],
-  wallStreamIds: Set<string>,
-  favoriteLinks: ReadonlySet<string>,
-  filter: string,
-) {
-  const wallStreams = []
-  const liveStreams = []
-  const otherStreams = []
-  const favoriteStreams = []
-  for (const stream of streams) {
-    const { _id, kind, status, label, source, state, city, link } = stream
-    if (kind && !normalStreamKinds.has(kind)) {
-      continue
-    }
-    if (
-      filter !== '' &&
-      !`${label}${source}${state}${city}`
-        .toLowerCase()
-        .includes(filter.toLowerCase())
-    ) {
-      continue
-    }
-    if (favoriteLinks.has(link)) {
-      favoriteStreams.push(stream)
-    }
-    if (wallStreamIds.has(_id)) {
-      wallStreams.push(stream)
-    } else if ((kind && kind !== 'video') || status === 'Live') {
-      liveStreams.push(stream)
-    } else {
-      otherStreams.push(stream)
-    }
-  }
-  return [wallStreams, liveStreams, otherStreams, favoriteStreams]
-}
 
 export { collabDataSchema, type CollabData } from './collabData.ts'
 export {
@@ -172,26 +95,12 @@ export function ControlUI({
   )
 
   const [showDebug, setShowDebug] = useState(false)
-  const handleChangeShowDebug = useCallback<
-    JSX.InputEventHandler<HTMLInputElement>
-  >((ev) => {
-    setShowDebug(ev.currentTarget.checked)
-  }, [])
 
-  const {
-    hoveringIdx,
-    swapStartIdx,
-    moveStart,
-    moveTargetIdx,
-    updateHoveringIdx,
-    clearHoveringIdx,
-    handleSwapView,
-    handleGridPointerDown,
-  } = useTileDrag({ cols, rows, stateDoc, stateIdxMap, role })
-  const { resize, handleResizeStart, handleResizeKeyDown } = useTileResize({
+  const tileDrag = useTileDrag({ cols, rows, stateDoc, stateIdxMap, role })
+  const tileResize = useTileResize({
     cols,
     rows,
-    hoveringIdx,
+    hoveringIdx: tileDrag.hoveringIdx,
     stateDoc,
     sharedState,
     role,
@@ -200,486 +109,89 @@ export function ControlUI({
   const [focusedInputIdx, setFocusedInputIdx] = useState<number | undefined>()
   const handleBlurInput = useCallback(() => setFocusedInputIdx(undefined), [])
 
-  const handleSetView = useCallback(
-    (idx: number, streamId: string) => {
-      const resolved = resolveEagerWriteStreamId(streams, streamId)
-      if (resolved === undefined) {
-        return
-      }
-      stateDoc
-        .getMap<Y.Map<string | undefined>>('views')
-        .get(String(idx))
-        ?.set('streamId', resolved)
-    },
-    [stateDoc, streams],
-  )
-
-  const handleSetListening = useCallback(
-    (viewId: number, listening: boolean) => {
-      send({
-        type: 'set-listening-view',
-        viewId: listening ? viewId : null,
-      })
-    },
-    [send],
-  )
-
-  // Double-clicking a stream tile expands it to fill the whole wall; double-
-  // clicking again (any tile, since only the expanded one is shown) collapses
-  // back to the grid. Purely runtime state -- the persisted layout is untouched
-  // (issue #362).
-  const handleToggleFullscreen = useCallback(
-    (viewId: number) => {
-      send({
-        type: 'set-view-fullscreen',
-        viewId,
-        fullscreen: fullscreenViewIdx == null,
-      })
-    },
-    [send, fullscreenViewIdx],
-  )
-
-  const handleSetGridSize = useCallback(
-    (nextCols: number, nextRows: number) => {
-      const targetCols = clampGridDimension(nextCols)
-      const targetRows = clampGridDimension(nextRows)
-      // Shrinking the grid permanently drops any placement whose (x, y) no
-      // longer fits. Warn before that happens so it is never silent.
-      if (cols != null && sharedState) {
-        const assignments = new Map<number, string | undefined>()
-        for (const [idx, view] of Object.entries(sharedState.views)) {
-          assignments.set(Number(idx), view.streamId)
-        }
-        if (
-          gridWouldDropAssignments(cols, targetCols, targetRows, assignments) &&
-          !window.confirm(
-            'The new grid is smaller and will permanently remove occupied tiles. Continue?',
-          )
-        ) {
-          return
-        }
-      }
-      send({
-        type: 'set-grid-size',
-        cols: targetCols,
-        rows: targetRows,
-      })
-    },
-    [send, cols, sharedState],
-  )
-
-  const handleSetBackgroundListening = useCallback(
-    (viewId: number, listening: boolean) => {
-      send({
-        type: 'set-view-background-listening',
-        viewId,
-        listening,
-      })
-    },
-    [send],
-  )
-
-  const handleSetBlurred = useCallback(
-    (viewId: number, blurred: boolean) => {
-      send({
-        type: 'set-view-blurred',
-        viewId,
-        blurred,
-      })
-    },
-    [send],
-  )
-
-  const handleSetVolume = useCallback(
-    (viewId: number, volume: number) => {
-      send({
-        type: 'set-view-volume',
-        viewId,
-        volume,
-      })
-    },
-    [send],
-  )
-
-  const handleReloadView = useCallback(
-    (viewId: number) => {
-      send({
-        type: 'reload-view',
-        viewId,
-      })
-    },
-    [send],
-  )
-
-  const handleRotateStream = useCallback(
-    (streamId: string) => {
-      const stream = streams.find((d) => d._id === streamId)
-      if (!stream) {
-        return
-      }
-      send({
-        type: 'rotate-stream',
-        url: stream.link,
-        rotation: ((stream.rotation || 0) + 90) % 360,
-      })
-    },
-    [streams, send],
-  )
-
-  const handleBrowse = useCallback(
-    (streamId: string) => {
-      const stream = streams.find((d) => d._id === streamId)
-      if (!stream) {
-        return
-      }
-      send({
-        type: 'browse',
-        url: stream.link,
-      })
-    },
-    [streams, send],
-  )
-
-  const handleDevTools = useCallback(
-    (viewId: number) => {
-      send({
-        type: 'dev-tools',
-        viewId,
-      })
-    },
-    [send],
-  )
-
-  const handleClickId = useCallback(
-    (streamId: string) => {
-      if (cols == null || rows == null || sharedState == null) {
-        return
-      }
-
-      copyTextToClipboard(streamId)
-
-      const targetIdx = resolveTargetViewIdx({
-        views: sharedState.views,
-        cellCount: cols * rows,
-        focusedInputIdx,
-      })
-      if (targetIdx === undefined) {
-        return
-      }
-      handleSetView(targetIdx, streamId)
-    },
-    [cols, rows, sharedState, focusedInputIdx, handleSetView],
-  )
-
-  const handleChangeCustomStream = useCallback(
-    (url: string, customStream: LocalStreamData) => {
-      send({
-        type: 'update-custom-stream',
-        url,
-        data: customStream,
-      })
-    },
-    [send],
-  )
-
-  const handleDeleteCustomStream = useCallback(
-    (url: string) => {
-      send({
-        type: 'delete-custom-stream',
-        url,
-      })
-      return
-    },
-    [send],
-  )
-
-  const setStreamCensored = useCallback(
-    (isCensored: boolean) => {
-      send({
-        type: 'set-stream-censored',
-        isCensored,
-      })
-    },
-    [send],
-  )
-
-  const setStreamRunning = useCallback(
-    (isStreamRunning: boolean) => {
-      send({
-        type: 'set-stream-running',
-        isStreamRunning,
-      })
-    },
-    [send],
-  )
+  const {
+    streamFilter,
+    handleStreamFilterChange,
+    favoritesSet,
+    wallStreams,
+    liveStreams,
+    otherStreams,
+    favoriteStreams,
+  } = useStreamFilters({ streams, sharedState, favorites })
 
   const [newInvite, setNewInvite] = useState<Invite>()
 
-  const handleCreateInvite = useCallback(
-    ({ name, role }: { name: string; role: InvitableRole }) => {
-      send(
-        {
-          type: 'create-invite',
-          name,
-          role,
-        },
-        (msg) => {
-          const invite = parseInviteResponse(msg)
-          if (!invite) {
-            setCommandError(
-              'Received a malformed invite response from the server',
-            )
-            return
-          }
-          setNewInvite(invite)
-        },
-      )
-    },
-    [send, setCommandError],
-  )
+  const {
+    handleSetView,
+    handleSetListening,
+    handleToggleFullscreen,
+    handleSetGridSize,
+    handleSetBackgroundListening,
+    handleSetBlurred,
+    handleSetVolume,
+    handleReloadView,
+    handleRotateStream,
+    handleBrowse,
+    handleDevTools,
+    handleClickId,
+    handleChangeCustomStream,
+    handleDeleteCustomStream,
+    setStreamCensored,
+    setStreamRunning,
+    handleCreateInvite,
+    handleDeleteToken,
+    handleSaveLayoutPreset,
+    handleLoadLayoutPreset,
+    handleDeleteLayoutPreset,
+    handleToggleFavorite,
+  } = useGridCommands({
+    send,
+    streams,
+    sharedState,
+    stateDoc,
+    cols,
+    rows,
+    fullscreenViewIdx,
+    focusedInputIdx,
+    favoritesSet,
+    onInvite: setNewInvite,
+    onError: setCommandError,
+  })
 
-  const handleDeleteToken = useCallback(
-    (tokenId: string) => {
-      send({
-        type: 'delete-token',
-        tokenId,
-      })
-    },
-    [send],
-  )
+  useControlHotkeys({
+    stateIdxMap,
+    focusedInputIdx,
+    role,
+    handleSetListening,
+    handleSetBlurred,
+    setStreamCensored,
+    handleSwapView: tileDrag.handleSwapView,
+    undoManager,
+  })
 
-  const handleSaveLayoutPreset = useCallback(
-    (name: string) => {
-      send({ type: 'save-layout-preset', name })
-    },
-    [send],
-  )
-
-  const handleLoadLayoutPreset = useCallback(
-    (presetId: string) => {
-      // Loading a preset unconditionally replaces every cell (see
-      // applyLayoutPreset), unlike a grid resize which only drops cells that
-      // fall outside the new bounds. So warn whenever the current layout has
-      // any live assignment, mirroring handleSetGridSize's confirm above.
-      if (sharedState) {
-        const assignments = new Map<number, string | undefined>()
-        for (const [idx, view] of Object.entries(sharedState.views)) {
-          assignments.set(Number(idx), view.streamId)
-        }
-        if (
-          hasGridAssignments(assignments) &&
-          !window.confirm(
-            'Loading this preset will replace the current layout. Save it as a preset first if you want to keep it. Continue?',
-          )
-        ) {
-          return
-        }
-      }
-      send({ type: 'load-layout-preset', presetId })
-    },
-    [send, sharedState],
-  )
-
-  const handleDeleteLayoutPreset = useCallback(
-    (presetId: string) => {
-      send({ type: 'delete-layout-preset', presetId })
-    },
-    [send],
-  )
-
-  const favoritesSet = useMemo(() => new Set(favorites), [favorites])
-
-  const handleToggleFavorite = useCallback(
-    (url: string) => {
-      if (favoritesSet.has(url)) {
-        send({ type: 'remove-favorite', url })
-      } else {
-        send({ type: 'add-favorite', url })
-      }
-    },
-    [send, favoritesSet],
-  )
-
-  const preventLinkClick = useCallback((ev: Event) => {
-    ev.preventDefault()
-  }, [])
-
-  const [streamFilter, setStreamFilter] = useState('')
-  const handleStreamFilterChange = useCallback<
-    JSX.InputEventHandler<HTMLInputElement>
-  >((ev) => {
-    setStreamFilter(ev.currentTarget?.value)
-  }, [])
-
-  // Set up keyboard shortcuts.
-  const toggleListening = useCallback(
-    (idx: number) => {
-      const isListening = stateIdxMap.get(idx)?.isListening ?? false
-      handleSetListening(idx, !isListening)
-    },
-    [stateIdxMap, handleSetListening],
-  )
-  // Audio-listen toggle, layer 0: alt+<key> -> cells 0-19. `enableOnFormTags`
-  // keeps the hotkey live while a grid input is focused.
-  useHotkeys(
-    hotkeyLayerBindings[0],
-    (ev, { hotkey }) => {
-      ev.preventDefault()
-      toggleListening(hotkeyTriggers.indexOf(hotkey[hotkey.length - 1]))
-    },
-    { enableOnFormTags: true },
-    [toggleListening],
-  )
-  // Audio-listen toggle, layer 1: alt+ctrl+<key> -> cells 20-39 (see
-  // `hotkeyLayers`). Same trigger keys, offset by one layer of 20 cells.
-  useHotkeys(
-    hotkeyLayerBindings[1],
-    (ev, { hotkey }) => {
-      ev.preventDefault()
-      toggleListening(
-        hotkeyTriggers.length +
-          hotkeyTriggers.indexOf(hotkey[hotkey.length - 1]),
-      )
-    },
-    { enableOnFormTags: true },
-    [toggleListening],
-  )
-  const toggleBlurred = useCallback(
-    (idx: number) => {
-      const isBlurred = stateIdxMap.get(idx)?.isBlurred ?? false
-      handleSetBlurred(idx, !isBlurred)
-    },
-    [stateIdxMap, handleSetBlurred],
-  )
-  // Blur toggle, layer 0: alt+shift+<key> -> cells 0-19.
-  useHotkeys(
-    blurHotkeyLayerBindings[0],
-    (ev, { hotkey }) => {
-      ev.preventDefault()
-      toggleBlurred(hotkeyTriggers.indexOf(hotkey[hotkey.length - 1]))
-    },
-    [toggleBlurred],
-  )
-  // Blur toggle, layer 1: alt+ctrl+shift+<key> -> cells 20-39 (see
-  // `blurHotkeyLayers`). Same trigger keys, offset by one layer of 20 cells.
-  useHotkeys(
-    blurHotkeyLayerBindings[1],
-    (ev, { hotkey }) => {
-      ev.preventDefault()
-      toggleBlurred(
-        hotkeyTriggers.length +
-          hotkeyTriggers.indexOf(hotkey[hotkey.length - 1]),
-      )
-    },
-    [toggleBlurred],
-  )
-  useHotkeys(
-    `alt+c`,
-    () => {
-      setStreamCensored(true)
-    },
-    [setStreamCensored],
-  )
-  useHotkeys(
-    `alt+shift+c`,
-    () => {
-      setStreamCensored(false)
-    },
-    [setStreamCensored],
-  )
-  useHotkeys(
-    `alt+s`,
-    () => {
-      if (focusedInputIdx != null && roleCan(role, 'mutate-state-doc')) {
-        handleSwapView(focusedInputIdx)
-      }
-    },
-    [handleSwapView, focusedInputIdx, role],
-  )
-  // Undo/redo edits to the shared views doc (drag-move, swap, and destructive
-  // grid-shrink remaps alike - see `useYDoc`'s `remoteOrigin` wiring).
-  // `enableOnFormTags` defaults to false so this doesn't hijack native
-  // undo/redo while a text input (e.g. a grid-size field) is focused.
-  useHotkeys(
-    'mod+z',
-    (ev) => {
-      ev.preventDefault()
-      undoManager?.undo()
-    },
-    [undoManager],
-  )
-  useHotkeys(
-    'mod+shift+z',
-    (ev) => {
-      ev.preventDefault()
-      undoManager?.redo()
-    },
-    [undoManager],
-  )
-
-  const wallStreamIds = useMemo(
-    () =>
-      new Set(
-        Object.values(sharedState?.views ?? {})
-          .map(({ streamId }) => streamId)
-          .filter((x) => x !== undefined),
-      ),
-    [sharedState],
-  )
-  const [wallStreams, liveStreams, otherStreams, favoriteStreams] = useMemo(
-    () => filterStreams(streams, wallStreamIds, favoritesSet, streamFilter),
-    [streams, wallStreamIds, favoritesSet, streamFilter],
-  )
-  const toggleFavoriteHandler = roleCan(role, 'add-favorite')
-    ? handleToggleFavorite
-    : undefined
   return (
     <AppShell className="app-shell">
       <Stack className="grid-container">
-        <StyledHeader>
-          <div className="wm">
-            STREAM<span>·</span>WALL
-          </div>
-          <div className="crumbs">
-            //&nbsp; <b>Multiview</b> &nbsp;·&nbsp; {cols}×{rows}
-          </div>
-          {cols != null && rows != null && (
-            <GridSizeControls
-              cols={cols}
-              rows={rows}
-              role={role}
-              onSetGridSize={handleSetGridSize}
-            />
-          )}
-          <LayoutPresetControls
-            presets={layoutPresets}
-            role={role}
-            onSavePreset={handleSaveLayoutPreset}
-            onLoadPreset={handleLoadLayoutPreset}
-            onDeletePreset={handleDeleteLayoutPreset}
-          />
-          <div className="spacer" />
-          {liveStreams.length > 0 && (
-            <div className="livecount">● {liveStreams.length} On Air</div>
-          )}
-          {role !== 'local' && (
-            <div className="status" data-testid="header-connection-status">
-              <span className={`dot ${isConnected ? 'on' : 'off'}`} />
-              {isConnected ? 'connected' : 'connecting...'} · {role}
-              <ServerVersionLabel version={serverStatus?.version ?? null} />
-            </div>
-          )}
-          <ThemeToggle />
-        </StyledHeader>
-        <ConnectionStatusBanner
+        <ControlHeader
+          cols={cols}
+          rows={rows}
+          role={role}
+          onSetGridSize={handleSetGridSize}
+          presets={layoutPresets}
+          onSavePreset={handleSaveLayoutPreset}
+          onLoadPreset={handleLoadLayoutPreset}
+          onDeletePreset={handleDeleteLayoutPreset}
+          liveCount={liveStreams.length}
           isConnected={isConnected}
-          reason={disconnectReason}
+          serverVersion={serverStatus?.version ?? null}
         />
-        <DataSourceHealthBanner dataSourceHealth={dataSourceHealth} />
-        <ServerUpdateBanner status={serverStatus} />
-        <CommandErrorBanner
-          error={commandError}
-          onDismiss={() => setCommandError(null)}
+        <ControlBanners
+          isConnected={isConnected}
+          disconnectReason={disconnectReason}
+          dataSourceHealth={dataSourceHealth}
+          serverStatus={serverStatus}
+          commandError={commandError}
+          onDismissError={() => setCommandError(null)}
         />
         {delayState && (
           <StreamDelayBox
@@ -700,687 +212,63 @@ export function ControlUI({
           }}
         >
           {cols != null && rows != null && (
-            <StyledGridContainer
-              className="grid"
-              data-testid="grid"
-              onPointerMove={updateHoveringIdx}
-              onPointerLeave={clearHoveringIdx}
-              $windowWidth={windowWidth}
-              $windowHeight={windowHeight}
-            >
-              <StyledGridInputs>
-                {range(0, rows).map((y) =>
-                  range(0, cols).map((x) => {
-                    const idx = cols * y + x
-                    const { streamId } = sharedState?.views?.[idx] ?? {}
-                    const isMoveHighlight =
-                      moveStart != null &&
-                      moveTargetIdx != null &&
-                      moveStart.idx !== moveTargetIdx &&
-                      (
-                        stateIdxMap.get(moveTargetIdx)?.spaces ?? [
-                          moveTargetIdx,
-                        ]
-                      ).includes(idx)
-                    const isResizeHighlight =
-                      resize != null &&
-                      hoveringIdx != null &&
-                      isIdxInResizeBox(
-                        cols,
-                        resize.anchorIdx,
-                        hoveringIdx,
-                        resize.handle,
-                        resize.originalSpaces,
-                        idx,
-                      )
-                    const isHighlighted = isMoveHighlight || isResizeHighlight
-                    return (
-                      <GridInput
-                        key={idx}
-                        style={{
-                          width: `${100 / cols}%`,
-                          height: `${100 / rows}%`,
-                          left: `${(100 * x) / cols}%`,
-                          top: `${(100 * y) / rows}%`,
-                        }}
-                        idx={idx}
-                        spaceValue={streamId ?? ''}
-                        onChangeSpace={handleSetView}
-                        isHighlighted={isHighlighted}
-                        role={role}
-                        onPointerDown={handleGridPointerDown}
-                        onFocus={setFocusedInputIdx}
-                        onBlur={handleBlurInput}
-                      />
-                    )
-                  }),
-                )}
-              </StyledGridInputs>
-              <div
-                style={{
-                  position: 'absolute',
-                  inset: 0,
-                  pointerEvents: 'none',
-                }}
-              >
-                {views.map(({ state }) => {
-                  const { pos } = state.context
-                  if (pos == null) {
-                    return null
-                  }
-                  const anchorIdx = Math.min(...pos.spaces)
-                  return (
-                    <div
-                      key={`rh-${anchorIdx}`}
-                      style={{
-                        position: 'absolute',
-                        left: `${(100 * pos.x) / windowWidth}%`,
-                        top: `${(100 * pos.y) / windowHeight}%`,
-                        width: `${(100 * pos.width) / windowWidth}%`,
-                        height: `${(100 * pos.height) / windowHeight}%`,
-                        pointerEvents: 'none',
-                      }}
-                    >
-                      <ResizeHandles
-                        anchorIdx={anchorIdx}
-                        originalSpaces={pos.spaces}
-                        role={role}
-                        onResizeStart={handleResizeStart}
-                        onResizeKeyDown={handleResizeKeyDown}
-                      />
-                    </div>
-                  )
-                })}
-              </div>
-              <StyledGridPreview>
-                {views.map(({ state, isListening }) => {
-                  const { pos } = state.context
-                  if (pos == null) {
-                    return null
-                  }
-
-                  const { streamId } =
-                    sharedState?.views[
-                      resolveAnchorIdx(pos.spaces, fullscreenViewIdx)
-                    ] ?? {}
-                  const data = streams.find((d) => d._id === streamId)
-                  if (streamId == null || data == null) {
-                    return null
-                  }
-
-                  const isSmall = pos.height < 200
-                  const isError = matchesState('displaying.error', state.state)
-                  const errorReason = state.context.error
-                  return (
-                    <GridPreviewBox
-                      key={pos.spaces[0]}
-                      streamId={streamId}
-                      color={idColor(streamId)}
-                      style={{
-                        left: `${(100 * pos.x) / windowWidth}%`,
-                        top: `${(100 * pos.y) / windowHeight}%`,
-                        width: `${(100 * pos.width) / windowWidth}%`,
-                        height: `${(100 * pos.height) / windowHeight}%`,
-                      }}
-                      pos={pos}
-                      windowWidth={windowWidth}
-                      windowHeight={windowHeight}
-                      isListening={isListening}
-                      isSmall={isSmall}
-                      isError={isError}
-                      errorReason={errorReason}
-                      orientation={data?.orientation ?? null}
-                      source={data?.source}
-                      city={data?.city}
-                      state={data?.state}
-                    />
-                  )
-                })}
-              </StyledGridPreview>
-              {views.map(
-                ({
-                  state,
-                  isListening,
-                  isBackgroundListening,
-                  isBlurred,
-                  volume,
-                }) => {
-                  const { id: viewId, pos } = state.context
-                  if (!pos) {
-                    return null
-                  }
-                  const { streamId } =
-                    sharedState?.views[
-                      resolveAnchorIdx(pos.spaces, fullscreenViewIdx)
-                    ] ?? {}
-                  if (!streamId) {
-                    return null
-                  }
-                  return (
-                    <GridControls
-                      key={pos.spaces[0]}
-                      idx={pos.spaces[0]}
-                      viewId={viewId}
-                      streamId={streamId}
-                      onToggleFullscreen={handleToggleFullscreen}
-                      style={{
-                        left: `${(100 * pos.x) / windowWidth}%`,
-                        top: `${(100 * pos.y) / windowHeight}%`,
-                        width: `${(100 * pos.width) / windowWidth}%`,
-                        height: `${(100 * pos.height) / windowHeight}%`,
-                      }}
-                      isDisplaying={matchesState('displaying', state.state)}
-                      isListening={isListening}
-                      isBackgroundListening={isBackgroundListening}
-                      isBlurred={isBlurred}
-                      volume={volume}
-                      isSwapping={
-                        swapStartIdx != null &&
-                        pos.spaces.includes(swapStartIdx)
-                      }
-                      showDebug={showDebug}
-                      role={role}
-                      onSetListening={handleSetListening}
-                      onSetBackgroundListening={handleSetBackgroundListening}
-                      onSetBlurred={handleSetBlurred}
-                      onSetVolume={handleSetVolume}
-                      onReloadView={handleReloadView}
-                      onSwapView={handleSwapView}
-                      onRotateView={handleRotateStream}
-                      onBrowse={handleBrowse}
-                      onDevTools={handleDevTools}
-                      onPointerDown={handleGridPointerDown}
-                    />
-                  )
-                },
-              )}
-            </StyledGridContainer>
+            <ControlGrid
+              cols={cols}
+              rows={rows}
+              windowWidth={windowWidth}
+              windowHeight={windowHeight}
+              role={role}
+              showDebug={showDebug}
+              sharedState={sharedState}
+              views={views}
+              stateIdxMap={stateIdxMap}
+              streams={streams}
+              fullscreenViewIdx={fullscreenViewIdx}
+              tileDrag={tileDrag}
+              tileResize={tileResize}
+              onSetView={handleSetView}
+              onFocusInput={setFocusedInputIdx}
+              onBlurInput={handleBlurInput}
+              onToggleFullscreen={handleToggleFullscreen}
+              onSetListening={handleSetListening}
+              onSetBackgroundListening={handleSetBackgroundListening}
+              onSetBlurred={handleSetBlurred}
+              onSetVolume={handleSetVolume}
+              onReloadView={handleReloadView}
+              onRotateView={handleRotateStream}
+              onBrowse={handleBrowse}
+              onDevTools={handleDevTools}
+            />
           )}
         </StyledDataContainer>
-        <StyledStatusBar>
-          {(roleCan(role, 'dev-tools') || roleCan(role, 'browse')) && (
-            <label className="dbg">
-              <input
-                type="checkbox"
-                checked={showDebug}
-                onChange={handleChangeShowDebug}
-              />
-              Debug-Tools
-            </label>
-          )}
-          <span className="spacer" />
-          <span className="meta">
-            {streams.length} sources · {liveStreams.length} live
-          </span>
-        </StyledStatusBar>
+        <ControlStatusBar
+          role={role}
+          showDebug={showDebug}
+          onSetShowDebug={setShowDebug}
+          sourceCount={streams.length}
+          liveCount={liveStreams.length}
+        />
       </Stack>
-      <Stack className="stream-list" $scroll={true} $minHeight={200}>
-        {
-          // Keyed on `role` (persists across a reconnect, see
-          // `StreamwallConnection`) rather than `isConnected`, so a brief
-          // disconnect dims the last-known list instead of replacing it with
-          // "loading..." (issue #37). Only the very first load, before any
-          // state has ever arrived, shows the loading placeholder.
-        }
-        <StyledDataContainer $isConnected={isConnected}>
-          {role != null ? (
-            <div>
-              <input
-                className="filter-input"
-                onChange={handleStreamFilterChange}
-                value={streamFilter}
-                placeholder="Filter streams…"
-              />
-              <h3>
-                Favorites <span className="ct">{favoriteStreams.length}</span>
-              </h3>
-              <StreamList
-                rows={favoriteStreams}
-                disabled={!roleCan(role, 'mutate-state-doc')}
-                onClickId={handleClickId}
-                favorites={favoritesSet}
-                onToggleFavorite={toggleFavoriteHandler}
-              />
-              <h3>
-                Viewing <span className="ct">{wallStreams.length}</span>
-              </h3>
-              <StreamList
-                rows={wallStreams}
-                disabled={!roleCan(role, 'mutate-state-doc')}
-                onClickId={handleClickId}
-                favorites={favoritesSet}
-                onToggleFavorite={toggleFavoriteHandler}
-              />
-              <h3>
-                Live <span className="ct">{liveStreams.length}</span>
-              </h3>
-              <StreamList
-                rows={liveStreams}
-                disabled={!roleCan(role, 'mutate-state-doc')}
-                onClickId={handleClickId}
-                favorites={favoritesSet}
-                onToggleFavorite={toggleFavoriteHandler}
-              />
-              <h3>
-                Offline / Unknown{' '}
-                <span className="ct">{otherStreams.length}</span>
-              </h3>
-              <StreamList
-                rows={otherStreams}
-                disabled={!roleCan(role, 'mutate-state-doc')}
-                onClickId={handleClickId}
-                favorites={favoritesSet}
-                onToggleFavorite={toggleFavoriteHandler}
-              />
-            </div>
-          ) : (
-            <div>loading...</div>
-          )}
-          {roleCan(role, 'update-custom-stream') &&
-            roleCan(role, 'delete-custom-stream') && (
-              <>
-                <h2>Custom Streams</h2>
-                <div>
-                  {/*
-                    Keyed by `link` (each custom stream's stable id) rather
-                    than array index, so deleting an earlier entry doesn't
-                    shift later entries onto a different DOM node mid-edit.
-                  */}
-                  {customStreams.map(({ link, label, kind }) => (
-                    <CustomStreamInput
-                      key={link}
-                      link={link}
-                      label={label}
-                      kind={kind}
-                      onChange={handleChangeCustomStream}
-                      onDelete={handleDeleteCustomStream}
-                    />
-                  ))}
-                  <CreateCustomStreamInput
-                    onCreate={handleChangeCustomStream}
-                  />
-                </div>
-              </>
-            )}
-          {(roleCan(role, 'create-invite') || roleCan(role, 'delete-token')) &&
-            authState && (
-              <>
-                <h2>Access</h2>
-                <div>
-                  <CreateInviteInput onCreateInvite={handleCreateInvite} />
-                  <h3>Invites</h3>
-                  {newInvite && (
-                    <StyledNewInviteBox>
-                      Invite link created:{' '}
-                      <a
-                        href={inviteLink({
-                          tokenId: newInvite.tokenId,
-                          secret: newInvite.secret,
-                        })}
-                        onClick={preventLinkClick}
-                      >
-                        "{newInvite.name}"
-                      </a>
-                    </StyledNewInviteBox>
-                  )}
-                  {authState.invites.map(({ tokenId, name, role }) => (
-                    <AuthTokenLine
-                      key={tokenId}
-                      id={tokenId}
-                      name={name}
-                      role={role}
-                      onDelete={handleDeleteToken}
-                    />
-                  ))}
-                  <h3>Sessions</h3>
-                  {authState.sessions.map(({ tokenId, name, role }) => (
-                    <AuthTokenLine
-                      key={tokenId}
-                      id={tokenId}
-                      name={name}
-                      role={role}
-                      onDelete={handleDeleteToken}
-                    />
-                  ))}
-                </div>
-              </>
-            )}
-        </StyledDataContainer>
-      </Stack>
+      <ControlSidebar
+        role={role}
+        isConnected={isConnected}
+        streamFilter={streamFilter}
+        onStreamFilterChange={handleStreamFilterChange}
+        favoriteStreams={favoriteStreams}
+        wallStreams={wallStreams}
+        liveStreams={liveStreams}
+        otherStreams={otherStreams}
+        favoritesSet={favoritesSet}
+        onClickId={handleClickId}
+        onToggleFavorite={handleToggleFavorite}
+        customStreams={customStreams}
+        onChangeCustomStream={handleChangeCustomStream}
+        onDeleteCustomStream={handleDeleteCustomStream}
+        authState={authState}
+        newInvite={newInvite}
+        onCreateInvite={handleCreateInvite}
+        onDeleteToken={handleDeleteToken}
+      />
     </AppShell>
   )
 }
-
-const Stack = styled.div<{
-  $direction?: string
-  $flex?: string
-  $gap?: number
-  $scroll?: boolean
-  $minHeight?: number
-}>`
-  display: flex;
-  flex-direction: ${({ $direction }) => $direction ?? 'column'};
-  flex: ${({ $flex }) => $flex};
-  ${({ $gap }) => $gap && `gap: ${$gap}px`};
-  ${({ $scroll }) => $scroll && `overflow-y: auto`};
-  ${({ $minHeight }) => $minHeight && `min-height: ${$minHeight}px`};
-`
-
-// Below this viewport width the side-by-side wall/stream-list layout stops
-// fitting, so the shell stacks the two regions vertically instead (see #81).
-// Shared with the header so both switch to their narrow layout together.
-const NARROW_BREAKPOINT = 820
-
-// Root layout. Desktop: the wall preview and the stream list sit side by side,
-// pinned to the viewport height with only the stream list scrolling. Narrow
-// screens (phones, small windows): the two regions stack and the whole page
-// scrolls. Layout that the media query needs to override lives here rather than
-// as inline styles on the children so the cascade can win cleanly.
-const AppShell = styled.div`
-  display: flex;
-  flex: 1;
-  flex-direction: row;
-  gap: 16px;
-  height: 100vh;
-  min-height: 0;
-  padding: 16px;
-  overflow: hidden;
-
-  > .grid-container {
-    flex: 1;
-    min-width: 0;
-    min-height: 0;
-  }
-
-  > .stream-list {
-    flex: 0 0 340px;
-  }
-
-  @media (max-width: ${NARROW_BREAKPOINT}px) {
-    flex-direction: column;
-    height: auto;
-    min-height: 100vh;
-    overflow: visible;
-
-    /* Stack both regions at their natural height and let the whole page
-       scroll, rather than pinning them to the viewport and competing for its
-       height (which collapses the wall region to nothing). */
-    > .grid-container {
-      flex: 0 0 auto;
-    }
-
-    > .stream-list {
-      flex: 0 0 auto;
-      min-width: 0;
-      overflow-y: visible;
-    }
-  }
-`
-
-function StreamDurationClock({ startTime }: { startTime: number }) {
-  const [now, setNow] = useState(() => DateTime.now())
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setNow(DateTime.now())
-    }, 500)
-    return () => {
-      clearInterval(interval)
-    }
-  }, [startTime])
-  return (
-    <span>{now.diff(DateTime.fromMillis(startTime)).toFormat('hh:mm:ss')}</span>
-  )
-}
-
-function StreamDelayBox({
-  role,
-  delayState,
-  setStreamCensored,
-  setStreamRunning,
-}: {
-  role: StreamwallRole | null
-  delayState: StreamDelayStatus
-  setStreamCensored: (isCensored: boolean) => void
-  setStreamRunning: (isStreamRunning: boolean) => void
-}) {
-  const handleToggleStreamCensored = useCallback(() => {
-    setStreamCensored(!delayState.isCensored)
-  }, [delayState.isCensored, setStreamCensored])
-  const handleToggleStreamRunning = useCallback(() => {
-    if (!delayState.isStreamRunning || confirm('End stream?')) {
-      setStreamRunning(!delayState.isStreamRunning)
-    }
-  }, [delayState.isStreamRunning, setStreamRunning])
-  let buttonText
-  if (delayState.isConnected) {
-    if (matchesState('censorship.censored.deactivating', delayState.state)) {
-      buttonText = 'Deactivating...'
-    } else if (delayState.isCensored) {
-      buttonText = 'Uncensor stream'
-    } else {
-      buttonText = 'Censor stream'
-    }
-  }
-  return (
-    <div>
-      <StyledStreamDelayBox>
-        <strong>Streamdelay</strong>
-        {!delayState.isConnected && <span>connecting...</span>}
-        {!delayState.isStreamRunning && <span>stream stopped</span>}
-        {delayState.isConnected && (
-          <>
-            {delayState.startTime !== null && (
-              <StreamDurationClock startTime={delayState.startTime} />
-            )}
-            <span>delay: {delayState.delaySeconds}s</span>
-            {delayState.isStreamRunning && (
-              <StyledButton
-                $isActive={delayState.isCensored}
-                onClick={handleToggleStreamCensored}
-              >
-                {buttonText}
-              </StyledButton>
-            )}
-            {roleCan(role, 'set-stream-running') && (
-              <StyledButton onClick={handleToggleStreamRunning}>
-                {delayState.isStreamRunning ? 'End stream' : 'Start stream'}
-              </StyledButton>
-            )}
-          </>
-        )}
-      </StyledStreamDelayBox>
-    </div>
-  )
-}
-
-const StyledHeader = styled.header`
-  display: flex;
-  align-items: center;
-  gap: 18px;
-  flex: 0 0 auto;
-  position: relative;
-  padding: 4px 2px 14px;
-  margin-bottom: 14px;
-
-  /* Stencil-editorial anchor: a red rule that runs out into the border line. */
-  &::after {
-    content: '';
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    height: 2px;
-    background: linear-gradient(
-      90deg,
-      var(--accent) 0 132px,
-      var(--border) 132px
-    );
-  }
-
-  .wm {
-    font-family: var(--font-display);
-    font-size: 27px;
-    line-height: 1;
-    letter-spacing: 0.03em;
-    color: var(--text);
-    white-space: nowrap;
-  }
-  .wm span {
-    color: var(--accent);
-  }
-
-  .crumbs {
-    font-family: var(--font-mono);
-    font-size: 12px;
-    letter-spacing: 0.04em;
-    color: var(--text-faint);
-  }
-  .crumbs b {
-    color: var(--text-dim);
-    font-weight: 500;
-  }
-
-  .spacer {
-    flex: 1;
-  }
-
-  .livecount {
-    font-family: 'Oswald', var(--font-ui);
-    text-transform: uppercase;
-    font-weight: 600;
-    font-size: 13px;
-    letter-spacing: 0.12em;
-    color: var(--accent);
-    border: 1px solid var(--accent);
-    background: var(--accent-soft);
-    padding: 5px 11px;
-  }
-
-  .status {
-    display: flex;
-    align-items: center;
-    gap: 7px;
-    font-family: var(--font-mono);
-    font-size: 11px;
-    letter-spacing: 0.02em;
-    color: var(--text-dim);
-    text-transform: uppercase;
-  }
-  .status .dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-  }
-  .status .dot.on {
-    background: var(--ok);
-  }
-  .status .dot.off {
-    background: var(--text-faint);
-  }
-
-  /* On narrow screens the header controls no longer fit on one line - let them
-     wrap instead of overflowing the viewport (see #81). */
-  @media (max-width: ${NARROW_BREAKPOINT}px) {
-    flex-wrap: wrap;
-    gap: 10px 14px;
-  }
-`
-
-const StyledStreamDelayBox = styled.div`
-  display: inline-flex;
-  align-items: center;
-  margin: 5px 0;
-  padding: 10px 12px;
-  gap: 1em;
-  border-radius: var(--r-md);
-  background: var(--accent-soft);
-  border: 1px solid var(--accent);
-  color: var(--text);
-`
-
-const StyledGridPreview = styled.div`
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-`
-
-const StyledGridInputs = styled.div`
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
-  transition: opacity 100ms ease-out;
-  overflow: hidden;
-  z-index: 100;
-`
-
-const StyledGridContainer = styled.div<{
-  $windowWidth: number
-  $windowHeight: number
-}>`
-  position: relative;
-  /* Responsive: keep the wall's aspect ratio but fit the available space
-     instead of a hard-coded pixel size, so the layout never overflows. */
-  aspect-ratio: ${({ $windowWidth, $windowHeight }) =>
-    `${$windowWidth} / ${$windowHeight}`};
-  width: 100%;
-  max-height: 100%;
-  margin: 0 auto;
-  border: 1px solid var(--border-2);
-  border-radius: var(--r-md);
-  background: var(--cell-bg);
-  overflow: hidden;
-
-  &:hover ${StyledGridInputs} {
-    opacity: 0.35;
-  }
-`
-
-const StyledNewInviteBox = styled.div`
-  display: block;
-  padding: 10px 12px;
-  margin: 8px 0;
-  border-radius: var(--r-md);
-  background: color-mix(in srgb, var(--ok) 14%, transparent);
-  border: 1px solid color-mix(in srgb, var(--ok) 45%, transparent);
-  color: var(--text);
-  font-size: 13px;
-`
-
-const StyledStatusBar = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  flex: 0 0 auto;
-  margin-top: 12px;
-  padding-top: 10px;
-  border-top: 1px solid var(--border);
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--text-dim);
-
-  .spacer {
-    flex: 1;
-  }
-
-  .meta {
-    color: var(--text-faint);
-  }
-
-  label.dbg {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    cursor: pointer;
-    color: var(--text-dim);
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-  }
-  label.dbg input {
-    accent-color: var(--accent);
-  }
-`

--- a/packages/streamwall-control-ui/src/layout.tsx
+++ b/packages/streamwall-control-ui/src/layout.tsx
@@ -1,0 +1,67 @@
+import { styled } from 'styled-components'
+
+export const Stack = styled.div<{
+  $direction?: string
+  $flex?: string
+  $gap?: number
+  $scroll?: boolean
+  $minHeight?: number
+}>`
+  display: flex;
+  flex-direction: ${({ $direction }) => $direction ?? 'column'};
+  flex: ${({ $flex }) => $flex};
+  ${({ $gap }) => $gap && `gap: ${$gap}px`};
+  ${({ $scroll }) => $scroll && `overflow-y: auto`};
+  ${({ $minHeight }) => $minHeight && `min-height: ${$minHeight}px`};
+`
+
+// Below this viewport width the side-by-side wall/stream-list layout stops
+// fitting, so the shell stacks the two regions vertically instead (see #81).
+// Shared with the header so both switch to their narrow layout together.
+export const NARROW_BREAKPOINT = 820
+
+// Root layout. Desktop: the wall preview and the stream list sit side by side,
+// pinned to the viewport height with only the stream list scrolling. Narrow
+// screens (phones, small windows): the two regions stack and the whole page
+// scrolls. Layout that the media query needs to override lives here rather than
+// as inline styles on the children so the cascade can win cleanly.
+export const AppShell = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: row;
+  gap: 16px;
+  height: 100vh;
+  min-height: 0;
+  padding: 16px;
+  overflow: hidden;
+
+  > .grid-container {
+    flex: 1;
+    min-width: 0;
+    min-height: 0;
+  }
+
+  > .stream-list {
+    flex: 0 0 340px;
+  }
+
+  @media (max-width: ${NARROW_BREAKPOINT}px) {
+    flex-direction: column;
+    height: auto;
+    min-height: 100vh;
+    overflow: visible;
+
+    /* Stack both regions at their natural height and let the whole page
+       scroll, rather than pinning them to the viewport and competing for its
+       height (which collapses the wall region to nothing). */
+    > .grid-container {
+      flex: 0 0 auto;
+    }
+
+    > .stream-list {
+      flex: 0 0 auto;
+      min-width: 0;
+      overflow-y: visible;
+    }
+  }
+`


### PR DESCRIPTION
## Problem

`packages/streamwall-control-ui/src/index.tsx` had grown into a ~1500-line god component: view-state derivation, ~22 command handlers, grid gestures, sidebar filtering, hotkey registration, Streamdelay controls, layout presets, styled-components, and the full layout composition all lived in one file. This drove the repo's highest churn (54 commits/90d), a high merge-conflict rate, and made "where is X handled?" impossible to answer without reading the whole file.

## Solution

Behavior-preserving decomposition into focused hooks and components, keeping `index.tsx` as a composition root that only wires data and callbacks. Extracted in six independently-reviewable, always-green steps:

**Hooks (`src/hooks/`)**
- `useStreamwallState.ts` — the view-index → XState sub-state mapping plus the `ViewInfo`/`StreamwallConnection` types.
- `useStreamFilters.ts` — the `filterStreams` partitioning, filter-text state, favorites set, and wall/live/other bucket derivation.
- `useGridCommands.ts` — every `send`/`stateDoc` command wrapper (view controls, grid resize, layout presets, streamdelay, custom streams, invites, favorites) as a testable command layer.
- `useControlHotkeys.ts` — the two-layer audio-listen/blur toggles, censor shortcuts, role-gated swap, and undo/redo.

**Components (`src/components/`)** + `layout.tsx`
- `ControlHeader`, `ControlGrid`, `ControlSidebar`, `ControlStatusBar`, `ControlBanners`, `StreamDelayBox`, and the `AppShell`/`Stack` shell primitives.

`index.tsx` is now **274 lines (from 1506, an 82% reduction)** — the `ControlUI` composition root plus the stable public re-exports.

## Architecture decisions

- **Public API unchanged.** The package entry (`./src/index.tsx`) still re-exports `ControlUI`, `GlobalStyle`, `useStreamwallState`, `StreamwallConnection`, `ViewInfo`, `collabDataSchema`, `CollabData`, and `useYDoc`, so `streamwall-control-client` and `streamwall`'s renderer import paths are untouched.
- **Explicit props over prop-bags.** The composition root passes named callbacks/data to each leaf rather than opaque objects, keeping the wiring reviewable. `ControlGrid` receives the whole `useTileDrag`/`useTileResize` return objects so its prop types stay in sync with those hooks. This is the main reason `index.tsx` lands at 274 rather than strictly ≤200; the god component and its responsibilities are fully split.
- **No behavior change.** Every handler, guard (`window.confirm` on destructive grid-shrink/preset-load), role gate, and hotkey option (`enableOnFormTags`) was moved verbatim.

## Testing

- Added dedicated unit tests for the new command/filter layers: `useGridCommands.test.tsx` (8 tests — dispatch, destructive-shrink/preset confirm guards, invite parse flow, Yjs write) and `useStreamFilters.test.tsx` (7 tests — bucket partitioning, kind/text filtering, favorites; `filterStreams` was previously untested).
- The existing 278 component tests (which render `ControlUI`) act as the behavior-preservation net and stay green throughout — `293 passed` after the additions.
- Full CI gate green locally: `format:check`, `lint`, `typecheck` (all packages), `npm test` (all workspaces — control-ui 293, control-client 16, shared 319, control-server 141, streamwall 580, root 10), and `npm -w streamwall-control-client run build` (bundles the refactored package via its consumer).

## Risks / breaking changes

None. Pure internal refactor; no public export, prop, or runtime behavior changed.

Closes #393
