### PR TITLE
feat(control-server): replace console logging with structured Fastify logs

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -50,6 +50,12 @@ STREAMWALL_TRUST_PROXY=true
 # that must make no outbound connections at all.
 #STREAMWALL_UPDATE_CHECK=false
 
+# Optional: log verbosity. One of fatal, error, warn, info, debug, trace,
+# silent. Defaults to info. Logs are structured JSON on stdout; see the
+# redaction policy in packages/streamwall-control-server/README.md before
+# raising this to debug on a shared host.
+#LOG_LEVEL=info
+
 # Optional: crash reporting to your own Sentry project (off by default).
 #STREAMWALL_SENTRY_ENABLED=true
 #STREAMWALL_SENTRY_DSN=

--- a/packages/streamwall-control-server/README.md
+++ b/packages/streamwall-control-server/README.md
@@ -90,6 +90,36 @@ host, rate limit, malformed response) is non-fatal and simply leaves the last
 known result in place. See
 [`docs/self-hosting.md`](../../docs/self-hosting.md) for the update procedure.
 
+### Logging
+
+The server logs through Fastify's built-in [pino](https://getpino.io) logger:
+one structured JSON object per line on stdout, each carrying a severity level
+and the request correlation id (`reqId`) of the connection it belongs to.
+Client WebSocket entries additionally carry the per-connection `clientId`, so a
+whole session can be filtered out of an aggregated log store.
+
+| Variable    | Default | Description                                                                                                 |
+| ----------- | ------- | ----------------------------------------------------------------------------------------------------------- |
+| `LOG_LEVEL` | `info`  | One of `fatal`, `error`, `warn`, `info`, `debug`, `trace`, `silent`. An unknown value falls back to `info`. |
+
+**Redaction policy.** Logs are assumed to end up somewhere less trusted than
+the server itself (shared hosting, a log aggregator, a support ticket), so
+identifiable session metadata never reaches them:
+
+- The operator-supplied token **name** is never logged, at any level.
+- **Token ids** are never logged at `info` and above — neither as a field nor
+  inside a request path: the ids embedded in `/streamwall/:id/ws` and
+  `/invite/:id` are replaced with `[redacted]` in request log lines.
+- At `debug`, a four-character `tokenIdPrefix` is logged instead, which is
+  enough to correlate entries within one process but useless as a credential.
+- The `role` is logged, since authorization decisions are unreadable without
+  it and a role is not identifying on its own.
+
+The startup banner (server version, uplink endpoint, admin invite link) is
+written directly to stdout rather than through the logger, so it stays visible
+regardless of `LOG_LEVEL`. It is the one place credentials are printed on
+purpose — see [Running](#running).
+
 ### Telemetry
 
 Crash reporting to [Sentry](https://sentry.io) (via `@sentry/node`) is

--- a/packages/streamwall-control-server/src/auth.ts
+++ b/packages/streamwall-control-server/src/auth.ts
@@ -7,6 +7,7 @@ import {
   type StreamwallState,
   validRolesSet,
 } from 'streamwall-shared'
+import { type Logger, tokenIdPrefix } from './logger.ts'
 import type { StoredData } from './storage.ts'
 
 export interface AuthToken extends AuthTokenInfo {
@@ -135,9 +136,18 @@ export class StateWrapper extends EventEmitter {
 export class Auth extends EventEmitter<AuthEvents> {
   salt: string
   tokensById: Map<string, AuthToken>
+  /**
+   * Optional so `Auth` stays usable standalone (specs, tooling); when absent,
+   * token lifecycle events simply go unlogged rather than to raw stdout.
+   */
+  private log?: Logger
 
-  constructor({ salt, tokens = [] }: Partial<StoredData['auth']> = {}) {
+  constructor(
+    { salt, tokens = [] }: Partial<StoredData['auth']> = {},
+    log?: Logger,
+  ) {
     super()
+    this.log = log
     this.salt = salt ?? rand62(24)
     this.tokensById = new Map()
     for (const token of tokens) {
@@ -245,7 +255,12 @@ export class Auth extends EventEmitter<AuthEvents> {
     this.tokensById.set(tokenId, tokenData)
     this.emitState()
 
-    console.log(`Created ${kind} token:`, { tokenId, role, name })
+    // The operator-supplied `name` identifies a person, so it never reaches
+    // the log; the token id is truncated to a correlation-only prefix.
+    this.log?.debug(
+      { kind, role, tokenIdPrefix: tokenIdPrefix(tokenId) },
+      'Created token',
+    )
 
     return { tokenId, secret }
   }

--- a/packages/streamwall-control-server/src/bootstrap.ts
+++ b/packages/streamwall-control-server/src/bootstrap.ts
@@ -98,6 +98,10 @@ export async function initialInviteCodes({
  * Logs the bootstrap credentials to stdout. The uplink secret is printed only
  * when it was just minted (shown once); on subsequent starts we print the
  * endpoint without it and point the operator at how to rotate.
+ *
+ * Deliberately written to `console` rather than the structured logger: this
+ * banner is the operator's only chance to copy these credentials, so it must
+ * stay visible whatever `LOG_LEVEL` is set to (issue #410).
  */
 export function logBootstrap({
   uplinkSecret,

--- a/packages/streamwall-control-server/src/context.ts
+++ b/packages/streamwall-control-server/src/context.ts
@@ -4,6 +4,7 @@ import type * as Y from 'yjs'
 import { type AuthTokenInfo, stateDiff } from 'streamwall-shared'
 import type { Auth, StateWrapper } from './auth.ts'
 import type { WsMessageLimitConfig } from './config.ts'
+import { identityFields, type Logger } from './logger.ts'
 import type { DocUpdateLimits } from './stateDocGuard.ts'
 import type { UpdateChecker } from './updateCheck.ts'
 
@@ -34,6 +35,8 @@ export interface StreamwallConnection {
  * destructured up front.
  */
 export interface AppContext {
+  /** Server-wide logger; per-connection handlers prefer `request.log`. */
+  log: Logger
   auth: Auth
   updateChecker: UpdateChecker
   expectedOrigin: string
@@ -59,6 +62,7 @@ export interface AppContext {
 export function createBroadcastStateDeltas(
   clients: Map<string, Client>,
   reportCaughtError: (err: unknown) => void,
+  log: Logger,
 ): (clientState: StateWrapper) => void {
   return (clientState: StateWrapper) => {
     for (const client of clients.values()) {
@@ -74,7 +78,14 @@ export function createBroadcastStateDeltas(
         client.ws.send(JSON.stringify({ type: 'state-delta', delta }))
         client.lastStateSent = stateView
       } catch (err) {
-        console.error('failed to send client state delta', client, err)
+        log.error(
+          {
+            err,
+            clientId: client.clientId,
+            ...identityFields(client.identity),
+          },
+          'Failed to send client state delta',
+        )
         reportCaughtError(err)
       }
     }

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -22,6 +22,7 @@ import {
   createBroadcastStateDeltas,
 } from './context.ts'
 import { registerInviteRoutes } from './inviteExchange/invite.ts'
+import { getLoggerOptions, type LogLevel } from './logger.ts'
 import {
   captureException,
   initSentry,
@@ -51,12 +52,18 @@ export async function initApp({
   baseURL,
   clientStaticPath,
   db: injectedDb,
+  logLevel,
+  logStream,
   sentryEnabled: injectedSentryEnabled,
   sentryClient,
   trustProxy: injectedTrustProxy,
   updateChecker: injectedUpdateChecker,
 }: AppOptions & {
   db?: StorageDB
+  /** Overrides the level from `LOG_LEVEL` (used by tests to silence or widen output). */
+  logLevel?: LogLevel
+  /** Test-only sink for log output; defaults to pino's stdout destination. */
+  logStream?: { write(line: string): void }
   /** Test-only override so specs can exercise Sentry-enabled paths without a real DSN. */
   sentryEnabled?: boolean
   /** Test-only override for the client `captureException(...)` reports to. */
@@ -69,13 +76,19 @@ export async function initApp({
   const expectedOrigin = new URL(baseURL).origin
   const isSecure = baseURL.startsWith('https')
 
-  const db = injectedDb ?? (await loadStorage())
-  const auth = new Auth(db.data.auth)
-  const updateChecker = injectedUpdateChecker ?? createUpdateChecker()
-
   const trustProxy =
     injectedTrustProxy ?? parseTrustProxy(process.env.STREAMWALL_TRUST_PROXY)
-  const app = Fastify({ trustProxy })
+  const app = Fastify({
+    trustProxy,
+    logger: {
+      ...getLoggerOptions(logLevel),
+      ...(logStream && { stream: logStream }),
+    },
+  })
+
+  const db = injectedDb ?? (await loadStorage())
+  const auth = new Auth(db.data.auth, app.log)
+  const updateChecker = injectedUpdateChecker ?? createUpdateChecker()
 
   // Opt-in crash reporting (see sentry.ts for why there is no default DSN).
   // Must be wired up before routes are registered so their errors are covered.
@@ -98,11 +111,13 @@ export async function initApp({
   const broadcastStateDeltas = createBroadcastStateDeltas(
     clients,
     reportCaughtError,
+    app.log,
   )
 
   const rateLimitConfig = getRateLimitConfig()
 
   const ctx: AppContext = {
+    log: app.log,
     auth,
     updateChecker,
     expectedOrigin,
@@ -148,7 +163,7 @@ export async function initApp({
 
   await app.register(fastifyWebsocket, {
     errorHandler: (err) => {
-      console.warn('Error handling socket request', err)
+      app.log.warn({ err }, 'Error handling socket request')
     },
   })
 

--- a/packages/streamwall-control-server/src/logger.test.ts
+++ b/packages/streamwall-control-server/src/logger.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict'
+import process from 'node:process'
+import { after, test } from 'node:test'
+
+import {
+  getLoggerOptions,
+  redactRequestUrl,
+  resolveLogLevel,
+  tokenIdPrefix,
+} from './logger.ts'
+
+after(() => {
+  delete process.env.LOG_LEVEL
+})
+
+test('resolveLogLevel defaults to info when unset or blank', () => {
+  assert.equal(resolveLogLevel(undefined), 'info')
+  assert.equal(resolveLogLevel(''), 'info')
+  assert.equal(resolveLogLevel('   '), 'info')
+})
+
+test('resolveLogLevel accepts every pino level, case-insensitively', () => {
+  for (const level of [
+    'fatal',
+    'error',
+    'warn',
+    'info',
+    'debug',
+    'trace',
+    'silent',
+  ]) {
+    assert.equal(resolveLogLevel(level), level)
+    assert.equal(resolveLogLevel(level.toUpperCase()), level)
+  }
+})
+
+test('resolveLogLevel falls back to info for an unknown level', () => {
+  // A typo must never silence the server or crash it at boot.
+  assert.equal(resolveLogLevel('verbose'), 'info')
+})
+
+test('getLoggerOptions reads LOG_LEVEL from the environment', () => {
+  process.env.LOG_LEVEL = 'debug'
+  assert.equal(getLoggerOptions().level, 'debug')
+  delete process.env.LOG_LEVEL
+  assert.equal(getLoggerOptions().level, 'info')
+})
+
+test('tokenIdPrefix keeps only a short, non-identifying prefix', () => {
+  const prefix = tokenIdPrefix('abcdefgh')
+  assert.equal(prefix, 'abcd')
+  assert.ok(!('abcdefgh'.startsWith(prefix) && prefix.length >= 8))
+})
+
+test('redactRequestUrl strips token ids out of logged paths', () => {
+  assert.equal(
+    redactRequestUrl('/streamwall/s3cr3tId/ws'),
+    '/streamwall/[redacted]/ws',
+  )
+  assert.equal(redactRequestUrl('/invite/s3cr3tId'), '/invite/[redacted]')
+  assert.equal(
+    redactRequestUrl('/invite/s3cr3tId?next=/'),
+    '/invite/[redacted]?next=/',
+  )
+})
+
+test('redactRequestUrl leaves unrelated paths untouched', () => {
+  assert.equal(redactRequestUrl('/admin/status'), '/admin/status')
+  assert.equal(redactRequestUrl('/client/ws'), '/client/ws')
+  assert.equal(redactRequestUrl('/'), '/')
+})

--- a/packages/streamwall-control-server/src/logger.ts
+++ b/packages/streamwall-control-server/src/logger.ts
@@ -1,0 +1,109 @@
+import type { FastifyBaseLogger, FastifyRequest } from 'fastify'
+import process from 'node:process'
+
+import type { AuthTokenInfo } from 'streamwall-shared'
+
+/**
+ * The logger interface the server codes against: Fastify's own (pino) logger,
+ * reached as `app.log` / `request.log`. Handlers take it as a parameter rather
+ * than importing a module-level singleton, so every entry inherits the request
+ * correlation id (`reqId`) of the connection it belongs to.
+ */
+export type Logger = FastifyBaseLogger
+
+const LOG_LEVELS = [
+  'fatal',
+  'error',
+  'warn',
+  'info',
+  'debug',
+  'trace',
+  'silent',
+] as const
+
+export type LogLevel = (typeof LOG_LEVELS)[number]
+
+const DEFAULT_LOG_LEVEL: LogLevel = 'info'
+
+/**
+ * Parses `LOG_LEVEL` into a pino level. An unset, blank or unrecognized value
+ * falls back to `info`: a typo must never silence the server (or crash it at
+ * boot), which is the failure mode that hurts most in production.
+ */
+export function resolveLogLevel(raw: string | undefined): LogLevel {
+  const value = raw?.trim().toLowerCase()
+  return (LOG_LEVELS as readonly string[]).includes(value ?? '')
+    ? (value as LogLevel)
+    : DEFAULT_LOG_LEVEL
+}
+
+/**
+ * How many leading characters of a token id survive into a debug log entry.
+ * Enough to correlate two entries within one process, far too few to be used
+ * as a credential or to re-identify a session from an aggregated log store.
+ */
+const TOKEN_ID_PREFIX_LENGTH = 4
+
+/** Truncates a token id to a correlation-only prefix (debug level). */
+export function tokenIdPrefix(tokenId: string): string {
+  return tokenId.slice(0, TOKEN_ID_PREFIX_LENGTH)
+}
+
+/**
+ * Identity fields safe to log at info level and above: the role only. Token
+ * ids and the operator-supplied token name are deliberately omitted — they are
+ * identifiable session metadata that would otherwise end up in shared hosting
+ * or log-aggregation systems (issue #410).
+ */
+export function identityFields(identity: AuthTokenInfo): { role: string } {
+  return { role: identity.role }
+}
+
+/** Identity fields for debug level: adds a truncated token id, never the name. */
+export function identityDebugFields(identity: AuthTokenInfo): {
+  role: string
+  kind: string
+  tokenIdPrefix: string
+} {
+  return {
+    role: identity.role,
+    kind: identity.kind,
+    tokenIdPrefix: tokenIdPrefix(identity.tokenId),
+  }
+}
+
+// Routes that carry a token id in their path. Fastify's default request
+// serializer logs the raw url, which would otherwise publish those ids on
+// every request line.
+const TOKEN_PATH_PATTERN = /^\/(streamwall|invite)\/[^/?#]+/
+
+/** Replaces a token id embedded in a request path with a redaction marker. */
+export function redactRequestUrl(url: string): string {
+  return url.replace(TOKEN_PATH_PATTERN, '/$1/[redacted]')
+}
+
+/** Request serializer mirroring pino's default, with the url redacted. */
+function serializeRequest(request: FastifyRequest) {
+  return {
+    method: request.method,
+    url: redactRequestUrl(request.url),
+    host: request.host,
+    remoteAddress: request.ip,
+  }
+}
+
+export interface LoggerOptions {
+  level: LogLevel
+  serializers: { req: typeof serializeRequest }
+}
+
+/**
+ * Fastify logger options: structured JSON on stdout (pino's default output),
+ * at the level configured via `LOG_LEVEL`. Read per `initApp` call rather than
+ * at module load so overrides apply cleanly in tests.
+ */
+export function getLoggerOptions(
+  level: LogLevel = resolveLogLevel(process.env.LOG_LEVEL),
+): LoggerOptions {
+  return { level, serializers: { req: serializeRequest } }
+}

--- a/packages/streamwall-control-server/src/logging.test.ts
+++ b/packages/streamwall-control-server/src/logging.test.ts
@@ -1,0 +1,155 @@
+import assert from 'node:assert/strict'
+import { once } from 'node:events'
+import { after, test } from 'node:test'
+import { setTimeout as delay } from 'node:timers/promises'
+import WebSocket from 'ws'
+
+import {
+  buildTestApp,
+  captureLogs,
+  listenTestApp,
+  mintUplinkToken,
+  redeemInviteAndConnectClient,
+  VALID_STATE,
+} from './testHelpers.ts'
+
+const BASE_URL = 'http://localhost:3000'
+
+/** Pino numeric levels, for asserting on the severity of a captured entry. */
+const INFO = 30
+const WARN = 40
+
+/**
+ * Boots a live server whose logs are captured as parsed JSON entries, connects
+ * an authenticated Streamwall uplink and seeds it with a valid state.
+ */
+async function bootWithCapturedLogs() {
+  process.env.STREAMWALL_RATE_LIMIT_MAX = '10000'
+  process.env.STREAMWALL_AUTH_RATE_LIMIT_MAX = '10000'
+
+  const logs = captureLogs()
+  const { app, auth } = await buildTestApp({ baseURL: BASE_URL, logs })
+  after(() => app.close())
+  const port = await listenTestApp(app)
+
+  const { tokenId, secret, base } = await mintUplinkToken(auth, port)
+  const ws = new WebSocket(base, {
+    headers: { authorization: `Bearer ${secret}` },
+  })
+  after(() => ws.terminate())
+  await once(ws, 'open')
+  ws.send(JSON.stringify({ type: 'state', state: VALID_STATE }))
+  await delay(150)
+
+  return { app, auth, port, ws, logs, uplinkTokenId: tokenId }
+}
+
+test('emits structured JSON log entries with a severity level', async () => {
+  const { logs } = await bootWithCapturedLogs()
+
+  const connecting = logs.entries.find((e) => e.msg === 'Streamwall connecting')
+  assert.ok(connecting, 'the uplink connection must be logged')
+  assert.equal(connecting.level, INFO)
+  assert.equal(connecting.role, 'admin')
+  assert.ok(
+    typeof connecting.reqId === 'string' ||
+      typeof connecting.reqId === 'number',
+    'entries must carry a request correlation id',
+  )
+})
+
+test('never logs uplink token ids or token names at info level or above', async () => {
+  const { logs, uplinkTokenId } = await bootWithCapturedLogs()
+
+  const visible = logs.entries.filter((e) => Number(e.level) >= INFO)
+  assert.ok(visible.length > 0, 'expected some info-level entries')
+  for (const entry of visible) {
+    const serialized = JSON.stringify(entry)
+    assert.ok(
+      !serialized.includes(uplinkTokenId),
+      `token id leaked into an info-level log entry: ${serialized}`,
+    )
+    assert.ok(
+      !serialized.includes('"uplink"'),
+      `token name leaked into an info-level log entry: ${serialized}`,
+    )
+  }
+})
+
+test('logs only a truncated token id prefix at debug level', async () => {
+  const { logs, uplinkTokenId } = await bootWithCapturedLogs()
+
+  const debugEntry = logs.entries.find(
+    (e) => typeof e.tokenIdPrefix === 'string',
+  )
+  assert.ok(debugEntry, 'expected a debug entry carrying a token id prefix')
+  assert.ok(Number(debugEntry.level) < INFO, 'the prefix must stay at debug')
+  assert.equal(debugEntry.tokenIdPrefix, uplinkTokenId.slice(0, 4))
+  assert.notEqual(debugEntry.tokenIdPrefix, uplinkTokenId)
+})
+
+test('redacts the uplink token id out of logged request paths', async () => {
+  const { logs, uplinkTokenId } = await bootWithCapturedLogs()
+
+  const requestEntry = logs.entries.find(
+    (e) =>
+      typeof (e.req as { url?: unknown } | undefined)?.url === 'string' &&
+      String((e.req as { url: string }).url).startsWith('/streamwall/'),
+  )
+  assert.ok(requestEntry, 'the uplink request must be logged')
+  assert.equal(
+    (requestEntry.req as { url: string }).url,
+    '/streamwall/[redacted]/ws',
+  )
+  assert.ok(!JSON.stringify(requestEntry).includes(uplinkTokenId))
+})
+
+test('logs an unauthorized client command as a warning without the session name', async () => {
+  const { app, auth, port, logs } = await bootWithCapturedLogs()
+
+  const { ws: clientWs } = await redeemInviteAndConnectClient(
+    app,
+    auth,
+    port,
+    BASE_URL,
+    'monitor',
+  )
+  clientWs.send(
+    JSON.stringify({ id: 1, type: 'create-invite', role: 'admin', name: 'x' }),
+  )
+  await delay(150)
+
+  const entry = logs.entries.find((e) =>
+    String(e.msg).includes('Unauthorized attempt to "create-invite"'),
+  )
+  assert.ok(entry, 'the rejection must be logged')
+  assert.equal(entry.level, WARN)
+  assert.equal(entry.role, 'monitor')
+  assert.equal(
+    typeof entry.clientId,
+    'string',
+    'the entry must carry the client correlation id',
+  )
+  assert.ok(
+    !JSON.stringify(entry).includes('"client"'),
+    'the session name must not be logged',
+  )
+})
+
+test('honours a log level that filters out info entries', async () => {
+  const logs = captureLogs()
+  const { app } = await buildTestApp({
+    baseURL: BASE_URL,
+    logs,
+    logLevel: 'warn',
+  })
+  after(() => app.close())
+
+  const response = await app.inject({ method: 'GET', url: '/admin/status' })
+  assert.equal(response.statusCode, 403)
+  assert.equal(
+    logs.entries.filter((e) => Number(e.level) < WARN).length,
+    0,
+    'entries below the configured level must not be emitted',
+  )
+})

--- a/packages/streamwall-control-server/src/multiplexing.test.ts
+++ b/packages/streamwall-control-server/src/multiplexing.test.ts
@@ -17,6 +17,7 @@ import {
 } from 'streamwall-shared'
 import {
   buildTestApp,
+  captureLogs,
   connectStreamwallUplink,
   listenTestApp,
   messageCollector,
@@ -51,21 +52,6 @@ function applyDelta(state: StreamwallState, delta: Delta): StreamwallState {
   return stateDiff.patch(structuredClone(state), delta) as StreamwallState
 }
 
-/** Temporarily replaces `console.warn`, capturing every call made while active. */
-function spyOnConsoleWarn() {
-  const calls: unknown[][] = []
-  const original = console.warn
-  console.warn = (...args: unknown[]) => {
-    calls.push(args)
-  }
-  return {
-    calls,
-    restore: () => {
-      console.warn = original
-    },
-  }
-}
-
 /**
  * Boots a live server, connects a Streamwall uplink and seeds it with
  * `VALID_STATE`, and returns a `connectClient` helper that redeems a
@@ -76,7 +62,8 @@ async function bootServerWithUplink() {
   process.env.STREAMWALL_RATE_LIMIT_MAX = '10000'
   process.env.STREAMWALL_AUTH_RATE_LIMIT_MAX = '10000'
 
-  const { app, auth } = await buildTestApp({ baseURL: BASE_URL })
+  const logs = captureLogs()
+  const { app, auth } = await buildTestApp({ baseURL: BASE_URL, logs })
   after(() => app.close())
   const port = await listenTestApp(app)
 
@@ -98,141 +85,109 @@ async function bootServerWithUplink() {
     return { clientWs, client }
   }
 
-  return { app, auth, port, streamwallWs, streamwall, connectClient }
+  return { app, auth, port, streamwallWs, streamwall, connectClient, logs }
 }
 
 test('an operator cannot create-invite: it is dropped, logged, and never forwarded', async () => {
-  const { streamwall, connectClient } = await bootServerWithUplink()
+  const { streamwall, connectClient, logs } = await bootServerWithUplink()
   const { clientWs, client } = await connectClient('operator')
-  const warn = spyOnConsoleWarn()
+  clientWs.send(
+    JSON.stringify({
+      id: 1,
+      type: 'create-invite',
+      role: 'admin',
+      name: 'x',
+    }),
+  )
+  clientWs.send(JSON.stringify({ id: 2, type: 'reload-view', viewId: 0 }))
 
-  try {
-    clientWs.send(
-      JSON.stringify({
-        id: 1,
-        type: 'create-invite',
-        role: 'admin',
-        name: 'x',
-      }),
-    )
-    clientWs.send(JSON.stringify({ id: 2, type: 'reload-view', viewId: 0 }))
+  const response = await client.waitFor(isResponseTo(1))
+  assert.equal(response.error, 'unauthorized')
 
-    const response = await client.waitFor(isResponseTo(1))
-    assert.equal(response.error, 'unauthorized')
-
-    await streamwall.waitFor((m) => m.type === 'reload-view')
-    assert.ok(
-      !streamwall.messages.some((m) => m.type === 'create-invite'),
-      'create-invite must never reach the Streamwall uplink',
-    )
-    assert.ok(
-      warn.calls.some((args) =>
-        String(args[0]).includes('Unauthorized attempt to "create-invite"'),
-      ),
-      'the rejection must be logged',
-    )
-  } finally {
-    warn.restore()
-  }
+  await streamwall.waitFor((m) => m.type === 'reload-view')
+  assert.ok(
+    !streamwall.messages.some((m) => m.type === 'create-invite'),
+    'create-invite must never reach the Streamwall uplink',
+  )
+  assert.ok(
+    logs.hasMessage('Unauthorized attempt to "create-invite"'),
+    'the rejection must be logged',
+  )
 })
 
 test('an operator cannot browse: it is dropped, logged, and never forwarded', async () => {
-  const { streamwall, connectClient } = await bootServerWithUplink()
+  const { streamwall, connectClient, logs } = await bootServerWithUplink()
   const { clientWs, client } = await connectClient('operator')
-  const warn = spyOnConsoleWarn()
+  clientWs.send(
+    JSON.stringify({ id: 3, type: 'browse', url: 'https://example.com' }),
+  )
+  clientWs.send(JSON.stringify({ id: 4, type: 'reload-view', viewId: 0 }))
 
-  try {
-    clientWs.send(
-      JSON.stringify({ id: 3, type: 'browse', url: 'https://example.com' }),
-    )
-    clientWs.send(JSON.stringify({ id: 4, type: 'reload-view', viewId: 0 }))
+  const response = await client.waitFor(isResponseTo(3))
+  assert.equal(response.error, 'unauthorized')
 
-    const response = await client.waitFor(isResponseTo(3))
-    assert.equal(response.error, 'unauthorized')
-
-    await streamwall.waitFor((m) => m.type === 'reload-view')
-    assert.ok(
-      !streamwall.messages.some((m) => m.type === 'browse'),
-      'browse must never reach the Streamwall uplink',
-    )
-    assert.ok(
-      warn.calls.some((args) =>
-        String(args[0]).includes('Unauthorized attempt to "browse"'),
-      ),
-      'the rejection must be logged',
-    )
-  } finally {
-    warn.restore()
-  }
+  await streamwall.waitFor((m) => m.type === 'reload-view')
+  assert.ok(
+    !streamwall.messages.some((m) => m.type === 'browse'),
+    'browse must never reach the Streamwall uplink',
+  )
+  assert.ok(
+    logs.hasMessage('Unauthorized attempt to "browse"'),
+    'the rejection must be logged',
+  )
 })
 
 test('a monitor cannot create-invite: it is dropped, logged, and never forwarded', async () => {
-  const { streamwall, connectClient } = await bootServerWithUplink()
+  const { streamwall, connectClient, logs } = await bootServerWithUplink()
   const { clientWs, client } = await connectClient('monitor')
-  const warn = spyOnConsoleWarn()
+  clientWs.send(
+    JSON.stringify({
+      id: 5,
+      type: 'create-invite',
+      role: 'admin',
+      name: 'x',
+    }),
+  )
+  clientWs.send(
+    JSON.stringify({ id: 6, type: 'set-stream-censored', isCensored: true }),
+  )
 
-  try {
-    clientWs.send(
-      JSON.stringify({
-        id: 5,
-        type: 'create-invite',
-        role: 'admin',
-        name: 'x',
-      }),
-    )
-    clientWs.send(
-      JSON.stringify({ id: 6, type: 'set-stream-censored', isCensored: true }),
-    )
+  const response = await client.waitFor(isResponseTo(5))
+  assert.equal(response.error, 'unauthorized')
 
-    const response = await client.waitFor(isResponseTo(5))
-    assert.equal(response.error, 'unauthorized')
-
-    await streamwall.waitFor((m) => m.type === 'set-stream-censored')
-    assert.ok(
-      !streamwall.messages.some((m) => m.type === 'create-invite'),
-      'create-invite must never reach the Streamwall uplink',
-    )
-    assert.ok(
-      warn.calls.some((args) =>
-        String(args[0]).includes('Unauthorized attempt to "create-invite"'),
-      ),
-      'the rejection must be logged',
-    )
-  } finally {
-    warn.restore()
-  }
+  await streamwall.waitFor((m) => m.type === 'set-stream-censored')
+  assert.ok(
+    !streamwall.messages.some((m) => m.type === 'create-invite'),
+    'create-invite must never reach the Streamwall uplink',
+  )
+  assert.ok(
+    logs.hasMessage('Unauthorized attempt to "create-invite"'),
+    'the rejection must be logged',
+  )
 })
 
 test('a monitor cannot browse: it is dropped, logged, and never forwarded', async () => {
-  const { streamwall, connectClient } = await bootServerWithUplink()
+  const { streamwall, connectClient, logs } = await bootServerWithUplink()
   const { clientWs, client } = await connectClient('monitor')
-  const warn = spyOnConsoleWarn()
+  clientWs.send(
+    JSON.stringify({ id: 7, type: 'browse', url: 'https://example.com' }),
+  )
+  clientWs.send(
+    JSON.stringify({ id: 8, type: 'set-stream-censored', isCensored: true }),
+  )
 
-  try {
-    clientWs.send(
-      JSON.stringify({ id: 7, type: 'browse', url: 'https://example.com' }),
-    )
-    clientWs.send(
-      JSON.stringify({ id: 8, type: 'set-stream-censored', isCensored: true }),
-    )
+  const response = await client.waitFor(isResponseTo(7))
+  assert.equal(response.error, 'unauthorized')
 
-    const response = await client.waitFor(isResponseTo(7))
-    assert.equal(response.error, 'unauthorized')
-
-    await streamwall.waitFor((m) => m.type === 'set-stream-censored')
-    assert.ok(
-      !streamwall.messages.some((m) => m.type === 'browse'),
-      'browse must never reach the Streamwall uplink',
-    )
-    assert.ok(
-      warn.calls.some((args) =>
-        String(args[0]).includes('Unauthorized attempt to "browse"'),
-      ),
-      'the rejection must be logged',
-    )
-  } finally {
-    warn.restore()
-  }
+  await streamwall.waitFor((m) => m.type === 'set-stream-censored')
+  assert.ok(
+    !streamwall.messages.some((m) => m.type === 'browse'),
+    'browse must never reach the Streamwall uplink',
+  )
+  assert.ok(
+    logs.hasMessage('Unauthorized attempt to "browse"'),
+    'the rejection must be logged',
+  )
 })
 
 test('an operator can set-listening-view: it is forwarded to the Streamwall uplink', async () => {
@@ -271,11 +226,12 @@ test("an admin's state broadcast includes auth while an operator's does not", as
 /** Boots a live server and mints a Streamwall uplink token, without connecting yet. */
 async function startUplinkServer() {
   process.env.STREAMWALL_RATE_LIMIT_MAX = '10000'
-  const { app, auth } = await buildTestApp({ baseURL: BASE_URL })
+  const logs = captureLogs()
+  const { app, auth } = await buildTestApp({ baseURL: BASE_URL, logs })
   after(() => app.close())
   const port = await listenTestApp(app)
   const { base, secret } = await mintUplinkToken(auth, port)
-  return { app, auth, port, base, secret }
+  return { app, auth, port, base, secret, logs }
 }
 
 test('rejects a second Streamwall connection while the first stays connected', async () => {
@@ -284,55 +240,48 @@ test('rejects a second Streamwall connection while the first stays connected', a
     port,
     streamwallWs: first,
     connectClient,
+    logs,
   } = await bootServerWithUplink()
-  const warn = spyOnConsoleWarn()
+  // Registering the first uplink connection requires the server to await a
+  // real `validateToken` scrypt derivation, so the client's 'open' event
+  // (and even the fixed delay in `bootServerWithUplink`) is not proof that
+  // registration has actually completed — most visible on a loaded/slower
+  // CI runner. Round-trip a client through the state broadcast the uplink
+  // just sent: that broadcast can only happen after registration finished,
+  // so it deterministically proves the race window has closed rather than
+  // assuming a fixed ordering.
+  const { client } = await connectClient('admin')
+  await client.waitFor(isStateMessage)
 
-  try {
-    // Registering the first uplink connection requires the server to await a
-    // real `validateToken` scrypt derivation, so the client's 'open' event
-    // (and even the fixed delay in `bootServerWithUplink`) is not proof that
-    // registration has actually completed — most visible on a loaded/slower
-    // CI runner. Round-trip a client through the state broadcast the uplink
-    // just sent: that broadcast can only happen after registration finished,
-    // so it deterministically proves the race window has closed rather than
-    // assuming a fixed ordering.
-    const { client } = await connectClient('admin')
-    await client.waitFor(isStateMessage)
+  const secondToken = await auth.createToken({
+    kind: 'streamwall',
+    role: 'admin',
+    name: 'second uplink',
+  })
+  const second = new WebSocket(
+    `ws://127.0.0.1:${port}/streamwall/${secondToken.tokenId}/ws`,
+    { headers: { authorization: `Bearer ${secondToken.secret}` } },
+  )
+  after(() => second.terminate())
+  const nextMessage = messageCollector(second)
 
-    const secondToken = await auth.createToken({
-      kind: 'streamwall',
-      role: 'admin',
-      name: 'second uplink',
-    })
-    const second = new WebSocket(
-      `ws://127.0.0.1:${port}/streamwall/${secondToken.tokenId}/ws`,
-      { headers: { authorization: `Bearer ${secondToken.secret}` } },
-    )
-    after(() => second.terminate())
-    const nextMessage = messageCollector(second)
+  assert.deepEqual(
+    await nextMessage(2000),
+    { error: 'streamwall already connected' },
+    'the second connection must be rejected',
+  )
 
-    assert.deepEqual(
-      await nextMessage(2000),
-      { error: 'streamwall already connected' },
-      'the second connection must be rejected',
-    )
+  await once(second, 'close', { signal: AbortSignal.timeout(2000) })
 
-    await once(second, 'close', { signal: AbortSignal.timeout(2000) })
-
-    assert.equal(
-      first.readyState,
-      WebSocket.OPEN,
-      'the first Streamwall connection must remain unaffected',
-    )
-    assert.ok(
-      warn.calls.some((args) =>
-        String(args[0]).includes('Rejecting Streamwall connection'),
-      ),
-      'the rejection must be logged',
-    )
-  } finally {
-    warn.restore()
-  }
+  assert.equal(
+    first.readyState,
+    WebSocket.OPEN,
+    'the first Streamwall connection must remain unaffected',
+  )
+  assert.ok(
+    logs.hasMessage('Rejecting Streamwall connection'),
+    'the rejection must be logged',
+  )
 })
 
 test('a state message sent immediately on connect is not dropped while auth validation is pending', async () => {

--- a/packages/streamwall-control-server/src/sentryReporting.test.ts
+++ b/packages/streamwall-control-server/src/sentryReporting.test.ts
@@ -6,8 +6,10 @@ import type WebSocket from 'ws'
 import * as Y from 'yjs'
 
 import type { SentryCaptureClient } from './sentry.ts'
+import type { LogCapture } from './testHelpers.ts'
 import {
   buildTestApp,
+  captureLogs,
   connectStreamwallUplink,
   listenTestApp,
   redeemInviteAndConnectClient,
@@ -22,6 +24,16 @@ function updateFrom(mutate: (doc: Y.Doc) => void): Uint8Array {
 }
 
 const BASE_URL = 'http://localhost:3000'
+
+/** Finds the captured log entry with exactly this message. */
+function findLogged(logs: LogCapture, msg: string) {
+  return logs.entries.find((entry) => entry.msg === msg)
+}
+
+/** Reads the message off pino's serialized `err` field of a log entry. */
+function loggedErrorMessage(entry: Record<string, unknown>) {
+  return (entry.err as { message?: string } | undefined)?.message
+}
 
 /**
  * `@fastify/websocket` bundles its own nested `ws` install
@@ -56,10 +68,12 @@ test('a synchronous ws.send() failure while broadcasting a state delta is report
   process.env.STREAMWALL_AUTH_RATE_LIMIT_MAX = '10000'
 
   const sentryClient = fakeSentryClient()
+  const logs = captureLogs()
   const { app, auth } = await buildTestApp({
     baseURL: BASE_URL,
     sentryEnabled: true,
     sentryClient,
+    logs,
   })
   t.after(() => app.close())
   const port = await listenTestApp(app)
@@ -95,8 +109,6 @@ test('a synchronous ws.send() failure while broadcasting a state delta is report
     },
   )
 
-  const errorMock = t.mock.method(console, 'error')
-
   streamwallWs.send(
     JSON.stringify({
       type: 'state',
@@ -108,13 +120,11 @@ test('a synchronous ws.send() failure while broadcasting a state delta is report
   assert.equal(sentryClient.calls.length, 1)
   assert.equal(sentryClient.calls[0], sendError)
 
-  const loggedCall = errorMock.mock.calls.find(
-    (call) => call.arguments[0] === 'failed to send client state delta',
-  )
-  assert.ok(loggedCall, 'expected the send failure to be logged locally too')
+  const logged = findLogged(logs, 'Failed to send client state delta')
+  assert.ok(logged, 'expected the send failure to be logged locally too')
   assert.equal(
-    loggedCall?.arguments.at(-1),
-    sendError,
+    loggedErrorMessage(logged),
+    sendError.message,
     'the local log should include the caught error, not just the client',
   )
 })
@@ -124,10 +134,12 @@ test('a synchronous ws.send() failure while relaying a doc update is reported to
   process.env.STREAMWALL_AUTH_RATE_LIMIT_MAX = '10000'
 
   const sentryClient = fakeSentryClient()
+  const logs = captureLogs()
   const { app, auth } = await buildTestApp({
     baseURL: BASE_URL,
     sentryEnabled: true,
     sentryClient,
+    logs,
   })
   t.after(() => app.close())
   const port = await listenTestApp(app)
@@ -161,8 +173,6 @@ test('a synchronous ws.send() failure while relaying a doc update is reported to
     },
   )
 
-  const errorMock = t.mock.method(console, 'error')
-
   streamwallWs.send(updateFrom((d) => d.getMap('test').set('a', 'b')))
   await delay(150)
 
@@ -170,23 +180,19 @@ test('a synchronous ws.send() failure while relaying a doc update is reported to
   assert.equal(sentryClient.calls[0], sendError)
   assert.equal(sentryClient.calls[1], sendError)
 
-  const uplinkCall = errorMock.mock.calls.find(
-    (call) => call.arguments[0] === 'Failed to send Streamwall doc update',
-  )
-  assert.ok(uplinkCall, 'expected the uplink send failure to be logged')
+  const uplinkEntry = findLogged(logs, 'Failed to send Streamwall doc update')
+  assert.ok(uplinkEntry, 'expected the uplink send failure to be logged')
   assert.equal(
-    uplinkCall?.arguments.at(-1),
-    sendError,
+    loggedErrorMessage(uplinkEntry),
+    sendError.message,
     'the local log should include the caught error',
   )
 
-  const clientCall = errorMock.mock.calls.find(
-    (call) => call.arguments[0] === 'Failed to send client doc update:',
-  )
-  assert.ok(clientCall, 'expected the client send failure to be logged')
+  const clientEntry = findLogged(logs, 'Failed to send client doc update')
+  assert.ok(clientEntry, 'expected the client send failure to be logged')
   assert.equal(
-    clientCall?.arguments.at(-1),
-    sendError,
+    loggedErrorMessage(clientEntry),
+    sendError.message,
     'the local log should include the caught error, not just the client',
   )
 })

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -13,6 +13,7 @@ import type {
 } from 'streamwall-shared'
 import WebSocket from 'ws'
 import { type AppOptions, initApp } from './index.ts'
+import type { LogLevel } from './logger.ts'
 import type { SentryCaptureClient } from './sentry.ts'
 import type { StorageDB, StoredData } from './storage.ts'
 import type { UpdateChecker } from './updateCheck.ts'
@@ -39,22 +40,64 @@ export function inMemoryDb(): Low<StoredData> {
 }
 
 /**
+ * Collects the server's structured log output as parsed JSON entries, so specs
+ * can assert on what was logged (and on what was deliberately *not* logged)
+ * instead of spying on `console`.
+ */
+export interface LogCapture {
+  entries: Record<string, unknown>[]
+  stream: { write(line: string): void }
+  /** True when any captured entry's message contains `substring`. */
+  hasMessage(substring: string): boolean
+}
+
+export function captureLogs(): LogCapture {
+  const entries: Record<string, unknown>[] = []
+  return {
+    entries,
+    stream: {
+      write(line: string) {
+        try {
+          entries.push(JSON.parse(line))
+        } catch {
+          // Non-JSON output cannot be asserted on; ignore it.
+        }
+      },
+    },
+    hasMessage(substring: string) {
+      return entries.some(
+        (entry) =>
+          typeof entry.msg === 'string' && entry.msg.includes(substring),
+      )
+    },
+  }
+}
+
+/**
  * Builds a fully-wired app instance backed by in-memory storage and throwaway
  * static assets, ready for `app.inject()` or `app.listen()` in tests.
+ *
+ * Logging is silent unless a `logs` capture is passed, in which case every
+ * entry down to `trace` is recorded (override with `logLevel`).
  */
 export function buildTestApp(
   overrides: Partial<AppOptions> & {
     db?: StorageDB
+    logs?: LogCapture
+    logLevel?: LogLevel
     sentryEnabled?: boolean
     sentryClient?: SentryCaptureClient
     updateChecker?: UpdateChecker
   } = {},
 ) {
+  const { logs, logLevel, ...rest } = overrides
   return initApp({
     baseURL: 'http://localhost:3000',
     clientStaticPath: makeStaticDir(),
     db: inMemoryDb(),
-    ...overrides,
+    logLevel: logLevel ?? (logs ? 'trace' : 'silent'),
+    ...(logs && { logStream: logs.stream }),
+    ...rest,
   })
 }
 

--- a/packages/streamwall-control-server/src/ws/client.ts
+++ b/packages/streamwall-control-server/src/ws/client.ts
@@ -11,6 +11,7 @@ import {
 import { uniqueRand62 } from '../auth.ts'
 import { SESSION_COOKIE_NAME } from '../config.ts'
 import { type AppContext, type Client } from '../context.ts'
+import { identityDebugFields, identityFields } from '../logger.ts'
 import { applyValidatedDocUpdate } from '../stateDocGuard.ts'
 import { createWsMessageGuard, queueWebSocketMessages } from '../wsSupport.ts'
 
@@ -88,6 +89,13 @@ export function registerClientRoutes(
       }
       ctx.clients.set(clientId, client)
 
+      // Child logger so every entry from this connection carries the same
+      // correlation ids, and only non-identifying identity fields.
+      const log = request.log.child({
+        clientId,
+        ...identityFields(identity),
+      })
+
       const pingInterval = setInterval(() => {
         ws.ping()
       }, 20 * 1000)
@@ -96,27 +104,17 @@ export function registerClientRoutes(
         ctx.clients.delete(clientId)
         clearInterval(pingInterval)
 
-        console.log(
-          'Client',
-          clientId,
-          'disconnected from',
-          request.ip,
-          client.identity,
-        )
+        log.info('Client disconnected')
       })
 
-      console.log(
-        'Client',
-        clientId,
-        'connected from',
-        request.ip,
-        client.identity,
-      )
+      log.info('Client connected')
+      log.debug(identityDebugFields(identity), 'Client session authorized')
 
       const allowMessage = createWsMessageGuard(
         ws,
         ctx.wsMessageLimitConfig,
         `client ${clientId} from ${request.ip}`,
+        log,
       )
 
       handleMessage(async (rawData) => {
@@ -144,9 +142,7 @@ export function registerClientRoutes(
 
         if (rawData instanceof ArrayBuffer) {
           if (!roleCan(identity.role, 'mutate-state-doc')) {
-            console.warn(
-              `Unauthorized attempt to edit state doc by "${identity.name}"`,
-            )
+            log.warn('Unauthorized attempt to edit the state doc')
             respond({ error: 'unauthorized' })
             return
           }
@@ -162,8 +158,8 @@ export function registerClientRoutes(
             // it server-side would leave the operator UI out of sync with the
             // shared doc, so close the socket (like a rate-limit violation) to
             // force a clean reconnect and resync.
-            console.warn(
-              `Rejected invalid state doc update from client ${clientId}, closing to force resync`,
+            log.warn(
+              'Rejected invalid state doc update, closing to force resync',
             )
             ws.close(1008, 'invalid state update')
           }
@@ -174,7 +170,7 @@ export function registerClientRoutes(
         try {
           raw = JSON.parse(rawData.toString())
         } catch (err) {
-          console.warn('Received unexpected ws data: ', rawData.length, 'bytes')
+          log.warn({ bytes: rawData.length }, 'Received unexpected ws data')
           return
         }
 
@@ -194,9 +190,9 @@ export function registerClientRoutes(
         // from being forwarded to — and executed on — the desktop.
         const parsed = controlCommandMessageSchema.safeParse(raw)
         if (!parsed.success) {
-          console.warn(
-            `Rejected invalid control message from client ${clientId}:`,
-            parsed.error.issues[0]?.message,
+          log.warn(
+            { issue: parsed.error.issues[0]?.message },
+            'Rejected invalid control message',
           )
           respond({ error: 'invalid message' })
           return
@@ -205,15 +201,13 @@ export function registerClientRoutes(
 
         try {
           if (!roleCan(identity.role, msg.type)) {
-            console.warn(
-              `Unauthorized attempt to "${msg.type}" by "${identity.name}"`,
-            )
+            log.warn(`Unauthorized attempt to "${msg.type}"`)
             respond({ error: 'unauthorized' })
             return
           }
 
           if (msg.type === 'create-invite') {
-            console.debug('Creating invite for role:', msg.role)
+            log.debug({ inviteRole: msg.role }, 'Creating invite')
             const { tokenId, secret } = await ctx.auth.createToken({
               kind: 'invite',
               role: msg.role as StreamwallRole,
@@ -221,7 +215,7 @@ export function registerClientRoutes(
             })
             respond({ name: msg.name, secret, tokenId })
           } else if (msg.type === 'delete-token') {
-            console.debug('Deleting token:', msg.tokenId)
+            log.debug('Deleting token')
             ctx.auth.deleteToken(msg.tokenId)
           } else {
             streamwallConn.ws.send(
@@ -229,7 +223,7 @@ export function registerClientRoutes(
             )
           }
         } catch (err) {
-          console.error('Failed to handle ws message:', rawData, err)
+          log.error({ err }, 'Failed to handle ws message')
           ctx.reportCaughtError(err)
         }
       })

--- a/packages/streamwall-control-server/src/ws/uplink.ts
+++ b/packages/streamwall-control-server/src/ws/uplink.ts
@@ -8,6 +8,7 @@ import {
 import { StateWrapper } from '../auth.ts'
 import { STREAMWALL_PING_TIMEOUT_MS } from '../config.ts'
 import type { AppContext } from '../context.ts'
+import { identityDebugFields, identityFields } from '../logger.ts'
 import {
   bearerToken,
   createWsMessageGuard,
@@ -47,12 +48,10 @@ export function registerUplinkRoute(
         return
       }
 
+      const log = request.log.child(identityFields(tokenInfo))
+
       if (ctx.currentStreamwallWs != null) {
-        console.warn(
-          'Rejecting Streamwall connection (already connected) from',
-          request.ip,
-          tokenInfo,
-        )
+        log.warn('Rejecting Streamwall connection (already connected)')
         ws.send(JSON.stringify({ error: 'streamwall already connected' }))
         ws.close()
         return
@@ -64,7 +63,7 @@ export function registerUplinkRoute(
         ws.ping()
         const pongTimeout = setTimeout(() => {
           if (ws.readyState === ws.OPEN) {
-            console.warn(
+            log.warn(
               `Streamwall timeout: no pong within ${STREAMWALL_PING_TIMEOUT_MS}ms. Closing connection.`,
             )
             ws.terminate()
@@ -76,7 +75,7 @@ export function registerUplinkRoute(
       }, STREAMWALL_PING_TIMEOUT_MS)
 
       ws.on('close', () => {
-        console.log('Streamwall disconnected')
+        log.info('Streamwall disconnected')
         ctx.currentStreamwallWs = null
         ctx.currentStreamwallConn = null
         clearInterval(pingInterval)
@@ -89,12 +88,14 @@ export function registerUplinkRoute(
       let clientState: StateWrapper | null = null
       const stateDoc = new Y.Doc()
 
-      console.log('Streamwall connecting from', request.ip, tokenInfo)
+      log.info('Streamwall connecting')
+      log.debug(identityDebugFields(tokenInfo), 'Streamwall uplink authorized')
 
       const allowMessage = createWsMessageGuard(
         ws,
         ctx.wsMessageLimitConfig,
         `streamwall connection from ${request.ip}`,
+        log,
       )
 
       handleMessage((rawData) => {
@@ -114,7 +115,7 @@ export function registerUplinkRoute(
         try {
           raw = JSON.parse(rawData.toString())
         } catch (err) {
-          console.warn('Received unexpected ws data: ', rawData.length, 'bytes')
+          log.warn({ bytes: rawData.length }, 'Received unexpected ws data')
           return
         }
 
@@ -123,9 +124,9 @@ export function registerUplinkRoute(
         // shared StateWrapper around garbage (which crashed clients on view()).
         const parsed = controlStateMessageSchema.safeParse(raw)
         if (!parsed.success) {
-          console.warn(
-            'Rejected invalid Streamwall state message:',
-            parsed.error.issues[0]?.message,
+          log.warn(
+            { issue: parsed.error.issues[0]?.message },
+            'Rejected invalid Streamwall state message',
           )
           return
         }
@@ -136,9 +137,9 @@ export function registerUplinkRoute(
         // view() or corrupts the role-scoped projection (issue #387).
         const stateResult = streamwallStateSchema.safeParse(parsed.data.state)
         if (!stateResult.success) {
-          console.warn(
-            'Rejected invalid Streamwall state payload:',
-            stateResult.error.issues[0]?.message,
+          log.warn(
+            { issue: stateResult.error.issues[0]?.message },
+            'Rejected invalid Streamwall state payload',
           )
           return
         }
@@ -162,12 +163,12 @@ export function registerUplinkRoute(
               stateDoc,
             }
 
-            console.log('Streamwall connected from', request.ip, tokenInfo)
+            log.info('Streamwall connected')
           } else {
             clientState.update(state)
           }
         } catch (err) {
-          console.error('Failed to handle ws message:', rawData, err)
+          log.error({ err }, 'Failed to handle ws message')
           ctx.reportCaughtError(err)
         }
       })
@@ -176,7 +177,7 @@ export function registerUplinkRoute(
         try {
           ws.send(update)
         } catch (err) {
-          console.error('Failed to send Streamwall doc update', err)
+          log.error({ err }, 'Failed to send Streamwall doc update')
           ctx.reportCaughtError(err)
         }
         for (const client of ctx.clients.values()) {
@@ -186,7 +187,10 @@ export function registerUplinkRoute(
           try {
             client.ws.send(update)
           } catch (err) {
-            console.error('Failed to send client doc update:', client, err)
+            log.error(
+              { err, clientId: client.clientId },
+              'Failed to send client doc update',
+            )
             ctx.reportCaughtError(err)
           }
         }

--- a/packages/streamwall-control-server/src/wsSupport.ts
+++ b/packages/streamwall-control-server/src/wsSupport.ts
@@ -1,6 +1,7 @@
 import WebSocket from 'ws'
 
 import type { WsMessageLimitConfig } from './config.ts'
+import type { Logger } from './logger.ts'
 import { TokenBucket } from './rateLimiter.ts'
 
 /**
@@ -63,6 +64,7 @@ export function createWsMessageGuard(
   ws: WebSocket,
   config: WsMessageLimitConfig,
   label: string,
+  log: Logger,
 ): () => boolean {
   const bucket = new TokenBucket({
     capacity: config.capacity,
@@ -77,7 +79,7 @@ export function createWsMessageGuard(
       return true
     }
     closed = true
-    console.warn(`WebSocket message rate limit exceeded, closing ${label}`)
+    log.warn(`WebSocket message rate limit exceeded, closing ${label}`)
     try {
       ws.send(JSON.stringify({ error: 'rate limit exceeded' }))
     } catch {

--- a/packages/streamwall-control-server/src/wsValidation.test.ts
+++ b/packages/streamwall-control-server/src/wsValidation.test.ts
@@ -12,6 +12,7 @@ import type {
 import * as Y from 'yjs'
 import {
   buildTestApp,
+  captureLogs,
   connectStreamwallUplink,
   listenTestApp,
   redeemInviteAndConnectClient,
@@ -36,21 +37,6 @@ function isCommandType<Type extends ControlCommandMessage['type']>(type: Type) {
 /** Narrows to a bare connection-level rejection (never has `response`). */
 const isBareError = (m: ServerToClientMessage): m is ClientErrorMessage =>
   !('response' in m) && 'error' in m
-
-/** Temporarily replaces `console.warn`, capturing every call made while active. */
-function spyOnConsoleWarn() {
-  const calls: unknown[][] = []
-  const original = console.warn
-  console.warn = (...args: unknown[]) => {
-    calls.push(args)
-  }
-  return {
-    calls,
-    restore: () => {
-      console.warn = original
-    },
-  }
-}
 
 // A per-test override of the update cap must not leak into other test files.
 after(() => {
@@ -82,7 +68,8 @@ async function connectStreamwallAndClient({
     delete process.env.STREAMWALL_WS_UPDATE_MAX_BYTES
   }
 
-  const { app, auth } = await buildTestApp({ baseURL: BASE_URL })
+  const logs = captureLogs()
+  const { app, auth } = await buildTestApp({ baseURL: BASE_URL, logs })
   after(() => app.close())
   const port = await listenTestApp(app)
 
@@ -101,7 +88,7 @@ async function connectStreamwallAndClient({
     role,
   )
 
-  return { app, auth, streamwallWs, clientWs, streamwall, client }
+  return { app, auth, streamwallWs, clientWs, streamwall, client, logs }
 }
 
 test('does not forward an out-of-bounds command to the Streamwall uplink', async () => {
@@ -163,24 +150,17 @@ test('rejects an initial state payload missing a required field (issue #387)', a
   // rejected by the full streamwallStateSchema check before a StateWrapper is
   // ever built, exactly like a payload with no `state` key at all.
   const { streams: _streams, ...withoutStreams } = VALID_STATE
-  const warn = spyOnConsoleWarn()
 
-  try {
-    const { client } = await connectStreamwallAndClient({
-      stateMessage: { type: 'state', state: withoutStreams },
-    })
+  const { client, logs } = await connectStreamwallAndClient({
+    stateMessage: { type: 'state', state: withoutStreams },
+  })
 
-    const response = await client.waitFor(isBareError)
-    assert.equal(response.error, 'streamwall disconnected')
-    assert.ok(
-      warn.calls.some((args) =>
-        String(args[0]).includes('Rejected invalid Streamwall state payload'),
-      ),
-      'a structured warning must be logged for the rejected payload',
-    )
-  } finally {
-    warn.restore()
-  }
+  const response = await client.waitFor(isBareError)
+  assert.equal(response.error, 'streamwall disconnected')
+  assert.ok(
+    logs.hasMessage('Rejected invalid Streamwall state payload'),
+    'a structured warning must be logged for the rejected payload',
+  )
 })
 
 test('rejects an initial state payload with a malformed view state machine snapshot (issue #387)', async () => {
@@ -225,26 +205,19 @@ test('accepts an initial state payload with legitimately empty views', async () 
 })
 
 test('drops a malformed state update on an already-connected uplink without crashing the session (issue #387)', async () => {
-  const { streamwallWs, clientWs, streamwall } =
+  const { streamwallWs, clientWs, streamwall, logs } =
     await connectStreamwallAndClient()
 
-  const warn = spyOnConsoleWarn()
-  try {
-    // Malicious/buggy follow-up update: `streams` is not an array at all.
-    streamwallWs.send(
-      JSON.stringify({ type: 'state', state: { ...VALID_STATE, streams: {} } }),
-    )
-    await delay(150)
+  // Malicious/buggy follow-up update: `streams` is not an array at all.
+  streamwallWs.send(
+    JSON.stringify({ type: 'state', state: { ...VALID_STATE, streams: {} } }),
+  )
+  await delay(150)
 
-    assert.ok(
-      warn.calls.some((args) =>
-        String(args[0]).includes('Rejected invalid Streamwall state payload'),
-      ),
-      'the malformed update must be rejected with a structured warning',
-    )
-  } finally {
-    warn.restore()
-  }
+  assert.ok(
+    logs.hasMessage('Rejected invalid Streamwall state payload'),
+    'the malformed update must be rejected with a structured warning',
+  )
 
   // The session must still be alive and functional: a subsequent valid
   // command from the client is still forwarded to the (still-connected)


### PR DESCRIPTION
## Summary

The control server logged through raw `console.log/warn/error`, so production output had no severity field, no correlation ids, and printed token metadata (role, name, tokenId) straight to stdout — identifiable session data once it lands in shared hosting or an aggregated log store.

Every request and WebSocket hot path now logs through Fastify's built-in pino logger (structured JSON on stdout), with the verbosity selected by `LOG_LEVEL`.

**Design**

- Handlers take a logger explicitly rather than importing a singleton: `request.log` for uplink handlers, a `request.log.child({ clientId, role })` per browser client. Every entry therefore carries Fastify's `reqId` plus the connection's own `clientId`, so a whole session can be filtered out of a log store.
- New `logger.ts` owns the policy: `resolveLogLevel` (unknown/blank values fall back to `info`, so a typo can never silence the server), `identityFields`/`identityDebugFields`, `tokenIdPrefix`, and a request serializer that redacts token ids embedded in paths.
- `Auth` takes an optional logger, so token creation is logged at `debug` with redacted fields instead of writing `{ tokenId, role, name }` to stdout. It stays optional so `Auth` remains usable standalone.

**Redaction policy** (documented in the server README):

- the operator-supplied token **name** is never logged, at any level
- **token ids** never appear at `info` and above — including inside request paths: the ids in `/streamwall/:id/ws` and `/invite/:id` are replaced with `[redacted]`
- at `debug`, a four-character `tokenIdPrefix` is logged instead: enough to correlate entries within one process, useless as a credential
- the `role` is kept, since authorization decisions are unreadable without it and a role is not identifying on its own

The startup banner stays on `console` on purpose (and is called out as such in code and README): it is the operator's only chance to copy the uplink secret and admin invite link, so it must stay visible whatever `LOG_LEVEL` is set to. `sentry.ts`'s misconfiguration warning likewise runs before the Fastify instance exists.

Closes #410

## How was this tested?

- New `logging.test.ts` boots a live server against a capturing log stream and asserts on real emitted entries: JSON shape and severity level, presence of `reqId`/`clientId`, that no info-level entry contains the uplink token id or token name, that the debug prefix is a strict truncation, that the uplink request path is logged redacted, and that a configured level actually filters lower entries out.
- New `logger.test.ts` covers `resolveLogLevel` (default, case-insensitivity, unknown value), `getLoggerOptions` reading `LOG_LEVEL`, `tokenIdPrefix`, and `redactRequestUrl` (including that unrelated paths are untouched).
- The existing specs that spied on `console.warn` (`multiplexing`, `wsValidation`, `sentryReporting`) now assert on captured structured entries via a new `captureLogs()` test helper. Test output is silent by default, since `buildTestApp` runs at level `silent` unless a capture is passed.
- `npm run lint`, `npx prettier --check .`, `npm run typecheck` and `npm test` (1470 tests across all workspaces) pass locally.

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests (or this PR explains why none apply)
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments