### PR TITLE
refactor(streamwall): extract main-process orchestration from index.ts

### DIFF
--- a/packages/streamwall/src/main/TwitchBot.ts
+++ b/packages/streamwall/src/main/TwitchBot.ts
@@ -9,7 +9,7 @@ import * as ejs from 'ejs'
 import EventEmitter from 'events'
 import { StreamList, StreamwallState } from 'streamwall-shared'
 import { matchesState } from 'xstate'
-import { StreamwallConfig } from '.'
+import { StreamwallConfig } from './cliArgs'
 import log from './logger'
 
 const VOTE_RE = /^!(\d+)$/

--- a/packages/streamwall/src/main/cliArgs.test.ts
+++ b/packages/streamwall/src/main/cliArgs.test.ts
@@ -1,0 +1,120 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { parseArgs } from './cliArgs'
+import { ConfigError } from './config'
+import log from './logger'
+
+// yargs lands the first two argv entries (node + script path) in `argv._`,
+// mirroring how `process.argv` is forwarded in production.
+function argv(...flags: string[]): string[] {
+  return ['node', 'streamwall', ...flags]
+}
+
+describe('parseArgs', () => {
+  let configDir: string
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    configDir = mkdtempSync(join(tmpdir(), 'streamwall-cliargs-'))
+    warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => log)
+  })
+
+  afterEach(() => {
+    rmSync(configDir, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  it('applies schema defaults when no config file and no flags are given', () => {
+    const config = parseArgs({ configDir, argv: argv() })
+
+    expect(config.grid).toEqual({ cols: 3, rows: 3 })
+    expect(config.window.width).toBe(1920)
+    expect(config.window.height).toBe(1080)
+    expect(config.presets).toEqual(['de-tv'])
+    expect(config.retry.enabled).toBe(true)
+    expect(config.telemetry.sentry).toBe(true)
+    expect(config.control.endpoint).toBeNull()
+    expect(config.playlist).toEqual([])
+  })
+
+  it('lets CLI flags override defaults', () => {
+    const config = parseArgs({
+      configDir,
+      argv: argv(
+        '--grid.cols',
+        '4',
+        '--grid.rows',
+        '2',
+        '--window.width',
+        '800',
+      ),
+    })
+
+    expect(config.grid).toEqual({ cols: 4, rows: 2 })
+    expect(config.window.width).toBe(800)
+  })
+
+  it('reads config.toml from the config dir', () => {
+    writeFileSync(
+      join(configDir, 'config.toml'),
+      '[grid]\ncols = 5\nrows = 4\n',
+    )
+
+    const config = parseArgs({ configDir, argv: argv() })
+
+    expect(config.grid).toEqual({ cols: 5, rows: 4 })
+  })
+
+  it('lets CLI flags take precedence over config.toml', () => {
+    writeFileSync(join(configDir, 'config.toml'), '[grid]\ncols = 5\n')
+
+    const config = parseArgs({ configDir, argv: argv('--grid.cols', '2') })
+
+    expect(config.grid.cols).toBe(2)
+  })
+
+  it('warns about unknown keys in config.toml without throwing', () => {
+    // `grid.count` was removed in favour of grid.cols/grid.rows; it must be
+    // surfaced rather than silently dropped.
+    writeFileSync(join(configDir, 'config.toml'), '[grid]\ncount = 5\n')
+
+    const config = parseArgs({ configDir, argv: argv() })
+
+    // The unknown key is warned about but not stripped; the known defaults
+    // still apply.
+    expect(config.grid.cols).toBe(3)
+    expect(config.grid.rows).toBe(3)
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown config key "grid.count"'),
+    )
+  })
+
+  it('layers a --config file over the home config', () => {
+    writeFileSync(join(configDir, 'config.toml'), '[grid]\ncols = 5\n')
+    const extraConfig = join(configDir, 'extra.toml')
+    writeFileSync(extraConfig, '[grid]\nrows = 6\n')
+
+    const config = parseArgs({
+      configDir,
+      argv: argv('--config', extraConfig),
+    })
+
+    expect(config.grid).toEqual({ cols: 5, rows: 6 })
+  })
+
+  it('throws a ConfigError when a value is out of range', () => {
+    expect(() =>
+      parseArgs({ configDir, argv: argv('--window.width', '0') }),
+    ).toThrow(ConfigError)
+  })
+
+  it('ignores a missing config.toml (ENOENT) and falls back to defaults', () => {
+    // configDir exists but holds no config.toml.
+    const config = parseArgs({ configDir, argv: argv() })
+
+    expect(config.grid).toEqual({ cols: 3, rows: 3 })
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/streamwall/src/main/cliArgs.ts
+++ b/packages/streamwall/src/main/cliArgs.ts
@@ -1,0 +1,367 @@
+import fs from 'fs'
+import { join } from 'node:path'
+import yargs from 'yargs'
+import {
+  findUnknownConfigKeys,
+  parseConfigToml,
+  validateConfig,
+} from './config'
+import log, { LOG_LEVELS, type LogLevel } from './logger'
+
+export interface StreamwallConfig {
+  help: boolean
+  log: {
+    level: LogLevel
+  }
+  grid: {
+    cols: number
+    rows: number
+  }
+  window: {
+    x?: number
+    y?: number
+    width: number
+    height: number
+    frameless: boolean
+    fullscreen: boolean
+    display?: number
+    'background-color': string
+    'active-color': string
+  }
+  data: {
+    interval: number
+    'json-url': string[]
+    'toml-file': string[]
+  }
+  presets: string[]
+  streamdelay: {
+    endpoint: string
+    key: string | null
+  }
+  control: {
+    endpoint: string
+  }
+  retry: {
+    enabled: boolean
+    delay: number
+    'max-delay': number
+    'max-retries': number
+    'stalled-timeout': number
+  }
+  park: {
+    pause: boolean
+  }
+  twitch: {
+    channel: string | null
+    username: string | null
+    token: string | null
+    color: string
+    announce: {
+      template: string
+      interval: number
+      delay: number
+    }
+    vote: {
+      template: string
+      interval: number
+    }
+  }
+  telemetry: {
+    sentry: boolean
+  }
+  playlist: {
+    view: number
+    interval: number
+    urls: string[]
+  }[]
+}
+
+// Warns (does not throw) about keys in a raw parsed config file that the
+// schema doesn't recognize — typos and stale keys (e.g. the removed
+// `grid.count`) that would otherwise be silently dropped and fall back to
+// defaults with no indication anything was wrong.
+function warnUnknownConfigKeys(raw: unknown, source: string) {
+  for (const key of findUnknownConfigKeys(raw)) {
+    log.warn(`Unknown config key "${key}" in "${source}" is ignored.`)
+  }
+}
+
+export interface ParseArgsOptions {
+  /**
+   * Directory holding the user's `config.toml` (Electron's `userData` path in
+   * production). Passed in rather than read from `app` so the CLI parsing can
+   * be exercised without the Electron runtime.
+   */
+  configDir: string
+  /**
+   * Raw process arguments, forwarded verbatim to yargs. In production this is
+   * `process.argv`; its first two entries (node + script path) land in
+   * `argv._` since no positional commands are defined.
+   */
+  argv: string[]
+}
+
+/**
+ * Resolves the effective Streamwall configuration by layering CLI flags over
+ * an optional `config.toml` in `configDir` (and any `--config` file), applying
+ * schema defaults, and validating the result.
+ *
+ * Unknown keys in a config file are warned about but not rejected; validation
+ * is skipped entirely when only `--help` was requested so an invalid config can
+ * never block the help text.
+ */
+export function parseArgs({
+  configDir,
+  argv,
+}: ParseArgsOptions): StreamwallConfig {
+  // Load config from user data dir, if it exists
+  const configPath = join(configDir, 'config.toml')
+  log.debug('Reading config from ', configPath)
+
+  let configText: string | null = null
+  try {
+    configText = fs.readFileSync(configPath, 'utf-8')
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw err
+    }
+  }
+
+  const homeConfig = configText ? parseConfigToml(configText, configPath) : {}
+  if (configText) {
+    warnUnknownConfigKeys(homeConfig, configPath)
+  }
+
+  const parsed = yargs()
+    .config(homeConfig)
+    .config('config', (configFilePath) => {
+      const config = parseConfigToml(
+        fs.readFileSync(configFilePath, 'utf-8'),
+        configFilePath,
+      )
+      warnUnknownConfigKeys(config, configFilePath)
+      return config
+    })
+    .group(['log.level'], 'Logging')
+    .option('log.level', {
+      describe:
+        'Verbosity of log output, written to both the console and the log file',
+      choices: LOG_LEVELS,
+      default: 'debug',
+    })
+    .group(['grid.cols', 'grid.rows'], 'Grid dimensions')
+    .option('grid.cols', {
+      number: true,
+      default: 3,
+    })
+    .option('grid.rows', {
+      number: true,
+      default: 3,
+    })
+    .group(
+      [
+        'window.width',
+        'window.height',
+        'window.x',
+        'window.y',
+        'window.frameless',
+        'window.fullscreen',
+        'window.display',
+        'window.background-color',
+        'window.active-color',
+      ],
+      'Window settings',
+    )
+    .option('window.x', {
+      number: true,
+    })
+    .option('window.y', {
+      number: true,
+    })
+    .option('window.width', {
+      number: true,
+      default: 1920,
+    })
+    .option('window.height', {
+      number: true,
+      default: 1080,
+    })
+    .option('window.frameless', {
+      boolean: true,
+      default: false,
+    })
+    .option('window.fullscreen', {
+      describe: 'Open the wall fullscreen (on the selected display, if any)',
+      boolean: true,
+      default: false,
+    })
+    .option('window.display', {
+      describe:
+        'Index of the display to open the wall on (0-based; see --window.fullscreen)',
+      number: true,
+    })
+    .option('window.background-color', {
+      describe: 'Background color of wall (useful for chroma-keying)',
+      default: '#000',
+    })
+    .option('window.active-color', {
+      describe: 'Active (highlight) color of wall',
+      default: '#fff',
+    })
+    .group(['data.interval', 'data.json-url', 'data.toml-file'], 'Datasources')
+    .option('data.interval', {
+      describe: 'Interval (in seconds) for refreshing polled data sources',
+      number: true,
+      default: 30,
+    })
+    .option('data.json-url', {
+      describe: 'Fetch streams from the specified URL(s)',
+      array: true,
+      string: true,
+      default: [],
+    })
+    .option('data.toml-file', {
+      describe: 'Fetch streams from the specified file(s)',
+      normalize: true,
+      array: true,
+      default: [],
+    })
+    .group(['presets'], 'Presets')
+    .option('presets', {
+      describe: 'Enabled built-in preset stream packs (e.g. "de-tv")',
+      array: true,
+      string: true,
+      default: ['de-tv'],
+    })
+    .group(['streamdelay.endpoint', 'streamdelay.key'], 'Streamdelay')
+    .option('streamdelay.endpoint', {
+      describe: 'URL of Streamdelay endpoint',
+      default: 'http://localhost:8404',
+    })
+    .option('streamdelay.key', {
+      describe: 'Streamdelay API key',
+      default: null,
+    })
+    .group(['control'], 'Remote Control')
+    .option('control.endpoint', {
+      describe: 'URL of control server endpoint',
+      default: null,
+    })
+    .group(
+      [
+        'retry.enabled',
+        'retry.delay',
+        'retry.max-delay',
+        'retry.max-retries',
+        'retry.stalled-timeout',
+      ],
+      'Auto-retry',
+    )
+    .option('retry.enabled', {
+      describe: 'Automatically reload views that error or stall',
+      boolean: true,
+      default: true,
+    })
+    .option('retry.delay', {
+      describe: 'Base backoff (in seconds) before the first reload',
+      number: true,
+      default: 5,
+    })
+    .option('retry.max-delay', {
+      describe: 'Maximum backoff (in seconds) between reloads',
+      number: true,
+      default: 60,
+    })
+    .option('retry.max-retries', {
+      describe: 'Maximum number of automatic reloads before giving up',
+      number: true,
+      default: 5,
+    })
+    .option('retry.stalled-timeout', {
+      describe: 'How long (in seconds) a view may stall before it is reloaded',
+      number: true,
+      default: 30,
+    })
+    .group(['park.pause'], 'Fullscreen Parking')
+    .option('park.pause', {
+      describe:
+        'Pause playback of parked (hidden) views instead of keeping them fully live while a stream is expanded to fullscreen',
+      boolean: true,
+      default: false,
+    })
+    .group(
+      [
+        'twitch.channel',
+        'twitch.username',
+        'twitch.token',
+        'twitch.color',
+        'twitch.announce.template',
+        'twitch.announce.interval',
+        'twitch.vote.template',
+        'twitch.vote.interval',
+      ],
+      'Twitch Chat',
+    )
+    .option('twitch.channel', {
+      describe: 'Name of Twitch channel',
+      default: null,
+    })
+    .option('twitch.username', {
+      describe: 'Username of Twitch bot account',
+      default: null,
+    })
+    .option('twitch.token', {
+      describe: 'Password of Twitch bot account',
+      default: null,
+    })
+    .option('twitch.color', {
+      describe: 'Color of Twitch bot username',
+      default: '#ff0000',
+    })
+    .option('twitch.announce.template', {
+      describe: 'Message template for stream announcements',
+      default:
+        'SingsMic <%- stream.source %> <%- stream.city && stream.state ? `(${stream.city} ${stream.state})` : `` %> <%- stream.link %>',
+    })
+    .option('twitch.announce.interval', {
+      describe:
+        'Minimum time interval (in seconds) between re-announcing the same stream',
+      number: true,
+      default: 60,
+    })
+    .option('twitch.announce.delay', {
+      describe: 'Time to dwell on a stream before its details are announced',
+      number: true,
+      default: 30,
+    })
+    .option('twitch.vote.template', {
+      describe: 'Message template for vote result announcements',
+      default: 'Switching to #<%- selectedIdx %> (with <%- voteCount %> votes)',
+    })
+    .option('twitch.vote.interval', {
+      describe: 'Time interval (in seconds) between votes (0 to disable)',
+      number: true,
+      default: 0,
+    })
+    .group(['telemetry.sentry'], 'Telemetry')
+    .option('telemetry.sentry', {
+      describe: 'Enable error reporting to Sentry',
+      boolean: true,
+      default: true,
+    })
+    // Configured only via `[[playlist]]` tables in config.toml (or --config);
+    // not exposed as an individual CLI flag since it's a list of tables.
+    .option('playlist', {
+      default: [],
+    })
+    .help()
+    // https://github.com/yargs/yargs/issues/2137
+    .parseSync(argv) as unknown as StreamwallConfig
+
+  // Skip validation when the user only asked for --help, so an invalid config
+  // can never block the help text from being shown.
+  if (!parsed.help) {
+    validateConfig(parsed)
+  }
+  return parsed
+}

--- a/packages/streamwall/src/main/commandHandlers.test.ts
+++ b/packages/streamwall/src/main/commandHandlers.test.ts
@@ -1,0 +1,396 @@
+import { type ControlCommand, type StreamwallState } from 'streamwall-shared'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as Y from 'yjs'
+import {
+  type BrowseWindow,
+  type CommandHandlerDeps,
+  createOnCommand,
+} from './commandHandlers'
+import { buildLayoutPreset } from './layoutPresets'
+
+/** Casts a plain literal to a ControlCommand for routing tests. */
+function cmd(msg: Record<string, unknown>): ControlCommand {
+  return msg as unknown as ControlCommand
+}
+
+function fakeBrowseWindow(): BrowseWindow & {
+  destroy: ReturnType<typeof vi.fn>
+  loadURL: ReturnType<typeof vi.fn>
+} {
+  return {
+    isDestroyed: vi.fn(() => false),
+    destroy: vi.fn(),
+    loadURL: vi.fn(),
+    webContents: {} as BrowseWindow['webContents'],
+  }
+}
+
+function makeDeps(overrides: Partial<CommandHandlerDeps> = {}) {
+  const doc = new Y.Doc()
+  const viewsState = doc.getMap<Y.Map<string | undefined>>('views')
+
+  let clientState = {
+    layoutPresets: [],
+    favorites: [],
+  } as unknown as StreamwallState
+
+  const streamWindow = {
+    setListeningView: vi.fn(),
+    setViewBackgroundListening: vi.fn(),
+    setViewBlurred: vi.fn(),
+    setViewVolume: vi.fn(),
+    reloadView: vi.fn(),
+    setGridSize: vi.fn(),
+    openDevTools: vi.fn(),
+    // Resolves a stable view id to the grid cell it currently occupies.
+    getViewAnchorIdx: vi.fn((viewId: number) => viewId + 3),
+  }
+
+  const deps: CommandHandlerDeps = {
+    streamWindow,
+    overlayStreamData: { update: vi.fn() },
+    localStreamData: { update: vi.fn(), delete: vi.fn() },
+    viewsState,
+    transact: (fn) => doc.transact(fn),
+    streamWindowConfig: { cols: 3, rows: 3 },
+    getClientState: () => clientState,
+    getStreamdelayClient: () => null,
+    updateState: vi.fn((partial: Partial<StreamwallState>) => {
+      clientState = { ...clientState, ...partial }
+    }),
+    updateViewsFromStateDoc: vi.fn(),
+    persistLayoutPresets: vi.fn(),
+    persistFavorites: vi.fn(),
+    createBrowseWindow: vi.fn(() => fakeBrowseWindow()),
+    validateBrowseURL: vi.fn(async () => {}),
+    generateId: () => 'preset-id',
+    ...overrides,
+  }
+
+  return {
+    deps,
+    streamWindow,
+    viewsState,
+    setClientState: (next: Partial<StreamwallState>) => {
+      clientState = { ...clientState, ...next }
+    },
+    getClientState: () => clientState,
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('createOnCommand — uplink gate', () => {
+  it('rejects a browse command arriving from the uplink', async () => {
+    const { deps } = makeDeps()
+    const onCommand = createOnCommand(deps)
+
+    await onCommand(
+      cmd({ type: 'browse', url: 'https://example.com' }),
+      'uplink',
+    )
+
+    expect(deps.createBrowseWindow).not.toHaveBeenCalled()
+  })
+
+  it('allows an allowlisted command from the uplink', async () => {
+    const { deps, streamWindow } = makeDeps()
+    const onCommand = createOnCommand(deps)
+
+    await onCommand(cmd({ type: 'set-listening-view', viewId: 1 }), 'uplink')
+
+    expect(streamWindow.setListeningView).toHaveBeenCalledWith(1)
+  })
+})
+
+describe('createOnCommand — view controls', () => {
+  let ctx: ReturnType<typeof makeDeps>
+  let onCommand: ReturnType<typeof createOnCommand>
+
+  beforeEach(() => {
+    ctx = makeDeps()
+    onCommand = createOnCommand(ctx.deps)
+  })
+
+  it('routes set-listening-view', async () => {
+    await onCommand(cmd({ type: 'set-listening-view', viewId: 2 }))
+    expect(ctx.streamWindow.setListeningView).toHaveBeenCalledWith(2)
+  })
+
+  it('routes set-view-background-listening', async () => {
+    await onCommand(
+      cmd({
+        type: 'set-view-background-listening',
+        viewId: 1,
+        listening: true,
+      }),
+    )
+    expect(ctx.streamWindow.setViewBackgroundListening).toHaveBeenCalledWith(
+      1,
+      true,
+    )
+  })
+
+  it('routes set-view-blurred', async () => {
+    await onCommand(cmd({ type: 'set-view-blurred', viewId: 0, blurred: true }))
+    expect(ctx.streamWindow.setViewBlurred).toHaveBeenCalledWith(0, true)
+  })
+
+  it('routes set-view-volume', async () => {
+    await onCommand(cmd({ type: 'set-view-volume', viewId: 0, volume: 0.5 }))
+    expect(ctx.streamWindow.setViewVolume).toHaveBeenCalledWith(0, 0.5)
+  })
+
+  it('routes reload-view', async () => {
+    await onCommand(cmd({ type: 'reload-view', viewId: 3 }))
+    expect(ctx.streamWindow.reloadView).toHaveBeenCalledWith(3)
+  })
+
+  it('routes rotate-stream to the overlay data source', async () => {
+    await onCommand(cmd({ type: 'rotate-stream', url: 'u', rotation: 90 }))
+    expect(ctx.deps.overlayStreamData.update).toHaveBeenCalledWith('u', {
+      rotation: 90,
+    })
+  })
+
+  it('routes update-custom-stream and delete-custom-stream', async () => {
+    await onCommand(cmd({ type: 'update-custom-stream', url: 'u', data: {} }))
+    expect(ctx.deps.localStreamData.update).toHaveBeenCalledWith('u', {})
+
+    await onCommand(cmd({ type: 'delete-custom-stream', url: 'u' }))
+    expect(ctx.deps.localStreamData.delete).toHaveBeenCalledWith('u')
+  })
+
+  it('resolves the view id to its anchor cell when expanding, and clears it', async () => {
+    await onCommand(
+      cmd({ type: 'set-view-fullscreen', viewId: 2, fullscreen: true }),
+    )
+    // The command carries a stable view id (#397); the broadcast state keys on
+    // the cell that view currently occupies.
+    expect(ctx.streamWindow.getViewAnchorIdx).toHaveBeenCalledWith(2)
+    expect(ctx.deps.updateState).toHaveBeenCalledWith({ fullscreenViewIdx: 5 })
+    expect(ctx.deps.updateViewsFromStateDoc).toHaveBeenCalled()
+
+    await onCommand(
+      cmd({ type: 'set-view-fullscreen', viewId: 2, fullscreen: false }),
+    )
+    expect(ctx.deps.updateState).toHaveBeenCalledWith({
+      fullscreenViewIdx: null,
+    })
+  })
+
+  it('does not expand a view that has no placement', async () => {
+    const ctx = makeDeps()
+    ctx.streamWindow.getViewAnchorIdx.mockReturnValue(null as unknown as number)
+    const onCommand = createOnCommand(ctx.deps)
+
+    await onCommand(
+      cmd({ type: 'set-view-fullscreen', viewId: 9, fullscreen: true }),
+    )
+
+    expect(ctx.deps.updateState).toHaveBeenCalledWith({
+      fullscreenViewIdx: null,
+    })
+  })
+})
+
+describe('createOnCommand — browse / dev-tools', () => {
+  it('opens a validated URL in a fresh browse window', async () => {
+    const win = fakeBrowseWindow()
+    const { deps } = makeDeps({ createBrowseWindow: vi.fn(() => win) })
+    const onCommand = createOnCommand(deps)
+
+    await onCommand(cmd({ type: 'browse', url: 'https://example.com' }))
+
+    expect(deps.validateBrowseURL).toHaveBeenCalledWith(
+      'https://example.com',
+      win,
+    )
+    expect(win.loadURL).toHaveBeenCalledWith('https://example.com')
+  })
+
+  it('returns an error and does not load when the URL is rejected', async () => {
+    const win = fakeBrowseWindow()
+    const { deps } = makeDeps({
+      createBrowseWindow: vi.fn(() => win),
+      validateBrowseURL: vi.fn(async () => {
+        throw new Error('blocked')
+      }),
+    })
+    const onCommand = createOnCommand(deps)
+
+    const result = await onCommand(
+      cmd({ type: 'browse', url: 'http://169.254.169.254' }),
+    )
+
+    expect(result).toEqual({ error: 'invalid url' })
+    expect(win.loadURL).not.toHaveBeenCalled()
+  })
+
+  it('recreates the browse window for dev-tools and opens the tools', async () => {
+    const createBrowseWindow = vi.fn(() => fakeBrowseWindow())
+    const { deps, streamWindow } = makeDeps({ createBrowseWindow })
+    const onCommand = createOnCommand(deps)
+
+    await onCommand(cmd({ type: 'browse', url: 'https://example.com' }))
+    await onCommand(cmd({ type: 'dev-tools', viewId: 1 }))
+
+    // A fresh window is created for dev-tools (the first is destroyed).
+    expect(createBrowseWindow).toHaveBeenCalledTimes(2)
+    expect(streamWindow.openDevTools).toHaveBeenCalledWith(1, expect.anything())
+  })
+})
+
+describe('createOnCommand — streamdelay', () => {
+  it('forwards censor/running to the stream-delay client when present', async () => {
+    const streamdelayClient = {
+      setCensored: vi.fn(),
+      setStreamRunning: vi.fn(),
+    }
+    const { deps } = makeDeps({
+      getStreamdelayClient: () => streamdelayClient,
+    })
+    const onCommand = createOnCommand(deps)
+
+    await onCommand(cmd({ type: 'set-stream-censored', isCensored: true }))
+    await onCommand(cmd({ type: 'set-stream-running', isStreamRunning: false }))
+
+    expect(streamdelayClient.setCensored).toHaveBeenCalledWith(true)
+    expect(streamdelayClient.setStreamRunning).toHaveBeenCalledWith(false)
+  })
+
+  it('does nothing when no stream-delay client is configured', async () => {
+    const { deps } = makeDeps({ getStreamdelayClient: () => null })
+    const onCommand = createOnCommand(deps)
+
+    // Should not throw despite no client.
+    await expect(
+      onCommand(cmd({ type: 'set-stream-censored', isCensored: true })),
+    ).resolves.toBeUndefined()
+  })
+})
+
+describe('createOnCommand — grid and layout presets', () => {
+  it('applies a grid resize and rebroadcasts state', async () => {
+    const { deps, streamWindow } = makeDeps()
+    const onCommand = createOnCommand(deps)
+
+    await onCommand(cmd({ type: 'set-grid-size', cols: 4, rows: 2 }))
+
+    expect(streamWindow.setGridSize).toHaveBeenCalledWith(4, 2)
+    expect(deps.updateState).toHaveBeenCalledWith({})
+  })
+
+  it('saves a layout preset and persists it', async () => {
+    const { deps } = makeDeps()
+    const onCommand = createOnCommand(deps)
+
+    await onCommand(cmd({ type: 'save-layout-preset', name: 'My Preset' }))
+
+    expect(deps.persistLayoutPresets).toHaveBeenCalledTimes(1)
+    const persisted = (deps.persistLayoutPresets as ReturnType<typeof vi.fn>)
+      .mock.calls[0][0]
+    expect(persisted).toEqual([
+      expect.objectContaining({ id: 'preset-id', name: 'My Preset' }),
+    ])
+    expect(deps.updateState).toHaveBeenCalledWith({ layoutPresets: persisted })
+  })
+
+  it('loads an existing layout preset', async () => {
+    const ctx = makeDeps()
+    const preset = buildLayoutPreset(
+      { viewsState: ctx.viewsState, cols: 3, rows: 3 },
+      'preset-id',
+      'Saved',
+    )
+    ctx.setClientState({ layoutPresets: [preset] })
+    const onCommand = createOnCommand(ctx.deps)
+
+    await onCommand(cmd({ type: 'load-layout-preset', presetId: 'preset-id' }))
+
+    expect(ctx.deps.updateState).toHaveBeenCalledWith({})
+  })
+
+  it('ignores loading a non-existent layout preset', async () => {
+    const { deps } = makeDeps()
+    const onCommand = createOnCommand(deps)
+
+    await onCommand(cmd({ type: 'load-layout-preset', presetId: 'missing' }))
+
+    expect(deps.updateState).not.toHaveBeenCalled()
+  })
+
+  it('deletes a layout preset by id', async () => {
+    const ctx = makeDeps()
+    const preset = buildLayoutPreset(
+      { viewsState: ctx.viewsState, cols: 3, rows: 3 },
+      'preset-id',
+      'Saved',
+    )
+    ctx.setClientState({ layoutPresets: [preset] })
+    const onCommand = createOnCommand(ctx.deps)
+
+    await onCommand(
+      cmd({ type: 'delete-layout-preset', presetId: 'preset-id' }),
+    )
+
+    expect(ctx.deps.persistLayoutPresets).toHaveBeenCalledWith([])
+    expect(ctx.deps.updateState).toHaveBeenCalledWith({ layoutPresets: [] })
+  })
+})
+
+describe('createOnCommand — favorites', () => {
+  it('adds a new favorite and persists it', async () => {
+    const ctx = makeDeps()
+    ctx.setClientState({
+      favorites: [] as unknown as StreamwallState['favorites'],
+    })
+    const onCommand = createOnCommand(ctx.deps)
+
+    await onCommand(cmd({ type: 'add-favorite', url: 'https://a' }))
+
+    expect(ctx.deps.persistFavorites).toHaveBeenCalledTimes(1)
+    expect(ctx.deps.updateState).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing when adding a duplicate favorite', async () => {
+    const ctx = makeDeps()
+    ctx.setClientState({
+      favorites: ['https://a'] as unknown as StreamwallState['favorites'],
+    })
+    const onCommand = createOnCommand(ctx.deps)
+
+    await onCommand(cmd({ type: 'add-favorite', url: 'https://a' }))
+
+    expect(ctx.deps.persistFavorites).not.toHaveBeenCalled()
+    expect(ctx.deps.updateState).not.toHaveBeenCalled()
+  })
+
+  it('removes an existing favorite and persists it', async () => {
+    const ctx = makeDeps()
+    ctx.setClientState({
+      favorites: ['https://a'] as unknown as StreamwallState['favorites'],
+    })
+    const onCommand = createOnCommand(ctx.deps)
+
+    await onCommand(cmd({ type: 'remove-favorite', url: 'https://a' }))
+
+    expect(ctx.deps.persistFavorites).toHaveBeenCalledTimes(1)
+    expect(ctx.deps.updateState).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing when removing a favorite that is not present', async () => {
+    const ctx = makeDeps()
+    ctx.setClientState({
+      favorites: [] as unknown as StreamwallState['favorites'],
+    })
+    const onCommand = createOnCommand(ctx.deps)
+
+    await onCommand(cmd({ type: 'remove-favorite', url: 'https://missing' }))
+
+    expect(ctx.deps.persistFavorites).not.toHaveBeenCalled()
+    expect(ctx.deps.updateState).not.toHaveBeenCalled()
+  })
+})

--- a/packages/streamwall/src/main/commandHandlers.ts
+++ b/packages/streamwall/src/main/commandHandlers.ts
@@ -1,0 +1,274 @@
+import { type WebContents } from 'electron'
+import { randomUUID } from 'node:crypto'
+import { type ControlCommand, type StreamwallState } from 'streamwall-shared'
+import * as Y from 'yjs'
+import {
+  type CommandSource,
+  type ControlCommandResult,
+} from './commandDispatch'
+import { type LocalStreamData } from './data'
+import { addFavorite, removeFavorite } from './favorites'
+import { applyGridResize } from './gridResize'
+import {
+  addLayoutPreset,
+  applyLayoutPreset,
+  buildLayoutPreset,
+} from './layoutPresets'
+import log from './logger'
+import { type default as StreamdelayClient } from './StreamdelayClient'
+import { type default as StreamWindow } from './StreamWindow'
+import { checkUplinkCommandGate } from './uplinkCommandGate'
+
+/** The `browseWindow` surface the browse / dev-tools commands drive. */
+export interface BrowseWindow {
+  isDestroyed(): boolean
+  destroy(): void
+  loadURL(url: string): unknown
+  webContents: WebContents
+}
+
+/** The StreamWindow methods reachable from control commands. */
+export type CommandStreamWindow = Pick<
+  StreamWindow,
+  | 'setListeningView'
+  | 'setViewBackgroundListening'
+  | 'setViewBlurred'
+  | 'setViewVolume'
+  | 'reloadView'
+  | 'setGridSize'
+  | 'openDevTools'
+  | 'getViewAnchorIdx'
+>
+
+export interface CommandHandlerDeps {
+  streamWindow: CommandStreamWindow
+  /** Overlay data source (rotation overrides). */
+  overlayStreamData: Pick<LocalStreamData, 'update'>
+  /** Operator-defined custom streams. */
+  localStreamData: Pick<LocalStreamData, 'update' | 'delete'>
+  /** Yjs map of grid cell index (as string) -> a `{ streamId }` map. */
+  viewsState: Y.Map<Y.Map<string | undefined>>
+  /** Runs `fn` inside the shared `stateDoc.transact`, batching the mutations. */
+  transact: (fn: () => void) => void
+  /** The shared, mutated-in-place stream window config (grid dimensions). */
+  streamWindowConfig: { cols: number; rows: number }
+  /** Reads the current broadcast client state (layout presets, favorites). */
+  getClientState: () => StreamwallState
+  /** The stream-delay client, or null when none is configured. */
+  getStreamdelayClient: () => Pick<
+    StreamdelayClient,
+    'setCensored' | 'setStreamRunning'
+  > | null
+  /** Merges a partial into the client state and rebroadcasts it. */
+  updateState: (partial: Partial<StreamwallState>) => void
+  /** Re-derives the wall layout from the current stateDoc + streams. */
+  updateViewsFromStateDoc: () => void
+  /** Persists the layout presets to storage. */
+  persistLayoutPresets: (presets: StreamwallState['layoutPresets']) => void
+  /** Persists the favorites to storage. */
+  persistFavorites: (favorites: StreamwallState['favorites']) => void
+  /**
+   * Creates a hardened, isolated browse window. Injected so the security
+   * wiring (partition, session hardening, popup denial) stays at the call site
+   * and the command routing can be tested without the Electron runtime.
+   */
+  createBrowseWindow: () => BrowseWindow
+  /**
+   * Validates a URL against the browse window's session before it is loaded,
+   * throwing when the URL is disallowed.
+   */
+  validateBrowseURL: (url: string, browseWindow: BrowseWindow) => Promise<void>
+  /** Generates a unique id for a saved layout preset (defaults to randomUUID). */
+  generateId?: () => string
+}
+
+/**
+ * Builds the control-command handler that routes every `ControlCommand` — from
+ * the local control window or the remote uplink — to the matching collaborator.
+ *
+ * The returned handler owns the lifecycle of the ephemeral browse window
+ * (created on demand, destroyed and recreated for dev-tools), the only piece of
+ * mutable state local to command handling.
+ */
+export function createOnCommand(deps: CommandHandlerDeps) {
+  const generateId = deps.generateId ?? randomUUID
+  let browseWindow: BrowseWindow | null = null
+
+  return async (
+    msg: ControlCommand,
+    source: CommandSource = 'local',
+  ): Promise<ControlCommandResult | void> => {
+    log.debug('Received message:', msg)
+
+    // The remote control-server uplink is untrusted: re-validate every command
+    // against the uplink allowlist so a compromised or man-in-the-middled
+    // server cannot drive code execution (browse/dev-tools) on the desktop.
+    const uplinkGate = checkUplinkCommandGate(msg, source)
+    if (!uplinkGate.allowed) {
+      log.warn(
+        'Rejecting disallowed command from control uplink:',
+        uplinkGate.type,
+      )
+      return
+    }
+
+    const streamdelayClient = deps.getStreamdelayClient()
+
+    if (msg.type === 'set-listening-view') {
+      log.debug('Setting listening view:', msg.viewId)
+      deps.streamWindow.setListeningView(msg.viewId)
+    } else if (msg.type === 'set-view-background-listening') {
+      log.debug('Setting view background listening:', msg.viewId, msg.listening)
+      deps.streamWindow.setViewBackgroundListening(msg.viewId, msg.listening)
+    } else if (msg.type === 'set-view-blurred') {
+      log.debug('Setting view blurred:', msg.viewId, msg.blurred)
+      deps.streamWindow.setViewBlurred(msg.viewId, msg.blurred)
+    } else if (msg.type === 'set-view-volume') {
+      log.debug('Setting view volume:', msg.viewId, msg.volume)
+      deps.streamWindow.setViewVolume(msg.viewId, msg.volume)
+    } else if (msg.type === 'rotate-stream') {
+      log.debug('Rotating stream:', msg.url, msg.rotation)
+      deps.overlayStreamData.update(msg.url, {
+        rotation: msg.rotation,
+      })
+    } else if (msg.type === 'update-custom-stream') {
+      log.debug('Updating custom stream:', msg.url)
+      deps.localStreamData.update(msg.url, msg.data)
+    } else if (msg.type === 'delete-custom-stream') {
+      log.debug('Deleting custom stream:', msg.url)
+      deps.localStreamData.delete(msg.url)
+    } else if (msg.type === 'reload-view') {
+      log.debug('Reloading view:', msg.viewId)
+      deps.streamWindow.reloadView(msg.viewId)
+    } else if (msg.type === 'set-view-fullscreen') {
+      // Runtime-only wall zoom (issue #362): remember which view fills the
+      // wall (or null) and re-derive the layout. Broadcast the new value first
+      // so clients render the expansion consistently, then re-lay-out the wall.
+      //
+      // The command carries a stable view id (issue #397); resolve it to the
+      // cell that view currently occupies so the cell-based `fullscreenViewIdx`
+      // (which the layout state and clients still key on) reflects the view the
+      // operator actually double-clicked, even if a resize just moved it. If
+      // the view has no placement, `getViewAnchorIdx` returns null and no
+      // expansion happens.
+      log.debug('Setting view fullscreen:', msg.viewId, msg.fullscreen)
+      deps.updateState({
+        fullscreenViewIdx: msg.fullscreen
+          ? deps.streamWindow.getViewAnchorIdx(msg.viewId)
+          : null,
+      })
+      deps.updateViewsFromStateDoc()
+    } else if (msg.type === 'browse' || msg.type === 'dev-tools') {
+      if (browseWindow && !browseWindow.isDestroyed()) {
+        // DevTools needs a fresh webContents to work. Close any existing window.
+        browseWindow.destroy()
+        browseWindow = null
+      }
+      if (!browseWindow || browseWindow.isDestroyed()) {
+        browseWindow = deps.createBrowseWindow()
+      }
+      if (msg.type === 'browse') {
+        log.debug('Attempting to browse URL:', msg.url)
+        try {
+          await deps.validateBrowseURL(msg.url, browseWindow)
+          browseWindow.loadURL(msg.url)
+        } catch (error) {
+          log.error('Invalid URL:', msg.url)
+          log.error('Error:', error)
+          return { error: 'invalid url' }
+        }
+      } else if (msg.type === 'dev-tools') {
+        log.debug('Opening DevTools for view:', msg.viewId)
+        deps.streamWindow.openDevTools(msg.viewId, browseWindow.webContents)
+      }
+    } else if (msg.type === 'set-stream-censored' && streamdelayClient) {
+      log.debug('Setting stream censored:', msg.isCensored)
+      streamdelayClient.setCensored(msg.isCensored)
+    } else if (msg.type === 'set-stream-running' && streamdelayClient) {
+      log.debug('Setting stream running:', msg.isStreamRunning)
+      streamdelayClient.setStreamRunning(msg.isStreamRunning)
+    } else if (msg.type === 'set-grid-size') {
+      applyGridResize(
+        {
+          viewsState: deps.viewsState,
+          transact: deps.transact,
+          getCols: () => deps.streamWindowConfig.cols,
+          getRows: () => deps.streamWindowConfig.rows,
+          setGridSize: (cols, rows) =>
+            deps.streamWindow.setGridSize(cols, rows),
+        },
+        msg.cols,
+        msg.rows,
+      )
+
+      // streamWindow.config, streamWindowConfig and clientState.config are the
+      // same shared object, and setGridSize mutates it in place. Broadcast that
+      // shared object via updateState({}) rather than detaching a copy, so a
+      // later window resize keeps the overlay/control grid in sync with the wall
+      // (issue #14). The wall itself was already re-laid-out by the stateDoc
+      // observer during applyGridResize's transact — now that the config holds
+      // the new dimensions (issue #15) — so no explicit updateViewsFromStateDoc()
+      // call is needed here.
+      deps.updateState({})
+    } else if (msg.type === 'save-layout-preset') {
+      log.debug('Saving layout preset:', msg.name)
+      const preset = buildLayoutPreset(
+        {
+          viewsState: deps.viewsState,
+          cols: deps.streamWindowConfig.cols,
+          rows: deps.streamWindowConfig.rows,
+        },
+        generateId(),
+        msg.name,
+      )
+      const layoutPresets = addLayoutPreset(
+        deps.getClientState().layoutPresets,
+        preset,
+      )
+      deps.persistLayoutPresets(layoutPresets)
+      deps.updateState({ layoutPresets })
+    } else if (msg.type === 'load-layout-preset') {
+      const preset = deps
+        .getClientState()
+        .layoutPresets.find((p) => p.id === msg.presetId)
+      if (preset) {
+        log.debug('Loading layout preset:', preset.name)
+        applyLayoutPreset(
+          {
+            viewsState: deps.viewsState,
+            transact: deps.transact,
+            setGridSize: (cols, rows) =>
+              deps.streamWindow.setGridSize(cols, rows),
+          },
+          preset,
+        )
+        // See the set-grid-size branch above: broadcast the shared config
+        // object via updateState({}) rather than detaching a copy.
+        deps.updateState({})
+      }
+    } else if (msg.type === 'delete-layout-preset') {
+      log.debug('Deleting layout preset:', msg.presetId)
+      const layoutPresets = deps
+        .getClientState()
+        .layoutPresets.filter((p) => p.id !== msg.presetId)
+      deps.persistLayoutPresets(layoutPresets)
+      deps.updateState({ layoutPresets })
+    } else if (msg.type === 'add-favorite') {
+      const clientState = deps.getClientState()
+      const favorites = addFavorite(clientState.favorites, msg.url)
+      if (favorites !== clientState.favorites) {
+        log.debug('Adding favorite:', msg.url)
+        deps.persistFavorites(favorites)
+        deps.updateState({ favorites })
+      }
+    } else if (msg.type === 'remove-favorite') {
+      const clientState = deps.getClientState()
+      const favorites = removeFavorite(clientState.favorites, msg.url)
+      if (favorites !== clientState.favorites) {
+        log.debug('Removing favorite:', msg.url)
+        deps.persistFavorites(favorites)
+        deps.updateState({ favorites })
+      }
+    }
+  }
+}

--- a/packages/streamwall/src/main/dataSources.test.ts
+++ b/packages/streamwall/src/main/dataSources.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { type LocalStreamData } from './data'
+import { buildDataSources } from './dataSources'
+import log from './logger'
+
+/** A LocalStreamData stand-in whose gen() yields nothing. */
+function fakeStreamData(): Pick<LocalStreamData, 'gen'> {
+  return {
+    gen: () =>
+      (async function* () {
+        // No data emitted; the source is never iterated in these tests.
+      })() as ReturnType<LocalStreamData['gen']>,
+  }
+}
+
+function baseInput() {
+  return {
+    jsonUrls: [] as string[],
+    tomlFiles: [] as string[],
+    presets: [] as string[],
+    interval: 30,
+    localStreamData: fakeStreamData(),
+    overlayStreamData: fakeStreamData(),
+    trackDataSourceHealth: vi.fn(() => vi.fn()),
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('buildDataSources', () => {
+  it('always includes the custom and overlay sources', () => {
+    const sources = buildDataSources(baseInput())
+    expect(sources).toHaveLength(2)
+  })
+
+  it('adds one source per json-url and toml-file with health tracking', () => {
+    const trackDataSourceHealth = vi.fn(() => vi.fn())
+    const sources = buildDataSources({
+      ...baseInput(),
+      jsonUrls: ['http://a', 'http://b'],
+      tomlFiles: ['/streams.toml'],
+      trackDataSourceHealth,
+    })
+
+    // 2 json-url + 1 toml-file + custom + overlay
+    expect(sources).toHaveLength(5)
+    expect(trackDataSourceHealth).toHaveBeenCalledWith('http://a', 'json-url')
+    expect(trackDataSourceHealth).toHaveBeenCalledWith('http://b', 'json-url')
+    expect(trackDataSourceHealth).toHaveBeenCalledWith(
+      '/streams.toml',
+      'toml-file',
+    )
+  })
+
+  it('includes a source for a known preset pack', () => {
+    const sources = buildDataSources({ ...baseInput(), presets: ['de-tv'] })
+    // de-tv preset + custom + overlay
+    expect(sources).toHaveLength(3)
+  })
+
+  it('warns about and skips an unknown preset pack', () => {
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => log)
+    const sources = buildDataSources({
+      ...baseInput(),
+      presets: ['does-not-exist'],
+    })
+
+    // Only custom + overlay; the unknown preset is skipped.
+    expect(sources).toHaveLength(2)
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown preset pack "does-not-exist"'),
+    )
+  })
+})

--- a/packages/streamwall/src/main/dataSources.ts
+++ b/packages/streamwall/src/main/dataSources.ts
@@ -1,0 +1,82 @@
+import { type DataSourceType } from 'streamwall-shared'
+import {
+  type DataSourceHealthCallback,
+  type LocalStreamData,
+  OVERLAY_DATA_SOURCE_NAME,
+  markDataSource,
+  pollDataURL,
+  presetDataSource,
+  watchDataFile,
+} from './data'
+import log from './logger'
+import { loadPresetPack } from './presets'
+
+/** A marked, ready-to-combine data source (as produced by `markDataSource`). */
+type DataSource = ReturnType<typeof markDataSource>
+
+export interface BuildDataSourcesInput {
+  /** URLs polled for stream data (`--data.json-url`). */
+  jsonUrls: string[]
+  /** TOML files watched for stream data (`--data.toml-file`). */
+  tomlFiles: string[]
+  /** Enabled built-in preset pack ids (`--presets`). */
+  presets: string[]
+  /** Poll interval (seconds) for the URL sources. */
+  interval: number
+  /** Operator-defined custom streams source. */
+  localStreamData: Pick<LocalStreamData, 'gen'>
+  /** Overlay (rotate-stream) source. */
+  overlayStreamData: Pick<LocalStreamData, 'gen'>
+  /** Builds a health reporter for a data source of the given id and type. */
+  trackDataSourceHealth: (
+    id: string,
+    type: DataSourceType,
+  ) => DataSourceHealthCallback
+}
+
+/**
+ * Assembles every data source feeding the wall: polled URLs, watched TOML
+ * files, enabled preset packs, and the always-present custom and overlay
+ * sources. Unknown preset ids are warned about and skipped rather than failing
+ * startup.
+ *
+ * The sources are lazy — no polling, file watching, or network I/O happens
+ * until they are iterated by `combineDataSources`.
+ */
+export function buildDataSources({
+  jsonUrls,
+  tomlFiles,
+  presets,
+  interval,
+  localStreamData,
+  overlayStreamData,
+  trackDataSourceHealth,
+}: BuildDataSourcesInput): DataSource[] {
+  return [
+    ...jsonUrls.map((url) => {
+      log.debug('Setting data source from json-url:', url)
+      return markDataSource(
+        pollDataURL(url, interval, trackDataSourceHealth(url, 'json-url')),
+        'json-url',
+      )
+    }),
+    ...tomlFiles.map((path) => {
+      log.debug('Setting data source from toml-file:', path)
+      return markDataSource(
+        watchDataFile(path, trackDataSourceHealth(path, 'toml-file')),
+        'toml-file',
+      )
+    }),
+    ...presets.flatMap((packId) => {
+      const pack = loadPresetPack(packId)
+      if (!pack) {
+        log.warn(`Unknown preset pack "${packId}", skipping`)
+        return []
+      }
+      log.debug('Loading preset pack:', pack.id)
+      return [markDataSource(presetDataSource(pack), `preset:${pack.id}`)]
+    }),
+    markDataSource(localStreamData.gen(), 'custom'),
+    markDataSource(overlayStreamData.gen(), OVERLAY_DATA_SOURCE_NAME),
+  ]
+}

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -17,7 +17,6 @@ import {
   parseControlEndpoint,
 } from 'streamwall-shared'
 import WebSocket from 'ws'
-import yargs from 'yargs'
 import * as Y from 'yjs'
 import packageJson from '../../package.json'
 import {
@@ -28,12 +27,8 @@ import {
 import { parseRepositorySlug } from '../updateStatus'
 import { createSessionHostResolver, ensureValidURL } from '../util'
 import { AppUpdater } from './appUpdater'
+import { StreamwallConfig, parseArgs } from './cliArgs'
 import { dispatchCommand, dispatchLocalCommand } from './commandDispatch'
-import {
-  findUnknownConfigKeys,
-  parseConfigToml,
-  validateConfig,
-} from './config'
 import { resolveConfigInitError } from './configInitError'
 import { decideControlEndpointConnection } from './controlEndpointConnection'
 import ControlWindow from './ControlWindow'
@@ -60,12 +55,7 @@ import {
   buildLayoutPreset,
 } from './layoutPresets'
 import { LinuxUpdateChecker } from './linuxUpdateChecker'
-import log, {
-  LOG_LEVELS,
-  initLogger,
-  setLogLevel,
-  type LogLevel,
-} from './logger'
+import log, { initLogger, setLogLevel } from './logger'
 import { installApplicationMenu } from './menu'
 import { denyWindowOpen } from './navigationSecurity'
 import { BROWSE_PARTITION, hardenSession } from './partitions'
@@ -107,337 +97,6 @@ function makeControlWebSocket(authorization: string | null) {
       })
     }
   }
-}
-
-export interface StreamwallConfig {
-  help: boolean
-  log: {
-    level: LogLevel
-  }
-  grid: {
-    cols: number
-    rows: number
-  }
-  window: {
-    x?: number
-    y?: number
-    width: number
-    height: number
-    frameless: boolean
-    fullscreen: boolean
-    display?: number
-    'background-color': string
-    'active-color': string
-  }
-  data: {
-    interval: number
-    'json-url': string[]
-    'toml-file': string[]
-  }
-  presets: string[]
-  streamdelay: {
-    endpoint: string
-    key: string | null
-  }
-  control: {
-    endpoint: string
-  }
-  retry: {
-    enabled: boolean
-    delay: number
-    'max-delay': number
-    'max-retries': number
-    'stalled-timeout': number
-  }
-  park: {
-    pause: boolean
-  }
-  twitch: {
-    channel: string | null
-    username: string | null
-    token: string | null
-    color: string
-    announce: {
-      template: string
-      interval: number
-      delay: number
-    }
-    vote: {
-      template: string
-      interval: number
-    }
-  }
-  telemetry: {
-    sentry: boolean
-  }
-  playlist: {
-    view: number
-    interval: number
-    urls: string[]
-  }[]
-}
-
-// Warns (does not throw) about keys in a raw parsed config file that the
-// schema doesn't recognize — typos and stale keys (e.g. the removed
-// `grid.count`) that would otherwise be silently dropped and fall back to
-// defaults with no indication anything was wrong.
-function warnUnknownConfigKeys(raw: unknown, source: string) {
-  for (const key of findUnknownConfigKeys(raw)) {
-    log.warn(`Unknown config key "${key}" in "${source}" is ignored.`)
-  }
-}
-
-function parseArgs(): StreamwallConfig {
-  // Load config from user data dir, if it exists
-  const configPath = join(app.getPath('userData'), 'config.toml')
-  log.debug('Reading config from ', configPath)
-
-  let configText: string | null = null
-  try {
-    configText = fs.readFileSync(configPath, 'utf-8')
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
-      throw err
-    }
-  }
-
-  const homeConfig = configText ? parseConfigToml(configText, configPath) : {}
-  if (configText) {
-    warnUnknownConfigKeys(homeConfig, configPath)
-  }
-
-  const argv = yargs()
-    .config(homeConfig)
-    .config('config', (configFilePath) => {
-      const config = parseConfigToml(
-        fs.readFileSync(configFilePath, 'utf-8'),
-        configFilePath,
-      )
-      warnUnknownConfigKeys(config, configFilePath)
-      return config
-    })
-    .group(['log.level'], 'Logging')
-    .option('log.level', {
-      describe:
-        'Verbosity of log output, written to both the console and the log file',
-      choices: LOG_LEVELS,
-      default: 'debug',
-    })
-    .group(['grid.cols', 'grid.rows'], 'Grid dimensions')
-    .option('grid.cols', {
-      number: true,
-      default: 3,
-    })
-    .option('grid.rows', {
-      number: true,
-      default: 3,
-    })
-    .group(
-      [
-        'window.width',
-        'window.height',
-        'window.x',
-        'window.y',
-        'window.frameless',
-        'window.fullscreen',
-        'window.display',
-        'window.background-color',
-        'window.active-color',
-      ],
-      'Window settings',
-    )
-    .option('window.x', {
-      number: true,
-    })
-    .option('window.y', {
-      number: true,
-    })
-    .option('window.width', {
-      number: true,
-      default: 1920,
-    })
-    .option('window.height', {
-      number: true,
-      default: 1080,
-    })
-    .option('window.frameless', {
-      boolean: true,
-      default: false,
-    })
-    .option('window.fullscreen', {
-      describe: 'Open the wall fullscreen (on the selected display, if any)',
-      boolean: true,
-      default: false,
-    })
-    .option('window.display', {
-      describe:
-        'Index of the display to open the wall on (0-based; see --window.fullscreen)',
-      number: true,
-    })
-    .option('window.background-color', {
-      describe: 'Background color of wall (useful for chroma-keying)',
-      default: '#000',
-    })
-    .option('window.active-color', {
-      describe: 'Active (highlight) color of wall',
-      default: '#fff',
-    })
-    .group(['data.interval', 'data.json-url', 'data.toml-file'], 'Datasources')
-    .option('data.interval', {
-      describe: 'Interval (in seconds) for refreshing polled data sources',
-      number: true,
-      default: 30,
-    })
-    .option('data.json-url', {
-      describe: 'Fetch streams from the specified URL(s)',
-      array: true,
-      string: true,
-      default: [],
-    })
-    .option('data.toml-file', {
-      describe: 'Fetch streams from the specified file(s)',
-      normalize: true,
-      array: true,
-      default: [],
-    })
-    .group(['presets'], 'Presets')
-    .option('presets', {
-      describe: 'Enabled built-in preset stream packs (e.g. "de-tv")',
-      array: true,
-      string: true,
-      default: ['de-tv'],
-    })
-    .group(['streamdelay.endpoint', 'streamdelay.key'], 'Streamdelay')
-    .option('streamdelay.endpoint', {
-      describe: 'URL of Streamdelay endpoint',
-      default: 'http://localhost:8404',
-    })
-    .option('streamdelay.key', {
-      describe: 'Streamdelay API key',
-      default: null,
-    })
-    .group(['control'], 'Remote Control')
-    .option('control.endpoint', {
-      describe: 'URL of control server endpoint',
-      default: null,
-    })
-    .group(
-      [
-        'retry.enabled',
-        'retry.delay',
-        'retry.max-delay',
-        'retry.max-retries',
-        'retry.stalled-timeout',
-      ],
-      'Auto-retry',
-    )
-    .option('retry.enabled', {
-      describe: 'Automatically reload views that error or stall',
-      boolean: true,
-      default: true,
-    })
-    .option('retry.delay', {
-      describe: 'Base backoff (in seconds) before the first reload',
-      number: true,
-      default: 5,
-    })
-    .option('retry.max-delay', {
-      describe: 'Maximum backoff (in seconds) between reloads',
-      number: true,
-      default: 60,
-    })
-    .option('retry.max-retries', {
-      describe: 'Maximum number of automatic reloads before giving up',
-      number: true,
-      default: 5,
-    })
-    .option('retry.stalled-timeout', {
-      describe: 'How long (in seconds) a view may stall before it is reloaded',
-      number: true,
-      default: 30,
-    })
-    .group(['park.pause'], 'Fullscreen Parking')
-    .option('park.pause', {
-      describe:
-        'Pause playback of parked (hidden) views instead of keeping them fully live while a stream is expanded to fullscreen',
-      boolean: true,
-      default: false,
-    })
-    .group(
-      [
-        'twitch.channel',
-        'twitch.username',
-        'twitch.token',
-        'twitch.color',
-        'twitch.announce.template',
-        'twitch.announce.interval',
-        'twitch.vote.template',
-        'twitch.vote.interval',
-      ],
-      'Twitch Chat',
-    )
-    .option('twitch.channel', {
-      describe: 'Name of Twitch channel',
-      default: null,
-    })
-    .option('twitch.username', {
-      describe: 'Username of Twitch bot account',
-      default: null,
-    })
-    .option('twitch.token', {
-      describe: 'Password of Twitch bot account',
-      default: null,
-    })
-    .option('twitch.color', {
-      describe: 'Color of Twitch bot username',
-      default: '#ff0000',
-    })
-    .option('twitch.announce.template', {
-      describe: 'Message template for stream announcements',
-      default:
-        'SingsMic <%- stream.source %> <%- stream.city && stream.state ? `(${stream.city} ${stream.state})` : `` %> <%- stream.link %>',
-    })
-    .option('twitch.announce.interval', {
-      describe:
-        'Minimum time interval (in seconds) between re-announcing the same stream',
-      number: true,
-      default: 60,
-    })
-    .option('twitch.announce.delay', {
-      describe: 'Time to dwell on a stream before its details are announced',
-      number: true,
-      default: 30,
-    })
-    .option('twitch.vote.template', {
-      describe: 'Message template for vote result announcements',
-      default: 'Switching to #<%- selectedIdx %> (with <%- voteCount %> votes)',
-    })
-    .option('twitch.vote.interval', {
-      describe: 'Time interval (in seconds) between votes (0 to disable)',
-      number: true,
-      default: 0,
-    })
-    .group(['telemetry.sentry'], 'Telemetry')
-    .option('telemetry.sentry', {
-      describe: 'Enable error reporting to Sentry',
-      boolean: true,
-      default: true,
-    })
-    // Configured only via `[[playlist]]` tables in config.toml (or --config);
-    // not exposed as an individual CLI flag since it's a list of tables.
-    .option('playlist', {
-      default: [],
-    })
-    .help()
-    // https://github.com/yargs/yargs/issues/2137
-    .parseSync(process.argv) as unknown as StreamwallConfig
-
-  // Skip validation when the user only asked for --help, so an invalid config
-  // can never block the help text from being shown.
-  if (!argv.help) {
-    validateConfig(argv)
-  }
-  return argv
 }
 
 async function main(argv: ReturnType<typeof parseArgs>) {
@@ -1155,9 +814,12 @@ async function main(argv: ReturnType<typeof parseArgs>) {
 function init() {
   initLogger()
   log.debug('Parsing command line arguments...')
-  let argv: ReturnType<typeof parseArgs>
+  let argv: StreamwallConfig
   try {
-    argv = parseArgs()
+    argv = parseArgs({
+      configDir: app.getPath('userData'),
+      argv: process.argv,
+    })
   } catch (err) {
     const outcome = resolveConfigInitError(err)
     if (outcome.action === 'exit') {

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -4,17 +4,12 @@ import fs from 'fs'
 import { throttle } from 'lodash-es'
 import EventEmitter from 'node:events'
 import { join } from 'node:path'
-import ReconnectingWebSocket from 'reconnecting-websocket'
 import 'source-map-support/register'
 import {
-  ControlCommand,
   DataSourceType,
   StreamwallState,
   fullscreenViewContentMap,
-  isSocketOpen,
-  parseControlEndpoint,
 } from 'streamwall-shared'
-import WebSocket from 'ws'
 import * as Y from 'yjs'
 import packageJson from '../../package.json'
 import {
@@ -25,10 +20,9 @@ import {
 import { parseRepositorySlug } from '../updateStatus'
 import { createSessionHostResolver, ensureValidURL } from '../util'
 import { StreamwallConfig, parseArgs } from './cliArgs'
-import { dispatchCommand, dispatchLocalCommand } from './commandDispatch'
+import { dispatchLocalCommand } from './commandDispatch'
 import { createOnCommand } from './commandHandlers'
 import { resolveConfigInitError } from './configInitError'
-import { decideControlEndpointConnection } from './controlEndpointConnection'
 import ControlWindow from './ControlWindow'
 import {
   CONTROL_WINDOW_ORIGIN,
@@ -56,38 +50,12 @@ import StreamdelayClient from './StreamdelayClient'
 import StreamWindow from './StreamWindow'
 import TwitchBot from './TwitchBot'
 import { setupAppUpdater } from './updaterSetup'
-import { UPLINK_ORIGIN, shouldForwardUpdateToUplink } from './uplinkEcho'
-import { routeUplinkWsMessage } from './uplinkMessageRouting'
+import { connectControlUplink } from './uplinkConnection'
 import { initializeViewsState } from './viewsStateInit'
 import {
   shouldHideInsteadOfQuit,
   shouldQuitOnAllWindowsClosed,
 } from './windowCloseBehavior'
-
-/**
- * Builds a WebSocket subclass for the control uplink.
- *
- * It enforces TLS certificate validation on wss:// connections: together with
- * the wss:// requirement on the control endpoint, this authenticates the
- * control server to the desktop and prevents a man-in-the-middle from
- * impersonating it. `rejectUnauthorized` defaults to true in `ws`, but we set
- * it explicitly so the guarantee cannot be silently lost to a future change.
- *
- * It also injects the uplink credential as an `Authorization` header rather
- * than a URL query parameter, keeping the secret out of server and proxy
- * access logs. `reconnecting-websocket` does not forward constructor options,
- * so the header is baked into the subclass here.
- */
-function makeControlWebSocket(authorization: string | null) {
-  return class ControlWebSocket extends WebSocket {
-    constructor(url: string, protocols?: string | string[]) {
-      super(url, protocols, {
-        rejectUnauthorized: true,
-        headers: authorization ? { authorization } : undefined,
-      })
-    }
-  }
-}
 
 async function main(argv: ReturnType<typeof parseArgs>) {
   const db = await loadStorage(
@@ -427,77 +395,13 @@ async function main(argv: ReturnType<typeof parseArgs>) {
       })
   })
 
-  const controlConnection = decideControlEndpointConnection(
-    argv.control.endpoint,
-  )
-  if (
-    controlConnection.action === 'skip' &&
-    controlConnection.reason === 'insecure'
-  ) {
-    log.error(
-      `Refusing to connect to insecure control endpoint "${controlConnection.endpoint}". ` +
-        'The control connection must use wss:// (or ws:// to a loopback host).',
-    )
-  } else if (controlConnection.action === 'connect') {
-    log.debug('Connecting to control server...')
-    // Move the uplink secret out of the URL query string and into an
-    // Authorization header so it never reaches server or proxy access logs.
-    const { url: controlURL, authorization } = parseControlEndpoint(
-      controlConnection.endpoint,
-    )
-    const ws = new ReconnectingWebSocket(controlURL, [], {
-      WebSocket: makeControlWebSocket(authorization),
-      maxReconnectionDelay: 5000,
-      minReconnectionDelay: 100 + Math.random() * 500,
-      reconnectionDelayGrowFactor: 1.25,
-      // The 'open' handler below always re-sends the full client state and
-      // Yjs doc as soon as the connection (re)opens, so anything sent while
-      // disconnected is stale by the time it could be delivered. Disable the
-      // library's default unbounded queue rather than let it buffer full
-      // state snapshots for as long as the control server is unreachable.
-      maxEnqueuedMessages: 0,
-    })
-    ws.binaryType = 'arraybuffer'
-    ws.addEventListener('open', () => {
-      log.debug('Control WebSocket connected.')
-      ws.send(JSON.stringify({ type: 'state', state: clientState }))
-      ws.send(Y.encodeStateAsUpdate(stateDoc))
-    })
-    ws.addEventListener('close', () => {
-      log.debug('Control WebSocket disconnected.')
-    })
-    ws.addEventListener('message', (ev) => {
-      const route = routeUplinkWsMessage(ev.data)
-      switch (route.kind) {
-        case 'yjs-update':
-          Y.applyUpdate(stateDoc, route.update, UPLINK_ORIGIN)
-          return
-        case 'parse-error':
-          log.warn('Failed to parse control WebSocket message:', route.error)
-          return
-        case 'uplink-error':
-          log.warn(
-            'Control server refused the uplink connection:',
-            route.message,
-          )
-          return
-        case 'command':
-          dispatchCommand(onCommand, route.message as ControlCommand, 'uplink')
-      }
-    })
-    stateEmitter.on('state', () => {
-      if (!isSocketOpen(ws)) {
-        return
-      }
-      ws.send(JSON.stringify({ type: 'state', state: clientState }))
-    })
-    stateDoc.on('update', (update, origin) => {
-      if (!shouldForwardUpdateToUplink(origin) || !isSocketOpen(ws)) {
-        return
-      }
-      ws.send(update)
-    })
-  }
+  connectControlUplink({
+    endpoint: argv.control.endpoint,
+    stateDoc,
+    stateEmitter,
+    getClientState: () => clientState,
+    onCommand,
+  })
 
   if (argv.streamdelay.key) {
     log.debug('Setting up Streamdelay client...')

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -24,23 +24,14 @@ import {
   CONTROL_WINDOW_ORIGIN,
   shouldForwardUpdateToControlWindow,
 } from './controlWindowEcho'
-import {
-  LocalStreamData,
-  OVERLAY_DATA_SOURCE_NAME,
-  StreamIDGenerator,
-  combineDataSources,
-  markDataSource,
-  pollDataURL,
-  presetDataSource,
-  watchDataFile,
-} from './data'
+import { LocalStreamData, StreamIDGenerator, combineDataSources } from './data'
 import { DataSourceHealthTracker } from './dataSourceHealth'
+import { buildDataSources } from './dataSources'
 import log, { initLogger, setLogLevel } from './logger'
 import { installApplicationMenu } from './menu'
 import { denyWindowOpen } from './navigationSecurity'
 import { BROWSE_PARTITION, hardenSession } from './partitions'
 import { PlaylistScheduler } from './playlist'
-import { loadPresetPack } from './presets'
 import { flushStorage, loadStorage, safeUpdate } from './storage'
 import StreamdelayClient from './StreamdelayClient'
 import StreamWindow from './StreamWindow'
@@ -395,37 +386,15 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     }
   }
 
-  const dataSources = [
-    ...argv.data['json-url'].map((url) => {
-      log.debug('Setting data source from json-url:', url)
-      return markDataSource(
-        pollDataURL(
-          url,
-          argv.data.interval,
-          trackDataSourceHealth(url, 'json-url'),
-        ),
-        'json-url',
-      )
-    }),
-    ...argv.data['toml-file'].map((path) => {
-      log.debug('Setting data source from toml-file:', path)
-      return markDataSource(
-        watchDataFile(path, trackDataSourceHealth(path, 'toml-file')),
-        'toml-file',
-      )
-    }),
-    ...argv.presets.flatMap((packId) => {
-      const pack = loadPresetPack(packId)
-      if (!pack) {
-        log.warn(`Unknown preset pack "${packId}", skipping`)
-        return []
-      }
-      log.debug('Loading preset pack:', pack.id)
-      return [markDataSource(presetDataSource(pack), `preset:${pack.id}`)]
-    }),
-    markDataSource(localStreamData.gen(), 'custom'),
-    markDataSource(overlayStreamData.gen(), OVERLAY_DATA_SOURCE_NAME),
-  ]
+  const dataSources = buildDataSources({
+    jsonUrls: argv.data['json-url'],
+    tomlFiles: argv.data['toml-file'],
+    presets: argv.presets,
+    interval: argv.data.interval,
+    localStreamData,
+    overlayStreamData,
+    trackDataSourceHealth,
+  })
 
   for await (const streams of combineDataSources(dataSources, idGen)) {
     updateState({ streams })

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -1,6 +1,5 @@
 import * as Sentry from '@sentry/electron/main'
 import { BrowserWindow, Event as ElectronEvent, app, shell } from 'electron'
-import { MacUpdater, NsisUpdater } from 'electron-updater'
 import fs from 'fs'
 import { throttle } from 'lodash-es'
 import { randomUUID } from 'node:crypto'
@@ -26,7 +25,6 @@ import {
 } from '../sentryConfig'
 import { parseRepositorySlug } from '../updateStatus'
 import { createSessionHostResolver, ensureValidURL } from '../util'
-import { AppUpdater } from './appUpdater'
 import { StreamwallConfig, parseArgs } from './cliArgs'
 import { dispatchCommand, dispatchLocalCommand } from './commandDispatch'
 import { resolveConfigInitError } from './configInitError'
@@ -54,7 +52,6 @@ import {
   applyLayoutPreset,
   buildLayoutPreset,
 } from './layoutPresets'
-import { LinuxUpdateChecker } from './linuxUpdateChecker'
 import log, { initLogger, setLogLevel } from './logger'
 import { installApplicationMenu } from './menu'
 import { denyWindowOpen } from './navigationSecurity'
@@ -65,6 +62,7 @@ import { flushStorage, loadStorage, safeUpdate } from './storage'
 import StreamdelayClient from './StreamdelayClient'
 import StreamWindow from './StreamWindow'
 import TwitchBot from './TwitchBot'
+import { setupAppUpdater } from './updaterSetup'
 import { checkUplinkCommandGate } from './uplinkCommandGate'
 import { UPLINK_ORIGIN, shouldForwardUpdateToUplink } from './uplinkEcho'
 import { routeUplinkWsMessage } from './uplinkMessageRouting'
@@ -160,84 +158,14 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     hasUserConfig,
   })
 
-  // electron-updater has no self-update story for .deb/.rpm installs, so on
-  // Linux it never notifies users. LinuxUpdateChecker polls GitHub Releases
-  // directly instead, and only ever offers a link since those installs go
-  // through the OS package manager, not a self-updater (#433).
-  const repositorySlug = parseRepositorySlug(packageJson.repository)
-  if (process.platform === 'linux') {
-    const linuxUpdateChecker = new LinuxUpdateChecker({
-      currentVersion: app.getVersion(),
-      repository: repositorySlug,
-    })
-    linuxUpdateChecker.on('status', (status) => {
-      log.debug('Update status:', status.state)
-      controlWindow.onUpdateStatus(status)
-    })
-    controlWindow.setUpdateHandlers({
-      getAppVersion: () => app.getVersion(),
-      getStatus: () => linuxUpdateChecker.getStatus(),
-      download: () => {
-        // Never reachable from the banner (`available` carries
-        // `canDownload: false` on Linux), but the handler bundle requires one.
-      },
-      install: () => {
-        // Never reachable from the banner (no install action is offered for
-        // `available`), but the handler bundle requires one.
-      },
-      openReleaseNotes: () => {
-        const status = linuxUpdateChecker.getStatus()
-        if (status.state === 'available' && status.releaseUrl) {
-          shell.openExternal(status.releaseUrl)
-        }
-      },
-    })
-    linuxUpdateChecker.start()
-  } else {
-    // electron-updater instead of Electron's built-in Squirrel autoUpdater
-    // (#432): Squirrel starts downloading as soon as it finds an update and
-    // reports no byte-level progress, so it could neither ask for consent nor
-    // show how far along a download is. The release feed is GitHub Releases,
-    // with latest.yml/latest-mac.yml generated at publish time (see
-    // forge.updateMetadata.ts).
-    const backend =
-      process.platform === 'darwin' ? new MacUpdater() : new NsisUpdater()
-    backend.logger = log
-    if (repositorySlug) {
-      const [owner, repo] = repositorySlug.split('/')
-      backend.setFeedURL({ provider: 'github', owner, repo })
-    }
-    const appUpdater = new AppUpdater(backend, repositorySlug)
-    appUpdater.on('status', (status) => {
-      if (status.state === 'error') {
-        // Not surfaced in the UI: a failed update check is routine (offline,
-        // rate limit) and not actionable by the user.
-        log.warn('Update check failed:', status.message)
-      } else {
-        log.debug('Update status:', status.state)
-      }
-      controlWindow.onUpdateStatus(status)
-    })
-    controlWindow.setUpdateHandlers({
-      getAppVersion: () => app.getVersion(),
-      getStatus: () => appUpdater.getStatus(),
-      download: () => appUpdater.download(),
-      install: () => appUpdater.install(),
-      openReleaseNotes: () => {
-        const status = appUpdater.getStatus()
-        if (status.state === 'available' && status.releaseUrl) {
-          shell.openExternal(status.releaseUrl)
-        } else if (status.state === 'ready' && status.releaseNotesUrl) {
-          shell.openExternal(status.releaseNotesUrl)
-        }
-      },
-    })
-    // In development there is no packaged app to update against; electron-
-    // updater would just log a skip message every interval.
-    if (app.isPackaged && repositorySlug) {
-      appUpdater.start()
-    }
-  }
+  setupAppUpdater({
+    platform: process.platform,
+    isPackaged: app.isPackaged,
+    currentVersion: app.getVersion(),
+    repositorySlug: parseRepositorySlug(packageJson.repository),
+    controlWindow,
+    openExternal: (url) => shell.openExternal(url),
+  })
 
   let browseWindow: BrowserWindow | null = null
   let streamdelayClient: StreamdelayClient | null = null

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -5,11 +5,7 @@ import { throttle } from 'lodash-es'
 import EventEmitter from 'node:events'
 import { join } from 'node:path'
 import 'source-map-support/register'
-import {
-  DataSourceType,
-  StreamwallState,
-  fullscreenViewContentMap,
-} from 'streamwall-shared'
+import { DataSourceType, StreamwallState } from 'streamwall-shared'
 import * as Y from 'yjs'
 import packageJson from '../../package.json'
 import {
@@ -52,6 +48,7 @@ import TwitchBot from './TwitchBot'
 import { setupAppUpdater } from './updaterSetup'
 import { connectControlUplink } from './uplinkConnection'
 import { initializeViewsState } from './viewsStateInit'
+import { deriveWallViews } from './wallViews'
 import {
   shouldHideInsteadOfQuit,
   shouldQuitOnAllWindowsClosed,
@@ -147,53 +144,26 @@ async function main(argv: ReturnType<typeof parseArgs>) {
 
   function updateViewsFromStateDoc() {
     try {
-      // When a view is expanded to fullscreen (issue #362), override the
-      // derived layout so the expanded stream fills every grid cell -- one
-      // wall-spanning box, with the other views parked (hidden but kept
-      // alive, not torn down) behind it, so a later collapse can reposition
-      // them instead of reloading them from scratch (issue #369). This
-      // override is transient: it reads the expanded stream from
-      // `viewsState` but never writes back, so the persisted grid
-      // assignments are untouched and a later collapse restores the normal
-      // layout verbatim.
-      const { fullscreenViewIdx } = clientState
-      if (fullscreenViewIdx != null) {
-        const streamId = viewsState
-          .get(String(fullscreenViewIdx))
-          ?.get('streamId')
-        const stream = clientState.streams.find((s) => s._id === streamId)
-        if (stream) {
-          streamWindow.setViews(
-            fullscreenViewContentMap(
-              streamWindowConfig.cols,
-              streamWindowConfig.rows,
-              { url: stream.link, kind: stream.kind || 'video' },
-            ),
-            clientState.streams,
-            { parkUnused: true },
-          )
-          return
-        }
-        // The expanded stream is gone (its cell was cleared or it dropped out
-        // of the data source): fall back to the normal layout and clear the
-        // stale override so clients stop rendering a phantom expansion. The
-        // setViews() below emits a state update that broadcasts the cleared
-        // value.
+      const wallViews = deriveWallViews({
+        fullscreenViewIdx: clientState.fullscreenViewIdx,
+        streams: clientState.streams,
+        viewsState,
+        cols: streamWindowConfig.cols,
+        rows: streamWindowConfig.rows,
+      })
+      if (wallViews.mode === 'fullscreen') {
+        streamWindow.setViews(wallViews.contentMap, clientState.streams, {
+          parkUnused: true,
+        })
+        return
+      }
+      // The expanded stream is gone: clear the stale override so clients stop
+      // rendering a phantom expansion. The setViews() below emits a state
+      // update that broadcasts the cleared value.
+      if (wallViews.clearedFullscreen) {
         clientState = { ...clientState, fullscreenViewIdx: null }
       }
-      const viewContentMap = new Map()
-      for (const [key, viewData] of viewsState) {
-        const streamId = viewData.get('streamId')
-        const stream = clientState.streams.find((s) => s._id === streamId)
-        if (!stream) {
-          continue
-        }
-        viewContentMap.set(key, {
-          url: stream.link,
-          kind: stream.kind || 'video',
-        })
-      }
-      streamWindow.setViews(viewContentMap, clientState.streams)
+      streamWindow.setViews(wallViews.contentMap, clientState.streams)
     } catch (err) {
       log.error('Error updating views', err)
     }

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -53,6 +53,7 @@ import {
   shouldHideInsteadOfQuit,
   shouldQuitOnAllWindowsClosed,
 } from './windowCloseBehavior'
+import { buildRetryConfig, buildStreamWindowConfig } from './windowConfig'
 
 async function main(argv: ReturnType<typeof parseArgs>) {
   const db = await loadStorage(
@@ -83,28 +84,8 @@ async function main(argv: ReturnType<typeof parseArgs>) {
 
   const overlayStreamData = new LocalStreamData()
 
-  const streamWindowConfig = {
-    cols: argv.grid.cols,
-    rows: argv.grid.rows,
-    width: argv.window.width,
-    height: argv.window.height,
-    x: argv.window.x,
-    y: argv.window.y,
-    frameless: argv.window.frameless,
-    fullscreen: argv.window.fullscreen,
-    display: argv.window.display,
-    activeColor: argv.window['active-color'],
-    backgroundColor: argv.window['background-color'],
-  }
-  // The state machine works in milliseconds; the config is in seconds for
-  // consistency with the other interval options.
-  const retryConfig = {
-    enabled: argv.retry.enabled,
-    delay: argv.retry.delay * 1000,
-    maxDelay: argv.retry['max-delay'] * 1000,
-    maxRetries: argv.retry['max-retries'],
-    stalledTimeout: argv.retry['stalled-timeout'] * 1000,
-  }
+  const streamWindowConfig = buildStreamWindowConfig(argv)
+  const retryConfig = buildRetryConfig(argv)
   const streamWindow = new StreamWindow(
     streamWindowConfig,
     retryConfig,

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/electron/main'
 import { BrowserWindow, Event as ElectronEvent, app, shell } from 'electron'
 import fs from 'fs'
 import { throttle } from 'lodash-es'
-import { randomUUID } from 'node:crypto'
 import EventEmitter from 'node:events'
 import { join } from 'node:path'
 import ReconnectingWebSocket from 'reconnecting-websocket'
@@ -27,6 +26,7 @@ import { parseRepositorySlug } from '../updateStatus'
 import { createSessionHostResolver, ensureValidURL } from '../util'
 import { StreamwallConfig, parseArgs } from './cliArgs'
 import { dispatchCommand, dispatchLocalCommand } from './commandDispatch'
+import { createOnCommand } from './commandHandlers'
 import { resolveConfigInitError } from './configInitError'
 import { decideControlEndpointConnection } from './controlEndpointConnection'
 import ControlWindow from './ControlWindow'
@@ -45,13 +45,6 @@ import {
   watchDataFile,
 } from './data'
 import { DataSourceHealthTracker } from './dataSourceHealth'
-import { addFavorite, removeFavorite } from './favorites'
-import { applyGridResize } from './gridResize'
-import {
-  addLayoutPreset,
-  applyLayoutPreset,
-  buildLayoutPreset,
-} from './layoutPresets'
 import log, { initLogger, setLogLevel } from './logger'
 import { installApplicationMenu } from './menu'
 import { denyWindowOpen } from './navigationSecurity'
@@ -63,7 +56,6 @@ import StreamdelayClient from './StreamdelayClient'
 import StreamWindow from './StreamWindow'
 import TwitchBot from './TwitchBot'
 import { setupAppUpdater } from './updaterSetup'
-import { checkUplinkCommandGate } from './uplinkCommandGate'
 import { UPLINK_ORIGIN, shouldForwardUpdateToUplink } from './uplinkEcho'
 import { routeUplinkWsMessage } from './uplinkMessageRouting'
 import { initializeViewsState } from './viewsStateInit'
@@ -167,7 +159,6 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     openExternal: (url) => shell.openExternal(url),
   })
 
-  let browseWindow: BrowserWindow | null = null
   let streamdelayClient: StreamdelayClient | null = null
 
   log.debug('Creating initial state...')
@@ -285,197 +276,49 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   })
   playlistScheduler.start()
 
-  const onCommand = async (
-    msg: ControlCommand,
-    source: 'local' | 'uplink' = 'local',
-  ): Promise<{ error: string } | void> => {
-    log.debug('Received message:', msg)
-
-    // The remote control-server uplink is untrusted: re-validate every command
-    // against the uplink allowlist so a compromised or man-in-the-middled
-    // server cannot drive code execution (browse/dev-tools) on the desktop.
-    const uplinkGate = checkUplinkCommandGate(msg, source)
-    if (!uplinkGate.allowed) {
-      log.warn(
-        'Rejecting disallowed command from control uplink:',
-        uplinkGate.type,
-      )
-      return
-    }
-
-    if (msg.type === 'set-listening-view') {
-      log.debug('Setting listening view:', msg.viewId)
-      streamWindow.setListeningView(msg.viewId)
-    } else if (msg.type === 'set-view-background-listening') {
-      log.debug('Setting view background listening:', msg.viewId, msg.listening)
-      streamWindow.setViewBackgroundListening(msg.viewId, msg.listening)
-    } else if (msg.type === 'set-view-blurred') {
-      log.debug('Setting view blurred:', msg.viewId, msg.blurred)
-      streamWindow.setViewBlurred(msg.viewId, msg.blurred)
-    } else if (msg.type === 'set-view-volume') {
-      log.debug('Setting view volume:', msg.viewId, msg.volume)
-      streamWindow.setViewVolume(msg.viewId, msg.volume)
-    } else if (msg.type === 'rotate-stream') {
-      log.debug('Rotating stream:', msg.url, msg.rotation)
-      overlayStreamData.update(msg.url, {
-        rotation: msg.rotation,
-      })
-    } else if (msg.type === 'update-custom-stream') {
-      log.debug('Updating custom stream:', msg.url)
-      localStreamData.update(msg.url, msg.data)
-    } else if (msg.type === 'delete-custom-stream') {
-      log.debug('Deleting custom stream:', msg.url)
-      localStreamData.delete(msg.url)
-    } else if (msg.type === 'reload-view') {
-      log.debug('Reloading view:', msg.viewId)
-      streamWindow.reloadView(msg.viewId)
-    } else if (msg.type === 'set-view-fullscreen') {
-      // Runtime-only wall zoom (issue #362): remember which view fills the
-      // wall (or null) and re-derive the layout. Broadcast the new value first
-      // so clients render the expansion consistently, then re-lay-out the wall.
-      //
-      // The command carries a stable view id (issue #397); resolve it to the
-      // cell that view currently occupies so the cell-based `fullscreenViewIdx`
-      // (which the layout state and clients still key on) reflects the view the
-      // operator actually double-clicked, even if a resize just moved it. If
-      // the view has no placement, `getViewAnchorIdx` returns null and no
-      // expansion happens.
-      log.debug('Setting view fullscreen:', msg.viewId, msg.fullscreen)
-      updateState({
-        fullscreenViewIdx: msg.fullscreen
-          ? streamWindow.getViewAnchorIdx(msg.viewId)
-          : null,
-      })
-      updateViewsFromStateDoc()
-    } else if (msg.type === 'browse' || msg.type === 'dev-tools') {
-      if (browseWindow && !browseWindow.isDestroyed()) {
-        // DevTools needs a fresh webContents to work. Close any existing window.
-        browseWindow.destroy()
-        browseWindow = null
-      }
-      if (!browseWindow || browseWindow.isDestroyed()) {
-        browseWindow = new BrowserWindow({
-          webPreferences: {
-            nodeIntegration: false,
-            contextIsolation: true,
-            // Keep the operator's browsing isolated from the stream views and
-            // off disk by using a dedicated ephemeral partition.
-            partition: BROWSE_PARTITION,
-            sandbox: true,
-          },
-        })
-        hardenSession(browseWindow.webContents.session)
-        // Deny popups; the browse window is meant to show a single URL.
-        denyWindowOpen(browseWindow.webContents)
-      }
-      if (msg.type === 'browse') {
-        log.debug('Attempting to browse URL:', msg.url)
-        try {
-          await ensureValidURL(
-            msg.url,
-            createSessionHostResolver(browseWindow.webContents.session),
-          )
-          browseWindow.loadURL(msg.url)
-        } catch (error) {
-          log.error('Invalid URL:', msg.url)
-          log.error('Error:', error)
-          return { error: 'invalid url' }
-        }
-      } else if (msg.type === 'dev-tools') {
-        log.debug('Opening DevTools for view:', msg.viewId)
-        streamWindow.openDevTools(msg.viewId, browseWindow.webContents)
-      }
-    } else if (msg.type === 'set-stream-censored' && streamdelayClient) {
-      log.debug('Setting stream censored:', msg.isCensored)
-      streamdelayClient.setCensored(msg.isCensored)
-    } else if (msg.type === 'set-stream-running' && streamdelayClient) {
-      log.debug('Setting stream running:', msg.isStreamRunning)
-      streamdelayClient.setStreamRunning(msg.isStreamRunning)
-    } else if (msg.type === 'set-grid-size') {
-      applyGridResize(
-        {
-          viewsState,
-          transact: (fn) => stateDoc.transact(fn),
-          getCols: () => streamWindowConfig.cols,
-          getRows: () => streamWindowConfig.rows,
-          setGridSize: (cols, rows) => streamWindow.setGridSize(cols, rows),
-        },
-        msg.cols,
-        msg.rows,
-      )
-
-      // streamWindow.config, streamWindowConfig and clientState.config are the
-      // same shared object, and setGridSize mutates it in place. Broadcast that
-      // shared object via updateState({}) rather than detaching a copy, so a
-      // later window resize keeps the overlay/control grid in sync with the wall
-      // (issue #14). The wall itself was already re-laid-out by the stateDoc
-      // observer during applyGridResize's transact — now that the config holds
-      // the new dimensions (issue #15) — so no explicit updateViewsFromStateDoc()
-      // call is needed here.
-      updateState({})
-    } else if (msg.type === 'save-layout-preset') {
-      log.debug('Saving layout preset:', msg.name)
-      const preset = buildLayoutPreset(
-        {
-          viewsState,
-          cols: streamWindowConfig.cols,
-          rows: streamWindowConfig.rows,
-        },
-        randomUUID(),
-        msg.name,
-      )
-      const layoutPresets = addLayoutPreset(clientState.layoutPresets, preset)
+  const onCommand = createOnCommand({
+    streamWindow,
+    overlayStreamData,
+    localStreamData,
+    viewsState,
+    transact: (fn) => stateDoc.transact(fn),
+    streamWindowConfig,
+    getClientState: () => clientState,
+    getStreamdelayClient: () => streamdelayClient,
+    updateState,
+    updateViewsFromStateDoc,
+    persistLayoutPresets: (layoutPresets) => {
       safeUpdate(db, (data) => {
         data.layoutPresets = layoutPresets
       })
-      updateState({ layoutPresets })
-    } else if (msg.type === 'load-layout-preset') {
-      const preset = clientState.layoutPresets.find(
-        (p) => p.id === msg.presetId,
-      )
-      if (preset) {
-        log.debug('Loading layout preset:', preset.name)
-        applyLayoutPreset(
-          {
-            viewsState,
-            transact: (fn) => stateDoc.transact(fn),
-            setGridSize: (cols, rows) => streamWindow.setGridSize(cols, rows),
-          },
-          preset,
-        )
-        // See the set-grid-size branch above: broadcast the shared config
-        // object via updateState({}) rather than detaching a copy.
-        updateState({})
-      }
-    } else if (msg.type === 'delete-layout-preset') {
-      log.debug('Deleting layout preset:', msg.presetId)
-      const layoutPresets = clientState.layoutPresets.filter(
-        (p) => p.id !== msg.presetId,
-      )
+    },
+    persistFavorites: (favorites) => {
       safeUpdate(db, (data) => {
-        data.layoutPresets = layoutPresets
+        data.favorites = favorites
       })
-      updateState({ layoutPresets })
-    } else if (msg.type === 'add-favorite') {
-      const favorites = addFavorite(clientState.favorites, msg.url)
-      if (favorites !== clientState.favorites) {
-        log.debug('Adding favorite:', msg.url)
-        safeUpdate(db, (data) => {
-          data.favorites = favorites
-        })
-        updateState({ favorites })
-      }
-    } else if (msg.type === 'remove-favorite') {
-      const favorites = removeFavorite(clientState.favorites, msg.url)
-      if (favorites !== clientState.favorites) {
-        log.debug('Removing favorite:', msg.url)
-        safeUpdate(db, (data) => {
-          data.favorites = favorites
-        })
-        updateState({ favorites })
-      }
-    }
-  }
+    },
+    createBrowseWindow: () => {
+      const win = new BrowserWindow({
+        webPreferences: {
+          nodeIntegration: false,
+          contextIsolation: true,
+          // Keep the operator's browsing isolated from the stream views and
+          // off disk by using a dedicated ephemeral partition.
+          partition: BROWSE_PARTITION,
+          sandbox: true,
+        },
+      })
+      hardenSession(win.webContents.session)
+      // Deny popups; the browse window is meant to show a single URL.
+      denyWindowOpen(win.webContents)
+      return win
+    },
+    validateBrowseURL: (url, browseWindow) =>
+      ensureValidURL(
+        url,
+        createSessionHostResolver(browseWindow.webContents.session),
+      ),
+  })
 
   const stateEmitter = new EventEmitter<{ state: [StreamwallState] }>()
 

--- a/packages/streamwall/src/main/updaterSetup.test.ts
+++ b/packages/streamwall/src/main/updaterSetup.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { type UpdateStatus } from '../updateStatus'
+import { type UpdateHandlers } from './ControlWindow'
+import log from './logger'
+import {
+  type SelfUpdater,
+  type SetupAppUpdaterContext,
+  type UpdateStatusSource,
+  setupAppUpdater,
+} from './updaterSetup'
+
+/** A controllable update source that records its status listener. */
+function fakeUpdateSource(initial: UpdateStatus = { state: 'idle' }) {
+  let status = initial
+  let listener: ((status: UpdateStatus) => void) | undefined
+  return {
+    on: vi.fn((_event: 'status', cb: (status: UpdateStatus) => void) => {
+      listener = cb
+    }),
+    getStatus: vi.fn(() => status),
+    start: vi.fn(),
+    download: vi.fn(),
+    install: vi.fn(),
+    setStatus(next: UpdateStatus) {
+      status = next
+    },
+    emit(next: UpdateStatus) {
+      status = next
+      listener?.(next)
+    },
+  }
+}
+
+function fakeControlWindow() {
+  let handlers: UpdateHandlers | undefined
+  return {
+    onUpdateStatus: vi.fn<(status: UpdateStatus) => void>(),
+    setUpdateHandlers: vi.fn((h: UpdateHandlers) => {
+      handlers = h
+    }),
+    get handlers() {
+      return handlers!
+    },
+  }
+}
+
+function baseContext(
+  overrides: Partial<SetupAppUpdaterContext> = {},
+): SetupAppUpdaterContext {
+  return {
+    platform: 'darwin',
+    isPackaged: true,
+    currentVersion: '1.2.3',
+    repositorySlug: 'owner/repo',
+    controlWindow: fakeControlWindow(),
+    openExternal: vi.fn(),
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('setupAppUpdater — Linux (notify-only)', () => {
+  it('wires the Linux checker and forwards status to the control window', () => {
+    const checker = fakeUpdateSource()
+    const controlWindow = fakeControlWindow()
+    const createLinuxUpdateChecker = vi.fn(() => checker as UpdateStatusSource)
+
+    setupAppUpdater(
+      baseContext({
+        platform: 'linux',
+        controlWindow,
+        createLinuxUpdateChecker,
+      }),
+    )
+
+    expect(createLinuxUpdateChecker).toHaveBeenCalledWith({
+      currentVersion: '1.2.3',
+      repository: 'owner/repo',
+    })
+    expect(checker.start).toHaveBeenCalledOnce()
+
+    checker.emit({ state: 'checking' })
+    expect(controlWindow.onUpdateStatus).toHaveBeenCalledWith({
+      state: 'checking',
+    })
+  })
+
+  it('offers only a release link and never downloads or installs', () => {
+    const checker = fakeUpdateSource()
+    const controlWindow = fakeControlWindow()
+    const openExternal = vi.fn()
+
+    setupAppUpdater(
+      baseContext({
+        platform: 'linux',
+        controlWindow,
+        openExternal,
+        createLinuxUpdateChecker: () => checker as UpdateStatusSource,
+      }),
+    )
+
+    const handlers = controlWindow.handlers
+    expect(handlers.getAppVersion()).toBe('1.2.3')
+
+    // download/install are inert on Linux.
+    expect(() => handlers.download()).not.toThrow()
+    expect(() => handlers.install()).not.toThrow()
+
+    checker.setStatus({
+      state: 'available',
+      version: '2.0.0',
+      releaseUrl: 'https://example.com/release',
+      canDownload: false,
+    })
+    handlers.openReleaseNotes()
+    expect(openExternal).toHaveBeenCalledWith('https://example.com/release')
+  })
+
+  it('does not open a link when no release is available', () => {
+    const checker = fakeUpdateSource({ state: 'idle' })
+    const controlWindow = fakeControlWindow()
+    const openExternal = vi.fn()
+
+    setupAppUpdater(
+      baseContext({
+        platform: 'linux',
+        controlWindow,
+        openExternal,
+        createLinuxUpdateChecker: () => checker as UpdateStatusSource,
+      }),
+    )
+
+    controlWindow.handlers.openReleaseNotes()
+    expect(openExternal).not.toHaveBeenCalled()
+  })
+})
+
+describe('setupAppUpdater — self-updater (macOS / Windows)', () => {
+  it('starts the updater only when packaged with a repository slug', () => {
+    const updater = fakeUpdateSource()
+    setupAppUpdater(
+      baseContext({
+        platform: 'darwin',
+        isPackaged: true,
+        createSelfUpdater: () => updater as SelfUpdater,
+      }),
+    )
+    expect(updater.start).toHaveBeenCalledOnce()
+  })
+
+  it('does not start the updater in development (not packaged)', () => {
+    const updater = fakeUpdateSource()
+    setupAppUpdater(
+      baseContext({
+        isPackaged: false,
+        createSelfUpdater: () => updater as SelfUpdater,
+      }),
+    )
+    expect(updater.start).not.toHaveBeenCalled()
+  })
+
+  it('does not start the updater without a repository slug', () => {
+    const updater = fakeUpdateSource()
+    setupAppUpdater(
+      baseContext({
+        repositorySlug: null,
+        createSelfUpdater: () => updater as SelfUpdater,
+      }),
+    )
+    expect(updater.start).not.toHaveBeenCalled()
+  })
+
+  it('routes download and install through the updater', () => {
+    const updater = fakeUpdateSource()
+    const controlWindow = fakeControlWindow()
+    setupAppUpdater(
+      baseContext({
+        controlWindow,
+        createSelfUpdater: () => updater as SelfUpdater,
+      }),
+    )
+    controlWindow.handlers.download()
+    controlWindow.handlers.install()
+    expect(updater.download).toHaveBeenCalledOnce()
+    expect(updater.install).toHaveBeenCalledOnce()
+  })
+
+  it('logs a warning but still forwards error statuses to the UI', () => {
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => log)
+    const updater = fakeUpdateSource()
+    const controlWindow = fakeControlWindow()
+    setupAppUpdater(
+      baseContext({
+        controlWindow,
+        createSelfUpdater: () => updater as SelfUpdater,
+      }),
+    )
+
+    updater.emit({ state: 'error', message: 'offline' })
+    expect(warnSpy).toHaveBeenCalledWith('Update check failed:', 'offline')
+    expect(controlWindow.onUpdateStatus).toHaveBeenCalledWith({
+      state: 'error',
+      message: 'offline',
+    })
+  })
+
+  it('opens the release URL for an available update and release notes when ready', () => {
+    const updater = fakeUpdateSource()
+    const controlWindow = fakeControlWindow()
+    const openExternal = vi.fn()
+    setupAppUpdater(
+      baseContext({
+        controlWindow,
+        openExternal,
+        createSelfUpdater: () => updater as SelfUpdater,
+      }),
+    )
+    const handlers = controlWindow.handlers
+
+    updater.setStatus({
+      state: 'available',
+      version: '2.0.0',
+      releaseUrl: 'https://example.com/available',
+      canDownload: true,
+    })
+    handlers.openReleaseNotes()
+    expect(openExternal).toHaveBeenLastCalledWith(
+      'https://example.com/available',
+    )
+
+    updater.setStatus({
+      state: 'ready',
+      version: '2.0.0',
+      releaseNotesUrl: 'https://example.com/notes',
+    })
+    handlers.openReleaseNotes()
+    expect(openExternal).toHaveBeenLastCalledWith('https://example.com/notes')
+  })
+})

--- a/packages/streamwall/src/main/updaterSetup.ts
+++ b/packages/streamwall/src/main/updaterSetup.ts
@@ -1,0 +1,159 @@
+import { MacUpdater, NsisUpdater } from 'electron-updater'
+import { type UpdateStatus } from '../updateStatus'
+import { AppUpdater } from './appUpdater'
+import { type UpdateHandlers } from './ControlWindow'
+import { LinuxUpdateChecker } from './linuxUpdateChecker'
+import log from './logger'
+
+/** The `controlWindow` surface the updater wiring drives. */
+export interface UpdaterControlWindow {
+  onUpdateStatus(status: UpdateStatus): void
+  setUpdateHandlers(handlers: UpdateHandlers): void
+}
+
+/** Minimal update source shape shared by the Linux and self-updater paths. */
+export interface UpdateStatusSource {
+  on(event: 'status', listener: (status: UpdateStatus) => void): void
+  getStatus(): UpdateStatus
+  start(): void
+}
+
+/** A self-updater that can also download and install (macOS / Windows). */
+export interface SelfUpdater extends UpdateStatusSource {
+  download(): void
+  install(): void
+}
+
+export interface SetupAppUpdaterContext {
+  platform: NodeJS.Platform
+  isPackaged: boolean
+  currentVersion: string
+  repositorySlug: string | null
+  controlWindow: UpdaterControlWindow
+  /** Opens a URL in the user's default browser (Electron's `shell.openExternal`). */
+  openExternal: (url: string) => void
+  /**
+   * Builds the notify-only Linux checker. Injectable so the wiring can be
+   * tested without electron-updater; defaults to the real implementation.
+   */
+  createLinuxUpdateChecker?: (opts: {
+    currentVersion: string
+    repository: string | null
+  }) => UpdateStatusSource
+  /**
+   * Builds the macOS/Windows self-updater. Injectable so the wiring can be
+   * tested without electron-updater; defaults to the real implementation.
+   */
+  createSelfUpdater?: (
+    platform: NodeJS.Platform,
+    repositorySlug: string | null,
+  ) => SelfUpdater
+}
+
+function defaultCreateLinuxUpdateChecker(opts: {
+  currentVersion: string
+  repository: string | null
+}): UpdateStatusSource {
+  return new LinuxUpdateChecker(opts)
+}
+
+function defaultCreateSelfUpdater(
+  platform: NodeJS.Platform,
+  repositorySlug: string | null,
+): SelfUpdater {
+  const backend = platform === 'darwin' ? new MacUpdater() : new NsisUpdater()
+  backend.logger = log
+  if (repositorySlug) {
+    const [owner, repo] = repositorySlug.split('/')
+    backend.setFeedURL({ provider: 'github', owner, repo })
+  }
+  return new AppUpdater(backend, repositorySlug)
+}
+
+/**
+ * Wires the application auto-updater to the control window.
+ *
+ * electron-updater has no self-update story for .deb/.rpm installs, so on Linux
+ * a notify-only GitHub Releases poll is used that only ever offers a link (the
+ * OS package manager, not a self-updater, applies the update — #433). Every
+ * other platform uses electron-updater instead of Electron's built-in Squirrel
+ * autoUpdater (#432): Squirrel starts downloading as soon as it finds an update
+ * and reports no byte-level progress, so it could neither ask for consent nor
+ * show download progress. The release feed is GitHub Releases, with
+ * latest.yml/latest-mac.yml generated at publish time (see
+ * forge.updateMetadata.ts).
+ */
+export function setupAppUpdater(ctx: SetupAppUpdaterContext): void {
+  const {
+    platform,
+    isPackaged,
+    currentVersion,
+    repositorySlug,
+    controlWindow,
+    openExternal,
+    createLinuxUpdateChecker = defaultCreateLinuxUpdateChecker,
+    createSelfUpdater = defaultCreateSelfUpdater,
+  } = ctx
+
+  if (platform === 'linux') {
+    const linuxUpdateChecker = createLinuxUpdateChecker({
+      currentVersion,
+      repository: repositorySlug,
+    })
+    linuxUpdateChecker.on('status', (status) => {
+      log.debug('Update status:', status.state)
+      controlWindow.onUpdateStatus(status)
+    })
+    controlWindow.setUpdateHandlers({
+      getAppVersion: () => currentVersion,
+      getStatus: () => linuxUpdateChecker.getStatus(),
+      download: () => {
+        // Never reachable from the banner (`available` carries
+        // `canDownload: false` on Linux), but the handler bundle requires one.
+      },
+      install: () => {
+        // Never reachable from the banner (no install action is offered for
+        // `available`), but the handler bundle requires one.
+      },
+      openReleaseNotes: () => {
+        const status = linuxUpdateChecker.getStatus()
+        if (status.state === 'available' && status.releaseUrl) {
+          openExternal(status.releaseUrl)
+        }
+      },
+    })
+    linuxUpdateChecker.start()
+    return
+  }
+
+  const selfUpdater = createSelfUpdater(platform, repositorySlug)
+  selfUpdater.on('status', (status) => {
+    if (status.state === 'error') {
+      // Not surfaced in the UI: a failed update check is routine (offline,
+      // rate limit) and not actionable by the user.
+      log.warn('Update check failed:', status.message)
+    } else {
+      log.debug('Update status:', status.state)
+    }
+    controlWindow.onUpdateStatus(status)
+  })
+  controlWindow.setUpdateHandlers({
+    getAppVersion: () => currentVersion,
+    getStatus: () => selfUpdater.getStatus(),
+    download: () => selfUpdater.download(),
+    install: () => selfUpdater.install(),
+    openReleaseNotes: () => {
+      const status = selfUpdater.getStatus()
+      if (status.state === 'available' && status.releaseUrl) {
+        openExternal(status.releaseUrl)
+      } else if (status.state === 'ready' && status.releaseNotesUrl) {
+        openExternal(status.releaseNotesUrl)
+      }
+    },
+  })
+  // In development there is no packaged app to update against; electron-updater
+  // would just log a skip message every interval.
+  if (isPackaged && repositorySlug) {
+    selfUpdater.start()
+  }
+}

--- a/packages/streamwall/src/main/uplinkConnection.test.ts
+++ b/packages/streamwall/src/main/uplinkConnection.test.ts
@@ -1,0 +1,192 @@
+import EventEmitter from 'node:events'
+import { type StreamwallState } from 'streamwall-shared'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import WebSocket from 'ws'
+import * as Y from 'yjs'
+import log from './logger'
+import {
+  type UplinkConnectionDeps,
+  type UplinkSocket,
+  connectControlUplink,
+  makeControlWebSocket,
+} from './uplinkConnection'
+
+const SOCKET_OPEN = 1
+const SOCKET_CLOSED = 3
+
+/** A controllable uplink socket that records its event listeners. */
+function fakeSocket() {
+  const listeners: Record<string, ((event: unknown) => void)[]> = {}
+  return {
+    binaryType: '',
+    readyState: SOCKET_OPEN,
+    addEventListener: vi.fn((type: string, cb: (event: unknown) => void) => {
+      ;(listeners[type] ??= []).push(cb)
+    }),
+    send: vi.fn(),
+    emit(type: string, event?: unknown) {
+      for (const cb of listeners[type] ?? []) {
+        cb(event)
+      }
+    },
+  }
+}
+
+function makeDeps(
+  overrides: Partial<UplinkConnectionDeps> = {},
+): UplinkConnectionDeps {
+  return {
+    endpoint: 'ws://localhost:8080',
+    stateDoc: new Y.Doc(),
+    stateEmitter: new EventEmitter<{ state: [StreamwallState] }>(),
+    getClientState: () => ({ streams: [] }) as unknown as StreamwallState,
+    onCommand: vi.fn(async () => {}),
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('makeControlWebSocket', () => {
+  it('returns a subclass of the ws WebSocket', () => {
+    const Cls = makeControlWebSocket('secret')
+    expect(typeof Cls).toBe('function')
+    expect(Cls.prototype).toBeInstanceOf(WebSocket)
+  })
+})
+
+describe('connectControlUplink — connection decision', () => {
+  it('does not connect when no endpoint is configured', () => {
+    const createSocket = vi.fn()
+    connectControlUplink(makeDeps({ endpoint: null, createSocket }))
+    expect(createSocket).not.toHaveBeenCalled()
+  })
+
+  it('refuses an insecure remote endpoint and logs an error', () => {
+    const errorSpy = vi.spyOn(log, 'error').mockImplementation(() => log)
+    const createSocket = vi.fn()
+
+    connectControlUplink(
+      makeDeps({ endpoint: 'ws://example.com:8080', createSocket }),
+    )
+
+    expect(createSocket).not.toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Refusing to connect to insecure control endpoint',
+      ),
+    )
+  })
+
+  it('connects to a secure (loopback) endpoint', () => {
+    const socket = fakeSocket()
+    const createSocket = vi.fn(() => socket as unknown as UplinkSocket)
+
+    connectControlUplink(makeDeps({ createSocket }))
+
+    expect(createSocket).toHaveBeenCalledOnce()
+    expect(socket.binaryType).toBe('arraybuffer')
+  })
+})
+
+describe('connectControlUplink — socket wiring', () => {
+  it('resends full state and the Yjs doc on open', () => {
+    const socket = fakeSocket()
+    const stateDoc = new Y.Doc()
+    connectControlUplink(
+      makeDeps({
+        stateDoc,
+        createSocket: () => socket as unknown as UplinkSocket,
+        getClientState: () =>
+          ({ streams: [{ _id: 'a' }] }) as unknown as StreamwallState,
+      }),
+    )
+
+    socket.emit('open')
+
+    expect(socket.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'state', state: { streams: [{ _id: 'a' }] } }),
+    )
+    // The second send is the encoded Yjs document.
+    expect(socket.send).toHaveBeenCalledTimes(2)
+  })
+
+  it('applies an incoming Yjs update to the state doc', () => {
+    const socket = fakeSocket()
+    const stateDoc = new Y.Doc()
+    connectControlUplink(
+      makeDeps({
+        stateDoc,
+        createSocket: () => socket as unknown as UplinkSocket,
+      }),
+    )
+
+    // Build an update from a separate doc and deliver it as an ArrayBuffer.
+    const source = new Y.Doc()
+    source.getMap('views').set('0', 'stream-x')
+    const update = Y.encodeStateAsUpdate(source)
+
+    socket.emit('message', { data: update.buffer })
+
+    expect(stateDoc.getMap('views').get('0')).toBe('stream-x')
+  })
+
+  it('dispatches an incoming command through onCommand', () => {
+    const socket = fakeSocket()
+    const onCommand = vi.fn(async () => {})
+    connectControlUplink(
+      makeDeps({
+        onCommand,
+        createSocket: () => socket as unknown as UplinkSocket,
+      }),
+    )
+
+    socket.emit('message', {
+      data: JSON.stringify({ type: 'reload-view', viewIdx: 0 }),
+    })
+
+    expect(onCommand).toHaveBeenCalledWith(
+      { type: 'reload-view', viewIdx: 0 },
+      'uplink',
+    )
+  })
+
+  it('broadcasts state changes only while the socket is open', () => {
+    const socket = fakeSocket()
+    const stateEmitter = new EventEmitter<{ state: [StreamwallState] }>()
+    connectControlUplink(
+      makeDeps({
+        stateEmitter,
+        createSocket: () => socket as unknown as UplinkSocket,
+        getClientState: () => ({ streams: [] }) as unknown as StreamwallState,
+      }),
+    )
+
+    socket.readyState = SOCKET_OPEN
+    stateEmitter.emit('state', {} as StreamwallState)
+    expect(socket.send).toHaveBeenCalledTimes(1)
+
+    socket.send.mockClear()
+    socket.readyState = SOCKET_CLOSED
+    stateEmitter.emit('state', {} as StreamwallState)
+    expect(socket.send).not.toHaveBeenCalled()
+  })
+
+  it('forwards local doc updates while open but not remote-origin updates', () => {
+    const socket = fakeSocket()
+    const stateDoc = new Y.Doc()
+    connectControlUplink(
+      makeDeps({
+        stateDoc,
+        createSocket: () => socket as unknown as UplinkSocket,
+      }),
+    )
+
+    socket.send.mockClear()
+    // A local edit (no special origin) should be forwarded while open.
+    stateDoc.getMap('views').set('0', 'local-edit')
+    expect(socket.send).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/streamwall/src/main/uplinkConnection.ts
+++ b/packages/streamwall/src/main/uplinkConnection.ts
@@ -1,0 +1,176 @@
+import EventEmitter from 'node:events'
+import ReconnectingWebSocket from 'reconnecting-websocket'
+import {
+  type ControlCommand,
+  type StreamwallState,
+  isSocketOpen,
+  parseControlEndpoint,
+} from 'streamwall-shared'
+import WebSocket from 'ws'
+import * as Y from 'yjs'
+import {
+  type CommandSource,
+  type ControlCommandResult,
+  dispatchCommand,
+} from './commandDispatch'
+import { decideControlEndpointConnection } from './controlEndpointConnection'
+import log from './logger'
+import { UPLINK_ORIGIN, shouldForwardUpdateToUplink } from './uplinkEcho'
+import { routeUplinkWsMessage } from './uplinkMessageRouting'
+
+/**
+ * Builds a WebSocket subclass for the control uplink.
+ *
+ * It enforces TLS certificate validation on wss:// connections: together with
+ * the wss:// requirement on the control endpoint, this authenticates the
+ * control server to the desktop and prevents a man-in-the-middle from
+ * impersonating it. `rejectUnauthorized` defaults to true in `ws`, but we set
+ * it explicitly so the guarantee cannot be silently lost to a future change.
+ *
+ * It also injects the uplink credential as an `Authorization` header rather
+ * than a URL query parameter, keeping the secret out of server and proxy
+ * access logs. `reconnecting-websocket` does not forward constructor options,
+ * so the header is baked into the subclass here.
+ */
+export function makeControlWebSocket(authorization: string | null) {
+  return class ControlWebSocket extends WebSocket {
+    constructor(url: string, protocols?: string | string[]) {
+      super(url, protocols, {
+        rejectUnauthorized: true,
+        headers: authorization ? { authorization } : undefined,
+      })
+    }
+  }
+}
+
+/** The uplink WebSocket surface `connectControlUplink` drives. */
+export interface UplinkSocket {
+  binaryType: string
+  readonly readyState: number
+  addEventListener(type: 'open', listener: () => void): void
+  addEventListener(type: 'close', listener: () => void): void
+  addEventListener(
+    type: 'message',
+    listener: (event: { data: ArrayBuffer | string }) => void,
+  ): void
+  send(data: string | ArrayBufferLike | ArrayBufferView): void
+}
+
+export interface UplinkConnectionDeps {
+  /** The configured control endpoint URL, or null when none is set. */
+  endpoint: string | null
+  stateDoc: Y.Doc
+  stateEmitter: EventEmitter<{ state: [StreamwallState] }>
+  /** Reads the current broadcast client state. */
+  getClientState: () => StreamwallState
+  /** Dispatches a command received over the uplink. */
+  onCommand: (
+    msg: ControlCommand,
+    source: CommandSource,
+  ) => Promise<void | ControlCommandResult>
+  /**
+   * Builds the reconnecting uplink socket. Injectable so the connection wiring
+   * can be tested without a live server; defaults to a ReconnectingWebSocket
+   * with the hardened control WebSocket subclass.
+   */
+  createSocket?: (opts: {
+    url: string
+    authorization: string | null
+  }) => UplinkSocket
+}
+
+function defaultCreateSocket({
+  url,
+  authorization,
+}: {
+  url: string
+  authorization: string | null
+}): UplinkSocket {
+  return new ReconnectingWebSocket(url, [], {
+    WebSocket: makeControlWebSocket(authorization),
+    maxReconnectionDelay: 5000,
+    minReconnectionDelay: 100 + Math.random() * 500,
+    reconnectionDelayGrowFactor: 1.25,
+    // The 'open' handler always re-sends the full client state and Yjs doc as
+    // soon as the connection (re)opens, so anything sent while disconnected is
+    // stale by the time it could be delivered. Disable the library's default
+    // unbounded queue rather than let it buffer full state snapshots for as
+    // long as the control server is unreachable.
+    maxEnqueuedMessages: 0,
+  }) as unknown as UplinkSocket
+}
+
+/**
+ * Connects the desktop to the remote control server, if one is configured and
+ * the endpoint is secure.
+ *
+ * An insecure endpoint is refused outright (the connection must use wss://, or
+ * ws:// to a loopback host). On connect, the full client state and Yjs doc are
+ * (re)sent on every open, incoming messages are routed (Yjs updates applied,
+ * commands dispatched through the uplink gate), and local state/doc changes are
+ * forwarded while the socket is open.
+ */
+export function connectControlUplink(deps: UplinkConnectionDeps): void {
+  const { stateDoc, stateEmitter, getClientState, onCommand } = deps
+  const createSocket = deps.createSocket ?? defaultCreateSocket
+
+  const controlConnection = decideControlEndpointConnection(deps.endpoint)
+  if (
+    controlConnection.action === 'skip' &&
+    controlConnection.reason === 'insecure'
+  ) {
+    log.error(
+      `Refusing to connect to insecure control endpoint "${controlConnection.endpoint}". ` +
+        'The control connection must use wss:// (or ws:// to a loopback host).',
+    )
+    return
+  }
+  if (controlConnection.action !== 'connect') {
+    return
+  }
+
+  log.debug('Connecting to control server...')
+  // Move the uplink secret out of the URL query string and into an
+  // Authorization header so it never reaches server or proxy access logs.
+  const { url: controlURL, authorization } = parseControlEndpoint(
+    controlConnection.endpoint,
+  )
+  const ws = createSocket({ url: controlURL, authorization })
+  ws.binaryType = 'arraybuffer'
+  ws.addEventListener('open', () => {
+    log.debug('Control WebSocket connected.')
+    ws.send(JSON.stringify({ type: 'state', state: getClientState() }))
+    ws.send(Y.encodeStateAsUpdate(stateDoc))
+  })
+  ws.addEventListener('close', () => {
+    log.debug('Control WebSocket disconnected.')
+  })
+  ws.addEventListener('message', (ev) => {
+    const route = routeUplinkWsMessage(ev.data)
+    switch (route.kind) {
+      case 'yjs-update':
+        Y.applyUpdate(stateDoc, route.update, UPLINK_ORIGIN)
+        return
+      case 'parse-error':
+        log.warn('Failed to parse control WebSocket message:', route.error)
+        return
+      case 'uplink-error':
+        log.warn('Control server refused the uplink connection:', route.message)
+        return
+      case 'command':
+        dispatchCommand(onCommand, route.message as ControlCommand, 'uplink')
+    }
+  })
+  stateEmitter.on('state', () => {
+    if (!isSocketOpen(ws)) {
+      return
+    }
+    ws.send(JSON.stringify({ type: 'state', state: getClientState() }))
+  })
+  stateDoc.on('update', (update, origin) => {
+    if (!shouldForwardUpdateToUplink(origin) || !isSocketOpen(ws)) {
+      return
+    }
+    ws.send(update)
+  })
+}

--- a/packages/streamwall/src/main/wallViews.test.ts
+++ b/packages/streamwall/src/main/wallViews.test.ts
@@ -1,0 +1,123 @@
+import { type StreamList } from 'streamwall-shared'
+import { describe, expect, it } from 'vitest'
+import * as Y from 'yjs'
+import { deriveWallViews } from './wallViews'
+
+/** Builds a viewsState Y.Map with the given cell -> streamId assignments. */
+function viewsStateWith(
+  assignments: Record<string, string | undefined>,
+): Y.Map<Y.Map<string | undefined>> {
+  const doc = new Y.Doc()
+  const viewsState = doc.getMap<Y.Map<string | undefined>>('views')
+  doc.transact(() => {
+    for (const [key, streamId] of Object.entries(assignments)) {
+      const cell = new Y.Map<string | undefined>()
+      cell.set('streamId', streamId)
+      viewsState.set(key, cell)
+    }
+  })
+  return viewsState
+}
+
+function streams(
+  entries: { _id: string; link: string; kind?: string }[],
+): StreamList {
+  return entries as unknown as StreamList
+}
+
+describe('deriveWallViews — normal grid', () => {
+  it('maps each assigned cell to its stream content', () => {
+    const result = deriveWallViews({
+      fullscreenViewIdx: null,
+      streams: streams([
+        { _id: 'a', link: 'http://a', kind: 'web' },
+        { _id: 'b', link: 'http://b', kind: 'video' },
+      ]),
+      viewsState: viewsStateWith({ '0': 'a', '1': 'b' }),
+      cols: 2,
+      rows: 1,
+    })
+
+    expect(result.mode).toBe('normal')
+    expect(result.contentMap.get('0')).toEqual({ url: 'http://a', kind: 'web' })
+    expect(result.contentMap.get('1')).toEqual({
+      url: 'http://b',
+      kind: 'video',
+    })
+    if (result.mode === 'normal') {
+      expect(result.clearedFullscreen).toBe(false)
+    }
+  })
+
+  it('defaults a missing kind to "video"', () => {
+    const result = deriveWallViews({
+      fullscreenViewIdx: null,
+      streams: streams([{ _id: 'a', link: 'http://a' }]),
+      viewsState: viewsStateWith({ '0': 'a' }),
+      cols: 1,
+      rows: 1,
+    })
+
+    expect(result.contentMap.get('0')).toEqual({
+      url: 'http://a',
+      kind: 'video',
+    })
+  })
+
+  it('skips cells whose stream is not present', () => {
+    const result = deriveWallViews({
+      fullscreenViewIdx: null,
+      streams: streams([{ _id: 'a', link: 'http://a', kind: 'video' }]),
+      viewsState: viewsStateWith({ '0': 'a', '1': 'missing' }),
+      cols: 2,
+      rows: 1,
+    })
+
+    expect(result.contentMap.has('0')).toBe(true)
+    expect(result.contentMap.has('1')).toBe(false)
+  })
+})
+
+describe('deriveWallViews — fullscreen', () => {
+  it('fills every cell with the expanded stream', () => {
+    const result = deriveWallViews({
+      fullscreenViewIdx: 1,
+      streams: streams([{ _id: 'b', link: 'http://b', kind: 'video' }]),
+      viewsState: viewsStateWith({ '0': undefined, '1': 'b' }),
+      cols: 2,
+      rows: 2,
+    })
+
+    expect(result.mode).toBe('fullscreen')
+    // 2x2 grid -> all four cells carry the expanded content.
+    expect(result.contentMap.size).toBe(4)
+    for (let idx = 0; idx < 4; idx++) {
+      expect(result.contentMap.get(String(idx))).toEqual({
+        url: 'http://b',
+        kind: 'video',
+      })
+    }
+  })
+
+  it('falls back to the normal grid and flags a cleared override when the stream is gone', () => {
+    const result = deriveWallViews({
+      fullscreenViewIdx: 1,
+      // The expanded cell references 'gone', which is not in the stream list.
+      streams: streams([{ _id: 'a', link: 'http://a', kind: 'video' }]),
+      viewsState: viewsStateWith({ '0': 'a', '1': 'gone' }),
+      cols: 2,
+      rows: 1,
+    })
+
+    expect(result.mode).toBe('normal')
+    if (result.mode === 'normal') {
+      expect(result.clearedFullscreen).toBe(true)
+    }
+    // The still-present stream is laid out normally.
+    expect(result.contentMap.get('0')).toEqual({
+      url: 'http://a',
+      kind: 'video',
+    })
+    expect(result.contentMap.has('1')).toBe(false)
+  })
+})

--- a/packages/streamwall/src/main/wallViews.ts
+++ b/packages/streamwall/src/main/wallViews.ts
@@ -1,0 +1,88 @@
+import {
+  type StreamList,
+  type ViewContentMap,
+  fullscreenViewContentMap,
+} from 'streamwall-shared'
+import * as Y from 'yjs'
+
+export interface DeriveWallViewsInput {
+  /** The view currently expanded to fill the wall, or null for the normal grid. */
+  fullscreenViewIdx: number | null
+  /** The streams the grid assignments resolve against. */
+  streams: StreamList
+  /** Yjs map of grid cell index (as string) -> a `{ streamId }` map. */
+  viewsState: Y.Map<Y.Map<string | undefined>>
+  cols: number
+  rows: number
+}
+
+/**
+ * The wall layout to render, either a single stream expanded across every cell
+ * or the normal per-cell grid.
+ */
+export type WallViews =
+  | { mode: 'fullscreen'; contentMap: ViewContentMap }
+  | {
+      mode: 'normal'
+      contentMap: ViewContentMap
+      /**
+       * True when a fullscreen view was requested but its stream is gone, so
+       * the caller should clear the stale `fullscreenViewIdx` override.
+       */
+      clearedFullscreen: boolean
+    }
+
+/**
+ * Derives the wall's view-content map from the current grid assignments and
+ * streams.
+ *
+ * When a view is expanded to fullscreen (issue #362), the derived layout is
+ * overridden so the expanded stream fills every grid cell — one wall-spanning
+ * box — with the other views parked (hidden but kept alive) behind it (issue
+ * #369). This override is transient: it reads the expanded stream from
+ * `viewsState` but never writes back, so the persisted grid assignments are
+ * untouched and a later collapse restores the normal layout verbatim.
+ *
+ * If the expanded stream is gone (its cell was cleared or it dropped out of the
+ * data source), the result falls back to the normal layout and signals
+ * `clearedFullscreen` so the caller can drop the stale override.
+ */
+export function deriveWallViews({
+  fullscreenViewIdx,
+  streams,
+  viewsState,
+  cols,
+  rows,
+}: DeriveWallViewsInput): WallViews {
+  if (fullscreenViewIdx != null) {
+    const streamId = viewsState.get(String(fullscreenViewIdx))?.get('streamId')
+    const stream = streams.find((s) => s._id === streamId)
+    if (stream) {
+      return {
+        mode: 'fullscreen',
+        contentMap: fullscreenViewContentMap(cols, rows, {
+          url: stream.link,
+          kind: stream.kind || 'video',
+        }),
+      }
+    }
+  }
+
+  const contentMap: ViewContentMap = new Map()
+  for (const [key, viewData] of viewsState) {
+    const streamId = viewData.get('streamId')
+    const stream = streams.find((s) => s._id === streamId)
+    if (!stream) {
+      continue
+    }
+    contentMap.set(key, {
+      url: stream.link,
+      kind: stream.kind || 'video',
+    })
+  }
+  return {
+    mode: 'normal',
+    contentMap,
+    clearedFullscreen: fullscreenViewIdx != null,
+  }
+}

--- a/packages/streamwall/src/main/windowConfig.test.ts
+++ b/packages/streamwall/src/main/windowConfig.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { type StreamwallConfig } from './cliArgs'
+import { buildRetryConfig, buildStreamWindowConfig } from './windowConfig'
+
+function baseArgv(overrides: Partial<StreamwallConfig> = {}): StreamwallConfig {
+  return {
+    help: false,
+    log: { level: 'debug' },
+    grid: { cols: 3, rows: 2 },
+    window: {
+      x: 10,
+      y: 20,
+      width: 1920,
+      height: 1080,
+      frameless: true,
+      fullscreen: false,
+      display: 1,
+      'background-color': '#111',
+      'active-color': '#eee',
+    },
+    data: { interval: 30, 'json-url': [], 'toml-file': [] },
+    presets: [],
+    streamdelay: { endpoint: 'http://localhost:8404', key: null },
+    control: { endpoint: '' },
+    retry: {
+      enabled: true,
+      delay: 5,
+      'max-delay': 60,
+      'max-retries': 4,
+      'stalled-timeout': 30,
+    },
+    park: { pause: false },
+    twitch: {
+      channel: null,
+      username: null,
+      token: null,
+      color: '#ff0000',
+      announce: { template: 't', interval: 60, delay: 30 },
+      vote: { template: 't', interval: 0 },
+    },
+    telemetry: { sentry: true },
+    playlist: [],
+    ...overrides,
+  }
+}
+
+describe('buildStreamWindowConfig', () => {
+  it('projects grid and window options into the wall config', () => {
+    expect(buildStreamWindowConfig(baseArgv())).toEqual({
+      cols: 3,
+      rows: 2,
+      width: 1920,
+      height: 1080,
+      x: 10,
+      y: 20,
+      frameless: true,
+      fullscreen: false,
+      display: 1,
+      activeColor: '#eee',
+      backgroundColor: '#111',
+    })
+  })
+})
+
+describe('buildRetryConfig', () => {
+  it('converts the second-valued fields to milliseconds', () => {
+    expect(buildRetryConfig(baseArgv())).toEqual({
+      enabled: true,
+      delay: 5000,
+      maxDelay: 60000,
+      maxRetries: 4,
+      stalledTimeout: 30000,
+    })
+  })
+
+  it('preserves the enabled flag and retry count verbatim', () => {
+    const config = buildRetryConfig(
+      baseArgv({
+        retry: {
+          enabled: false,
+          delay: 2,
+          'max-delay': 10,
+          'max-retries': 0,
+          'stalled-timeout': 15,
+        },
+      }),
+    )
+    expect(config.enabled).toBe(false)
+    expect(config.maxRetries).toBe(0)
+    expect(config.delay).toBe(2000)
+  })
+})

--- a/packages/streamwall/src/main/windowConfig.ts
+++ b/packages/streamwall/src/main/windowConfig.ts
@@ -1,0 +1,44 @@
+import { type StreamWindowConfig } from 'streamwall-shared'
+import { type StreamwallConfig } from './cliArgs'
+import { type RetryConfig } from './viewStateMachine'
+
+/**
+ * Projects the resolved CLI/config into the wall window's geometry and grid
+ * config. The returned object is shared by reference with the StreamWindow and
+ * the broadcast client state, so a runtime grid resize (which mutates it in
+ * place) stays visible to both.
+ */
+export function buildStreamWindowConfig(
+  argv: StreamwallConfig,
+): StreamWindowConfig {
+  return {
+    cols: argv.grid.cols,
+    rows: argv.grid.rows,
+    width: argv.window.width,
+    height: argv.window.height,
+    x: argv.window.x,
+    y: argv.window.y,
+    frameless: argv.window.frameless,
+    fullscreen: argv.window.fullscreen,
+    display: argv.window.display,
+    activeColor: argv.window['active-color'],
+    backgroundColor: argv.window['background-color'],
+  }
+}
+
+/**
+ * Projects the retry CLI/config into the view state machine's RetryConfig.
+ *
+ * The state machine works in milliseconds; the config is expressed in seconds
+ * for consistency with the other interval options, so the second-valued fields
+ * are converted here.
+ */
+export function buildRetryConfig(argv: StreamwallConfig): RetryConfig {
+  return {
+    enabled: argv.retry.enabled,
+    delay: argv.retry.delay * 1000,
+    maxDelay: argv.retry['max-delay'] * 1000,
+    maxRetries: argv.retry['max-retries'],
+    stalledTimeout: argv.retry['stalled-timeout'] * 1000,
+  }
+}


### PR DESCRIPTION
## Problem

`packages/streamwall/src/main/index.ts` had grown to ~1,200 lines, bundling CLI
parsing, updater wiring, the full control-command dispatch chain, the uplink
WebSocket setup, view derivation, config projection, and data-source assembly
into one module. Every feature touched the same file, conflicts on it were
routine, and almost none of the logic was reachable by a unit test (issue #389).

Closes #394.

## Solution

Extracted the self-contained logic into focused, dependency-injected modules,
leaving `index.ts` as `app.whenReady()` bootstrap/wiring. Each extraction is a
pure move — no behavior change to command handling, uplink sync, updates, or the
data pipeline — verified by the packaged app build and the full test suite.

New modules (each with unit tests):

| Module | Responsibility |
|--------|----------------|
| `cliArgs.ts` | `StreamwallConfig` + `parseArgs` (yargs schema, config-file layering, validation), parametrized by config dir + argv so it is testable without Electron |
| `updaterSetup.ts` | `setupAppUpdater` — Linux notify-only vs. macOS/Windows self-updater branching; updater construction injected via factories |
| `commandHandlers.ts` | `createOnCommand` — the full `ControlCommand` dispatch chain + uplink gate; owns the ephemeral browse-window lifecycle. Browse-window creation and URL validation injected so the security wiring stays at the call site |
| `uplinkConnection.ts` | `makeControlWebSocket` + `connectControlUplink` — endpoint decision, socket setup, message routing, state/doc forwarding; socket factory injected |
| `wallViews.ts` | `deriveWallViews` — pure fullscreen-override / stale-fallback / normal-grid view-content derivation |
| `windowConfig.ts` | `buildStreamWindowConfig` / `buildRetryConfig` — CLI → window/retry config projection (incl. seconds→ms) |
| `dataSources.ts` | `buildDataSources` — assembles URL/TOML/preset/custom/overlay sources; unknown presets warned and skipped |

`index.ts`: **1,197 → 461 lines** (−61%). `StreamwallConfig` moved to `cliArgs.ts`
(`TwitchBot.ts` import updated accordingly).

## Architecture decisions

- **Dependency injection over concrete coupling.** Electron- and network-bound
  collaborators (updater backends, browse window, uplink socket) are injected as
  factories with production defaults, so the branching/routing logic is unit-
  testable without the Electron runtime while the real wiring stays in `index.ts`.
- **Security wiring stays at the call site.** `hardenSession` / `denyWindowOpen` /
  the browse partition and `ensureValidURL` remain in `index.ts`; the command
  handler receives them as `createBrowseWindow` / `validateBrowseURL`, so the
  security guarantees remain co-located and reviewable.
- **Behavior preserved verbatim.** Ordering-sensitive paths (the synchronous
  `observeDeep` layout on grid resize, the fullscreen override, the stale-
  fullscreen clear, uplink echo suppression) are moved unchanged.

## Testing

- New unit tests for every extracted module (CLI parsing, updater branching &
  handlers, all command branches + uplink gate, uplink socket wiring, view
  derivation, config builders, data-source assembly).
- `streamwall` package suite: 642 tests pass (was 580).
- Full quality gate green: `format:check`, `lint`, `typecheck` (all workspaces),
  `npm test` (all workspaces), `streamwall-control-client` build, and
  `npm -w streamwall run package` (electron-forge/Vite bundle of the refactored
  main process — confirms no bundling/hoisting regressions).

## Scope note

The issue lists `<300 lines` as a *target*. What remains in `index.ts` is the
tightly-coupled `app.whenReady()` orchestration the issue explicitly wanted it to
retain — storage load, window creation, state/IPC wiring, and lifecycle handlers
(which already delegate to tested pure helpers). Splitting those further would
mean threading the shared mutable state (`clientState`, `updateState`, the
stateDoc) through artificial seams, reducing clarity rather than improving it.
All extractable, testable logic has been moved out.

## Risks / breaking changes

None. Pure internal refactor; no public API, config, or runtime behavior change.
Pairs with #389 (integration coverage), which is now unblocked by the extracted,
testable modules.
