### PR TITLE
ci: enforce a production dependency license allowlist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,24 @@ jobs:
           docker logs control-server
           exit 1
 
+  # Production dependencies are redistributed inside the release binaries, so
+  # their licenses have to stay compatible with shipping an MIT-licensed
+  # bundle. A transitive bump can introduce a new license without touching a
+  # first-party dependency, which is why this runs on every code change rather
+  # than only on manifest edits. Policy and allowlist: CONTRIBUTING.md.
+  licenses:
+    name: Dependency licenses
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - run: npm run licenses:check
+
   # Reviews the dependency diff of a PR for known vulnerabilities.
   dependency-review:
     name: Dependency review
@@ -273,6 +291,7 @@ jobs:
         e2e,
         docker,
         dependency-review,
+        licenses,
         codeql,
         actionlint,
       ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,9 @@ concurrency:
   cancel-in-progress: false
 
 # The quality gate mirrors the PR `ci-ok` inputs (format, cross-OS tests,
-# control-client build, Electron package smoke, E2E) so a tag can never ship
-# code that would have failed a PR. Unlike CI there are no docs-only path
+# control-client build, Electron package smoke, E2E, dependency licenses) so
+# a tag can never ship code that would have failed a PR. Unlike CI there are
+# no docs-only path
 # filters: a release always builds and ships binaries, so every check runs
 # unconditionally. `publish` fans out only after all of them pass.
 jobs:
@@ -103,9 +104,22 @@ jobs:
       - name: Run E2E smoke tests
         run: npm -w streamwall-control-e2e run test:e2e
 
+  # Same license allowlist the PR gate enforces: a release must not ship a
+  # dependency whose license is incompatible with redistribution.
+  licenses:
+    name: Dependency licenses
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - run: npm run licenses:check
+
   publish:
     name: Publish (${{ matrix.platform.name }})
-    needs: [checks, test, build, package, e2e]
+    needs: [checks, test, build, package, e2e, licenses]
     runs-on: ${{ matrix.platform.os }}
     timeout-minutes: 30
     permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,11 +183,42 @@ Streamwall is distributed under the [MIT License](LICENSE).
   attribution inline in the source (see
   `packages/streamwall/src/renderer/TailSpin.tsx` for an example).
 - When adding a new production dependency, confirm its license permits
-  redistribution inside the packaged Electron app (MIT, Apache-2.0, BSD, and
-  ISC are all fine; anything copyleft, e.g. GPL/AGPL, needs discussion first).
-  Distributed release binaries do not currently bundle a consolidated
-  `THIRD_PARTY_NOTICES` file; each dependency's own license file remains the
-  source of truth via `node_modules`.
+  redistribution inside the packaged Electron app. `npm run licenses:check`
+  enforces this against the allowlist below; CI and the release workflow run
+  the same check, so an incompatible license fails the merge gate instead of
+  reaching a release.
+
+### Allowed dependency licenses
+
+Every installed production dependency (`npm ls --omit=dev --all`, across all
+workspaces) must resolve to one of these SPDX identifiers:
+
+- `0BSD`
+- `Apache-2.0`
+- `BSD-2-Clause`
+- `BSD-3-Clause`
+- `BlueOak-1.0.0`
+- `CC0-1.0`
+- `ISC`
+- `MIT`
+- `MIT-0`
+- `OFL-1.1`
+- `Python-2.0`
+- `Unlicense`
+
+Dual licenses (`(MIT OR Apache-2.0)`) pass when at least one branch is
+allowed; conjunctions (`MIT AND …`) need every branch allowed. A missing
+license field, a `SEE LICENSE IN …` reference, or a `WITH` exception fails the
+check — all three need a human decision. Anything copyleft (GPL/AGPL/LGPL/MPL)
+needs discussion before it is added to `scripts/check-licenses.mjs`; that list
+and this section are kept in sync by `test/licenses.test.mjs`.
+
+Distributed release binaries deliberately do not bundle a consolidated
+`THIRD_PARTY_NOTICES` file: electron-forge packages each production dependency
+with its own license file, which is what the MIT/BSD/ISC notice clauses
+require, and a generated summary would be a second source of truth to keep
+current. Revisit if a dependency's license ever demands a separate,
+prominently placed notice.
 
 ## Cutting a release
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "typecheck": "npm run typecheck --workspaces --if-present",
     "test": "node --test test/*.test.mjs && npm run test --workspaces --if-present",
     "test:e2e": "npm -w streamwall-control-e2e run test:e2e",
