### PR TITLE
fix(control-ui): send stable view ids from audio and blur hotkeys

### DIFF
--- a/packages/streamwall-control-ui/src/hooks/useControlHotkeys.test.tsx
+++ b/packages/streamwall-control-ui/src/hooks/useControlHotkeys.test.tsx
@@ -1,0 +1,178 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import type { ViewState } from 'streamwall-shared'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { hotkeyTriggers } from '../hotkeyLabel.ts'
+import type { ViewInfo } from '../streamwallState.tsx'
+import { useControlHotkeys } from './useControlHotkeys.ts'
+
+const useHotkeysMock = vi.hoisted(() => vi.fn())
+vi.mock('react-hotkeys-hook', () => ({
+  useHotkeys: useHotkeysMock,
+}))
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+  useHotkeysMock.mockClear()
+})
+
+function makeViewInfo(
+  id: number,
+  spaces: number[],
+  overrides: Partial<ViewInfo> = {},
+): ViewInfo {
+  const state: ViewState = {
+    state: {
+      displaying: {
+        running: {
+          playback: 'playing',
+          video: 'normal',
+          audio: 'muted',
+          pause: 'unpaused',
+          swap: 'idle',
+        },
+      },
+    },
+    context: {
+      id,
+      content: null,
+      info: null,
+      pos: { x: 0, y: 0, width: 1, height: 1, spaces },
+      error: null,
+      volume: 1,
+    },
+  }
+  return {
+    state,
+    isListening: false,
+    isBackgroundListening: false,
+    isBlurred: false,
+    volume: 1,
+    spaces,
+    ...overrides,
+  }
+}
+
+function renderHotkeys(stateIdxMap: Map<number, ViewInfo>) {
+  const handleSetListening = vi.fn<(viewId: number, on: boolean) => void>()
+  const handleSetBlurred = vi.fn<(viewId: number, on: boolean) => void>()
+  function Probe() {
+    useControlHotkeys({
+      stateIdxMap,
+      focusedInputIdx: undefined,
+      role: 'operator',
+      handleSetListening,
+      handleSetBlurred,
+      setStreamCensored: () => {},
+      handleSwapView: () => {},
+      undoManager: undefined,
+    })
+    return null
+  }
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    render(<Probe />, container!)
+  })
+  return { handleSetListening, handleSetBlurred }
+}
+
+/**
+ * Invokes the handler registered for the hotkey layer bound to `prefix`, as if
+ * `${prefix}+${key}` had been pressed.
+ */
+function pressHotkey(prefix: string, key: string) {
+  const expected = hotkeyTriggers.map((t) => `${prefix}+${t}`).join(',')
+  const call = useHotkeysMock.mock.calls.find(([keys]) => keys === expected)
+  if (!call) {
+    throw new Error(`no hotkey layer registered for prefix ${prefix}`)
+  }
+  const handler = call[1] as (
+    ev: { preventDefault: () => void },
+    opts: { hotkey: string },
+  ) => void
+  act(() => {
+    handler({ preventDefault: () => {} }, { hotkey: `${prefix}+${key}` })
+  })
+}
+
+describe('useControlHotkeys view addressing (#470)', () => {
+  // Cell index and view id are independent axes: `stateIdxMap` is keyed by grid
+  // cell, while `viewId` is the Electron `webContents.id`. The fixtures below
+  // deliberately keep the two apart so a regression cannot pass by coincidence.
+  test('audio-listen hotkey dispatches the view id, not the cell index', () => {
+    const stateIdxMap = new Map<number, ViewInfo>([
+      [0, makeViewInfo(42, [0])],
+      [1, makeViewInfo(43, [1])],
+    ])
+    const { handleSetListening } = renderHotkeys(stateIdxMap)
+
+    pressHotkey('alt', hotkeyTriggers[1])
+
+    expect(handleSetListening).toHaveBeenCalledWith(43, true)
+  })
+
+  test('audio-listen hotkey toggles off using the view id', () => {
+    const stateIdxMap = new Map<number, ViewInfo>([
+      [0, makeViewInfo(42, [0], { isListening: true })],
+    ])
+    const { handleSetListening } = renderHotkeys(stateIdxMap)
+
+    pressHotkey('alt', hotkeyTriggers[0])
+
+    expect(handleSetListening).toHaveBeenCalledWith(42, false)
+  })
+
+  test('second audio layer offsets by 20 cells and still sends the view id', () => {
+    const stateIdxMap = new Map<number, ViewInfo>([
+      [hotkeyTriggers.length, makeViewInfo(77, [hotkeyTriggers.length])],
+    ])
+    const { handleSetListening } = renderHotkeys(stateIdxMap)
+
+    pressHotkey('alt+ctrl', hotkeyTriggers[0])
+
+    expect(handleSetListening).toHaveBeenCalledWith(77, true)
+  })
+
+  test('blur hotkey dispatches the view id, not the cell index', () => {
+    const stateIdxMap = new Map<number, ViewInfo>([
+      [0, makeViewInfo(42, [0])],
+      [1, makeViewInfo(43, [1], { isBlurred: true })],
+    ])
+    const { handleSetBlurred } = renderHotkeys(stateIdxMap)
+
+    pressHotkey('alt+shift', hotkeyTriggers[1])
+
+    expect(handleSetBlurred).toHaveBeenCalledWith(43, false)
+  })
+
+  test('second blur layer offsets by 20 cells and still sends the view id', () => {
+    const stateIdxMap = new Map<number, ViewInfo>([
+      [
+        hotkeyTriggers.length + 2,
+        makeViewInfo(88, [hotkeyTriggers.length + 2]),
+      ],
+    ])
+    const { handleSetBlurred } = renderHotkeys(stateIdxMap)
+
+    pressHotkey('alt+ctrl+shift', hotkeyTriggers[2])
+
+    expect(handleSetBlurred).toHaveBeenCalledWith(88, true)
+  })
+
+  test('hotkeys for empty cells dispatch nothing', () => {
+    const { handleSetListening, handleSetBlurred } = renderHotkeys(new Map())
+
+    pressHotkey('alt', hotkeyTriggers[3])
+    pressHotkey('alt+shift', hotkeyTriggers[3])
+
+    expect(handleSetListening).not.toHaveBeenCalled()
+    expect(handleSetBlurred).not.toHaveBeenCalled()
+  })
+})

