### PR TITLE
chore: add root test:e2e script and document Playwright setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
       - name: Run E2E smoke tests
-        run: npm -w streamwall-control-e2e run test:e2e
+        run: npm run test:e2e
 
   # Self-hosting smoke test: builds the control-server image the way
   # docs/self-hosting.md and deploy/docker-compose.yml build it (repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,9 +89,13 @@ The E2E smoke tests need a browser that is not installed by `npm ci`. They are
 locally:
 
 ```sh
-npx playwright install --with-deps chromium
-npm -w streamwall-control-e2e run test:e2e
+npx playwright install --with-deps chromium  # once; drop --with-deps on macOS
+npm run test:e2e                             # from the repo root
 ```
+
+The suite builds `streamwall-control-client` itself before the first test (a
+Playwright `globalSetup` hook, not the npm script), so the server has real
+`dist/` assets to serve — no separate build step is needed.
 
 ### Self-hosting image
 

--- a/README.md
+++ b/README.md
@@ -293,7 +293,15 @@ Run the checks CI runs before pushing:
 npm run lint          # ESLint
 npm run format:check  # Prettier (also checks Markdown and YAML)
 npm run typecheck     # tsc --noEmit across all workspaces
-npm test              # full test suite
+npm test              # full test suite (unit tests, all workspaces)
+```
+
+The Playwright end-to-end smoke tests are not part of `npm test` — they need a
+browser that `npm ci` does not install:
+
+```sh
+npx playwright install --with-deps chromium  # once; drop --with-deps on macOS
+npm run test:e2e
 ```
 
 The six workspaces under `packages/` are: `streamwall` (the Electron app),
@@ -305,8 +313,7 @@ The six workspaces under `packages/` are: `streamwall` (the Electron app),
 `npm run start:server`.
 
 Test runners differ per package — most use Vitest, while
-`streamwall-control-server` uses the native Node test runner. The Playwright
-E2E tests are not part of `npm test` and need a one-time browser install. See
+`streamwall-control-server` uses the native Node test runner. See
 [CONTRIBUTING.md](CONTRIBUTING.md) for the full setup, per-package test
 details, and commit/PR conventions, and [SECURITY.md](SECURITY.md) for how to
 report vulnerabilities.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format:check": "prettier --check .",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "test": "node --test test/*.test.mjs && npm run test --workspaces --if-present",
+    "test:e2e": "npm -w streamwall-control-e2e run test:e2e",
     "release:version": "node scripts/release-version.mjs"
   },
   "workspaces": [

--- a/packages/streamwall-control-e2e/README.md
+++ b/packages/streamwall-control-e2e/README.md
@@ -19,13 +19,15 @@ networking and real layout:
 # once, to fetch the browser (Linux CI uses `--with-deps`):
 npx playwright install chromium
 
-# build the client and run the suite:
+# run the suite (equivalent: `npm run test:e2e` from the repo root):
 npm -w streamwall-control-e2e run test:e2e
 ```
 
-`test:e2e` builds the control client first (the server serves its `dist/`), then
-runs Playwright. Each test spins up its own server + uplink on a fresh port, so
-there is no shared global setup or fixed port.
+The npm script itself only starts Playwright. The control-client build runs
+inside Playwright's `globalSetup` hook ([tests/global-setup.ts](tests/global-setup.ts)),
+once per suite run, so the server has real `dist/` assets to serve. Beyond that
+build there is no shared state: each test spins up its own server + uplink on a
+fresh ephemeral port, so there is no `webServer`, no `baseURL`, and no fixed port.
 
 The suite is intentionally kept out of the per-workspace `npm test` matrix (it
 has no `test` script) because it needs a browser and only runs on Linux/macOS —

--- a/test/workspace-metadata.test.mjs
+++ b/test/workspace-metadata.test.mjs
@@ -50,3 +50,32 @@ test('every workspace that builds typechecks first', () => {
     )
   }
 })
+
+// The E2E suite deliberately has no `test` script (it needs a browser, so it
+// stays out of the `npm test` workspace fan-out), which means the only way to
+// discover it is a root-level entry point. Issue #411.
+test('the root package exposes the E2E suite as `test:e2e`', () => {
+  const { scripts } = readPackageJson('package.json')
+
+  assert.equal(
+    scripts['test:e2e'],
+    'npm -w streamwall-control-e2e run test:e2e',
+    'root package.json is missing a `test:e2e` script delegating to the E2E workspace',
+  )
+})
+
+test('the E2E workspace defines the delegated `test:e2e` script', () => {
+  const { scripts } = readPackageJson(
+    'packages/streamwall-control-e2e/package.json',
+  )
+
+  assert.ok(
+    scripts?.['test:e2e'],
+    'streamwall-control-e2e must define the `test:e2e` script the root delegates to',
+  )
+  assert.equal(
+    scripts.test,
+    undefined,
+    'streamwall-control-e2e must not define `test`: it would join the `npm test` fan-out',
+  )
+})


### PR DESCRIPTION
## Problem

Root `npm test` fans out over the workspaces, but `streamwall-control-e2e` deliberately has no `test` script — so the Playwright suite was reachable only via `npm -w streamwall-control-e2e run test:e2e`, which the main README never mentioned. Contributors reasonably assumed `npm test` was enough before opening a PR, and E2E regressions surfaced only in CI.

The E2E package README was also inaccurate: it claimed the `test:e2e` npm script builds the control client and that there is "no shared global setup". The build actually happens in Playwright's `globalSetup` hook.

## Solution

- **Root `test:e2e` script** delegating to the E2E workspace, so the suite is discoverable from the repo root.
- **README Development section** now documents the one-time `npx playwright install chromium` and `npm run test:e2e`.
- **CONTRIBUTING** E2E section uses the root script and explains that the client build is a `globalSetup` hook, not part of the npm script.
- **E2E package README** corrected re: `globalSetup` vs. npm script; the "no shared state" claim is now scoped to per-test servers/ports.
- **CI** runs the root script, keeping one canonical entry point.

## Testing

- New assertions in `test/workspace-metadata.test.mjs` (node --test) pin the root `test:e2e` script and guard the invariant that the E2E package must *not* define `test` (which would drag it into the `npm test` fan-out). Verified red before the script was added.
- Full quality gate green locally: `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm test`.
- `npm run test:e2e` executed end-to-end from the repo root against a real Chromium: 16 passed.

## Risks

None functional — no production code paths touched. The CI change is a rename of the same invocation.

Closes #411