### PR TITLE
ci: build and smoke-test the control-server Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       dependencies: ${{ steps.filter.outputs.dependencies }}
+      docker: ${{ steps.filter.outputs.docker }}
       workflows: ${{ steps.filter.outputs.workflows }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -51,6 +52,19 @@ jobs:
               - 'package.json'
               - 'package-lock.json'
               - 'packages/*/package.json'
+            # Everything the control-server image is built from: the four
+            # workspaces the Dockerfile copies, the root manifests `npm ci`
+            # reads, and the deploy stack itself.
+            docker:
+              - 'packages/streamwall-shared/**'
+              - 'packages/streamwall-control-server/**'
+              - 'packages/streamwall-control-client/**'
+              - 'packages/streamwall-control-ui/**'
+              - 'deploy/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.dockerignore'
+              - '.github/workflows/ci.yml'
             workflows:
               - '.github/workflows/**'
               - '.github/actions/**'
@@ -151,6 +165,50 @@ jobs:
       - name: Run E2E smoke tests
         run: npm -w streamwall-control-e2e run test:e2e
 
+  # Self-hosting smoke test: builds the control-server image the way
+  # docs/self-hosting.md and deploy/docker-compose.yml build it (repository
+  # root as context). Without this, workspace-boundary mistakes in the
+  # Dockerfile (COPY paths, missing `npm ci` workspace filters, a broken
+  # control-client build) only surface when an operator deploys.
+  #
+  # The image is also started once: a container that builds but exits at
+  # boot is just as broken for self-hosters, and the check costs seconds.
+  docker:
+    name: Docker build (control server)
+    needs: changes
+    if: needs.changes.outputs.docker == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      # Renders the compose stack with the documented .env.example values, so
+      # a compose file that references a removed service, volume or variable
+      # fails here instead of on an operator's host.
+      - name: Validate compose stack
+        working-directory: deploy
+        run: |
+          cp .env.example .env
+          docker compose config --quiet
+      - name: Build control-server image
+        run: docker build -f packages/streamwall-control-server/Dockerfile -t streamwall-control-server:ci .
+      - name: Smoke test the image
+        run: |
+          docker run -d --name control-server -p 3000:3000 \
+            -e STREAMWALL_CONTROL_URL=http://localhost:3000 \
+            streamwall-control-server:ci
+          for _ in $(seq 1 30); do
+            if curl -fsS -o /dev/null http://localhost:3000/; then
+              echo "Control server served the web control client."
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Control server did not respond within 30s."
+          docker logs control-server
+          exit 1
+
   # Reviews the dependency diff of a PR for known vulnerabilities.
   dependency-review:
     name: Dependency review
@@ -199,6 +257,7 @@ jobs:
         build,
         package,
         e2e,
+        docker,
         dependency-review,
         actionlint,
       ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,18 @@ npx playwright install --with-deps chromium
 npm -w streamwall-control-e2e run test:e2e
 ```
 
+### Self-hosting image
+
+Changes to the control server, the web control client, the shared packages or
+`deploy/` are also exercised as a Docker build in CI: the image is built,
+started once, and the compose stack is validated. To reproduce that locally
+(needs Docker), from the repo root:
+
+```sh
+docker build -f packages/streamwall-control-server/Dockerfile .
+cd deploy && cp .env.example .env && docker compose config --quiet
+```
+
 ## Making changes
 
 - **Test-driven development is expected** for behavior changes: write a failing

--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ cp .env.example .env   # set your domain, then see docs/self-hosting.md
 docker compose up -d --build
 ```
 
+CI builds and boots this image (and validates the compose stack) on every
+pull request that touches it, so a deploy-breaking change cannot reach `main`
+unnoticed.
+
 **Known limitation:** grid edits (swap, drag-move, resize) sync as
 independent per-cell updates in the shared Yjs document. If two operators
 swap or move overlapping tiles at nearly the same instant, the last-writer-wins

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -45,6 +45,14 @@ Auth-token storage (`storage.json`) lives on the `control-server-data` named
 volume, so it survives container restarts/rebuilds; back that volume up like
 you would any other persistent data.
 
+CI covers this path: every pull request that touches the server, the web
+control client, the shared packages or `deploy/` builds the image, starts a
+container and checks it serves the control client, and validates the compose
+stack (see the `Docker build (control server)` job in
+[`.github/workflows/ci.yml`](../.github/workflows/ci.yml)). A broken
+`docker compose up -d --build` therefore blocks the merge instead of reaching
+you.
+
 ## First run
 
 Watch the logs for the two links the server prints once, on its very first


### PR DESCRIPTION
## Problem

Self-hosting is documented (`docs/self-hosting.md`, `deploy/docker-compose.yml`, `packages/streamwall-control-server/Dockerfile`), but the image was never built in CI. Workspace-boundary mistakes in the Dockerfile — COPY paths, missing `npm ci` workspace filters, a broken `streamwall-control-client` build — only surfaced when an operator deployed.

## Solution

New `docker` job in `.github/workflows/ci.yml`:

- **Path-filtered** via a new `docker` filter (the four workspaces the Dockerfile copies, `deploy/**`, root manifests, `.dockerignore`, the workflow itself) — unrelated PRs don't pay for it.
- **Validates the compose stack** (`docker compose config --quiet`) with the documented `.env.example` values, so a compose file referencing a removed service/volume/variable fails here instead of on an operator's host.
- **Builds the image** exactly as the docs do: repository root as build context.
- **Boots the image once** and checks it serves the web control client. An image that builds but exits at boot is just as broken for self-hosters, and the check costs seconds (cf. the startup crash in #442).

The job is wired into the `CI OK` gate, so a failure blocks the merge.

## Decisions

- Plain `docker build`, no buildx/GHA cache: the cache would need `actions: write` on a workflow that is deliberately read-only by default, and the build measures ~80s cold locally, running in parallel with the other jobs.
- Smoke run over build-only: it covers the deploy-regression class the issue is about at negligible extra cost.
- Not added to the release workflow — the control server does not ship with the Electron app releases, and PR coverage is what the acceptance criteria ask for.

## Testing

CI-config and docs change, so no unit tests (per CONTRIBUTING). Verified locally instead:

- `docker build -f packages/streamwall-control-server/Dockerfile .` → succeeds (~81s).
- Container started from that image → `GET /` returns `200` and the server logs its uplink/invite links.
- `cd deploy && cp .env.example .env && docker compose config --quiet` → clean.
- `actionlint 1.7.12` and `npm run format:check` → clean.

## Docs

`README.md`, `docs/self-hosting.md` and `CONTRIBUTING.md` now mention the CI coverage, including how to reproduce the checks locally.

## Risks

None to runtime code. Adds ~2 minutes of parallel CI time on PRs that touch the server/client/deploy paths.

Closes #401