### PR TITLE
ci: exercise electron-forge makers on a weekly cross-platform matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,8 @@ jobs:
   #
   # `package` only, not `make`: it exercises the Vite builds, asar packing
   # and native rebuild without paying for the maker-specific installer
-  # steps (Squirrel, deb, rpm), which are release concerns. Ubuntu alone is
+  # steps (NSIS, darwin zip, deb, rpm). Those are covered outside of PR CI
+  # by the weekly `.github/workflows/packaging.yml` matrix. Ubuntu alone is
   # enough for a smoke test — the shared failure modes are OS-independent.
   # Runtime: ~45 seconds (measured on ubuntu-latest, cached npm), and it runs
   # in parallel with the other jobs, so wall-clock CI time is unchanged.

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -1,0 +1,83 @@
+name: Packaging
+
+# Exercises the makers configured in `packages/streamwall/forge.config.ts`
+# (NSIS, darwin zip, rpm, deb) outside of a release. Without this, a
+# maker-specific regression — a rejected maker config after a Forge major
+# bump, a missing packaging tool on a runner image, a bad NSIS icon path —
+# surfaces for the first time during `electron-forge publish` on a `v*` tag,
+# i.e. once the version is already public and a failed matrix leg leaves a
+# partially-populated GitHub release behind (#425).
+#
+# Deliberately not part of PR CI: `make` costs several minutes per platform,
+# while the failure modes shared by every platform (Vite/Forge config, asar
+# packing, native module unpacking) are already covered by the much cheaper
+# `package` smoke job in ci.yml. Weekly is enough to catch Dependabot's Forge
+# and maker bumps well before the next release.
+on:
+  schedule:
+    # Mondays, 05:17 UTC — off the hour to avoid GitHub's scheduling peak.
+    - cron: '17 5 * * 1'
+  workflow_dispatch:
+    inputs:
+      debug:
+        description: 'Enable verbose electron-forge debug logging'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+# Never cancel a running matrix: a scheduled run and a manual re-run are
+# independent verdicts, and each leg is expensive.
+concurrency:
+  group: packaging-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  make:
+    name: Make (${{ matrix.platform.name }})
+    runs-on: ${{ matrix.platform.os }}
+    timeout-minutes: 30
+    strategy:
+      # One broken platform must not hide the state of the other two.
+      fail-fast: false
+      matrix:
+        platform:
+          - { name: linux, os: ubuntu-latest }
+          - { name: windows, os: windows-latest }
+          - { name: macos, os: macos-latest }
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+
+      # MakerRpm shells out to `rpmbuild`, MakerDeb to `dpkg`/`fakeroot`.
+      # Only the latter two ship on the GitHub Ubuntu runner image, so the
+      # rpm tooling is installed explicitly rather than left to chance.
+      - name: Install Linux maker tooling
+        if: matrix.platform.name == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends rpm fakeroot
+
+      # No signing secrets: this job verifies that the makers run and emit
+      # installers, not that they produce distributable signed artifacts.
+      # The signing paths stay a release concern (see release.yml).
+      - name: Make
+        env:
+          DEBUG: ${{ inputs.debug && 'electron-forge:*' || '' }}
+        run: npm -w streamwall run make
+
+      # A maker that is silently skipped (unsupported platform detection,
+      # a config change that drops it) produces no output but also no
+      # error, so an empty `out/make` is treated as a failure here.
+      - name: List produced installers
+        shell: bash
+        run: |
+          make_dir=packages/streamwall/out/make
+          if [ -z "$(find "$make_dir" -type f -print -quit 2>/dev/null)" ]; then
+            echo "::error::No installer artifacts found in $make_dir"
+            exit 1
+          fi
+          find "$make_dir" -type f -print | sort

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,8 @@ jobs:
   # Vite/Forge misconfiguration or a native-module unpacking failure fails
   # here once (~45 seconds) instead of three times in parallel, each after a
   # full Electron download. `package` only, not `make` — the maker-specific
