### PR TITLE
feat(control-ui): give the sidebar stream handle a keyboard path

### DIFF
--- a/packages/streamwall-control-ui/src/Sidebar.test.tsx
+++ b/packages/streamwall-control-ui/src/Sidebar.test.tsx
@@ -147,6 +147,124 @@ describe('StreamList', () => {
   })
 })
 
+describe('StreamList keyboard path', () => {
+  function renderHandle({
+    disabled = false,
+    onClickId = () => {},
+  }: {
+    disabled?: boolean
+    onClickId?: (id: string) => void
+  }): HTMLButtonElement {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      render(
+        <StreamList
+          rows={[baseRow({ _id: 'xyz' })]}
+          disabled={disabled}
+          onClickId={onClickId}
+          favorites={new Set()}
+        />,
+        container!,
+      )
+    })
+    return container.querySelector<HTMLButtonElement>(
+      '[aria-label="Add stream xyz to the wall"]',
+    )!
+  }
+
+  test('renders the id/drag handle as a focusable button', () => {
+    const handle = renderHandle({})
+
+    expect(handle.tagName).toBe('BUTTON')
+    expect(handle.type).toBe('button')
+    expect(handle.disabled).toBe(false)
+    expect(handle.getAttribute('tabindex')).not.toBe('-1')
+  })
+
+  test('marks the handle disabled so it drops out of the tab order', () => {
+    const handle = renderHandle({ disabled: true })
+
+    expect(handle.disabled).toBe(true)
+  })
+
+  for (const key of ['Enter', ' ']) {
+    test(`invokes onClickId when activated with ${key === ' ' ? 'Space' : key}`, () => {
+      const onClickId = vi.fn()
+      const handle = renderHandle({ onClickId })
+
+      const event = new KeyboardEvent('keydown', {
+        key,
+        bubbles: true,
+        cancelable: true,
+      })
+      act(() => {
+        handle.dispatchEvent(event)
+      })
+
+      expect(onClickId).toHaveBeenCalledWith('xyz')
+      // Suppress the browser's synthetic click so activation happens once.
+      expect(event.defaultPrevented).toBe(true)
+    })
+  }
+
+  test('ignores other keys', () => {
+    const onClickId = vi.fn()
+    const handle = renderHandle({ onClickId })
+
+    act(() => {
+      handle.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'a', bubbles: true }),
+      )
+    })
+
+    expect(onClickId).not.toHaveBeenCalled()
+  })
+
+  test('does not invoke onClickId on keydown when disabled', () => {
+    const onClickId = vi.fn()
+    const handle = renderHandle({ disabled: true, onClickId })
+
+    act(() => {
+      handle.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+      )
+    })
+
+    expect(onClickId).not.toHaveBeenCalled()
+  })
+
+  test('prevents the default mousedown focus shift so a destination grid input stays focused', () => {
+    const onClickId = vi.fn()
+    const handle = renderHandle({ onClickId })
+
+    const event = new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    })
+    act(() => {
+      handle.dispatchEvent(event)
+    })
+
+    expect(onClickId).toHaveBeenCalledWith('xyz')
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  test('activates only once for a full mouse press-and-release', () => {
+    const onClickId = vi.fn()
+    const handle = renderHandle({ onClickId })
+
+    act(() => {
+      handle.dispatchEvent(
+        new MouseEvent('mousedown', { bubbles: true, cancelable: true }),
+      )
+      handle.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(onClickId).toHaveBeenCalledTimes(1)
+  })
+})
+
 describe('StreamList accessible names', () => {
   test('gives the id/drag handle a descriptive accessible name', () => {
     container = document.createElement('div')
@@ -189,10 +307,10 @@ describe('StreamList favorites', () => {
       )
     })
 
-    const buttons = container.querySelectorAll('button')
-    expect(buttons).toHaveLength(2)
-    expect(buttons[0].textContent).toBe('★')
-    expect(buttons[1].textContent).toBe('☆')
+    const stars = container.querySelectorAll('button.favorite-star')
+    expect(stars).toHaveLength(2)
+    expect(stars[0].textContent).toBe('★')
+    expect(stars[1].textContent).toBe('☆')
   })
 
   test('invokes onToggleFavorite with the row link when the star is clicked, without triggering onClickId', () => {
@@ -213,9 +331,11 @@ describe('StreamList favorites', () => {
       )
     })
 
-    const button = container.querySelector('button') as HTMLButtonElement
+    const star = container.querySelector(
+      'button.favorite-star',
+    ) as HTMLButtonElement
     act(() => {
-      button.click()
+      star.click()
     })
 
     expect(onToggleFavorite).toHaveBeenCalledWith('https://example.com/a')
@@ -237,7 +357,7 @@ describe('StreamList favorites', () => {
       )
     })
 
-    expect(container.querySelector('button')).toBeNull()
+    expect(container.querySelector('button.favorite-star')).toBeNull()
   })
 })
 

--- a/packages/streamwall-control-ui/src/Sidebar.tsx
+++ b/packages/streamwall-control-ui/src/Sidebar.tsx
@@ -13,8 +13,9 @@ import { type ColorInstance } from './colorTypes.ts'
 import { LazyChangeInput } from './LazyChangeInput.tsx'
 import { OrientationIndicator } from './OrientationIndicator.tsx'
 
