### PR TITLE
fix(control-ui): keep banner live regions mounted while healthy

### DIFF
--- a/packages/streamwall-control-ui/src/CommandErrorBanner.test.tsx
+++ b/packages/streamwall-control-ui/src/CommandErrorBanner.test.tsx
@@ -29,9 +29,35 @@ function renderBanner(
 }
 
 describe('CommandErrorBanner', () => {
-  test('renders nothing when there is no error', () => {
+  test('renders no message when there is no error', () => {
     const el = renderBanner(null)
-    expect(el.querySelector('.command-error-banner')).toBeNull()
+    expect(el.textContent).toBe('')
+    expect(el.querySelector('.command-error-banner button')).toBeNull()
+  })
+
+  // `aria-live` only guarantees an announcement for content that changes
+  // inside an already-present region, so the region stays mounted (empty)
+  // while there is no error - otherwise the first command failure can go
+  // unannounced (WCAG 4.1.3, issue #463).
+  test('keeps the live region mounted while there is no error', () => {
+    const el = renderBanner(null)
+    const region = el.querySelector('.command-error-banner')
+    expect(region).not.toBeNull()
+    expect(region?.getAttribute('role')).toBe('alert')
+    expect(region?.getAttribute('aria-live')).toBe('assertive')
+  })
+
+  test('reuses the same live region element when an error appears', () => {
+    const el = renderBanner(null)
+    const regionWhileHealthy = el.querySelector('.command-error-banner')
+    act(() => {
+      render(
+        <CommandErrorBanner error="unauthorized" onDismiss={() => {}} />,
+        container!,
+      )
+    })
+    expect(el.querySelector('.command-error-banner')).toBe(regionWhileHealthy)
+    expect(regionWhileHealthy?.textContent).toContain('unauthorized')
   })
 
   test('shows the error message when set', () => {

--- a/packages/streamwall-control-ui/src/CommandErrorBanner.tsx
+++ b/packages/streamwall-control-ui/src/CommandErrorBanner.tsx
@@ -23,6 +23,12 @@ const StyledCommandErrorBanner = styled.div`
  * Surfaces a control-server command error (e.g. `unauthorized`) that would
  * otherwise be dropped silently by callers that don't pass a response
  * callback to `send` (issue #35).
+ *
+ * The live region itself stays mounted while there is no error and only its
+ * contents are swapped: `aria-live` announcements are only reliable for
+ * changes inside a region that already exists in the accessibility tree, so
+ * mounting the region together with its first message risks losing exactly
+ * that first announcement (WCAG 4.1.3, issue #463).
  */
 export function CommandErrorBanner({
   error,
@@ -31,21 +37,21 @@ export function CommandErrorBanner({
   error: string | null
   onDismiss: () => void
 }) {
-  if (error == null) {
-    return null
-  }
-
   return (
     <StyledCommandErrorBanner
       className="command-error-banner"
       role="alert"
       aria-live="assertive"
     >
-      <FaExclamationTriangle />
-      <span>Action failed: {error}</span>
-      <button type="button" onClick={onDismiss}>
-        Dismiss
-      </button>
+      {error != null && (
+        <>
+          <FaExclamationTriangle />
+          <span>Action failed: {error}</span>
+          <button type="button" onClick={onDismiss}>
+            Dismiss
+          </button>
+        </>
+      )}
     </StyledCommandErrorBanner>
   )
 }

--- a/packages/streamwall-control-ui/src/ConnectionStatusBanner.test.tsx
+++ b/packages/streamwall-control-ui/src/ConnectionStatusBanner.test.tsx
@@ -29,9 +29,36 @@ function renderBanner(
 }
 
 describe('ConnectionStatusBanner', () => {
-  test('renders nothing while connected', () => {
+  test('renders no message while connected', () => {
     const el = renderBanner({ isConnected: true, reason: null })
-    expect(el.querySelector('[role="status"]')).toBeNull()
+    expect(
+      el.querySelector('[data-testid="connection-status-banner"]'),
+    ).toBeNull()
+    expect(el.textContent).toBe('')
+  })
+
+  // `aria-live` only guarantees an announcement for content that changes
+  // inside an already-present region, so the region stays mounted (empty)
+  // while healthy - otherwise the first disconnect can go unannounced
+  // (WCAG 4.1.3, issue #463).
+  test('keeps the live region mounted while connected', () => {
+    const el = renderBanner({ isConnected: true, reason: null })
+    const region = el.querySelector('[role="status"]')
+    expect(region).not.toBeNull()
+    expect(region?.getAttribute('aria-live')).toBe('polite')
+  })
+
+  test('reuses the same live region element across a disconnect', () => {
+    const el = renderBanner({ isConnected: true, reason: null })
+    const regionWhileConnected = el.querySelector('[role="status"]')
+    act(() => {
+      render(
+        <ConnectionStatusBanner isConnected={false} reason={null} />,
+        container!,
+      )
+    })
+    expect(el.querySelector('[role="status"]')).toBe(regionWhileConnected)
+    expect(regionWhileConnected?.textContent).toContain('reconnecting')
   })
 
   test('shows a generic reconnecting message with no reason', () => {
@@ -48,7 +75,7 @@ describe('ConnectionStatusBanner', () => {
 
   test('distinguishes an unauthorized session from a generic disconnect', () => {
     const el = renderBanner({ isConnected: false, reason: 'unauthorized' })
-    const banner = el.querySelector('[role="status"]')
+    const banner = el.querySelector('[data-testid="connection-status-banner"]')
     expect(banner?.textContent).toContain('Session invalid')
     expect(banner?.className).toContain('unauthorized')
   })
@@ -64,7 +91,7 @@ describe('ConnectionStatusBanner', () => {
 
   test('distinguishes a rate-limited connection from a generic disconnect', () => {
     const el = renderBanner({ isConnected: false, reason: 'rate-limited' })
-    const banner = el.querySelector('[role="status"]')
+    const banner = el.querySelector('[data-testid="connection-status-banner"]')
     expect(banner?.textContent).toContain('Too many messages')
     expect(banner?.className).toContain('rate-limited')
   })

--- a/packages/streamwall-control-ui/src/ConnectionStatusBanner.tsx
+++ b/packages/streamwall-control-ui/src/ConnectionStatusBanner.tsx
@@ -9,7 +9,13 @@ const StyledConnectionStatusBanner = styled.div`
   font-size: 12px;
   color: #e0a800;
 
-  &.unauthorized {
+  .connection-status-message {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .unauthorized {
     color: #dc3545;
   }
 `
@@ -29,6 +35,13 @@ const GENERIC_MESSAGE = 'Connection lost - reconnecting...'
  * banner is the explicit "why" that previously only a small header dot
  * hinted at - and it distinguishes an invalid session from the Streamwall
  * app itself being unreachable, rather than a single generic message.
+ *
+ * The live region itself stays mounted while connected and only its contents
+ * are swapped: `aria-live` announcements are only reliable for changes inside
+ * a region that already exists in the accessibility tree, so mounting the
+ * region together with its first message risks losing exactly that first
+ * announcement (WCAG 4.1.3, issue #463). The `data-testid` therefore sits on
+ * the message, which is still present only while disconnected.
  */
 export function ConnectionStatusBanner({
   isConnected,
@@ -37,18 +50,17 @@ export function ConnectionStatusBanner({
   isConnected: boolean
   reason: DisconnectReason | null | undefined
 }) {
-  if (isConnected) {
-    return null
-  }
-
   return (
-    <StyledConnectionStatusBanner
-      className={reason ?? undefined}
-      role="status"
-      data-testid="connection-status-banner"
-    >
-      <FaExclamationTriangle />
-      {reason ? MESSAGE_BY_REASON[reason] : GENERIC_MESSAGE}
+    <StyledConnectionStatusBanner role="status" aria-live="polite">
+      {!isConnected && (
+        <span
+          className={`connection-status-message ${reason ?? ''}`.trim()}
+          data-testid="connection-status-banner"
+        >
+          <FaExclamationTriangle />
+          {reason ? MESSAGE_BY_REASON[reason] : GENERIC_MESSAGE}
+        </span>
+      )}
     </StyledConnectionStatusBanner>
   )
 }

--- a/packages/streamwall-control-ui/src/DataSourceHealthBanner.test.tsx
+++ b/packages/streamwall-control-ui/src/DataSourceHealthBanner.test.tsx
@@ -30,6 +30,51 @@ describe('DataSourceHealthBanner', () => {
   test('renders nothing when there is no data source health yet', () => {
     const el = renderBanner([])
     expect(el.querySelector('.data-source-health-warning')).toBeNull()
+    expect(el.textContent).toBe('')
+  })
+
+  // `aria-live` only guarantees an announcement for content that changes
+  // inside an already-present region, so the region stays mounted (empty)
+  // while every source is healthy - otherwise the first outage can go
+  // unannounced (WCAG 4.1.3, issue #463).
+  test('keeps the live region mounted while every source is healthy', () => {
+    const el = renderBanner([
+      {
+        id: 'https://a.example/streams.json',
+        type: 'json-url',
+        status: 'ok',
+        message: null,
+        updatedAt: 1000,
+      },
+    ])
+    const region = el.querySelector('[role="status"]')
+    expect(region).not.toBeNull()
+    expect(region?.getAttribute('aria-live')).toBe('polite')
+  })
+
+  test('reuses the same live region element when a source starts failing', () => {
+    const el = renderBanner([])
+    const regionWhileHealthy = el.querySelector('[role="status"]')
+    act(() => {
+      render(
+        <DataSourceHealthBanner
+          dataSourceHealth={[
+            {
+              id: 'https://dead.example/streams.json',
+              type: 'json-url',
+              status: 'error',
+              message: 'fetch failed',
+              updatedAt: 1000,
+            },
+          ]}
+        />,
+        container!,
+      )
+    })
+    expect(el.querySelector('[role="status"]')).toBe(regionWhileHealthy)
+    expect(regionWhileHealthy?.textContent).toContain(
+      'https://dead.example/streams.json',
+    )
   })
 
   test('renders nothing when every data source is healthy', () => {

--- a/packages/streamwall-control-ui/src/DataSourceHealthBanner.tsx
+++ b/packages/streamwall-control-ui/src/DataSourceHealthBanner.tsx
@@ -26,6 +26,12 @@ const LABEL_BY_TYPE: Record<DataSourceHealth['type'], string> = {
  * Surfaces a dead `--data.json-url`/`--data.toml-file` in the control UI,
  * naming the failing source, so it's diagnosable without reading the log
  * (issue #85).
+ *
+ * The live region itself stays mounted while every source is healthy and only
+ * its contents are swapped: `aria-live` announcements are only reliable for
+ * changes inside a region that already exists in the accessibility tree, so
+ * mounting the region together with its first warning risks losing exactly
+ * that first announcement (WCAG 4.1.3, issue #463).
  */
 export function DataSourceHealthBanner({
   dataSourceHealth,
@@ -33,9 +39,6 @@ export function DataSourceHealthBanner({
   dataSourceHealth: DataSourceHealth[]
 }) {
   const failing = dataSourceHealth.filter((health) => health.status === 'error')
-  if (failing.length === 0) {
-    return null
-  }
 
   return (
     <StyledDataSourceHealthBanner role="status" aria-live="polite">

--- a/packages/streamwall-control-ui/src/disconnectRendering.test.tsx
+++ b/packages/streamwall-control-ui/src/disconnectRendering.test.tsx
@@ -182,8 +182,14 @@ describe('rendering across a disconnect', () => {
     )
   })
 
-  test('renders no banner while connected', () => {
+  // The live region stays mounted but empty while connected, so that the
+  // first disconnect is a content change inside an existing region and gets
+  // announced (WCAG 4.1.3, issue #463).
+  test('renders no banner message while connected', () => {
     const root = renderControlUI({ isConnected: true, disconnectReason: null })
-    expect(root.querySelector('[role="status"]')).toBeNull()
+    expect(
+      root.querySelector('[data-testid="connection-status-banner"]'),
+    ).toBeNull()
+    expect(root.querySelector('[role="status"]')?.textContent).toBe('')
   })
 })


### PR DESCRIPTION
## Summary

`ConnectionStatusBanner`, `DataSourceHealthBanner` and `CommandErrorBanner` all returned `null` in their healthy state, so their `aria-live` region was inserted into the DOM at the same moment its first message appeared. Screen readers only reliably announce changes *inside a region that already exists* in the accessibility tree, so the first command failure, disconnect, or data-source outage after a clean state could be dropped silently — exactly the announcement WCAG 4.1.3 cares about most. This is the follow-up to #398 / #458, which added the `role`/`aria-live` semantics themselves.

Each banner now always renders its live-region container and swaps only the inner content:

- `ConnectionStatusBanner` — persistent `role="status" aria-live="polite"` wrapper; the message (with `data-testid="connection-status-banner"` and the `unauthorized`/`rate-limited` colour class) is the conditional child. Moving the test id onto the message keeps the existing E2E assertion "banner is gone after reconnect" (`toHaveCount(0)`) meaningful.
- `DataSourceHealthBanner` — persistent `role="status" aria-live="polite"` wrapper; failing sources render as children, healthy state renders none.
- `CommandErrorBanner` — persistent `role="alert" aria-live="assertive"` wrapper; icon, message and dismiss button render only while an error is set.

### Architecture decisions

- **Per-banner persistent region** rather than a single hoisted shared region (the issue's alternative): the banners already own distinct politeness levels (`assertive` for a user-triggered command failure, `polite` for recoverable outages) and distinct visual styling, and a shared region would have to re-derive both.
- **No `:empty { display: none }`** — that would take the region out of the accessibility tree again and reintroduce the exact bug. An empty flex container is zero-height and the enclosing `Stack` sets no `gap`, so there is no visual or layout change.
- No new abstraction was introduced for three small components; the shared rationale lives in each component's doc comment.

## How was this tested?

- Red/green TDD: new unit tests per banner assert (a) the live region is mounted while healthy, with the right `aria-live` value, and (b) the *same* region element is reused across the healthy → failing transition (i.e. it is not remounted). All six failed before the change.
- Existing assertions that the healthy state renders nothing were tightened to "renders no message" (empty region, no test id) instead of "no region", in `ConnectionStatusBanner.test.tsx`, `CommandErrorBanner.test.tsx`, `DataSourceHealthBanner.test.tsx`, and `disconnectRendering.test.tsx`.
- `npm run lint`, `npx prettier --check .`, `npm run typecheck`, `npm test` all pass locally (777 + 321 + 320 + … tests green).
- Not verifiable in happy-dom: the actual screen reader announcement. As the issue notes, a manual VoiceOver/NVDA pass on a first-occurrence error is still worthwhile; the structural guarantee (region present before content changes) is what the tests lock in.

## Risks / breaking changes

None functional. The only externally visible change is that an empty `[role="status"]` / `.command-error-banner` element is now always present in the DOM — the `data-testid` used by E2E still appears only while disconnected.

Closes #463

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments
