### PR TITLE
ci: build the web control client once per CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,17 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup
       - run: npm -w streamwall-control-client run build
+      # Hand the assets to the E2E job, whose control server serves the same
+      # `dist/`. Without this it runs `vite build` a second time in its own
+      # Playwright globalSetup. Kept for a day only — this is a CI handoff,
+      # not a release artifact.
+      - name: Upload control-client dist
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: control-client-dist
+          path: packages/streamwall-control-client/dist
+          if-no-files-found: error
+          retention-days: 1
 
   # Packaging smoke test for the Electron desktop app. Catches Vite/Forge
   # misconfiguration, native module unpacking (bufferutil, utf-8-validate)
@@ -150,9 +161,13 @@ jobs:
   # against a real control server + fake Streamwall uplink. Linux-only (the
   # Playwright browser install with system deps is Linux-only), so this stays
   # out of the cross-OS `test` matrix above.
+  #
+  # The client build comes from the `build` job as an artifact; the suite's
+  # globalSetup then skips its own `vite build` (see the env flag below), so
+  # a CI run builds the control client exactly once.
   e2e:
     name: E2E smoke (control client)
-    needs: changes
+    needs: [changes, build]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -161,9 +176,16 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
+      - name: Download control-client dist
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: control-client-dist
+          path: packages/streamwall-control-client/dist
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
       - name: Run E2E smoke tests
+        env:
+          STREAMWALL_E2E_SKIP_CLIENT_BUILD: '1'
         run: npm run test:e2e
 
   # Self-hosting smoke test: builds the control-server image the way

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,10 @@ npm run test:e2e                             # from the repo root
 
 The suite builds `streamwall-control-client` itself before the first test (a
 Playwright `globalSetup` hook, not the npm script), so the server has real
-`dist/` assets to serve — no separate build step is needed.
+`dist/` assets to serve — no separate build step is needed. Set
+`STREAMWALL_E2E_SKIP_CLIENT_BUILD=1` to reuse an existing `dist/` instead; CI
+does this and downloads the assets from the build job so a run builds the
+control client only once.
 
 ### Self-hosting image
 

--- a/packages/streamwall-control-e2e/tests/global-setup.ts
+++ b/packages/streamwall-control-e2e/tests/global-setup.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -7,12 +8,29 @@ import { fileURLToPath } from 'node:url'
  * has real `dist/` assets to serve. The build is spawned with `NODE_OPTIONS`
  * cleared so the harness's `--import tsx` loader can't interfere with Vite's
  * own config loading.
