### PR TITLE
ci: fold CodeQL into the CI OK merge gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,19 @@ jobs:
           fail-on-severity: high
           comment-summary-in-pr: on-failure
 
+  # Static security analysis. Runs here — instead of standing alone — so that
+  # a CodeQL failure fails the single `CI OK` check branch protection requires.
+  # The same analysis runs weekly from codeql.yml's schedule.
+  codeql:
+    name: CodeQL
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    uses: ./.github/workflows/codeql.yml
+
   # Lints the workflow files themselves (also shellchecks run: scripts).
   actionlint:
     name: Lint workflows (actionlint)
@@ -259,6 +272,7 @@ jobs:
         e2e,
         docker,
         dependency-review,
+        codeql,
         actionlint,
       ]
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,26 +1,10 @@
 name: CodeQL
 
+# Push and pull-request analysis is driven by ci.yml, which calls this
+# workflow as a job of the `CI OK` gate — that is what makes a CodeQL failure
+# block a merge. Only the periodic scan is triggered here.
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - '**/*.md'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.gitattributes'
-      - 'example.config.toml'
-      - 'example.streams.toml'
-      - '.github/dependabot.yml'
-  pull_request:
-    branches: [main]
-    paths-ignore:
-      - '**/*.md'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.gitattributes'
-      - 'example.config.toml'
-      - 'example.streams.toml'
-      - '.github/dependabot.yml'
+  workflow_call:
   schedule:
     # Weekly scan (Mondays 03:30 UTC) to catch newly disclosed patterns.
     - cron: '30 3 * * 1'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,30 @@ cd deploy && cp .env.example .env && docker compose config --quiet
 - **No AI-tool attribution** anywhere — not in commit messages, PR
   descriptions, or code comments.
 
+### Required status checks
+
+Branch protection on `main` requires exactly these two checks, and nothing
+else:
+
+- `CI OK` — the aggregate gate of `.github/workflows/ci.yml`. It is green only
+  when every job in that workflow succeeded or was skipped as irrelevant to the
+  change (docs-only edits skip the heavy jobs). Format, lint, typecheck, tests,
+  builds, packaging, E2E, the control-server Docker build, dependency review,
+  workflow linting and **CodeQL**
+  all report through it — CodeQL runs as a job of `ci.yml` rather than as a
+  standalone workflow precisely so that its failures block a merge.
+- `Conventional Commits title` — `.github/workflows/pr-title.yml`.
+
+Adding a job to `ci.yml` therefore also means adding it to the `ci-ok` gate's
+`needs:` list; `test/ci-gate.test.mjs` fails if that is forgotten, and it also
+keeps this list in sync with the workflows.
+
+Two things intentionally sit outside this gate: `.github/workflows/release.yml`
+(tag-triggered) and CodeQL's weekly scheduled scan, which surfaces newly
+disclosed patterns in code that was already merged. Open code-scanning alerts
+are triaged in the Security tab; the gate blocks on the analysis _failing_, not
+on pre-existing alerts.
+
 ### PR checklist
 
 - [ ] `npm run lint`, `npm run format:check`, `npm run typecheck`, and

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "eslint-plugin-import-x": "^4.17.1",
         "eslint-plugin-react-hooks": "^7.1.1",
         "globals": "^17.7.0",
+        "js-yaml": "^4.3.0",
         "prettier": "^3.9.5",
         "prettier-plugin-organize-imports": "^4.3.0",
         "typescript": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-import-x": "^4.17.1",
     "eslint-plugin-react-hooks": "^7.1.1",
     "globals": "^17.7.0",
+    "js-yaml": "^4.3.0",
     "prettier": "^3.9.5",
     "prettier-plugin-organize-imports": "^4.3.0",
     "typescript": "^6.0.3",

