### PR TITLE
ci(release): run the installer makers in the release quality gate

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -1,12 +1,14 @@
 name: Packaging
 
 # Exercises the makers configured in `packages/streamwall/forge.config.ts`
-# (NSIS, darwin zip, rpm, deb) outside of a release. Without this, a
-# maker-specific regression — a rejected maker config after a Forge major
-# bump, a missing packaging tool on a runner image, a bad NSIS icon path —
-# surfaces for the first time during `electron-forge publish` on a `v*` tag,
-# i.e. once the version is already public and a failed matrix leg leaves a
-# partially-populated GitHub release behind (#425).
+# (NSIS, darwin zip, rpm, deb) on all three platforms, well before a release
+# (#425). A maker-specific regression — a rejected maker config after a Forge
+# major bump, a missing packaging tool on a runner image, a bad NSIS icon
+# path — is caught here rather than on release day.
+#
+# release.yml gates every tag on its own `make` smoke as the backstop (#453),
+# but that one is Ubuntu-only: it cross-builds the Windows NSIS installer and
+# cannot run the darwin-only zip maker at all, which stays this matrix's job.
 #
 # Deliberately not part of PR CI: `make` costs several minutes per platform,
 # while the failure modes shared by every platform (Vite/Forge config, asar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,10 @@ concurrency:
   cancel-in-progress: false
 
 # The quality gate mirrors the PR `ci-ok` inputs (format, cross-OS tests,
-# control-client build, Electron package smoke, E2E, dependency licenses) so
-# a tag can never ship code that would have failed a PR. Unlike CI there are
-# no docs-only path
-# filters: a release always builds and ships binaries, so every check runs
-# unconditionally. `publish` fans out only after all of them pass.
+# control-client build, Electron installer smoke, E2E, dependency licenses)
+# so a tag can never ship code that would have failed a PR. Unlike CI there
+# are no docs-only path filters: a release always builds and ships binaries,
+# so every check runs unconditionally. `publish` fans out only after all of them pass.
 jobs:
   # Prettier (also Markdown/YAML), ESLint and tsc — the CI `checks` job.
   checks:
@@ -70,22 +69,59 @@ jobs:
       - uses: ./.github/actions/setup
       - run: npm -w streamwall-control-client run build
 
-  # Packaging smoke test before the three-OS publish matrix fans out: a
-  # Vite/Forge misconfiguration or a native-module unpacking failure fails
-  # here once (~45 seconds) instead of three times in parallel, each after a
-  # full Electron download. `package` only, not `make` — the maker-specific
-  # installer steps are the publish job's concern here, and are exercised
-  # ahead of a release by the weekly `packaging.yml` matrix (#425).
-  package:
-    name: Package smoke (Electron app)
+  # Installer smoke test before the three-OS publish matrix fans out: a
+  # Vite/Forge misconfiguration, a native-module unpacking failure, a
+  # rejected maker config or a broken `postMake` update-metadata hook fails
+  # here once instead of half-way through the publish matrix, where a failed
+  # leg leaves a partially populated GitHub release behind and the tag has to
+  # be redone (#453).
+  #
+  # `make`, not just `package`: the weekly `packaging.yml` matrix (#425)
+  # exercises the makers too, but it is up to a week stale and does not gate
+  # the tag. Only the darwin ZIP stays uncovered here — MakerZIP is
+  # darwin-only and cannot be cross-built — so the macOS publish leg remains
+  # the first place it runs.
+  make:
+    name: Installer smoke (makers)
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
-      - run: npm -w streamwall run package
+
+      # MakerRpm shells out to `rpmbuild`, MakerDeb to `dpkg`/`fakeroot`.
+      # Only the latter two ship on the GitHub Ubuntu runner image.
+      - name: Install Linux maker tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends rpm fakeroot
+
+      - name: Make (linux installers)
+        run: npm -w streamwall run make
+
+      # The NSIS maker and the `latest.yml` half of the update-metadata hook
+      # only run for win32. electron-builder bundles makensis for every host
+      # OS, so the expensive Windows-only path is verified from this runner
+      # rather than trusting the Windows publish leg.
+      - name: Make (windows NSIS, cross-built)
+        run: npm -w streamwall run make -- --platform=win32
+
+      # A maker that is silently skipped (unsupported-platform detection, a
+      # config change that drops it) produces no output but also no error, so
+      # the expected artifact kinds are asserted explicitly.
+      - name: Verify installer artifacts
+        shell: bash
+        run: |
+          make_dir=packages/streamwall/out/make
+          find "$make_dir" -type f -print | sort
+          for pattern in '*.deb' '*.rpm' '*-setup-*.exe' 'latest.yml'; do
+            if [ -z "$(find "$make_dir" -type f -name "$pattern" -print -quit)" ]; then
+              echo "::error::No $pattern artifact found in $make_dir"
+              exit 1
+            fi
+          done
 
   # End-to-end smoke tests: the control client in a real Chromium browser
   # against a real control server + fake Streamwall uplink. Linux-only (the