-  # installer steps are the publish job's concern.
+  # installer steps are the publish job's concern here, and are exercised
+  # ahead of a release by the weekly `packaging.yml` matrix (#425).
   package:
     name: Package smoke (Electron app)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ changelog are kept in step.
 - Control server reports its own version and surfaces new releases (#430); the
   control UI shows the server version and an update notice to admins (#444).
 - Stop HLS segment loading for parked views to save bandwidth (#424).
+- Weekly cross-platform packaging workflow that runs `electron-forge make`, so
+  maker regressions surface before a release instead of during one (#425).
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,6 +162,15 @@ No other workspace tracks the release line:
 None of the workspaces are published to the npm registry — only the Electron
 app itself is distributed, via GitHub Releases.
 
+### Packaging checks
+
+PR CI runs `electron-forge package` (Ubuntu only) as a smoke test. The
+installer makers themselves — NSIS, the macOS zip, deb and rpm — are exercised
+by `.github/workflows/packaging.yml`, which runs `electron-forge make` across
+all three platforms every Monday and on manual dispatch. Run it from the
+Actions tab (optionally with the `debug` input for verbose Forge logging)
+before cutting a release, or after a Forge/maker dependency bump.
+
 ### Changelog
 
 Notable changes are tracked in [`CHANGELOG.md`](CHANGELOG.md), in


### PR DESCRIPTION
## Problem

The makers configured in `packages/streamwall/forge.config.ts` — `MakerNsis`,
`MakerZIP` (darwin), `MakerRpm`, `MakerDeb` — were only ever executed during
`electron-forge publish` on a `v*` tag. PR CI and the release quality gate stop
at `electron-forge package` (#423), which covers the platform-independent
failure modes (Vite/Forge config, asar packing, native module unpacking) but
none of the maker-specific ones.

A maker regression therefore surfaced for the first time after the tag was
already public, on one leg of the publish matrix, leaving a partially-populated
GitHub release that needs a re-tag or a hand-uploaded asset to recover from.

## Solution

New `.github/workflows/packaging.yml` (option 2 from the issue): a weekly
(Mondays 05:17 UTC) and manually dispatchable `ubuntu`/`windows`/`macos` matrix
running `npm -w streamwall run make`, without publishing.

- **Linux maker tooling**: `MakerRpm` shells out to `rpmbuild`, which the GitHub
  Ubuntu runner image does not ship, so `rpm` (and `fakeroot`) are installed
  explicitly rather than left to chance. `dpkg`/`fakeroot` for `MakerDeb` are
  present already.
- **Empty output is a failure**: a maker that is silently skipped (platform
  detection, a config change dropping it) produces neither artifacts nor an
  error. The `List produced installers` step fails on an empty
  `packages/streamwall/out/make` and otherwise prints the produced files.
- **`debug` dispatch input** sets `DEBUG=electron-forge:*` for a verbose re-run
  when a failure needs more than the default Forge output.
- `fail-fast: false` and `cancel-in-progress: false`: each leg is an independent,
  expensive verdict.

Deliberately *not* added to PR CI — `make` costs minutes per platform while the
shared failure modes are already covered by the ~45s `package` smoke job.
No signing secrets are used: the job verifies that the makers run and emit
installers; signed, distributable artifacts stay a release concern.

## Architecture decisions

- Kept `release.yml` unchanged apart from a comment: running the full `make`
  matrix before `publish` would roughly double release wall-clock time for
  regressions this workflow already catches days earlier.
- Stale comments in `ci.yml`/`release.yml` still referenced Squirrel (replaced
  by NSIS in #432/#454) and are corrected to point at the new workflow.

## Testing

- `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` — green.
- `actionlint 1.7.12` (the pinned CI version) on all four workflow files — clean.
- `npm -w streamwall run make` run locally on macOS: produces
  `out/make/zip/darwin/arm64/Streamwall-darwin-arm64-0.9.1.zip` plus
  `latest-mac.yml`, i.e. the exact command and the artifact-listing guard both
  behave as expected.
- No unit tests: the change is CI configuration with no testable runtime
  behaviour (the repo has no workflow test harness; `actionlint` is the gate).
  The Windows and Linux legs can only be exercised on their runners — the
  workflow is dispatchable, so it can be run manually right after merge.

## Risks

Low. The workflow is additive, runs on a schedule outside PR/release paths, has
read-only permissions and no secrets. The scheduled trigger only becomes active
once this is on the default branch; the first run can be triggered manually from
the Actions tab.

Closes #425
