### PR TITLE
fix(control-client): typecheck before vite build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,19 @@ Zero errors and no new warnings. Prettier runs on every PR — including
 documentation-only changes — so run `npm run format` to auto-fix before
 pushing.
 
+### Builds typecheck first
+
+Vite strips types without checking them, so `vite build` alone would happily
+bundle code that does not compile. Every workspace with a `build` script
+therefore declares `"prebuild": "npm run typecheck"`, which npm runs
+automatically before `build`. That covers all entry points — a local
+`npm -w streamwall-control-client run build`, the CI build job, and the E2E
+`globalSetup` — so a type error fails the build instead of slipping through to
+the separate `npm run typecheck` step.
+
+If you add a `build` script to a package, add the matching `prebuild` hook;
+`test/workspace-metadata.test.mjs` enforces this.
+
 ### Test runners differ per package
 
 `npm test` fans out across the workspaces, and the packages do **not** all use

--- a/packages/streamwall-control-client/package.json
+++ b/packages/streamwall-control-client/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.tsx",
   "type": "module",
   "scripts": {
+    "prebuild": "npm run typecheck",
     "build": "vite build",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run",

--- a/test/workspace-metadata.test.mjs
+++ b/test/workspace-metadata.test.mjs
@@ -10,17 +10,43 @@ function readPackageJson(relativePath) {
   return JSON.parse(readFileSync(join(rootDir, relativePath), 'utf8'))
 }
 
-test('every workspace package.json declares the MIT license', () => {
+function workspacePackageJsonPaths() {
   const rootPackageJson = readPackageJson('package.json')
-  const packageJsonPaths = [
-    'package.json',
-    ...rootPackageJson.workspaces.map((workspace) =>
-      join(workspace, 'package.json'),
-    ),
-  ]
+  return rootPackageJson.workspaces.map((workspace) =>
+    join(workspace, 'package.json'),
+  )
+}
+
+test('every workspace package.json declares the MIT license', () => {
+  const packageJsonPaths = ['package.json', ...workspacePackageJsonPaths()]
 
   for (const relativePath of packageJsonPaths) {
     const { license } = readPackageJson(relativePath)
     assert.equal(license, 'MIT', `${relativePath} is missing "license": "MIT"`)
+  }
+})
+
+// Bundlers (Vite) strip types without checking them, so a `build` script alone
+// can emit a passing bundle from code that does not typecheck. Binding the
+// check to the `prebuild` lifecycle hook means every entry point into a build
+// — local, CI, E2E `globalSetup` — pays for it, instead of relying on callers
+// to remember a separate `typecheck` run.
+test('every workspace that builds typechecks first', () => {
+  for (const relativePath of workspacePackageJsonPaths()) {
+    const { scripts = {} } = readPackageJson(relativePath)
+    if (!scripts.build) {
+      continue
+    }
+
+    assert.ok(
+      scripts.typecheck,
+      `${relativePath} has a "build" script but no "typecheck" script`,
+    )
+    assert.equal(
+      scripts.prebuild,
+      'npm run typecheck',
+      `${relativePath} must run "npm run typecheck" in its "prebuild" script ` +
+        'so builds cannot pass with type errors',
+    )
   }
 })


### PR DESCRIPTION
Closes #408.

## Problem

`streamwall-control-client` ships a `typecheck` script, but `vite build` never runs it — Vite strips types without checking them. A build could therefore emit a passing bundle from code that does not compile:

- a local `npm -w streamwall-control-client run build` succeeds with type errors
- the CI `build` job runs Vite only; `typecheck` lives in the separate `checks` job, so path filters can skip one and run the other
- the E2E `globalSetup` builds the client without any type check

## Solution

Bind the check to the `prebuild` lifecycle hook instead of to any single caller:

```json
"prebuild": "npm run typecheck",
"build": "vite build"
```

npm runs `prebuild` automatically before `build`, so every entry point into a build pays for it — local, the CI `build` job, `npm run start:server`, and the E2E `globalSetup` — with no changes needed at the call sites or in the workflow.

### Why not the alternatives

- **`vite-plugin-checker`**: adds a dependency and only covers builds that go through the Vite config, leaving `tsc` as a second source of truth for the same check.
- **CI `build` job `needs: checks`**: fixes CI only. Local build-only workflows and the E2E setup would still skip typechecking, which is the part of the issue that has no CI backstop.

## Testing

- New meta-test in `test/workspace-metadata.test.mjs`: every workspace with a `build` script must declare both `typecheck` and `prebuild: npm run typecheck`. Verified failing before the package.json change (TDD red), passing after.
- Manual end-to-end proof: with a deliberate type error added to `packages/streamwall-control-client/src`, `npm run build` now exits `2` and reports `error TS2322` without ever invoking `vite build`. Removing the error restores a clean build.
- Full quality gate green locally: `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm test`.

## Risks / breaking changes

None functional. Builds get marginally slower (one `tsc --noEmit` pass, ~1s) and will now fail loudly on pre-existing type errors — there are none on `main`.

## Docs

CONTRIBUTING gains a "Builds typecheck first" section explaining the hook and the rule for new packages.

## Follow-ups

- #472 — the Electron `streamwall` package packages/makes/publishes through Forge + Vite with no typecheck, the same gap in a different shape. Out of scope here because it has no single `build` script.