-const StyledId = styled.div<{ $color: ColorInstance; $disabled?: boolean }>`
+const StyledId = styled.button<{ $color: ColorInstance }>`
   flex-shrink: 0;
+  border: none;
   font-family: var(--font-mono);
   font-weight: 700;
   font-size: 11px;
@@ -26,7 +27,14 @@ const StyledId = styled.div<{ $color: ColorInstance; $disabled?: boolean }>`
   border-radius: var(--r-sm);
   width: 2.6em;
   text-align: center;
-  cursor: ${({ $disabled }) => ($disabled ? 'normal' : 'grab')};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: grab;
+
+  &:disabled {
+    cursor: default;
+  }
 `
 
 const StyledStreamLine = styled.div`
@@ -84,9 +92,30 @@ function StreamLine({
   onToggleFavorite?: (link: string) => void
 }) {
   // Use mousedown instead of click event so a potential destination grid input stays focused.
-  const handleMouseDownId = useCallback(() => {
-    onClickId(id)
-  }, [onClickId, id])
+  // preventDefault keeps the browser from moving focus to the button on press.
+  const handleMouseDownId = useCallback<
+    JSX.MouseEventHandler<HTMLButtonElement>
+  >(
+    (ev) => {
+      ev.preventDefault()
+      onClickId(id)
+    },
+    [onClickId, id],
+  )
+  // Keyboard users get the same action via Enter/Space. preventDefault suppresses
+  // the synthetic click the browser would otherwise fire, so activation happens once.
+  const handleKeyDownId = useCallback<
+    JSX.KeyboardEventHandler<HTMLButtonElement>
+  >(
+    (ev) => {
+      if (ev.key !== 'Enter' && ev.key !== ' ') {
+        return
+      }
+      ev.preventDefault()
+      onClickId(id)
+    },
+    [onClickId, id],
+  )
   const handleToggleFavoriteClick = useCallback<
     JSX.MouseEventHandler<HTMLButtonElement>
   >(
@@ -99,8 +128,10 @@ function StreamLine({
   return (
     <StyledStreamLine>
       <StyledId
-        $disabled={disabled}
+        type="button"
+        disabled={disabled}
         onMouseDown={disabled ? undefined : handleMouseDownId}
+        onKeyDown={disabled ? undefined : handleKeyDownId}
         $color={idColor(id)}
         aria-label={`Add stream ${id} to the wall`}
       >

--- a/packages/streamwall-control-ui/src/StreamList.test.tsx
+++ b/packages/streamwall-control-ui/src/StreamList.test.tsx
@@ -93,9 +93,9 @@ function renderControlUI(streams: StreamData[]): HTMLDivElement {
 }
 
 function findIdNode(root: HTMLDivElement, id: string): Element | undefined {
-  return [...root.querySelectorAll('.stream-list div')].find(
-    (el) => el.children.length === 0 && el.textContent === id,
-  )
+  return [
+    ...root.querySelectorAll('.stream-list div, .stream-list button'),
+  ].find((el) => el.children.length === 0 && el.textContent === id)
 }
 
 // The app re-renders <ControlUI connection={...} /> with a fresh `connection`


### PR DESCRIPTION
## Problem

The stream id/drag handle in the sidebar (`StyledId` in `Sidebar.tsx`) was a plain `<div onMouseDown=…>`. It was not focusable and offered no keyboard-operable way to place a stream on the wall, so the "add stream to wall" action was reachable with a pointer only — a WCAG 2.1.1 (Keyboard) failure for keyboard and switch-device users.

## Solution

- `StyledId` is now a real `<button type="button">` instead of a `div`.
- `onKeyDown` activates on `Enter`/`Space` and calls `preventDefault`, so the browser's synthetic click cannot activate the handle a second time.
- `onMouseDown` keeps the existing behaviour but now calls `preventDefault`, so pressing the handle does not move focus away from a destination grid input. `useGridCommands.handleClickId` resolves the target cell from `focusedInputIdx`, so that focus must survive the press.
- Disabled rows render a `disabled` button, which also removes the handle from the tab order (previously the handler was simply omitted).
- The badge keeps its previous layout by carrying `overflow: hidden` / `text-overflow: ellipsis` / `white-space: nowrap` explicitly — as a `div` it inherited those from the row's `& > div` rule.

## Architecture decisions

Native `<button>` over `role="button"` + `tabIndex={0}`: it gets focusability, the correct role, and disabled semantics for free. The mouse path stays on `mousedown` (not `click`) because the target-cell resolution depends on the grid input still being focused at press time.

## Testing

- New `StreamList keyboard path` suite in `Sidebar.test.tsx`: the handle is a focusable, non-disabled `<button type="button">`; `Enter` and `Space` invoke `onClickId` and prevent the default; other keys are ignored; disabled rows ignore keydown and render `disabled`; `mousedown` prevents the default focus shift; a full press-and-release activates exactly once.
- Existing selectors that assumed a `div` handle (`StreamList.test.tsx`) or the star being the only `<button>` in a row (`Sidebar.test.tsx` favorites) were narrowed.
- `npm run format` / `lint` / `typecheck` / `test` all green (322 tests).

## Risks

Visual only: as a `div`, the badge's own `color: #0a0d12` was overridden by the row's more specific `& > div { color: var(--text) }` rule. As a `button` the badge now renders with its intended dark-on-light text. Playwright E2E selectors are unaffected — the `add stream` submit-button lookups are scoped to the custom-stream form.

Closes #460