--- a/packages/streamwall-control-ui/src/hooks/useControlHotkeys.ts
+++ b/packages/streamwall-control-ui/src/hooks/useControlHotkeys.ts
@@ -30,16 +30,23 @@ export function useControlHotkeys({
   stateIdxMap: Map<number, ViewInfo>
   focusedInputIdx: number | undefined
   role: StreamwallRole | null
-  handleSetListening: (idx: number, listening: boolean) => void
-  handleSetBlurred: (idx: number, blurred: boolean) => void
+  handleSetListening: (viewId: number, listening: boolean) => void
+  handleSetBlurred: (viewId: number, blurred: boolean) => void
   setStreamCensored: (isCensored: boolean) => void
   handleSwapView: (idx: number) => void
   undoManager: Y.UndoManager | undefined
 }) {
+  // The hotkeys are addressed by grid cell, but the commands take a stable
+  // view id (`webContents.id`, see #397/#467) - resolve one into the other via
+  // the cell's view instead of passing the index through (issue #470). An
+  // empty cell has no view to toggle, so the keypress is a no-op.
   const toggleListening = useCallback(
     (idx: number) => {
-      const isListening = stateIdxMap.get(idx)?.isListening ?? false
-      handleSetListening(idx, !isListening)
+      const view = stateIdxMap.get(idx)
+      if (!view) {
+        return
+      }
+      handleSetListening(view.state.context.id, !view.isListening)
     },
     [stateIdxMap, handleSetListening],
   )
@@ -68,10 +75,14 @@ export function useControlHotkeys({
     { enableOnFormTags: true },
     [toggleListening],
   )
+  // Same cell-index -> view-id resolution as `toggleListening` above (#470).
   const toggleBlurred = useCallback(
     (idx: number) => {
-      const isBlurred = stateIdxMap.get(idx)?.isBlurred ?? false
-      handleSetBlurred(idx, !isBlurred)
+      const view = stateIdxMap.get(idx)
+      if (!view) {
+        return
+      }
+      handleSetBlurred(view.state.context.id, !view.isBlurred)
     },
     [stateIdxMap, handleSetBlurred],
   )


### PR DESCRIPTION
## Problem

The `alt+<key>` audio-listen and `alt+shift+<key>` blur hotkeys resolved the targeted view through `stateIdxMap`, which is keyed by **grid cell index**, and then passed that same index on to `handleSetListening` / `handleSetBlurred`. Since #397/#467 those commands take a **stable view id** (`view.webContents.id`, assigned by Electron and unrelated to cell position).

Pressing an audio or blur hotkey therefore addressed a view whose id happened to equal the cell index — usually no view at all, occasionally an unrelated one. The mouse/UI path was unaffected, so this was a silent keyboard-only regression in a core operator workflow.

## Solution

`useControlHotkeys` now resolves the view id from the `ViewInfo` it already looks up:

```ts
const view = stateIdxMap.get(idx)
if (!view) return
handleSetListening(view.state.context.id, !view.isListening)
```

Same for `toggleBlurred`. A hotkey on an empty cell is now a no-op instead of dispatching a command for a non-existent view (previously it sent `viewId: idx` with a `false` default state). The handler parameter names in the hook's prop types were renamed `idx` → `viewId` to match the command layer.

## Architecture notes

The two addressing axes stay separate on purpose: the hotkey layers keep mapping keys to grid cells (that is what the operator sees), and the translation to a view id happens at the boundary to the command layer — the same place the grid overlay does it via `state.context.id`. No change to `ViewInfo`'s shape was needed, so nothing else in the state pipeline moves.

## Testing

New `packages/streamwall-control-ui/src/hooks/useControlHotkeys.test.tsx` renders the hook with a mocked `react-hotkeys-hook`, captures the registered layer handlers and invokes them directly. Fixtures deliberately keep cell index and view id apart (cell 1 → id 43, cell 20 → id 77, …) so a regression cannot pass by coincidence. Covers: both audio layers, both blur layers, toggling off from an already-active state, and the empty-cell no-op. All six failed before the fix.

Full quality gate green locally: `format`, `lint`, `typecheck`, and the complete test suite (1594 tests across all packages).

## Risks

None known. Behavior change is limited to the two hotkey toggles; the empty-cell keypress going from "send a bogus command" to "do nothing" is the intended part of the fix.

Closes #470
