### PR TITLE
fix(streamwall): typecheck before electron-forge packages the app

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,8 +65,15 @@ automatically before `build`. That covers all entry points — a local
 `globalSetup` — so a type error fails the build instead of slipping through to
 the separate `npm run typecheck` step.
 
+The `streamwall` package has no `build` script — it packages through
+electron-forge, whose Vite plugin strips types the same way. There the check
+runs from forge's `prePackage` hook (see `packages/streamwall/forge.typecheck.ts`),
+which `electron-forge package`, `make` and `publish` all pass through, so
+release artifacts cannot be built from code that does not compile.
+`electron-forge start` stays unchecked to keep the dev loop fast.
+
 If you add a `build` script to a package, add the matching `prebuild` hook;
-`test/workspace-metadata.test.mjs` enforces this.
+`test/workspace-metadata.test.mjs` enforces this, along with the forge hook.
 
 ### Test runners differ per package
 

--- a/packages/streamwall/forge.config.test.ts
+++ b/packages/streamwall/forge.config.test.ts
@@ -1,0 +1,29 @@
+import type { ForgeConfig } from '@electron-forge/shared-types'
+import { describe, expect, it, vi } from 'vitest'
+
+const runTypecheck = vi.fn()
+vi.mock('./forge.typecheck', () => ({ runTypecheck: () => runTypecheck() }))
+
+const { default: config }: { default: ForgeConfig } =
+  await import('./forge.config')
+
+// `package`, `make` and `publish` all funnel through forge's package step, so
+// a single `prePackage` hook covers every path that produces a distributable
+// (#472). `start` deliberately stays fast and unchecked.
+describe('forge prePackage hook', () => {
+  it('typechecks before packaging the app', async () => {
+    await config.hooks?.prePackage?.(config, '', '')
+
+    expect(runTypecheck).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails the packaging run when the typecheck fails', async () => {
+    runTypecheck.mockImplementationOnce(() => {
+      throw new Error('typecheck failed')
+    })
+
+    await expect(config.hooks?.prePackage?.(config, '', '')).rejects.toThrow(
+      /typecheck failed/,
+    )
+  })
+})

--- a/packages/streamwall/forge.config.ts
+++ b/packages/streamwall/forge.config.ts
@@ -13,6 +13,7 @@ import {
   getWindowsSigningConfig,
   isSigningConfigured,
 } from './forge.signing'
+import { runTypecheck } from './forge.typecheck'
 import { appendUpdateMetadata } from './forge.updateMetadata'
 import packageJson from './package.json'
 
@@ -54,6 +55,12 @@ const config: ForgeConfig = {
     },
   ],
   hooks: {
+    // Vite strips types without checking them, so packaging would otherwise
+    // emit a release artifact from code that does not compile (#472). `make`
+    // and `publish` both run the package step, so this one hook covers every
+    // command that produces a distributable; `start` stays unchecked to keep
+    // the dev loop fast (`npm run typecheck` still covers it in CI).
+    prePackage: async () => runTypecheck(),
     // latest.yml / latest-mac.yml for electron-updater (#432); uploaded to
     // the release alongside the installers by the GitHub publisher.
     postMake: async (_forgeConfig, makeResults) =>

--- a/packages/streamwall/forge.typecheck.test.ts
+++ b/packages/streamwall/forge.typecheck.test.ts
@@ -1,0 +1,68 @@
+import type { SpawnSyncReturns } from 'node:child_process'
+import { describe, expect, it, vi } from 'vitest'
+import { runTypecheck } from './forge.typecheck'
+
+function spawnResult(
+  overrides: Partial<SpawnSyncReturns<Buffer>> = {},
+): SpawnSyncReturns<Buffer> {
+  return {
+    pid: 1,
+    output: [],
+    stdout: Buffer.alloc(0),
+    stderr: Buffer.alloc(0),
+    status: 0,
+    signal: null,
+    ...overrides,
+  }
+}
+
+describe('runTypecheck', () => {
+  it('runs the package `typecheck` script', () => {
+    const spawn = vi.fn(() => spawnResult())
+
+    runTypecheck(spawn)
+
+    expect(spawn).toHaveBeenCalledTimes(1)
+    const [command, args] = spawn.mock.calls[0]
+    expect(command).toBe('npm')
+    expect(args).toEqual(['run', 'typecheck'])
+  })
+
+  it('runs in the package directory so it does not typecheck the caller workspace', () => {
+    const spawn = vi.fn(() => spawnResult())
+
+    runTypecheck(spawn)
+
+    const [, , options] = spawn.mock.calls[0]
+    expect(options?.cwd).toBe(import.meta.dirname)
+  })
+
+  it('streams tsc output to the terminal instead of swallowing it', () => {
+    const spawn = vi.fn(() => spawnResult())
+
+    runTypecheck(spawn)
+
+    const [, , options] = spawn.mock.calls[0]
+    expect(options?.stdio).toBe('inherit')
+  })
+
+  it('throws when the typecheck reports errors, aborting the packaging run', () => {
+    const spawn = vi.fn(() => spawnResult({ status: 2 }))
+
+    expect(() => runTypecheck(spawn)).toThrow(/typecheck failed/i)
+  })
+
+  it('throws when the typecheck is killed by a signal', () => {
+    const spawn = vi.fn(() => spawnResult({ status: null, signal: 'SIGKILL' }))
+
+    expect(() => runTypecheck(spawn)).toThrow(/SIGKILL/)
+  })
+
+  it('throws when npm cannot be spawned at all', () => {
+    const spawn = vi.fn(() =>
+      spawnResult({ status: null, error: new Error('spawn npm ENOENT') }),
+    )
+
+    expect(() => runTypecheck(spawn)).toThrow(/ENOENT/)
+  })
+})

--- a/packages/streamwall/forge.typecheck.ts
+++ b/packages/streamwall/forge.typecheck.ts
@@ -1,0 +1,45 @@
+import {
+  spawnSync,
+  type SpawnSyncOptions,
+  type SpawnSyncReturns,
+} from 'node:child_process'
+
+/**
+ * Runs this package's `typecheck` script as part of packaging (#472).
+ *
+ * Forge builds the main, preload and renderer bundles with Vite, which strips
+ * types without checking them - so `electron-forge package`/`make`/`publish`
+ * would happily emit a release artifact from code that does not compile. The
+ * other workspaces bind `npm run typecheck` to npm's `prebuild` hook, but this
+ * package has no `build` script; wiring it into forge's `prePackage` hook
+ * instead covers all three commands at once, because make and publish both run
+ * the package step.
+ */
+
+export type SpawnSync = (
+  command: string,
+  args: readonly string[],
+  options: SpawnSyncOptions,
+) => SpawnSyncReturns<Buffer>
+
+export function runTypecheck(spawn: SpawnSync = spawnSync): void {
+  const result = spawn('npm', ['run', 'typecheck'], {
+    // Forge runs hooks from the directory it was invoked in, which is not
+    // necessarily this package (a root-level `npm -w streamwall run make`
+    // starts elsewhere), so anchor the check to this file's package.
+    cwd: import.meta.dirname,
+    stdio: 'inherit',
+  })
+
+  if (result.error) {
+    throw result.error
+  }
+  if (result.signal) {
+    throw new Error(`Typecheck failed: npm run typecheck got ${result.signal}`)
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `Typecheck failed: npm run typecheck exited with ${result.status}`,
+    )
+  }
+}

