### PR TITLE
test(streamwall): guard the shared view-state schema against machine drift

### DIFF
--- a/packages/streamwall-control-ui/src/GridViewIdentity.test.tsx
+++ b/packages/streamwall-control-ui/src/GridViewIdentity.test.tsx
@@ -55,7 +55,13 @@ function makeView(streamIdx: number, spaces: number[]): ViewInfo {
     state: {
       state: {
         displaying: {
-          running: { playback: 'playing', video: 'normal', audio: 'muted' },
+          running: {
+            playback: 'playing',
+            video: 'normal',
+            audio: 'muted',
+            pause: 'unpaused',
+            swap: 'idle',
+          },
         },
       },
       context: {

--- a/packages/streamwall-control-ui/src/gridFullscreen.test.tsx
+++ b/packages/streamwall-control-ui/src/gridFullscreen.test.tsx
@@ -55,7 +55,13 @@ function makeView(streamId: string, spaces: number[]): ViewInfo {
     state: {
       state: {
         displaying: {
-          running: { playback: 'playing', video: 'normal', audio: 'muted' },
+          running: {
+            playback: 'playing',
+            video: 'normal',
+            audio: 'muted',
+            pause: 'unpaused',
+            swap: 'idle',
+          },
         },
       },
       context: {

--- a/packages/streamwall-shared/src/schemas.test.ts
+++ b/packages/streamwall-shared/src/schemas.test.ts
@@ -605,6 +605,8 @@ describe('streamwallStateSchema', () => {
                 playback: 'playing',
                 video: 'normal',
                 audio: 'listening',
+                pause: 'unpaused',
+                swap: { preloading: 'waitForVideo' },
               },
             },
           },

--- a/packages/streamwall-shared/src/schemas.ts
+++ b/packages/streamwall-shared/src/schemas.ts
@@ -312,8 +312,21 @@ const viewPosSchema = z.object({
   spaces: z.array(z.number()),
 })
 
-/** Matches the shape produced by `viewStateMachine.ts`'s XState snapshot `.value`. */
-const viewStateValueSchema = z.union([
+/**
+ * Matches the shape produced by `viewStateMachine.ts`'s XState snapshot
+ * `.value`.
+ *
+ * This is a hand-written mirror of a machine that lives in another package
+ * (`streamwall`), so nothing but a test can keep the two in step: it is
+ * exported for `viewStateMachineSchemaDrift.test.ts`, which enumerates the
+ * machine's reachable state values and asserts every one of them parses here
+ * losslessly (issue #419).
+ *
+ * Unknown keys are stripped rather than rejected on purpose: an unforeseen new
+ * region should degrade the control server's picture of that view, never sever
+ * the uplink of an otherwise healthy desktop build.
+ */
+export const viewStateValueSchema = z.union([
   z.literal('empty'),
   z.object({
     displaying: z.union([
@@ -326,6 +339,15 @@ const viewStateValueSchema = z.union([
           playback: z.enum(['playing', 'stalled']),
           video: z.enum(['normal', 'blurred']),
           audio: z.enum(['background', 'muted', 'listening']),
+          // Media playback paused while the view is parked (issue #374).
+          pause: z.enum(['unpaused', 'paused']),
+          // Background preload of the next view during a content swap.
+          swap: z.union([
+            z.literal('idle'),
+            z.object({
+              preloading: z.enum(['navigate', 'waitForInit', 'waitForVideo']),
+            }),
+          ]),
         }),
       }),
     ]),

--- a/packages/streamwall-shared/src/types.ts
+++ b/packages/streamwall-shared/src/types.ts
@@ -1,7 +1,8 @@
 import type { Delta } from 'jsondiffpatch'
+import type { z } from 'zod'
 import type { ViewContent, ViewPos } from './geometry.ts'
 import type { StreamwallRole } from './roles.ts'
-import type { ControlCommand } from './schemas.ts'
+import type { ControlCommand, viewStateValueSchema } from './schemas.ts'
 
 export interface StreamWindowConfig {
   cols: number
@@ -54,23 +55,12 @@ export type LocalStreamData = Omit<StreamData, '_id' | '_dataSource'>
 
 export type StreamList = StreamData[] & { byURL?: Map<string, StreamData> }
 
-// matches viewStateMachine.ts
-export type ViewStateValue =
-  | 'empty'
-  | {
-      displaying:
-        | 'error'
-        | {
-            loading: 'navigate' | 'waitForInit' | 'waitForVideo'
-          }
-        | {
-            running: {
-              playback: 'playing' | 'stalled'
-              video: 'normal' | 'blurred'
-              audio: 'background' | 'muted' | 'listening'
-            }
-          }
-    }
+/**
+ * Mirrors `viewStateMachine.ts`'s snapshot `.value`. Derived from the schema so
+ * that the type and the runtime validation can never disagree; the schema in
+ * turn is held to the machine by `viewStateMachineSchemaDrift.test.ts` (#419).
+ */
+export type ViewStateValue = z.infer<typeof viewStateValueSchema>
 
 export interface ViewState {
   state: ViewStateValue

--- a/packages/streamwall/src/main/viewStateMachineSchemaDrift.test.ts
+++ b/packages/streamwall/src/main/viewStateMachineSchemaDrift.test.ts
@@ -1,0 +1,95 @@
+import { viewStateValueSchema } from 'streamwall-shared'
+import { describe, expect, it, vi } from 'vitest'
+
+// viewStateMachine imports electron (directly and via ./loadHTML). Only the
+// machine's static state tree is inspected here, so bare stubs are enough.
+vi.mock('electron', () => ({
+  BrowserWindow: class {},
+  WebContentsView: class {},
+  WebContents: class {},
+}))
+
+const { default: viewStateMachine } = await import('./viewStateMachine')
+
+type StateNodeLike = {
+  key: string
+  type: string
+  states: Record<string, StateNodeLike>
+}
+
+type StateValue = string | { [key: string]: StateValue }
+
+/**
+ * Every state value this node can report for its own subtree, i.e. what XState
+ * puts under the node's key in a snapshot `.value`. Atomic (and final) nodes
+ * have no subtree and therefore contribute nothing; their parent represents
+ * them by their bare key.
+ */
+function subtreeValues(node: StateNodeLike): StateValue[] {
+  const children = Object.values(node.states ?? {})
+  if (children.length === 0) {
+    return []
+  }
+  if (node.type === 'parallel') {
+    // All regions are active simultaneously, so the node's value is the
+    // cartesian product of its regions' values.
+    return children.reduce<StateValue[]>(
+      (combinations, region) =>
+        combinations.flatMap((combination) =>
+          childValues(region).map((value) => ({
+            ...(combination as object),
+            ...(value as object),
+          })),
+        ),
+      [{}],
+    )
+  }
+  // Compound node: exactly one child is active at a time.
+  return children.flatMap(childValues)
+}
+
+/** How a parent represents `node` inside its own state value. */
+function childValues(node: StateNodeLike): StateValue[] {
+  const nested = subtreeValues(node)
+  if (nested.length === 0) {
+    if (node.type === 'parallel') {
+      throw new Error(`Parallel state '${node.key}' has no regions`)
+    }
+    return [node.key]
+  }
+  return nested.map((value) => ({ [node.key]: value }))
+}
+
+const allStateValues = subtreeValues(
+  viewStateMachine.root as unknown as StateNodeLike,
+)
+
+/**
+ * `streamwall-shared`'s `viewStateValueSchema` is a hand-written mirror of this
+ * machine's snapshot shape, and the control server validates every uplink state
+ * message against it (issue #387/#419). The two live in different packages with
+ * no compile-time link, so this exhaustively enumerates the machine's reachable
+ * state values and fails here — in CI — instead of silently degrading the
+ * control server's view of the wall once the machine grows a state.
+ */
+describe('view state value schema drift', () => {
+  it('enumerates the machine tree', () => {
+    // Sanity check on the enumeration itself: a bug that yields an empty (or
+    // trivially small) list would make every assertion below vacuous.
+    expect(allStateValues).toContain('empty')
+    expect(allStateValues).toContainEqual({ displaying: 'error' })
+    expect(allStateValues.length).toBeGreaterThan(10)
+  })
+
+  it.each(allStateValues.map((value) => [JSON.stringify(value), value]))(
+    'accepts %s without dropping data',
+    (_label, value) => {
+      const result = viewStateValueSchema.safeParse(value)
+      expect(result.error?.issues[0]?.message).toBeUndefined()
+      expect(result.success).toBe(true)
+      // Zod strips unknown keys rather than rejecting them, so a parse that
+      // "succeeds" can still silently discard a whole parallel region.
+      expect(result.data).toEqual(value)
+    },
+  )
+})


### PR DESCRIPTION
## Problem

`streamwall-shared`'s `viewStateValueSchema` is a hand-written mirror of the
XState snapshot shape produced by `packages/streamwall/src/main/viewStateMachine.ts`.
Since #416 the control server validates every uplink `state` message against
it, but the two live in separate packages with no compile-time link — so drift
is invisible until it shows up in production as a degraded or rejected uplink
from a perfectly healthy desktop build (issue #419).

The guard immediately proved the point: **the schema was already drifted.** The
`running` parallel region has grown two regions the schema never learned about:

- `pause` (`unpaused` / `paused`) — added with `--park.pause` (#374/#383)
- `swap` (`idle` / `{ preloading: … }`) — background preload of the next view

Zod strips unknown keys instead of rejecting them, so the control server has
silently been dropping both regions from every view state it broadcasts to
clients.

## Solution

- **Guard** (`viewStateMachineSchemaDrift.test.ts`): walks the machine's static
  state tree, enumerates every reachable state value (102 of them, including the
  full cartesian product of the `running` regions), and asserts each parses
  against the exported `viewStateValueSchema` *without losing data*. The
  round-trip equality check is what catches silently stripped regions — a plain
  `success === true` assertion would have passed on the drifted schema.
- **Fix**: add the `pause` and `swap` regions to `viewStateValueSchema`.
- **Derive the type**: `ViewStateValue` is now `z.infer<typeof viewStateValueSchema>`
  instead of a second hand-written copy, removing one drift axis by construction.

### Decisions

- **Enumerate statically, don't drive the machine.** The issue suggested driving
  the actor through every reachable state. Reaching e.g. `swap.preloading` needs
  Electron doubles, timers and invoked actors; a static walk of `machine.root`
  is deterministic, fast, and catches added/renamed/removed states just as well.
- **Keep the schema lenient (strip, don't reject).** Failing a parse in
  production severs the desktop↔control-server connection; stripping degrades
  one view's reported state. The loud failure belongs in CI, which is exactly
  what this test provides.

## Testing

- New guard test: 102 cases, red before the schema fix (96 failing on the
  stripped `pause`/`swap` regions), green after.
- Updated three fixtures that constructed a partial `running` value, now
  required to be complete by the derived type.
- Full quality gate green locally: `format:check`, `lint`, `typecheck`,
  `npm test` (all workspaces), `npm -w streamwall-control-client run build`.

## Risks

Low. The schema only becomes *more* accepting; no message that validated before
is rejected now. Consumers (`matchesState('displaying.running.audio.listening', …)`
etc.) are unaffected — they now simply see the `pause`/`swap` regions that were
previously stripped.

Closes #419
