### PR TITLE
fix(streamwall): validate IPC-delivered StreamwallState in control renderer

### DIFF
--- a/packages/streamwall/src/renderer/ipcCollabTransport.test.ts
+++ b/packages/streamwall/src/renderer/ipcCollabTransport.test.ts
@@ -1,7 +1,31 @@
 import { type CollabTransportEvents } from 'streamwall-control-ui'
-import { describe, expect, it, vi } from 'vitest'
+import { type StreamwallState } from 'streamwall-shared'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { type StreamwallControlGlobal } from '../preload/controlPreload'
 import { createIpcCollabTransport } from './ipcCollabTransport'
+
+/** A minimal snapshot that satisfies `streamwallStateSchema`. */
+const VALID_STATE = {
+  identity: { role: 'local' },
+  config: {
+    cols: 3,
+    rows: 3,
+    width: 1920,
+    height: 1080,
+    frameless: false,
+    fullscreen: false,
+    activeColor: '#fff',
+    backgroundColor: '#000',
+  },
+  streams: [],
+  customStreams: [],
+  views: [],
+  fullscreenViewIdx: null,
+  streamdelay: null,
+  layoutPresets: [],
+  favorites: [],
+  dataSourceHealth: [],
+} as unknown as StreamwallState
 
 function createMockControl() {
   const onStateUnsubscribe = vi.fn()
@@ -95,7 +119,7 @@ describe('createIpcCollabTransport', () => {
 
       transport.connect(events)
 
-      expect(mocks.onState).toHaveBeenCalledWith(events.onState)
+      expect(mocks.onState).toHaveBeenCalledTimes(1)
       expect(events.onConnected).toHaveBeenCalledTimes(1)
       expect(mocks.load).toHaveBeenCalledTimes(1)
       // The listener must be attached before load() so the pushed state and
@@ -125,6 +149,88 @@ describe('createIpcCollabTransport', () => {
 
       teardown()
       expect(onStateUnsubscribe).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('state validation', () => {
+    let warn: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+      warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      warn.mockRestore()
+    })
+
+    /** Connects the transport and returns the handler the preload received. */
+    function connectAndGetStateHandler(events: CollabTransportEvents) {
+      const { control, mocks } = createMockControl()
+      createIpcCollabTransport(control).connect(events)
+      return mocks.onState.mock.calls[0]![0] as (state: unknown) => void
+    }
+
+    it('forwards a valid snapshot unchanged', () => {
+      const events = noopEvents()
+      const handleState = connectAndGetStateHandler(events)
+
+      handleState(VALID_STATE)
+
+      expect(events.onState).toHaveBeenCalledTimes(1)
+      // Passed through by reference: validation is a gate, not a transform, so
+      // no field the schema does not model gets stripped on the way through.
+      expect(events.onState).toHaveBeenCalledWith(VALID_STATE)
+      expect(warn).not.toHaveBeenCalled()
+    })
+
+    it.each([
+      ['a non-object payload', 'nope'],
+      ['a null payload', null],
+      ['a snapshot missing required keys', { identity: { role: 'local' } }],
+      [
+        'a snapshot with a malformed views array',
+        { ...VALID_STATE, views: [{ state: 'bogus' }] },
+      ],
+      [
+        'a snapshot with a non-array streams field',
+        { ...VALID_STATE, streams: {} },
+      ],
+      [
+        'a snapshot with an unknown identity role',
+        { ...VALID_STATE, identity: { role: 'superuser' } },
+      ],
+    ])('drops %s and logs it', (_label, payload) => {
+      const events = noopEvents()
+      const handleState = connectAndGetStateHandler(events)
+
+      handleState(payload)
+
+      expect(events.onState).not.toHaveBeenCalled()
+      expect(warn).toHaveBeenCalledTimes(1)
+    })
+
+    it('keeps serving the last valid snapshot when an invalid one arrives', () => {
+      const events = noopEvents()
+      const handleState = connectAndGetStateHandler(events)
+
+      handleState(VALID_STATE)
+      handleState({ ...VALID_STATE, config: null })
+
+      // Only the good snapshot reached the shared hook, so the UI keeps
+      // rendering it instead of blanking on the malformed update.
+      expect(events.onState).toHaveBeenCalledTimes(1)
+      expect(events.onState).toHaveBeenCalledWith(VALID_STATE)
+    })
+
+    it('recovers once valid snapshots resume', () => {
+      const events = noopEvents()
+      const handleState = connectAndGetStateHandler(events)
+
+      handleState({ ...VALID_STATE, favorites: 'nope' })
+      handleState(VALID_STATE)
+
+      expect(events.onState).toHaveBeenCalledTimes(1)
+      expect(events.onState).toHaveBeenLastCalledWith(VALID_STATE)
     })
   })
 })

--- a/packages/streamwall/src/renderer/ipcCollabTransport.ts
+++ b/packages/streamwall/src/renderer/ipcCollabTransport.ts
@@ -1,4 +1,5 @@
 import { type CollabTransport } from 'streamwall-control-ui'
+import { streamwallStateSchema } from 'streamwall-shared'
 import { type StreamwallControlGlobal } from '../preload/controlPreload'
 
 /**
@@ -29,7 +30,28 @@ export function createIpcCollabTransport(
     subscribeYDocUpdates: (cb) => control.onYDoc(cb),
 
     connect: (events) => {
-      const unsubscribe = control.onState(events.onState)
+      const unsubscribe = control.onState((state) => {
+        // The main process is trusted, but it is also the one component that
+        // can regress: a partial or malformed snapshot pushed during a bug or
+        // a mid-upgrade schema drift would otherwise render as a garbage grid
+        // (issue #409). Validating here mirrors the uplink boundary the
+        // control server guards with the same schema (issue #387), so both
+        // consumers of `StreamwallState` enforce the same contract.
+        const result = streamwallStateSchema.safeParse(state)
+        if (!result.success) {
+          console.warn(
+            'Ignored invalid Streamwall state from main process:',
+            result.error.issues[0]?.message,
+          )
+          // Dropping the update leaves the shared hook on the last valid
+          // snapshot, which keeps the UI usable instead of blanking it.
+          return
+        }
+        // Forward the original object rather than the parsed copy: validation
+        // is a gate here, not a transform, so fields the schema does not model
+        // survive the hop.
+        events.onState(state)
+      })
       events.onConnected()
       // Ask the main process for the initial state + Yjs snapshot now that the
       // listeners are wired.


### PR DESCRIPTION
## Problem

The Electron control renderer accepted `StreamwallState` snapshots from the main process over IPC **without runtime validation**, while collab data arriving via Yjs was already validated through `useYDoc` + `collabDataSchema`. A partial or malformed snapshot — pushed by a main-process regression or during a mid-upgrade schema drift — rendered straight into the control grid, and schema drift between main and renderer stayed invisible.

Closes #409.

## Solution

`createIpcCollabTransport` now gates every incoming snapshot through `streamwallStateSchema` from `streamwall-shared` — the very schema the control server already applies at its uplink boundary (#387), so both `StreamwallState` consumers enforce one contract.

Invalid snapshots are logged via `console.warn` (matching the uplink handler's convention) and dropped. Dropping rather than clearing means the shared `useCollabConnection` hook stays on the last valid snapshot, so the UI keeps rendering usable state instead of blanking, and recovers automatically once valid snapshots resume.

## Architecture decisions

- **Validated in the transport adapter, not in `useCollabConnection`.** The shared hook is transport-agnostic; the WebSocket client's snapshots already pass the control server's `streamwallStateSchema` check, so validating centrally would double-validate that path (including its `state-delta` patches, which would need separate treatment). Keeping the gate in the IPC adapter puts it exactly at the unguarded boundary this issue is about.
- **Gate, not transform.** The original object is forwarded to `events.onState` instead of `result.data`, so fields the schema does not model are not silently stripped on the way through.
- **No new schema.** `streamwallStateSchema` shipped with #387 and is reused unchanged.

## Testing

`packages/streamwall/src/renderer/ipcCollabTransport.test.ts` gained a `state validation` block: valid snapshots forwarded by reference with no warning; malformed payloads dropped and logged, covering a non-object, `null`, missing required keys, a malformed `views` array, a non-array `streams`, and an unknown `identity.role`; last-valid-snapshot retention when an invalid one arrives; and recovery once valid snapshots resume.

Full quality gate green locally: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (all packages).

## Risks

Low. A false rejection would freeze the control UI on the last valid snapshot rather than crash it, and the schema is already proven against real desktop state on the uplink path, where the identical `clientState` object is validated today.