### PR TITLE
ci: exercise the electron-forge makers outside of releases

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -1,0 +1,72 @@
+name: Packaging
+
+# Exercises the makers configured in packages/streamwall/forge.config.ts
+# (NSIS, darwin zip, rpm, deb) on all three publish platforms — the one step
+# CI's `package` smoke test deliberately stops short of (#425). Without this,
+# a maker-specific regression (a Forge major bump changing a config field, a
+# broken NSIS template path, missing rpm tooling on the runner) only surfaces
+# during `electron-forge publish` on a `v*` tag, i.e. once the version is
+# already public and a failing leg leaves a half-populated release.
+#
+# Scheduled rather than run per PR: the makers cost minutes per platform and
+# regressions here arrive with dependency bumps, not with feature commits.
+on:
+  schedule:
+    # Mondays, 05:00 UTC — after Dependabot's weekly bumps have landed.
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+    inputs:
+      debug:
+        description: 'Enable verbose electron-forge logging'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: packaging-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  make:
+    name: Make (${{ matrix.platform.name }})
+    runs-on: ${{ matrix.platform.os }}
+    timeout-minutes: 30
+    strategy:
+      # One broken platform must not hide the state of the other two.
+      fail-fast: false
+      matrix:
+        platform:
+          - { name: linux, os: ubuntu-latest }
+          - { name: windows, os: windows-latest }
+          - { name: macos, os: macos-latest }
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+
+      # The runner image ships dpkg but neither rpmbuild nor fakeroot, which
+      # @electron-forge/maker-rpm and maker-deb shell out to.
+      - name: Install deb/rpm maker tooling
+        if: matrix.platform.name == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y rpm fakeroot
+
+      # No publisher runs here: `make` stops at the installers on disk.
+      - name: Make installers
+        env:
+          DEBUG: ${{ inputs.debug && 'electron-forge:*' || '' }}
+        run: npm -w streamwall run make
+
+      # Kept even on failure: a maker that fails late still leaves partial
+      # output, which is usually what identifies the broken step.
+      - name: Upload maker output
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: make-${{ matrix.platform.name }}
+          path: packages/streamwall/out/make
+          retention-days: 7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,6 +162,19 @@ No other workspace tracks the release line:
 None of the workspaces are published to the npm registry — only the Electron
 app itself is distributed, via GitHub Releases.
 
+### Packaging checks
+
+PR CI only runs `electron-forge package` (Linux), which covers the failure
+modes shared by every platform. The makers themselves — NSIS on Windows, the
+darwin zip, deb and rpm — are exercised by
+[`.github/workflows/packaging.yml`](.github/workflows/packaging.yml), which runs
+weekly on all three platforms and can be dispatched manually from the Actions
+tab. Run it before cutting a release, and after a Forge or maker dependency
+bump: a maker regression that first appears during `publish` leaves a
+partially-populated GitHub release behind. The dispatch form has a `debug`
+toggle that enables verbose Forge logging, and each leg uploads its
+`out/make` directory as an artifact.
+
 ### Changelog
 
 Notable changes are tracked in [`CHANGELOG.md`](CHANGELOG.md), in