--- a/test/ci-gate.test.mjs
+++ b/test/ci-gate.test.mjs
@@ -1,0 +1,77 @@
+import { load } from 'js-yaml'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)))
+
+function readWorkflow(fileName) {
+  return load(
+    readFileSync(join(rootDir, '.github/workflows', fileName), 'utf8'),
+  )
+}
+
+function readDoc(relativePath) {
+  return readFileSync(join(rootDir, relativePath), 'utf8')
+}
+
+// Branch protection requires a single aggregate check per workflow, so any job
+// that is not wired into `ci-ok` silently stops gating merges.
+test('the ci-ok gate depends on every other job in ci.yml', () => {
+  const ci = readWorkflow('ci.yml')
+  const gate = ci.jobs['ci-ok']
+  const otherJobs = Object.keys(ci.jobs).filter((job) => job !== 'ci-ok')
+
+  for (const job of otherJobs) {
+    assert.ok(
+      gate.needs.includes(job),
+      `ci.yml job "${job}" is missing from the ci-ok gate's needs`,
+    )
+  }
+})
+
+test('CodeQL runs inside ci.yml so its failures block the merge gate', () => {
+  const ci = readWorkflow('ci.yml')
+  const codeql = ci.jobs.codeql
+
+  assert.ok(codeql, 'ci.yml is missing a codeql job')
+  assert.equal(codeql.uses, './.github/workflows/codeql.yml')
+})
+
+test('codeql.yml is reusable and does not run standalone on pull requests', () => {
+  const triggers = Object.keys(readWorkflow('codeql.yml').on)
+
+  assert.ok(
+    triggers.includes('workflow_call'),
+    'codeql.yml must be callable from ci.yml',
+  )
+  assert.ok(
+    !triggers.includes('pull_request'),
+    'codeql.yml must not also trigger on pull_request, which would run the ' +
+      'analysis twice and outside the ci-ok gate',
+  )
+})
+
+// The documented list is what contributors and maintainers configure branch
+// protection from, so it has to name the checks the workflows actually report.
+test('CONTRIBUTING documents exactly the required status checks', () => {
+  const contributing = readDoc('CONTRIBUTING.md')
+  const section = contributing
+    .split('### Required status checks')[1]
+    ?.split(/^#{2,3} /m)[0]
+
+  assert.ok(
+    section,
+    'CONTRIBUTING.md is missing a required status checks section',
+  )
+
+  const documented = [...section.matchAll(/^- `([^`]+)`/gm)].map((m) => m[1])
+  const expected = [
+    readWorkflow('ci.yml').jobs['ci-ok'].name,
+    readWorkflow('pr-title.yml').jobs['conventional-title'].name,
+  ]
+
+  assert.deepEqual(documented, expected)
+})


### PR DESCRIPTION
Closes #403

## Problem

`.github/workflows/ci.yml` documents `ci-ok` (`CI OK`) as the single required status check, but CodeQL ran as a standalone workflow. The active `main-protection` ruleset requires `CI OK` and `Conventional Commits title` only — so a failing CodeQL analysis did not block a merge to `main`. Nothing kept the documented required-check list in sync with what the workflows actually report, either.

## Solution

Proposed fix option 2/3 from the issue, without duplicating the analysis config:

- `codeql.yml` becomes a **reusable** workflow: `on: [workflow_call, schedule]`. Its `push`/`pull_request` triggers are gone, so the analysis is never run twice.
- `ci.yml` gains a `codeql` job that `uses: ./.github/workflows/codeql.yml`, gated on the same `changes.outputs.code` filter as the other heavy jobs, with `security-events: write` passed through at the caller. It is wired into `ci-ok`, so a CodeQL failure now fails `CI OK`.
- The weekly scheduled scan is unchanged and still runs from `codeql.yml`.
- `CONTRIBUTING.md` gets a **Required status checks** section listing exactly the two contexts configured in branch protection, plus the rule that new `ci.yml` jobs must join the `ci-ok` gate.

### Architecture decision

Reusable workflow over a copied job body: the analysis steps (pinned action SHAs, query suite) exist once and both the PR gate and the weekly scan share them. The alternative — an inline job in `ci.yml` plus a schedule-only `codeql.yml` — would have duplicated those steps and let them drift.

## Testing

New `test/ci-gate.test.mjs` (`node --test`, runs as part of `npm test`) parses the workflows and asserts:

- every job in `ci.yml` other than `ci-ok` appears in the gate’s `needs:` — the regression that caused this issue class in the first place;
- `ci.yml` has a `codeql` job calling the reusable workflow;
- `codeql.yml` is callable and does not also trigger on `pull_request`;
- the check list documented in `CONTRIBUTING.md` matches the `ci-ok` and `conventional-title` job names verbatim.

`js-yaml` was already in the tree via `packages/streamwall`; it is now an explicit root devDependency so the root test does not rely on hoisting.

Full quality gate green locally: `format:check`, `lint`, `typecheck`, `npm test`, plus `actionlint` on all four workflows.

## Risks

- Low. The only behavioral change to CI is where CodeQL runs. `CI OK` and `Conventional Commits title` remain the required contexts, so no branch-protection edit is needed — the ruleset already matches the now-documented list.
- The standalone `Analyze (javascript-typescript)` check disappears from PR check lists; it appears as a nested job of the CI run instead.

## Follow-ups

- #475 — the README CodeQL badge now reflects only the weekly scheduled scan.
- #476 — decide whether open code-scanning *alerts* (not just a failed analysis) should block merges.