+    "licenses:check": "node scripts/check-licenses.mjs",
     "release:version": "node scripts/release-version.mjs"
   },
   "workspaces": [

--- a/scripts/check-licenses.mjs
+++ b/scripts/check-licenses.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+// Fails when a production dependency ships under a license that is not
+// compatible with redistributing it inside the MIT-licensed release binaries.
+// The policy this enforces is documented in CONTRIBUTING.md ("Allowed
+// dependency licenses"); test/licenses.test.mjs keeps the two in sync.
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Permissive licenses only: everything here allows redistribution in a
+// closed or differently-licensed bundle as long as the notice is kept.
+// Copyleft (GPL/AGPL/LGPL/MPL) is deliberately absent — adding one is a
+// project decision, not a mechanical allowlist edit.
+export const ALLOWED_LICENSES = [
+  '0BSD',
+  'Apache-2.0',
+  'BSD-2-Clause',
+  'BSD-3-Clause',
+  'BlueOak-1.0.0',
+  'CC0-1.0',
+  'ISC',
+  'MIT',
+  'MIT-0',
+  'OFL-1.1',
+  'Python-2.0',
+  'Unlicense',
+]
+
+const ALLOWED_LOOKUP = new Set(
+  ALLOWED_LICENSES.map((license) => license.toLowerCase()),
+)
+
+// SPDX identifiers are case-insensitive; the `AND`/`OR` operators are not.
+// `WITH` is not handled on purpose: an exception rewrites the terms of the
+// license it attaches to, so it needs a human decision.
+function tokenize(expression) {
+  return expression
+    .replace(/([()])/g, ' $1 ')
+    .split(/\s+/)
+    .filter(Boolean)
+}
+
+function parseExpression(tokens, position) {
+  let result = parseConjunction(tokens, position)
+  while (result && tokens[result.position] === 'OR') {
+    const right = parseConjunction(tokens, result.position + 1)
+    if (!right) {
+      return null
+    }
+    result = {
+      allowed: result.allowed || right.allowed,
+      position: right.position,
+    }
+  }
+  return result
+}
+
+function parseConjunction(tokens, position) {
+  let result = parseTerm(tokens, position)
+  while (result && tokens[result.position] === 'AND') {
+    const right = parseTerm(tokens, result.position + 1)
+    if (!right) {
+      return null
+    }
+    result = {
+      allowed: result.allowed && right.allowed,
+      position: right.position,
+    }
+  }
+  return result
+}
+
+function parseTerm(tokens, position) {
+  const token = tokens[position]
+  if (token === undefined || token === ')') {
+    return null
+  }
+  if (token === '(') {
+    const inner = parseExpression(tokens, position + 1)
+    if (!inner || tokens[inner.position] !== ')') {
+      return null
+    }
+    return { allowed: inner.allowed, position: inner.position + 1 }
+  }
+  if (token === 'AND' || token === 'OR' || token === 'WITH') {
+    return null
+  }
+  return {
+    allowed: ALLOWED_LOOKUP.has(token.toLowerCase()),
+    position: position + 1,
+  }
+}
+
+export function isLicenseAllowed(license) {
+  if (typeof license !== 'string' || license.trim() === '') {
+    return false
+  }
+  const tokens = tokenize(license)
+  const parsed = parseExpression(tokens, 0)
+  return Boolean(parsed && parsed.position === tokens.length && parsed.allowed)
+}
+
+// npm reports whatever the package manifest declares. Modern packages use the
+// SPDX `license` string; older ones use `{ type }` objects or a `licenses`
+// array. Anything else stays `null` so it surfaces as a violation instead of
+// passing unnoticed.
+function normalizeLicense(node) {
+  if (typeof node.license === 'string') {
+    return node.license
+  }
+  if (node.license && typeof node.license.type === 'string') {
+    return node.license.type
+  }
+  if (Array.isArray(node.licenses)) {
+    const types = node.licenses
+      .map((entry) =>
+        typeof entry === 'string' ? entry : (entry?.type ?? null),
+      )
+      .filter((type) => typeof type === 'string')
+    if (types.length === 1) {
+      return types[0]
+    }
+    if (types.length > 1) {
+      return `(${types.join(' OR ')})`
+    }
+  }
+  return null
+}
+
+// Reads the installed manifest a tree node points at. `npm ls --long` only
+// expands the manifest fields on some occurrences of a package — a second,
+// deduplicated occurrence can carry nothing but a version and a path — so the
+// manifest on disk is the authoritative source and the node is the fallback.
+export function readPackageManifest(path) {
+  try {
+    return JSON.parse(readFileSync(join(path, 'package.json'), 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+// Flattens `npm ls --omit=dev --all --long --json` into one entry per
+// installed package. Nodes without a `path` are unmet optional or peer
+// dependencies that npm lists but never installed, and extraneous nodes are
+// leftovers from an earlier install — neither reaches a packaged release.
+export function collectProductionPackages(
+  tree,
+  readManifest = readPackageManifest,
+) {
+  const packages = new Map()
+
+  const walk = (node) => {
+    for (const [name, dependency] of Object.entries(node.dependencies ?? {})) {
+      const key = `${name}@${dependency.version}`
+      if (packages.has(key)) {
+        continue
+      }
+      if (!dependency.path || dependency.extraneous) {
+        continue
+      }
+      packages.set(key, {
+        name,
+        version: dependency.version,
+        license: normalizeLicense({
+          ...dependency,
+          ...(readManifest(dependency.path) ?? {}),
+        }),
+      })
+      walk(dependency)
+    }
+  }
+
+  walk(tree)
+  return [...packages.values()]
+}
+
+export function findLicenseViolations(packages) {
+  return packages.filter(({ license }) => !isLicenseAllowed(license))
+}
+
+export function formatViolations(violations) {
+  return violations
+    .map(
+      ({ name, version, license }) =>
+        `  ${name}@${version}: ${license ?? 'no license field'}`,
+    )
+    .join('\n')
+}
+
+function readProductionTree() {
+  // `npm ls` exits non-zero whenever the tree has any problem (an unmet
+  // optional dependency is enough), so the exit code is not a useful signal
+  // here — the JSON on stdout is.
+  const output = execFileSync(
+    'npm',
+    ['ls', '--omit=dev', '--all', '--long', '--json'],
+    { encoding: 'utf8', maxBuffer: 256 * 1024 * 1024 },
+  )
+  return JSON.parse(output)
+}
+
+function main() {
+  let tree
+  try {
+    tree = readProductionTree()
+  } catch (error) {
+    if (typeof error.stdout === 'string' && error.stdout.trim() !== '') {
+      tree = JSON.parse(error.stdout)
+    } else {
+      console.error(
+        `Could not read the production dependency tree: ${error.message}`,
+      )
+      process.exit(1)
+    }
+  }
+
+  const packages = collectProductionPackages(tree)
+  const violations = findLicenseViolations(packages)
+
+  if (violations.length > 0) {
+    console.error(
+      `${violations.length} of ${packages.length} production dependencies are not covered by the license allowlist:\n` +
+        `${formatViolations(violations)}\n\n` +
+        `Allowed: ${ALLOWED_LICENSES.join(', ')}.\n` +
+        'See the "Allowed dependency licenses" section in CONTRIBUTING.md.',
+    )
+    process.exit(1)
+  }
+
+  console.log(
+    `All ${packages.length} production dependencies are covered by the license allowlist.`,
+  )
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  main()
+}

--- a/test/licenses.test.mjs
+++ b/test/licenses.test.mjs
@@ -1,0 +1,236 @@
+import { load } from 'js-yaml'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import {
+  ALLOWED_LICENSES,
+  collectProductionPackages,
+  findLicenseViolations,
+  formatViolations,
+  isLicenseAllowed,
+} from '../scripts/check-licenses.mjs'
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)))
+
+// Most fixtures describe the license on the tree node itself; only the
+// manifest-precedence test needs a reader.
+const noManifest = () => null
+
+function readWorkflow(fileName) {
+  return load(
+    readFileSync(join(rootDir, '.github/workflows', fileName), 'utf8'),
+  )
+}
+
+test('the allowlist accepts plain permissive SPDX identifiers', () => {
+  for (const license of ['MIT', 'Apache-2.0', 'ISC', 'BSD-3-Clause']) {
+    assert.ok(isLicenseAllowed(license), `${license} should be allowed`)
+  }
+})
+
+test('the allowlist rejects copyleft and unresolvable licenses', () => {
+  for (const license of [
+    'GPL-3.0-only',
+    'AGPL-3.0-or-later',
+    'LGPL-2.1',
+    'UNLICENSED',
+    'SEE LICENSE IN LICENSE.md',
+    '',
+    null,
+    undefined,
+  ]) {
+    assert.ok(
+      !isLicenseAllowed(license),
+      `${JSON.stringify(license)} should not be allowed`,
+    )
+  }
+})
+
+// Dual-licensed packages are shipped under whichever branch we pick, so a
+// single compatible branch is enough. A conjunction binds us to every branch.
+test('SPDX expressions are evaluated branch by branch', () => {
+  assert.ok(isLicenseAllowed('(MIT OR GPL-3.0-only)'))
+  assert.ok(isLicenseAllowed('MIT AND ISC'))
+  assert.ok(isLicenseAllowed('(MIT OR Apache-2.0) AND ISC'))
+  assert.ok(!isLicenseAllowed('MIT AND GPL-3.0-only'))
+  assert.ok(!isLicenseAllowed('(GPL-3.0-only OR AGPL-3.0-only)'))
+})
+
+// A `WITH` exception changes the terms of the underlying license, so it needs
+// a human decision rather than an implicit pass from the base identifier.
+test('license exceptions are not silently accepted', () => {
+  assert.ok(!isLicenseAllowed('Apache-2.0 WITH LLVM-exception'))
+})
+
+test('malformed expressions are rejected instead of throwing', () => {
+  for (const license of ['(MIT', 'MIT OR', 'AND MIT', '()']) {
+    assert.ok(
+      !isLicenseAllowed(license),
+      `${JSON.stringify(license)} should not be allowed`,
+    )
+  }
+})
+
+test('production packages are collected once per name and version', () => {
+  const tree = {
+    dependencies: {
+      a: {
+        version: '1.0.0',
+        path: '/repo/node_modules/a',
+        license: 'MIT',
+        dependencies: {
+          b: { version: '2.0.0', path: '/repo/node_modules/b', license: 'ISC' },
+        },
+      },
+      b: { version: '2.0.0', path: '/repo/node_modules/b', license: 'ISC' },
+    },
+  }
+
+  assert.deepEqual(collectProductionPackages(tree, noManifest), [
+    { name: 'a', version: '1.0.0', license: 'MIT' },
+    { name: 'b', version: '2.0.0', license: 'ISC' },
+  ])
+})
+
+// `npm ls` reports unmet optional dependencies (e.g. the platform-specific
+// esbuild binaries) as empty nodes, and a working tree can carry leftovers
+// from an older install. Neither ends up in a packaged release.
+test('uninstalled and extraneous nodes are skipped', () => {
+  const tree = {
+    dependencies: {
+      'unmet-optional': {},
+      leftover: {
+        version: '1.0.0',
+        path: '/repo/node_modules/leftover',
+        license: 'GPL-3.0-only',
+        extraneous: true,
+      },
+      real: {
+        version: '1.0.0',
+        path: '/repo/node_modules/real',
+        license: 'MIT',
+      },
+    },
+  }
+
+  assert.deepEqual(collectProductionPackages(tree, noManifest), [
+    { name: 'real', version: '1.0.0', license: 'MIT' },
+  ])
+})
+
+// Old packages predate the SPDX `license` string; npm still surfaces the
+// legacy shapes verbatim, and a dropped field must not read as "compatible".
+test('legacy license fields are normalized, unknown shapes are not', () => {
+  const tree = {
+    dependencies: {
+      legacyObject: {
+        version: '1.0.0',
+        path: '/repo/node_modules/legacyObject',
+        license: { type: 'MIT', url: 'https://example.test/LICENSE' },
+      },
+      legacyArray: {
+        version: '1.0.0',
+        path: '/repo/node_modules/legacyArray',
+        licenses: [{ type: 'MIT' }, { type: 'GPL-3.0-only' }],
+      },
+      unlicensed: {
+        version: '1.0.0',
+        path: '/repo/node_modules/unlicensed',
+      },
+    },
+  }
+
+  assert.deepEqual(collectProductionPackages(tree, noManifest), [
+    { name: 'legacyObject', version: '1.0.0', license: 'MIT' },
+    { name: 'legacyArray', version: '1.0.0', license: '(MIT OR GPL-3.0-only)' },
+    { name: 'unlicensed', version: '1.0.0', license: null },
+  ])
+})
+
+// `npm ls --long` expands the manifest fields on the first occurrence of a
+// package only; a deduplicated second occurrence can carry nothing but a
+// version and a path. Reading the installed manifest keeps that from being
+// mistaken for a package without a license.
+test('the installed manifest wins over a sparse tree node', () => {
+  const tree = {
+    dependencies: {
+      sparse: { version: '19.0.0', path: '/repo/node_modules/sparse' },
+    },
+  }
+
+  const readManifest = (path) =>
+    path === '/repo/node_modules/sparse' ? { license: 'MIT' } : null
+
+  assert.deepEqual(collectProductionPackages(tree, readManifest), [
+    { name: 'sparse', version: '19.0.0', license: 'MIT' },
+  ])
+})
+
+// An unreadable manifest must not read as "compatible".
+test('an unreadable manifest leaves the license unresolved', () => {
+  const tree = {
+    dependencies: {
+      broken: { version: '1.0.0', path: '/repo/node_modules/broken' },
+    },
+  }
+
+  assert.deepEqual(collectProductionPackages(tree, noManifest), [
+    { name: 'broken', version: '1.0.0', license: null },
+  ])
+})
+
+test('violations name every offending package and its license', () => {
+  const violations = findLicenseViolations([
+    { name: 'fine', version: '1.0.0', license: 'MIT' },
+    { name: 'copyleft', version: '2.3.4', license: 'GPL-3.0-only' },
+    { name: 'nameless', version: '0.1.0', license: null },
+  ])
+
+  assert.deepEqual(violations, [
+    { name: 'copyleft', version: '2.3.4', license: 'GPL-3.0-only' },
+    { name: 'nameless', version: '0.1.0', license: null },
+  ])
+
+  const report = formatViolations(violations)
+  assert.match(report, /copyleft@2\.3\.4/)
+  assert.match(report, /GPL-3\.0-only/)
+  assert.match(report, /nameless@0\.1\.0/)
+  assert.match(report, /no license field/)
+})
+
+// The check only gates merges while it hangs off the aggregate `CI OK` job,
+// and only gates releases while `publish` waits for it.
+test('the license check gates both CI and the release workflow', () => {
+  const ci = readWorkflow('ci.yml')
+  const licenses = ci.jobs.licenses
+
+  assert.ok(licenses, 'ci.yml is missing a licenses job')
+  assert.ok(
+    licenses.steps.some((step) => step.run?.includes('licenses:check')),
+    'the ci.yml licenses job must run the license check script',
+  )
+
+  const release = readWorkflow('release.yml')
+  assert.ok(release.jobs.licenses, 'release.yml is missing a licenses job')
+  assert.ok(
+    release.jobs.publish.needs.includes('licenses'),
+    'release.yml publish must wait for the licenses job',
+  )
+})
+
+// Contributors read the policy in CONTRIBUTING, CI enforces the constant.
+// If they drift apart, one of them is lying.
+test('CONTRIBUTING documents exactly the allowed licenses', () => {
+  const contributing = readFileSync(join(rootDir, 'CONTRIBUTING.md'), 'utf8')
+  const section = contributing
+    .split('### Allowed dependency licenses')[1]
+    ?.split(/^#{2,3} /m)[0]
+
+  assert.ok(section, 'CONTRIBUTING.md is missing an allowed licenses section')
+
+  const documented = [...section.matchAll(/^- `([^`]+)`/gm)].map((m) => m[1])
+
+  assert.deepEqual(documented, [...ALLOWED_LICENSES])
+})


### PR DESCRIPTION
## Problem

`CONTRIBUTING.md` documented that new production dependencies must be
license-compatible with MIT redistribution, but nothing enforced it. An
incompatible license (GPL/AGPL) could land through a new package or a
transitive bump and only a reviewer's attention would catch it. Release
binaries also had no recorded decision on third-party notices.

## Solution

- `scripts/check-licenses.mjs` reads the installed production tree via
  `npm ls --omit=dev --all --long --json`, normalizes the SPDX string,
  legacy `{ type }` object and legacy `licenses` array shapes, and fails on
  anything outside an allowlist of permissive licenses.
- Exposed as `npm run licenses:check`; runs as a dedicated job in `ci.yml`
  (wired into the `CI OK` gate) and in `release.yml` ahead of `publish`.
- `CONTRIBUTING.md` documents the allowlist and the notices decision.

### Architecture decisions

- **No new dependency.** `npm ls --long` already reports each installed
  package's license and path, so a `license-checker` devDependency would
  only add supply-chain surface for parsing we need anyway.
- **Fail closed.** A missing license field, `SEE LICENSE IN …`, and a `WITH`
  exception are all violations. An exception rewrites the terms of the
  license it attaches to, so it needs a human decision, not an implicit pass
  from the base identifier.
- **Expression semantics.** `(A OR B)` passes when one branch is allowed;
  `A AND B` needs both. Malformed expressions are rejected, not thrown on.
- **Skipped nodes.** `npm ls` lists unmet optional/peer dependencies as empty
  nodes and can report leftovers as extraneous; neither is installed into a
  packaged release, so both are ignored.
- **No `THIRD_PARTY_NOTICES` file.** electron-forge packages each production
  dependency together with its own license file, which is what the MIT/BSD/ISC
  notice clauses require. A generated summary would be a second source of
  truth to keep current. Recorded in `CONTRIBUTING.md`, to be revisited if a
  dependency ever demands a separately placed notice.
- **Trigger on `code`, not just `dependencies`.** The `dependencies` paths
  filter only covers manifests; the allowlist itself lives in a script, and
  `code` already covers both.

## Testing

- `test/licenses.test.mjs` (node:test, runs in `npm test`): allowlist
  matching, SPDX expression evaluation including `WITH` and malformed input,
  tree flattening/dedupe, skipping of uninstalled and extraneous nodes,
  legacy license shapes, violation reporting, plus drift guards that the
  workflows wire the check in and that `CONTRIBUTING.md` documents exactly
  the allowlist constant.
- `npm run licenses:check` against the real tree: all 233 production
  dependencies pass. Verified the failure path end to end by temporarily
  removing `MIT` from the allowlist — 184 violations reported, exit code 1.
- `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test`:
  all green locally.

## Risks

Low. The check is additive and does not touch runtime code. Worst case is a
false positive on an unusual license expression, which fails a build rather
than shipping something wrong; the allowlist is a one-line edit plus the
documented rationale.

Closes #431