### PR TITLE
fix(streamwall): disconnect mediaPreload MutationObservers on teardown

### DIFF
--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -358,6 +358,104 @@ describe('mediaPreload iframe video extraction (issue #413)', () => {
   })
 })
 
+describe('mediaPreload MutationObserver lifecycle (issue #412)', () => {
+  // Records every observer the module creates so the tests can assert on how
+  // many are still connected at a given point. Deliberately inert: it never
+  // delivers mutations, which is enough because waitForQuery also scans
+  // eagerly and the pages under test are static.
+  class FakeMutationObserver {
+    static instances: FakeMutationObserver[] = []
+    observe = vi.fn()
+    disconnect = vi.fn()
+    takeRecords = vi.fn(() => [])
+
+    constructor(public callback: () => void) {
+      FakeMutationObserver.instances.push(this)
+    }
+  }
+
+  function connectedObservers() {
+    return FakeMutationObserver.instances.filter(
+      (observer) =>
+        observer.observe.mock.calls.length > 0 &&
+        observer.disconnect.mock.calls.length === 0,
+    )
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    FakeMutationObserver.instances = []
+    vi.stubGlobal('MutationObserver', FakeMutationObserver)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+    vi.resetModules()
+    invoke.mockClear()
+    send.mockClear()
+    on.mockClear()
+    exposeInMainWorld.mockClear()
+    document.body.innerHTML = ''
+  })
+
+  async function loadVideoContent() {
+    invoke.mockResolvedValueOnce({
+      content: { kind: 'video', link: 'https://example.com/stream' },
+      options: {},
+      volume: 1,
+    })
+    await import('./mediaPreload')
+    document.dispatchEvent(new Event('DOMContentLoaded'))
+    process.emit('loaded' as never)
+    await vi.advanceTimersByTimeAsync(0)
+  }
+
+  async function loadAcquiredVideo(): Promise<HTMLVideoElement> {
+    const video = document.createElement('video')
+    ;(video as unknown as { videoWidth: number }).videoWidth = 100
+    document.body.appendChild(video)
+    await loadVideoContent()
+    expect(send).toHaveBeenCalledWith('view-loaded')
+    return video
+  }
+
+  it('leaves only the long-lived lockdown observer connected once media is acquired', async () => {
+    await loadAcquiredVideo()
+
+    // The element-search observer must not outlive the search that created
+    // it; only lockdownMediaTags' own observer keeps watching the document.
+    expect(connectedObservers()).toHaveLength(1)
+  })
+
+  it('disconnects the element-search observer when the acquisition times out', async () => {
+    // No <video> in the document, so findMedia's search runs to its timeout.
+    await loadVideoContent()
+    await vi.advanceTimersByTimeAsync(10 * 1000)
+
+    expect(connectedObservers()).toHaveLength(1)
+  })
+
+  it('does not register a duplicate lockdown observer when media is re-acquired', async () => {
+    const video = await loadAcquiredVideo()
+
+    video.dispatchEvent(new Event('emptied'))
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(send).toHaveBeenCalledWith('view-stalled')
+    expect(connectedObservers()).toHaveLength(1)
+  })
+
+  it('disconnects every remaining observer when the page goes away', async () => {
+    await loadAcquiredVideo()
+    expect(connectedObservers()).not.toHaveLength(0)
+
+    window.dispatchEvent(new Event('pagehide'))
+
+    expect(connectedObservers()).toHaveLength(0)
+  })
+})
+
 describe('mediaPreload pause/resume handling (issue #374)', () => {
   beforeEach(() => {
     vi.useFakeTimers()

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -167,8 +167,47 @@ class SnapshotController {
   }
 }
 
+// A throttled scan callback, as returned by lodash's `throttle`.
+type ScanCallback = (() => void) & { cancel(): void }
+
+// Every MutationObserver created here is registered so a single teardown can
+// disconnect them all. A document is discarded on navigation, but a view can
+// search for media repeatedly within one document (see acquireMedia's
+// 'emptied' re-acquisition), and an abandoned observer would otherwise keep
+// firing its throttled callback for the rest of the page's life -- see #412.
+const observerTeardowns = new Set<() => void>()
+
+function observeBody(scan: ScanCallback): () => void {
+  const observer = new MutationObserver(scan)
+  observer.observe(document.body, { subtree: true, childList: true })
+  const stop = () => {
+    observer.disconnect()
+    scan.cancel()
+    observerTeardowns.delete(stop)
+  }
+  observerTeardowns.add(stop)
+  return stop
+}
+
+// Nothing in the page world outlives its document, so once it goes away even
+// the deliberately long-lived lockdown observer below can stop watching.
+window.addEventListener('pagehide', () => {
+  for (const stop of [...observerTeardowns]) {
+    stop()
+  }
+})
+
+// Set once the lockdown observer is installed. It watches for the document's
+// lifetime by design, so repeated calls must reuse it rather than stack up a
+// second observer running the same scan (#412).
+let isMediaTagsLockedDown = false
+
 // Watch for media tags and mute them as soon as possible.
 async function lockdownMediaTags() {
+  if (isMediaTagsLockedDown) {
+    return
+  }
+  isMediaTagsLockedDown = true
   const lockdown = throttle(() => {
     webFrame.executeJavaScript(`
       for (const el of document.querySelectorAll('video, audio')) {
@@ -184,25 +223,58 @@ async function lockdownMediaTags() {
     `)
   }, SCAN_THROTTLE)
   await pageReady
-  const observer = new MutationObserver(lockdown)
-  observer.observe(document.body, { subtree: true, childList: true })
+  observeBody(lockdown)
 }
 
-async function waitForQuery(query: string): Promise<Element> {
+// Resolves once `signal` aborts, and never if there is no signal to abort.
+const aborted = (signal?: AbortSignal) =>
+  new Promise<void>((resolve) => {
+    if (!signal) {
+      return
+    }
+    if (signal.aborted) {
+      resolve()
+      return
+    }
+    signal.addEventListener('abort', () => resolve(), { once: true })
+  })
+
+// Resolves with the first element matching `query`, or with `undefined` if
+// `signal` aborts first. Callers that give up on a search (timeout, or a
+// sibling search winning a race) must abort it: without that, the search's
+// observer would stay connected forever, since its promise can only settle by
+// finding the element (#412).
+async function waitForQuery(
+  query: string,
+  signal?: AbortSignal,
+): Promise<Element | undefined> {
   console.log(`waiting for '${query}'...`)
-  await pageReady
+  // The abort has to cut this wait short too, not just the observing below:
+  // a page that never reaches DOMContentLoaded (a stalled or dead stream
+  // page) would otherwise leave the caller's timeout with nothing to settle.
+  await Promise.race([pageReady, aborted(signal)])
+  if (signal?.aborted) {
+    return undefined
+  }
   return new Promise((resolve) => {
     const scan = throttle(() => {
       const el = document.querySelector(query)
       if (el) {
         console.log(`found '${query}'`)
+        stop()
         resolve(el)
-        observer.disconnect()
       }
     }, SCAN_THROTTLE)
 
-    const observer = new MutationObserver(scan)
-    observer.observe(document.body, { subtree: true, childList: true })
+    const stop = observeBody(scan)
+    signal?.addEventListener(
+      'abort',
+      () => {
+        stop()
+        resolve(undefined)
+      },
+      { once: true },
+    )
     scan()
   })
 }
@@ -218,11 +290,20 @@ async function waitForVideo(
 }> {
   lockdownMediaTags()
 
-  let queryPromise: Promise<Element | void> = waitForQuery(kind)
-  if (timeoutMs !== Infinity) {
-    queryPromise = Promise.race([waitForQuery(kind), sleep(timeoutMs)])
+  // One search, bounded by its own abort timer. Racing a search against a
+  // sleep instead would both start a second, immediately orphaned search and
+  // leave the losing search observing the document forever (#412).
+  const search = new AbortController()
+  const searchTimeout =
+    timeoutMs === Infinity
+      ? undefined
+      : setTimeout(() => search.abort(), timeoutMs)
+  let video: Element | null | undefined
+  try {
+    video = await waitForQuery(kind, search.signal)
+  } finally {
+    clearTimeout(searchTimeout)
   }
-  let video: Element | null | void = await queryPromise
   if (video instanceof HTMLMediaElement) {
     return { video }
   }
@@ -252,11 +333,17 @@ const igHacks = {
     return location.host === 'www.instagram.com'
   },
   async onLoad() {
+    // Both searches share one abort: whichever settles the race first (a
+    // match or the timer), the other's observer is disconnected rather than
+    // left watching the document for the rest of the page's life (#412).
+    const search = new AbortController()
+    const searchTimeout = setTimeout(() => search.abort(), 1000)
     const playButton = await Promise.race([
-      waitForQuery('button'),
-      waitForQuery('video'),
-      sleep(1000),
+      waitForQuery('button', search.signal),
+      waitForQuery('video', search.signal),
     ])
+    clearTimeout(searchTimeout)
+    search.abort()
     if (
       playButton instanceof HTMLButtonElement &&
       playButton.tagName === 'BUTTON' &&


### PR DESCRIPTION
## Summary

`mediaPreload.ts` created `MutationObserver` instances that were never disconnected, so abandoned observers kept firing their throttled scan callbacks (and re-running `webFrame.executeJavaScript`) for the rest of the document's life.

Three distinct leaks were in play:

- **Orphaned duplicate search.** `waitForVideo()` called `waitForQuery(kind)` once, then immediately overwrote that promise with `Promise.race([waitForQuery(kind), sleep(...)])` — starting a *second* search and leaving the first one observing with no way to ever settle.
- **Losers of a race never stopped.** `waitForQuery` could only settle by finding its element. Whenever the timeout `sleep` won in `waitForVideo`, or a sibling search won in `igHacks.onLoad`, the losing search's observer stayed connected permanently.
- **Stacked lockdown observers.** `lockdownMediaTags()` installed a fresh observer on every acquisition, so each `'emptied'` re-acquisition added another observer running the identical scan against the same document.

Closes #412

## Technical solution

- New `observeBody(scan)` helper: creates the observer, registers it, and returns a teardown that disconnects it *and* cancels its lodash throttle (so a pending trailing invocation can't fire after teardown).
- `waitForQuery(query, signal?)` is now abortable and resolves `undefined` on abort, disconnecting as it goes. Callers that give up on a search now stop observing instead of leaking.
- `waitForVideo` runs a **single** search bounded by its own abort timer, replacing the race-against-`sleep` (which caused both the duplicate search and the lingering loser). `igHacks.onLoad` shares one `AbortController` across its two searches and its timer.
- `lockdownMediaTags()` is idempotent — its deliberately long-lived observer is installed once per document and reused.
- A `pagehide` handler disconnects whatever is still registered when the document goes away.

### Architecture decisions

- **No new IPC channel.** The issue suggested a `VIEW_UNLOAD` message from the main process, but a preload script's observers live and die with their document: navigation/reload discards the whole context. The leaks that actually accumulate are *within* one document (repeated searches, `'emptied'` re-acquisition), so the fix is local to the preload and needs no main-process coordination. `pagehide` covers the document-teardown criterion without adding protocol surface.
- **The lockdown observer stays connected on purpose.** It must keep muting media tags the page adds later, so the fix makes it a singleton rather than removing it.
- **Abort also short-circuits the `pageReady` wait.** Otherwise a page that never reaches `DOMContentLoaded` (stalled/dead stream page) would leave the caller's timeout with nothing to settle — this preserves the existing `findMedia` timeout behavior, which is covered by pre-existing tests.

## How was this tested?

Four new tests in `mediaPreload.test.ts` (`issue #412` block) stub `MutationObserver` with a recording fake and assert on how many observers remain *connected*:

- only the long-lived lockdown observer survives a successful acquisition (previously 2 — the orphaned duplicate search);
- the element-search observer is disconnected when the acquisition times out;
- re-acquisition via `'emptied'` does not add a duplicate lockdown observer;
- `pagehide` leaves zero connected observers.

All three failed before the change and pass after. Full gate green locally: `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm test` (streamwall 147, control-ui 314, all suites passing).

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests (or this PR explains why none apply)
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments