### PR TITLE
docs: document the manual Windows upgrade path off Squirrel installs (#452)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ changelog are kept in step.
 
 - Release version bumps are automated across the release-tracking workspace
   manifests via `npm run release:version` (#448).
+- Windows releases ship an NSIS installer instead of Squirrel.Windows (#432).
+  Installs from v0.9.1 or older cannot see newer releases and must be
+  reinstalled once by hand — README and the release-notes checklist in
+  CONTRIBUTING now spell out the steps (#452).
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,3 +243,26 @@ When cutting a release, alongside the `release:version` bump:
 is missing an `## [Unreleased]` section or a heading for the version currently
 in `packages/streamwall/package.json`, so a version bump without a matching
 changelog entry is caught before release.
+
+### Release notes: the Windows upgrade notice
+
+Releases after v0.9.1 ship an NSIS installer plus `latest.yml` instead of the
+Squirrel.Windows artifacts (`RELEASES`, `.nupkg`) that v0.9.x installs poll for
+(#432, #452). Those installs therefore find no update and report no error —
+they stay on their version until their owner reinstalls by hand, and only a
+release note tells them to.
+
+Until v0.9.x is safely out of circulation, paste this block near the top of
+every release's notes:
+
+```markdown
+**Windows: upgrading from v0.9.1 or older requires a manual reinstall.** Those
+builds cannot see this release through their in-app updater. Uninstall the old
+**Streamwall** entry (Settings → Apps → Installed apps), then download and run
+`streamwall-setup-<version>.exe` below. Your config and logs in
+`%APPDATA%\Streamwall` are preserved, and updates work automatically from then
+on. macOS and Linux are unaffected.
+```
+
+The same notice lives in the README's [Download](README.md#download) section
+for people who arrive there instead.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,23 @@ Grab the latest build from the [**Releases**](https://github.com/NilsR0711/strea
 >
 > Signed builds are opt-in and produced automatically once the signing secrets are provisioned (see the same section).
 
+> [!IMPORTANT]
+> **Windows users on v0.9.1 or older: update manually, once.** Those builds
+> were installed by a Squirrel.Windows installer and look for Squirrel update
+> artifacts that releases no longer contain, so they never find a newer
+> version and report no error either — they just stay where they are. To move
+> across:
+>
+> 1. Uninstall the old **Streamwall** entry via **Settings → Apps → Installed apps**.
+> 2. Download `streamwall-setup-<version>.exe` from the
+>    [Releases](https://github.com/NilsR0711/streamwall/releases/latest) page and run it.
+>
+> The new NSIS installer places the app in its own location rather than
+> replacing the Squirrel install, which is why the old one has to go first.
+> Your configuration and logs live in `%APPDATA%\Streamwall` and are left
+> untouched. From this installer on, in-app updates work again (see
+> [In-app updates](#in-app-updates)). macOS and Linux are unaffected.
+
 Prefer to run from source instead of installing? See [Configuration](#configuration) and the `start:app` script below.
 
 ## How it works
@@ -356,6 +373,13 @@ once a day and show a **View Release** banner when a newer version is found —
 notification only, since `.deb`/`.rpm` installs go through the OS package
 manager rather than a self-updater. Note that macOS additionally requires the
 app to be **signed** (see below) before updates can install.
+
+Windows installs from v0.9.1 or older are the one gap in that mechanism: they
+were made by a Squirrel.Windows installer and poll for Squirrel artifacts
+(`RELEASES`, `.nupkg`) that the NSIS releases no longer publish (#432), so they
+silently never see an update. Those installs need the one-time manual move
+described under [Download](#download); every install made by the NSIS
+installer updates itself normally.
 
 To produce signed, notarized builds, set these environment variables before
 running `make`/`publish` (see `packages/streamwall/forge.signing.ts`):


### PR DESCRIPTION
## Problem

Windows installs from v0.9.1 or older were produced by `@electron-forge/maker-squirrel` and check for updates via Squirrel artifacts (`RELEASES`, `.nupkg`). Since the switch to an NSIS installer driven by electron-updater (#432), releases no longer carry those artifacts, so those installs find no update *and* report no error — they silently stay on their old version.

## Solution

Option 1 from the issue (document it), applied in the three places a user or a release author can hit it:

- **README → Download**: an `[!IMPORTANT]` block with the one-time migration steps (uninstall the old entry, run `streamwall-setup-<version>.exe`), why it is needed (NSIS installs to its own location rather than replacing the Squirrel install), and that `%APPDATA%\Streamwall` config/logs survive.
- **README → In-app updates**: names the stranded-install case explicitly so the update section is not silently wrong for those users.
- **CONTRIBUTING → Cutting a release**: a new "Release notes: the Windows upgrade notice" step with a verbatim markdown block to paste into every release's notes until v0.9.x is out of circulation.
- **CHANGELOG**: records the NSIS switch (#432) and the manual-migration requirement.

## Testing

Docs-only — no behavior to test, so no tests were added. `npm run format:check`, `npm run lint`, `npm run typecheck` and `npm test` are green locally.

## Risks

None: no code paths change. The residual risk is procedural — if the release-notes block is dropped from a future release, stranded users are not reached; that is why the step now lives in the release checklist rather than only in this PR.

Closes #452