@@ -119,7 +155,7 @@ jobs:
 
   publish:
     name: Publish (${{ matrix.platform.name }})
-    needs: [checks, test, build, package, e2e, licenses]
+    needs: [checks, test, build, make, e2e, licenses]
     runs-on: ${{ matrix.platform.os }}
     timeout-minutes: 30
     permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,10 +266,17 @@ app itself is distributed, via GitHub Releases.
 
 PR CI runs `electron-forge package` (Ubuntu only) as a smoke test. The
 installer makers themselves — NSIS, the macOS zip, deb and rpm — are exercised
-by `.github/workflows/packaging.yml`, which runs `electron-forge make` across
-all three platforms every Monday and on manual dispatch. Run it from the
-Actions tab (optionally with the `debug` input for verbose Forge logging)
-before cutting a release, or after a Forge/maker dependency bump.
+in two other places:
+
+- `.github/workflows/release.yml` gates every tag on an `electron-forge make`
+  run that builds the deb and rpm installers natively and cross-builds the
+  Windows NSIS installer plus its `latest.yml` update metadata, so a maker or
+  `postMake` regression fails before the first artifact is published.
+- `.github/workflows/packaging.yml` runs `electron-forge make` across all
+  three platforms every Monday and on manual dispatch — this is the only
+  place the darwin zip maker runs outside a release. Run it from the Actions
+  tab (optionally with the `debug` input for verbose Forge logging) after a
+  Forge/maker dependency bump.
 
 ### Dependency deprecations
 

--- a/README.md
+++ b/README.md
@@ -421,7 +421,10 @@ failed a PR:
 - **Lint + typecheck** — ESLint and `tsc` across all workspaces
 - **Tests** — the full unit suite on Ubuntu, Windows, and macOS
 - **Control-client build** — `streamwall-control-client` production build
-- **Package smoke** — an Electron `package` of the desktop app
+- **Installer smoke** — an Electron `make` of the desktop app: the deb and rpm
+  installers natively, the Windows NSIS installer and its update metadata
+  cross-built, so a maker regression fails the gate instead of a half-finished
+  release
 - **E2E smoke** — the control client in a real browser against a live server
 
 Cross-OS tests run in the gate itself (not merely trusted from `main` CI):

--- a/test/ci-gate.test.mjs
+++ b/test/ci-gate.test.mjs
@@ -133,3 +133,41 @@ test('CONTRIBUTING documents exactly the required status checks', () => {
 
   assert.deepEqual(documented, expected)
 })
