### PR TITLE
fix(streamwall): use lodash-es imports in the Electron package

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,6 +48,27 @@ export default tseslint.config(
       // and idiomatic here; these stylistic checks add noise without value.
       'import-x/no-named-as-default': 'off',
       'import-x/no-named-as-default-member': 'off',
+      // The workspace standardizes on the ESM build of lodash. Importing the
+      // CJS package (or one of its `lodash/<fn>` subpaths) pulls a second copy
+      // of lodash into the Vite/Forge bundles and reintroduces ESM/CJS interop
+      // surprises in the main and preload builds.
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'lodash',
+              message: "Use named imports from 'lodash-es' instead.",
+            },
+          ],
+          patterns: [
+            {
+              group: ['lodash/*'],
+              message: "Use named imports from 'lodash-es' instead.",
+            },
+          ],
+        },
+      ],
     },
   },
   {

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -8,8 +8,7 @@ import {
   WebContentsView,
 } from 'electron'
 import EventEmitter from 'events'
-import intersection from 'lodash/intersection'
-import isEqual from 'lodash/isEqual'
+import { intersection, isEqual } from 'lodash-es'
 import path from 'path'
 import {
   boxesFromViewContentMap,

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer, webFrame } from 'electron'
-import throttle from 'lodash/throttle'
+import { throttle } from 'lodash-es'
 import { ContentDisplayOptions } from 'streamwall-shared'
 import { MEDIA_PAUSE_EVENT, MEDIA_RESUME_EVENT } from './mediaParkEvents'
 import { VolumeController } from './volumeController'


### PR DESCRIPTION
## Problem

The `streamwall` Electron package declares only `lodash-es` as a dependency, but `StreamWindow.ts` and `mediaPreload.ts` imported helpers from the CJS `lodash/*` subpaths:

```ts
import intersection from 'lodash/intersection'
import isEqual from 'lodash/isEqual'
import throttle from 'lodash/throttle'
```

`lodash` itself is only present transitively, hoisted from build tooling (`@electron-forge/maker-deb`, `maker-rpm`, `app-builder-lib`). Resolution therefore depended on hoisting, and the Vite main/preload builds bundled a second lodash module graph alongside `lodash-es`.

## Solution

- Replace the `lodash/*` imports with named `lodash-es` imports in both files.
- Add a `no-restricted-imports` rule to `eslint.config.mjs` that bans both `lodash` and the `lodash/*` pattern, so the mixed style cannot silently return.

## Testing

- `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` — all green.
- `electron-forge package` built before and after the change to compare the production Vite bundles:

| bundle | before | after | delta |
| --- | --- | --- | --- |
| `.vite/build/index-*.js` (main) | 1,781,699 B | 1,748,353 B | −33,346 B |
| `.vite/build/mediaPreload.js` | 11,239 B | 10,067 B | −1,172 B |

No new tests were added: the change has no behavioral surface of its own (identical lodash functions, same call sites), and the acceptance criterion "no `from 'lodash/` imports" is enforced by the lint rule, which fails on the pre-fix source.

## Risks

Low. `lodash-es` and `lodash` ship the same implementations; only the module format changes. The remaining transitive `lodash` copies belong to packaging tooling and never reach the app bundle.

## Acceptance criteria

- [x] No `from 'lodash/` imports in `packages/streamwall`
- [x] Single lodash dependency (`lodash-es`)
- [x] Bundle size unchanged or smaller (smaller, see table)

Closes #407