+ *
+ * CI sets `STREAMWALL_E2E_SKIP_CLIENT_BUILD=1` and supplies `dist/` from the
+ * build job's artifact instead, so a CI run builds the client only once. The
+ * assets are verified rather than assumed: a missing `index.html` would
+ * otherwise surface as a confusing 404 inside the browser tests.
  */
 export default function globalSetup() {
   const clientDir = path.resolve(
     fileURLToPath(new URL('.', import.meta.url)),
     '../../streamwall-control-client',
   )
+
+  if (process.env.STREAMWALL_E2E_SKIP_CLIENT_BUILD === '1') {
+    const entry = path.join(clientDir, 'dist/index.html')
+    if (!existsSync(entry)) {
+      throw new Error(
+        `STREAMWALL_E2E_SKIP_CLIENT_BUILD is set but ${entry} is missing. ` +
+          'Provide prebuilt control-client assets or unset the flag.',
+      )
+    }
+    return
+  }
+
   execFileSync('npm', ['run', 'build'], {
     cwd: clientDir,
     stdio: 'inherit',

--- a/test/ci-gate.test.mjs
+++ b/test/ci-gate.test.mjs
@@ -54,6 +54,64 @@ test('codeql.yml is reusable and does not run standalone on pull requests', () =
   )
 })
 
+// The control client is expensive to build, and the E2E job needs exactly the
+// artifact the build job already produced. Handing it over keeps CI down to a
+// single `vite build` per run (issue #489).
+test('the E2E job reuses the build job artifact instead of rebuilding', () => {
+  const ci = readWorkflow('ci.yml')
+  const distPath = 'packages/streamwall-control-client/dist'
+
+  const upload = ci.jobs.build.steps.find((step) =>
+    step.uses?.startsWith('actions/upload-artifact@'),
+  )
+  assert.ok(upload, 'the build job must upload the control-client dist')
+  assert.equal(upload.with.path, distPath)
+  assert.equal(
+    upload.with['if-no-files-found'],
+    'error',
+    'an empty upload would hand the E2E job nothing to serve',
+  )
+
+  assert.ok(
+    ci.jobs.e2e.needs.includes('build'),
+    'the E2E job must wait for the build job that produces its assets',
+  )
+
+  const download = ci.jobs.e2e.steps.find((step) =>
+    step.uses?.startsWith('actions/download-artifact@'),
+  )
+  assert.ok(download, 'the E2E job must download the control-client dist')
+  assert.equal(download.with.name, upload.with.name)
+  assert.equal(download.with.path, distPath)
+})
+
+// The E2E job only gets to skip its own build because the downloaded artifact
+// is already in place; the opt-out is an env var so local runs keep building.
+test('the E2E global setup honors the skip flag the E2E job sets', () => {
+  const ci = readWorkflow('ci.yml')
+  const runStep = ci.jobs.e2e.steps.find((step) =>
+    step.run?.includes('npm run test:e2e'),
+  )
+
+  assert.ok(runStep, 'the E2E job must run the E2E suite')
+  const flags = Object.keys(runStep.env ?? {})
+  assert.equal(
+    flags.length,
+    1,
+    'expected exactly one env flag on the E2E run step',
+  )
+  const [flag] = flags
+  assert.equal(runStep.env[flag], '1')
+
+  const globalSetup = readDoc(
+    'packages/streamwall-control-e2e/tests/global-setup.ts',
+  )
+  assert.ok(
+    globalSetup.includes(flag),
+    `global-setup.ts must read the ${flag} flag the workflow sets`,
+  )
+})
+
 // The documented list is what contributors and maintainers configure branch
 // protection from, so it has to name the checks the workflows actually report.
 test('CONTRIBUTING documents exactly the required status checks', () => {


### PR DESCRIPTION
## Problem

CI built `streamwall-control-client` twice per run: once in the **Build (web control client)** job and again inside the **E2E smoke** job, whose Playwright `globalSetup` runs `vite build` so the control server has `dist/` assets to serve. The jobs ran in parallel and shared nothing, so the second build was pure duplicated work (~30–40s of runner time per PR, plus a second chance to flake).

## Solution

- The `build` job uploads `packages/streamwall-control-client/dist` as a workflow artifact (`if-no-files-found: error`, 1-day retention — it is a CI handoff, not a release artifact).
- The `e2e` job now `needs: [changes, build]`, downloads that artifact into the same path, and sets `STREAMWALL_E2E_SKIP_CLIENT_BUILD=1`.
- `tests/global-setup.ts` skips its build when that flag is set, but verifies `dist/index.html` exists first and throws a clear error otherwise — a missing artifact would otherwise surface as confusing 404s inside the browser tests.
- Local runs are unchanged: without the flag, `globalSetup` builds as before.

### Decisions

- **Env flag, not a bare `dist/` existence check.** An existence check would silently reuse a stale local `dist/` forever; the flag keeps the local contract ("the suite builds for you") intact and makes CI's reuse explicit.
- **Kept the dedicated build job** rather than letting E2E be the build's proof — the issue's alternative — so build coverage survives even when the E2E job is skipped.
- E2E now waits on `build` instead of starting in parallel. Wall-clock cost is roughly the build it no longer runs itself; runner minutes drop.

## Testing

- `test/ci-gate.test.mjs` gained two tests (written first, confirmed failing): the upload/download pair must agree on artifact name and path and `e2e` must depend on `build`; and the env flag the workflow sets must be the one `global-setup.ts` actually reads — a drift guard in the spirit of the existing CONTRIBUTING check.
- Both `globalSetup` branches exercised locally: with the flag and no `dist/` it throws the explicit error; with prebuilt assets it returns without building.
- Full E2E suite run locally with `STREAMWALL_E2E_SKIP_CLIENT_BUILD=1` against a prebuilt `dist/`: 16 passed.
- `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` all green.

## Risks

Low, and CI-only. If the artifact were ever missing, the E2E job fails fast with an explicit message instead of running against an empty document root.

Closes #489