+
+// A maker regression must fail before the first artifact is published: once
+// the publish matrix has started, a failing leg leaves a partially populated
+// GitHub release behind and the tag has to be redone (#453).
+test('the release quality gate makes installers before publishing', () => {
+  const release = readWorkflow('release.yml')
+  const gateJobs = Object.entries(release.jobs).filter(
+    ([job]) => job !== 'publish',
+  )
+  const runScripts = (job) => job.steps.map((step) => step.run ?? '').join('\n')
+
+  const makeJobs = gateJobs.filter(([, job]) =>
+    /npm -w streamwall run make\b/.test(runScripts(job)),
+  )
+  assert.ok(
+    makeJobs.length > 0,
+    'release.yml must run `npm -w streamwall run make` before the publish ' +
+      'matrix, otherwise a maker or postMake regression first surfaces ' +
+      'mid-release',
+  )
+
+  for (const [name] of makeJobs) {
+    assert.ok(
+      release.jobs.publish.needs.includes(name),
+      `release.yml job "${name}" is not in the publish job's needs, so it ` +
+        'cannot gate the release',
+    )
+  }
+
+  // The NSIS maker and the latest.yml postMake hook only run for win32, and
+  // electron-builder bundles makensis for every host OS, so the gate
+  // cross-builds that target instead of trusting the Windows publish leg.
+  assert.ok(
+    makeJobs.some(([, job]) => /--platform=win32/.test(runScripts(job))),
+    'release.yml must cross-build the win32 target so the NSIS maker and ' +
+      'the update-metadata hook are exercised before publishing',
+  )
+})


### PR DESCRIPTION
## Summary

The release quality gate ran `npm -w streamwall run package` as its Electron
smoke test, which stops short of the maker stage. The NSIS maker (#432), the
ZIP/deb/rpm makers and the `postMake` update-metadata hook therefore only ever
ran inside the publish matrix — so a regression in any of them first surfaced
while a tag was half-published, leaving a partially populated GitHub release
behind and requiring a re-tag.

The `package` job becomes an `Installer smoke (makers)` job that runs
`electron-forge make` twice on the Ubuntu runner:

- natively, producing the deb and rpm installers (`rpm`/`fakeroot` are
  installed explicitly, as in `packaging.yml`),
- with `--platform=win32`, cross-building the NSIS installer and the
  `latest.yml` update metadata — electron-builder bundles makensis for every
  host OS, and `MakerNsis.isSupportedOnCurrentPlatform()` already returns
  `true` for exactly this reason.

The produced artifacts are then asserted by kind (`*.deb`, `*.rpm`,
`*-setup-*.exe`, `latest.yml`): a maker that is silently skipped emits no
output but also no error.

The darwin ZIP maker stays uncovered by the gate — `MakerZIP` is darwin-only
and cannot be cross-built — so the macOS publish leg remains its first run
inside a release; the weekly `packaging.yml` matrix keeps covering it outside
one. The workflow comments, `CONTRIBUTING.md` and `README.md` were updated to
describe this split, and closing that last gap is tracked in #517.

Rebased onto the current `main`: the gate now also keeps the new `licenses`
job in `publish`'s `needs`, and no `CHANGELOG.md` entry is added since release
notes are generated by release-please (#505).

Closes #453

## How was this tested?

- New guard test in `test/ci-gate.test.mjs`: the release workflow must run
  `npm -w streamwall run make` in a job that `publish` depends on, and one of
  those jobs must cross-build `--platform=win32`. Written first, confirmed
  failing against the old `package`-only gate.
- The cross-build itself was verified end to end locally (macOS, no wine, no
  signing secrets): `npm -w streamwall run make -- --platform=win32` exits 0
  and emits `streamwall-setup-0.9.1.exe`, its blockmap and a `latest.yml`
  whose `sha512`/`size` match the installer — i.e. the exact path the gate
  will exercise on the Ubuntu runner.
- `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test`,
  and `actionlint` on both changed workflows: all green.

## Risks

Release runs get slower (one extra `make` job of a few minutes) and the gate
now depends on `rpmbuild`/`fakeroot` being installable on the runner image —
both already true for `packaging.yml`. In exchange, no maker failure can reach
the publish matrix.

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests (or this PR explains why none apply)
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments

