### PR TITLE
fix(streamwall): report cross-origin iframe as a distinct media failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,14 @@ Each entry (a `[[streams]]` table in TOML, or an object in the JSON array) suppo
 - `background` — a webpage loaded behind the grid instead of in a tile.
 - `overlay` — a webpage loaded as a full-screen `<iframe>` layered over the whole wall (e.g. scoreboards, alerts). See [Security: overlay and background streams](#security-overlay-and-background-streams) below.
 
+For `video` and `audio` streams, Streamwall also looks inside `<iframe>` players
+on the page. That only works for **same-origin** iframes: a cross-origin player
+frame has an opaque origin, so its `<video>` tag is unreachable from the
+embedding page and no browser permission can change that. Such a tile fails with
+`could not find video: it may be inside a cross-origin iframe, which is
+unsupported` — use the player page's own URL (the one the iframe loads) as the
+stream `link` instead.
+
 ## Playlists
 
 A grid cell can optionally cycle through a fixed list of stream URLs on an

--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -244,6 +244,120 @@ describe("mediaPreload emptied handler's re-acquisition rejection", () => {
   })
 })
 
+describe('mediaPreload iframe video extraction (issue #413)', () => {
+  // Must match INITIAL_TIMEOUT in mediaPreload.ts; the iframe scan only runs
+  // after the top-level <video> wait loses its race against this timeout.
+  const INITIAL_TIMEOUT_MS = 10 * 1000
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.resetModules()
+    invoke.mockClear()
+    send.mockClear()
+    on.mockClear()
+    exposeInMainWorld.mockClear()
+    document.body.innerHTML = ''
+  })
+
+  function viewErrorCalls() {
+    return send.mock.calls.filter(([channel]) => channel === 'view-error')
+  }
+
+  // A same-origin iframe embed: the <video> lives in the iframe's own
+  // document, so the top-level waitForQuery never finds it and the iframe
+  // scan is the only path that can.
+  function appendSameOriginIframeWithVideo(): HTMLIFrameElement {
+    const iframe = document.createElement('iframe')
+    iframe.srcdoc = '<html><head></head><body><video></video></body></html>'
+    document.body.appendChild(iframe)
+    return iframe
+  }
+
+  // A cross-origin iframe has an opaque origin: the embedder can never reach
+  // its DOM, so `contentDocument` reads as null.
+  function appendCrossOriginIframe(): HTMLIFrameElement {
+    const iframe = document.createElement('iframe')
+    document.body.appendChild(iframe)
+    Object.defineProperty(iframe, 'contentDocument', { value: null })
+    return iframe
+  }
+
+  async function loadVideoContent() {
+    invoke.mockResolvedValueOnce({
+      content: { kind: 'video', link: 'https://example.com/stream' },
+      options: {},
+      volume: 1,
+    })
+    await import('./mediaPreload')
+    document.dispatchEvent(new Event('DOMContentLoaded'))
+    process.emit('loaded' as never)
+    await vi.advanceTimersByTimeAsync(0)
+  }
+
+  it('acquires a video embedded in a same-origin iframe and hoists it into the iframe document', async () => {
+    const iframe = appendSameOriginIframeWithVideo()
+    const frameDocument = iframe.contentDocument
+    const video = frameDocument?.querySelector('video')
+    if (!video) {
+      throw new Error('test fixture: iframe document has no <video>')
+    }
+    // happy-dom's HTMLVideoElement never implements videoWidth, so give it a
+    // truthy value to skip findMedia's "wait for playing" branch.
+    ;(video as unknown as { videoWidth: number }).videoWidth = 100
+
+    await loadVideoContent()
+    await vi.advanceTimersByTimeAsync(INITIAL_TIMEOUT_MS)
+
+    expect(viewErrorCalls()).toEqual([])
+    expect(send).toHaveBeenCalledWith('view-loaded')
+    // The video is moved to the iframe document's body and the iframe (plus
+    // its ancestors) marked so VIDEO_OVERRIDE_STYLE can size it to the tile.
+    expect(video.parentElement).toBe(frameDocument?.body)
+    expect(iframe.className).toBe('__video__')
+    expect(document.body.className).toBe('__video_parent__')
+    expect(frameDocument?.head.querySelector('style')).not.toBeNull()
+  })
+
+  it('reports the cross-origin iframe as the specific cause instead of a generic missing video', async () => {
+    appendCrossOriginIframe()
+
+    await loadVideoContent()
+    await vi.advanceTimersByTimeAsync(INITIAL_TIMEOUT_MS)
+
+    expect(viewErrorCalls()).toEqual([
+      [
+        'view-error',
+        {
+          error: expect.objectContaining({
+            message:
+              'could not find video: it may be inside a cross-origin iframe, which is unsupported',
+          }),
+        },
+      ],
+    ])
+  })
+
+  it('keeps the generic message when a reachable iframe simply contains no video', async () => {
+    const iframe = document.createElement('iframe')
+    iframe.srcdoc = '<html><head></head><body></body></html>'
+    document.body.appendChild(iframe)
+
+    await loadVideoContent()
+    await vi.advanceTimersByTimeAsync(INITIAL_TIMEOUT_MS)
+
+    expect(viewErrorCalls()).toEqual([
+      [
+        'view-error',
+        { error: expect.objectContaining({ message: 'could not find video' }) },
+      ],
+    ])
+  })
+})
+
 describe('mediaPreload pause/resume handling (issue #374)', () => {
   beforeEach(() => {
     vi.useFakeTimers()

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -213,6 +213,8 @@ async function waitForVideo(
 ): Promise<{
   video?: HTMLMediaElement
   iframe?: HTMLIFrameElement
+  iframeDocument?: Document
+  crossOriginIframe?: boolean
 }> {
   lockdownMediaTags()
 
@@ -225,14 +227,24 @@ async function waitForVideo(
     return { video }
   }
 
-  let iframe
-  for (iframe of document.querySelectorAll('iframe')) {
-    video = iframe.contentDocument?.querySelector?.(kind)
-    if (video instanceof HTMLVideoElement) {
-      return { video, iframe }
+  // Some pages embed their player in an iframe. Its document is only
+  // reachable when it is same-origin: a cross-origin frame has an opaque
+  // origin, so `contentDocument` reads as null and no amount of waiting will
+  // ever make the <video> inside visible from here. Remember that case so
+  // findMedia can name it instead of reporting a generic missing video.
+  let crossOriginIframe = false
+  for (const iframe of document.querySelectorAll('iframe')) {
+    const iframeDocument = iframe.contentDocument
+    if (!iframeDocument) {
+      crossOriginIframe = true
+      continue
+    }
+    video = iframeDocument.querySelector(kind)
+    if (video instanceof HTMLMediaElement) {
+      return { video, iframe, iframeDocument }
     }
   }
-  return {}
+  return { crossOriginIframe }
 }
 
 const igHacks = {
@@ -263,22 +275,33 @@ async function findMedia(
     await igHacks.onLoad()
   }
 
-  const { video, iframe } = await waitForVideo(kind, elementTimeout)
+  const { video, iframe, iframeDocument, crossOriginIframe } =
+    await waitForVideo(kind, elementTimeout)
   if (!video) {
-    throw new Error('could not find video')
+    // A cross-origin iframe is a hard limitation rather than a slow page, and
+    // an operator seeing only "could not find video" cannot tell the two
+    // apart (issue #413).
+    throw new Error(
+      crossOriginIframe
+        ? 'could not find video: it may be inside a cross-origin iframe, which is unsupported'
+        : 'could not find video',
+    )
   }
-  if (iframe && iframe.contentDocument) {
-    // TODO: verify iframe still works
-    const style = iframe.contentDocument.createElement('style')
+  if (iframe && iframeDocument) {
+    // The page's own styles live in the iframe document, so the override has
+    // to be injected there as well; the iframe itself and every ancestor are
+    // marked so VIDEO_OVERRIDE_STYLE's `display: none` blanket doesn't hide
+    // the chain leading to the video.
+    const style = iframeDocument.createElement('style')
     style.innerHTML = VIDEO_OVERRIDE_STYLE
-    iframe.contentDocument.head.appendChild(style)
+    iframeDocument.head.appendChild(style)
     iframe.className = '__video__'
     let parentEl = iframe.parentElement
     while (parentEl) {
       parentEl.className = '__video_parent__'
       parentEl = parentEl.parentElement
     }
-    iframe.contentDocument.body.appendChild(video)
+    iframeDocument.body.appendChild(video)
   } else {
     document.body.appendChild(video)
   }


### PR DESCRIPTION
## Problem

`mediaPreload.ts` reaches into `iframe.contentDocument` to find a `<video>` when a stream page embeds its player in an iframe. That path carried an explicit `TODO: verify iframe still works` and had no test coverage. Cross-origin frames have an opaque origin, so `contentDocument` is `null` and the loop skipped them silently — the tile then failed with the same generic `could not find video` as a slow or empty page, giving operators no way to tell an unsupported embed from a transient failure.

## Solution

- `waitForVideo()` now distinguishes "iframe present but unreachable" from "iframe reachable, no video", and returns the iframe document it already resolved.
- `findMedia()` throws a specific error for the cross-origin case: `could not find video: it may be inside a cross-origin iframe, which is unsupported`. It reaches the operator through the existing `view-error` channel.
- The redundant `iframe.contentDocument` re-check (and its stale TODO) is gone: the document is passed through from the scan.
- The iframe scan now accepts the requested `kind`, i.e. `<audio>` inside an iframe is matched too, instead of only `HTMLVideoElement`.
- README documents the same-origin-only limitation and the workaround (use the player page's own URL as the stream `link`).

## Testing

New `mediaPreload iframe video extraction (issue #413)` suite (vitest + happy-dom):

- same-origin iframe (`srcdoc` fixture): video is acquired, hoisted into the iframe document, override style injected, iframe and ancestors marked, `view-loaded` sent, no error — this verifies the path the TODO doubted.
- cross-origin iframe (`contentDocument === null`): the specific error is reported.
- reachable iframe without a video: the generic message is kept.

Full quality gate green locally: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (no root build script exists).

## Risks

Low. The only behavior change on the success path is that an `<audio>` element inside a same-origin iframe is now matched for `kind: "audio"` (previously silently missed). The error text changes only for the cross-origin case.

Closes #413