--- a/test/workspace-metadata.test.mjs
+++ b/test/workspace-metadata.test.mjs
@@ -51,6 +51,39 @@ test('every workspace that builds typechecks first', () => {
   }
 })
 
+// The Electron app has no `build` script - it packages through
+// electron-forge, whose Vite plugin strips types just as silently. The
+// equivalent guarantee lives in a forge `prePackage` hook, which `package`,
+// `make` and `publish` all run. Issue #472.
+test('every workspace that packages with electron-forge typechecks first', () => {
+  for (const relativePath of workspacePackageJsonPaths()) {
+    const { scripts = {} } = readPackageJson(relativePath)
+    if (
+      !Object.values(scripts).some((script) =>
+        script.startsWith('electron-forge package'),
+      )
+    ) {
+      continue
+    }
+
+    assert.ok(
+      scripts.typecheck,
+      `${relativePath} packages with electron-forge but has no "typecheck" script`,
+    )
+
+    const forgeConfig = readFileSync(
+      join(rootDir, dirname(relativePath), 'forge.config.ts'),
+      'utf8',
+    )
+    assert.match(
+      forgeConfig,
+      /prePackage:[^,]*runTypecheck\(\)/,
+      `${dirname(relativePath)}/forge.config.ts must run the typecheck in its ` +
+        '"prePackage" hook so packaging cannot pass with type errors',
+    )
+  }
+})
+
 // The E2E suite deliberately has no `test` script (it needs a browser, so it
 // stays out of the `npm test` workspace fan-out), which means the only way to
 // discover it is a root-level entry point. Issue #411.


### PR DESCRIPTION
## Problem

`packages/streamwall` builds its main, preload and renderer bundles through
`@electron-forge/plugin-vite`. Vite strips types without checking them, and
none of `package`, `make` or `publish` runs `tsc` — so the CI packaging smoke
job and every release build could succeed with type errors in the desktop app.
The package declares a `typecheck` script, but it was only reached via the root
`npm run typecheck` / the CI `checks` job.

#408 closed the same gap for `streamwall-control-client` via npm's `prebuild`
hook. That does not apply here: this package has no `build` script.

## Solution

A forge `prePackage` hook runs `npm run typecheck` (new
`packages/streamwall/forge.typecheck.ts`). `make` and `publish` both funnel
through the package step, so one hook covers all three commands that produce a
distributable. `electron-forge start` stays unchecked to keep the dev loop
fast — CI's `typecheck` job still covers it.

The runner is a small injectable-spawn module rather than an inline closure so
its failure paths (non-zero exit, signal, `ENOENT`) are unit-testable, matching
the existing `forge.publisher.ts` / `forge.updateMetadata.ts` split.

## Testing

- `forge.typecheck.test.ts` — command, working directory, inherited stdio, and
  each failure mode throwing.
- `forge.config.test.ts` — the `prePackage` hook is wired and propagates a
  failing typecheck.
- `test/workspace-metadata.test.mjs` — extended: any workspace packaging with
  electron-forge must declare `typecheck` and wire it into `prePackage`.
  Verified the guard fails when the hook is removed.
- Full quality gate green locally: format, lint, typecheck, `npm test`.

## Risks

Packaging now takes the typecheck's runtime (a few seconds) and fails on type
errors that previously slipped through — which is the point. No runtime code in
the shipped app changes.

Closes #472