### PR TITLE
refactor(control-server): use shared inMemoryDb() helper in index.test.ts

### DIFF
--- a/packages/streamwall-control-server/src/index.test.ts
+++ b/packages/streamwall-control-server/src/index.test.ts
@@ -1,4 +1,3 @@
-import { Low, Memory } from 'lowdb'
 import assert from 'node:assert/strict'
 import { after, describe, test } from 'node:test'
 
@@ -7,17 +6,10 @@ import runServer, {
   resolveListenPort,
   SESSION_COOKIE_NAME,
 } from './index.ts'
-import type { StoredData } from './storage.ts'
+import { inMemoryDb } from './testHelpers.ts'
 import type { UpdateChecker, UpdateStatus } from './updateCheck.ts'
 
 const ONE_YEAR_IN_SECONDS = 365 * 24 * 60 * 60
-
-function inMemoryDb(): Low<StoredData> {
-  return new Low<StoredData>(new Memory<StoredData>(), {
-    auth: { salt: null, tokens: [] },
-    streamwallToken: null,
-  })
-}
 
 /** Stub `UpdateChecker` so specs never reach GitHub. */
 function fakeUpdateChecker(): UpdateChecker {


### PR DESCRIPTION
## Problem

`packages/streamwall-control-server/src/index.test.ts` defined its own local `inMemoryDb()` helper that is byte-for-byte identical to the one `testHelpers.ts` already exports (added while resolving #216). The file was never migrated, so the duplication #216 set out to eliminate survived for this one helper.

No behavioral risk today, but a future change to the `StoredData` fixture shape would only update the shared copy and silently leave `index.test.ts` behind.

## Solution

- Drop the local `inMemoryDb()` from `index.test.ts` and import it from `./testHelpers.ts`, matching the pattern the other control-server spec files already follow.
- Remove the now-unused `lowdb` (`Low`, `Memory`) and `StoredData` imports that only existed to type the local copy.

## Architecture notes

`testHelpers.ts` imports `initApp` from `./index.ts`, so importing it from `index.test.ts` creates a test-only cycle back to the module under test. This is the same shape every other control-server spec already has and resolves cleanly under the Node ESM loader — the full control-server suite passes unchanged.

## Testing

No new tests: this is a pure test-fixture deduplication with no production code and no behavior change. The existing suite is the regression net.

- `npm run test` — control-server 160/160 pass, control-ui 314/314 pass, all workspaces green
- `npm run lint`, `npm run typecheck`, `npm run format` — clean

## Risks / breaking changes

None. Test-only change, no production code touched.

Closes #451