--- a/test/packaging-workflow.test.mjs
+++ b/test/packaging-workflow.test.mjs
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)))
+
+const workflow = readFileSync(
+  join(rootDir, '.github/workflows/packaging.yml'),
+  'utf8',
+)
+
+test('the packaging workflow runs the makers outside of a release', () => {
+  assert.match(
+    workflow,
+    /^\s*schedule:$/m,
+    'the workflow must run on a schedule so maker regressions surface without a tag',
+  )
+  assert.match(
+    workflow,
+    /^\s*workflow_dispatch:$/m,
+    'the workflow must be manually dispatchable',
+  )
+  assert.doesNotMatch(
+    workflow,
+    /run: npm -w streamwall run publish/,
+    'the workflow must never publish a release',
+  )
+  assert.match(
+    workflow,
+    /run: npm -w streamwall run make/,
+    'the workflow must invoke electron-forge make',
+  )
+})
+
+test('the packaging workflow covers every publish platform', () => {
+  for (const os of ['ubuntu-latest', 'windows-latest', 'macos-latest']) {
+    assert.match(
+      workflow,
+      new RegExp(`os: ${os} `),
+      `the maker matrix must include ${os}`,
+    )
+  }
+  assert.match(
+    workflow,
+    /fail-fast: false/,
+    'one failing platform must not hide the others',
+  )
+})
+
+test('the Linux leg installs the tooling the deb and rpm makers need', () => {
+  // ubuntu-latest ships dpkg but neither rpmbuild nor fakeroot, so
+  // @electron-forge/maker-rpm and maker-deb would fail on the runner.
+  assert.match(workflow, /\brpm\b/, 'the rpm maker needs rpmbuild installed')
+  assert.match(workflow, /\bfakeroot\b/, 'the deb maker needs fakeroot')
+})
+
+test('maker output and logs are retained for diagnosis', () => {
+  assert.match(
+    workflow,
+    /uses: actions\/upload-artifact@[0-9a-f]{40} #/,
+    'maker output must be uploaded as a pinned-action artifact',
+  )
+  assert.match(
+    workflow,
+    /DEBUG:/,
+    'a dispatch must be able to request verbose Forge logs',
+  )
+})


### PR DESCRIPTION
## Problem

The quality gates stop at `electron-forge package` (#423). The makers
configured in `packages/streamwall/forge.config.ts` — `MakerNsis`,
`MakerZIP` (darwin), `MakerRpm`, `MakerDeb` — are still first exercised
during `electron-forge publish` on a `v*` tag. A maker-specific regression
therefore surfaces only after the version is public, and fails one leg of the
publish matrix while the others succeed, leaving a partially-populated GitHub
release that needs a re-tag or a hand-uploaded asset to recover from.

## Solution

Option 2 from the issue: a new `.github/workflows/packaging.yml` that runs
`npm -w streamwall run make` across the full `ubuntu` / `windows` / `macos`
matrix, weekly (Mondays 05:00 UTC, after Dependabot's bumps land) and on
`workflow_dispatch`. No publisher runs — `make` stops at the installers on
disk.

Details:

- `fail-fast: false`, so one broken platform does not hide the state of the
  other two.
- The Linux leg installs `rpm` and `fakeroot`: the runner image ships `dpkg`
  but neither of the binaries `maker-rpm`/`maker-deb` shell out to. This was
  the open question in the issue.
- Each leg uploads `packages/streamwall/out/make` as an artifact, retained
  even on failure (`if: !cancelled()`) — a maker that fails late still leaves
  the partial output that identifies the broken step.
- The dispatch form has a `debug` toggle that sets `DEBUG=electron-forge:*`
  for verbose maker logs.
- Not wired into PR CI: the makers cost minutes per platform and regressions
  here arrive with dependency bumps, not with feature commits. `ci-ok` is
  unchanged.

## Architecture decisions

- **Scheduled instead of per-PR or per-release.** Option 1 (`make` in the
  release gate) leaves NSIS and the darwin zip uncovered; option 3 roughly
  doubles release wall-clock time. The scheduled matrix decouples the cost
  from both PRs and releases while covering every maker.
- **No signing.** The workflow deliberately has no access to signing secrets
  and runs `permissions: contents: read` — it verifies that the makers run,
  not that the artifacts are distributable.

## Testing

- `test/packaging-workflow.test.mjs` (node:test, part of `npm test`) pins the
  invariants: schedule + dispatch triggers, no `publish` invocation, all three
  runner OSes present, `fail-fast: false`, the deb/rpm tooling install, a
  SHA-pinned upload-artifact step and the debug env.
- `actionlint` clean.
- Full quality gate green locally: `format:check`, `lint`, `typecheck`,
  `npm test`.
- `npm -w streamwall run make` run locally on macOS: exits 0, `postMake`
  (`latest-mac.yml`) runs, artifacts land in
  `packages/streamwall/out/make/zip/darwin/arm64` — confirming the workflow's
  artifact path.

## Risks

Low: additive, no existing job or gate changes. The first scheduled run is the
real proof for the Windows and Linux legs; they can be verified immediately by
dispatching the workflow from the Actions tab once merged. If a maker turns out
to be broken today, the workflow reports it — which is the point.

Closes #425
