### PR TITLE
ci: fail the weekly build on deprecated direct dependencies

### DIFF
--- a/.github/deprecated-dependencies-allowlist.json
+++ b/.github/deprecated-dependencies-allowlist.json
@@ -1,0 +1,4 @@
+{
+  "$comment": "Direct dependencies whose npm deprecation is knowingly tolerated while a migration is planned, so the weekly deprecation check (.github/workflows/deprecated-deps.yml) stays actionable instead of permanently red. Every entry needs a reason and a tracking issue; entries that no longer apply are reported as stale and must be dropped.",
+  "allow": []
+}

--- a/.github/workflows/deprecated-deps.yml
+++ b/.github/workflows/deprecated-deps.yml
@@ -1,0 +1,48 @@
+name: Deprecated dependencies
+
+# Asks the npm registry whether any *direct* dependency of the workspace root
+# or of a workspace has been marked deprecated, and fails the run if one has
+# (#494). `npm ci` already prints those notices, but they scroll past in the
+# install log without failing or annotating anything, and Dependabot only
+# opens PRs for version bumps and advisories — never for a package that was
+# simply abandoned. That is how `dank-twitch-irc` stayed in the tree long
+# after its maintainer had announced it would receive no further updates
+# (#406).
+#
+# Deliberately not part of PR CI: an upstream deprecation lands independently
+# of any change here, so gating PRs on it would block unrelated work on
+# someone else's release, and every run costs a registry round-trip per
+# dependency. Weekly is early enough — the point is to learn about an
+# abandoned package while migrating off it is still cheap.
+on:
+  schedule:
+    # Mondays, 06:23 UTC — after the packaging workflow and off the hour, to
+    # avoid GitHub's scheduling peak.
+    - cron: '23 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deprecated-deps-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Check direct dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # No `npm ci`: the check reads the committed manifests and lockfile and
+      # queries the registry directly, so the install would only add minutes.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Check for deprecated direct dependencies
+        run: node scripts/check-deprecated-deps.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ changelog are kept in step.
 - Stop HLS segment loading for parked views to save bandwidth (#424).
 - Weekly cross-platform packaging workflow that runs `electron-forge make`, so
   maker regressions surface before a release instead of during one (#425).
+- Weekly check that fails when a direct dependency is marked deprecated on npm,
+  with an allowlist for deprecations whose migration is already tracked (#494).
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,11 +150,13 @@ Adding a job to `ci.yml` therefore also means adding it to the `ci-ok` gate's
 `needs:` list; `test/ci-gate.test.mjs` fails if that is forgotten, and it also
 keeps this list in sync with the workflows.
 
-Two things intentionally sit outside this gate: `.github/workflows/release.yml`
-(tag-triggered) and CodeQL's weekly scheduled scan, which surfaces newly
-disclosed patterns in code that was already merged. Open code-scanning alerts
-are triaged in the Security tab; the gate blocks on the analysis _failing_, not
-on pre-existing alerts.
+Some workflows intentionally sit outside this gate: `.github/workflows/release.yml`
+(tag-triggered), CodeQL's weekly scheduled scan, which surfaces newly
+disclosed patterns in code that was already merged, and the weekly
+[packaging](#packaging-checks) and [deprecation](#dependency-deprecations)
+checks, which react to upstream changes rather than to anything in a PR. Open
+code-scanning alerts are triaged in the Security tab; the gate blocks on the
+analysis _failing_, not on pre-existing alerts.
 
 ### PR checklist
 
@@ -223,6 +225,28 @@ by `.github/workflows/packaging.yml`, which runs `electron-forge make` across
 all three platforms every Monday and on manual dispatch. Run it from the
 Actions tab (optionally with the `debug` input for verbose Forge logging)
 before cutting a release, or after a Forge/maker dependency bump.
+
+### Dependency deprecations
+
+`.github/workflows/deprecated-deps.yml` asks the npm registry every Monday
+whether any _direct_ dependency — of the root manifest or of a workspace — has
+been marked `deprecated`, and fails the run if one has. `npm ci` prints those
+notices too, but they scroll past in the install log, and Dependabot only opens
+PRs for version bumps and advisories, never for an abandoned package. Run it
+from the Actions tab, or locally:
+
+```sh
+node scripts/check-deprecated-deps.mjs
+```
+
+The script reads the committed manifests and `package-lock.json`, so it needs
+no install. Transitive dependencies are deliberately not inspected: those
+deprecations are frequent and rarely actionable from here.
+
+When a deprecation cannot be migrated away from right now, add the package to
+`.github/deprecated-dependencies-allowlist.json` with a reason and a tracking
+issue, so the job stays actionable instead of permanently red. Allowlist
+entries that no longer apply are reported as warnings and should be dropped.
 
 ### Changelog
 

--- a/scripts/check-deprecated-deps.mjs
+++ b/scripts/check-deprecated-deps.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+// Fails when a *direct* dependency of the workspace root or of any workspace
+// carries a `deprecated` field on the npm registry (#494). `npm ci` prints
+// those notices, but they scroll past in the install log without failing or
+// annotating anything — which is why `dank-twitch-irc` stayed abandoned for a
+// long time before it was noticed by chance (#406).
+//
+// Only direct dependencies are inspected: transitive deprecations are frequent
+// and rarely actionable from here, so including them would make the check
+// noisy enough to be ignored.
+//
+// The dependency list comes from the manifests plus package-lock.json rather
+// than from `npm ls`. Both are committed, so the check needs no install, and
+// `npm ls` would additionally report the *installed* tree — which in a git
+// worktree nested inside the main checkout is polluted with extraneous
+// packages resolved from the parent's node_modules.
+import { execFile } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)))
+
+export const ALLOWLIST_PATH = '.github/deprecated-dependencies-allowlist.json'
+
+const DEPENDENCY_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+]
+
+// npm only ever nests a dependency directly under the workspace that pins it,
+// so a hoisted install is the single fallback.
+function lockfileEntry(lockfile, workspacePath, name) {
+  const candidates = workspacePath
+    ? [`${workspacePath}/node_modules/${name}`, `node_modules/${name}`]
+    : [`node_modules/${name}`]
+  for (const candidate of candidates) {
+    const entry = lockfile.packages?.[candidate]
+    if (entry) {
+      return entry
+    }
+  }
+  return undefined
+}
+
+export function collectDirectDependencies({ manifests, lockfile }) {
+  const byKey = new Map()
+
+  for (const { path: workspacePath, manifest } of manifests) {
+    const dependent = workspacePath || '.'
+    const declared = DEPENDENCY_FIELDS.flatMap((field) =>
+      Object.keys(manifest[field] ?? {}),
+    )
+
+    for (const name of declared) {
+      const entry = lockfileEntry(lockfile, workspacePath, name)
+      if (!entry) {
+        throw new Error(
+          `${dependent} depends on "${name}", which has no entry in ` +
+            'package-lock.json — run `npm install` to sync the lockfile.',
+        )
+      }
+      // A link points at another workspace in this repo: there is no registry
+      // entry to ask about.
+      if (entry.link) {
+        continue
+      }
+
+      const key = `${name}@${entry.version}`
+      const collected = byKey.get(key)
+      if (collected) {
+        if (!collected.dependents.includes(dependent)) {
+          collected.dependents.push(dependent)
+        }
+      } else {
+        byKey.set(key, {
+          name,
+          version: entry.version,
+          dependents: [dependent],
+        })
+      }
+    }
+  }
+
+  return [...byKey.values()].sort(
+    (a, b) =>
+      a.name.localeCompare(b.name) || a.version.localeCompare(b.version),
+  )
+}
+
+export function parseAllowlist(data) {
+  if (!Array.isArray(data?.allow)) {
+    throw new Error(`${ALLOWLIST_PATH} must contain an "allow" array.`)
+  }
+
+  const allowlist = new Map()
+  for (const entry of data.allow) {
+    for (const field of ['package', 'reason', 'issue']) {
+      if (typeof entry?.[field] !== 'string' || entry[field].trim() === '') {
+        throw new Error(
+          `${ALLOWLIST_PATH}: every entry needs a non-empty "${field}" ` +
+            `(offending entry: ${JSON.stringify(entry)}).`,
+        )
+      }
+    }
+    if (allowlist.has(entry.package)) {
+      throw new Error(`${ALLOWLIST_PATH}: "${entry.package}" is listed twice.`)
+    }
+    allowlist.set(entry.package, entry)
+  }
+  return allowlist
+}
+
+export async function fetchDeprecations(
+  dependencies,
+  { concurrency = 8, lookUp = lookUpDeprecation } = {},
+) {
+  const deprecations = new Map()
+  const queue = [...dependencies]
+
+  async function worker() {
+    for (let next = queue.shift(); next; next = queue.shift()) {
+      try {
+        deprecations.set(`${next.name}@${next.version}`, await lookUp(next))
+      } catch (error) {
+        // Left unset on purpose: a failed lookup is reported as unchecked
+        // rather than silently passing as "not deprecated".
+        console.warn(
+          `Registry lookup for ${next.name}@${next.version} failed: ${error.message}`,
+        )
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, queue.length) }, worker),
+  )
+  return deprecations
+}
+
+// `npm view <name>@<exact-version> deprecated --json` prints the deprecation
+// message, or nothing at all when the version is current.
+async function lookUpDeprecation({ name, version }) {
+  const { stdout } = await execFileAsync(
+    'npm',
+    ['view', `${name}@${version}`, 'deprecated', '--json'],
+    { cwd: rootDir },
+  )
+  const trimmed = stdout.trim()
+  return trimmed === '' ? null : JSON.parse(trimmed)
+}
+
+export function evaluateDeprecations({
+  dependencies,
+  deprecations,
+  allowlist,
+}) {
+  const violations = []
+  const tolerated = []
+  const unchecked = []
+  const applied = new Set()
+
+  for (const dependency of dependencies) {
+    const key = `${dependency.name}@${dependency.version}`
+    if (!deprecations.has(key)) {
+      unchecked.push(dependency)
+      continue
+    }
+    const message = deprecations.get(key)
+    if (!message) {
+      continue
+    }
+
+    const allowance = allowlist.get(dependency.name)
+    if (allowance) {
+      applied.add(dependency.name)
+      tolerated.push({ ...dependency, message, allowance })
+    } else {
+      violations.push({ ...dependency, message })
+    }
+  }
+
+  const stale = [...allowlist.values()].filter(
+    (entry) => !applied.has(entry.package),
+  )
+  return { violations, tolerated, stale, unchecked }
+}
+
+export function formatReport({ violations, tolerated, stale, unchecked }) {
+  const lines = []
+
+  for (const { name, version, dependents, message } of violations) {
+    lines.push(
+      `::error::${name}@${version} is deprecated on npm (required by ` +
+        `${dependents.join(', ')}): ${message}`,
+    )
+  }
+  for (const { name, version, allowance } of tolerated) {
+    lines.push(
+      `::notice::${name}@${version} is deprecated but allowlisted: ` +
+        `${allowance.reason} (${allowance.issue})`,
+    )
+  }
+  for (const entry of stale) {
+    lines.push(
+      `::warning::${ALLOWLIST_PATH} still allows "${entry.package}", which is ` +
+        'no longer a deprecated direct dependency — drop the entry.',
+    )
+  }
+  for (const { name, version } of unchecked) {
+    lines.push(
+      `::error::Could not determine whether ${name}@${version} is deprecated.`,
+    )
+  }
+
+  lines.push(
+    violations.length === 0 && unchecked.length === 0
+      ? 'No deprecated direct dependencies.'
+      : `${violations.length} deprecated direct ${
+          violations.length === 1 ? 'dependency' : 'dependencies'
+        }, ${unchecked.length} unchecked.`,
+  )
+  return lines.join('\n')
+}
+
+function readJson(relativePath) {
+  return JSON.parse(readFileSync(join(rootDir, relativePath), 'utf8'))
+}
+
+function readManifests() {
+  const root = readJson('package.json')
+  return [
+    { path: '', manifest: root },
+    ...root.workspaces.map((workspace) => ({
+      path: workspace,
+      manifest: readJson(join(workspace, 'package.json')),
+    })),
+  ]
+}
+
+async function main() {
+  const dependencies = collectDirectDependencies({
+    manifests: readManifests(),
+    lockfile: readJson('package-lock.json'),
+  })
+  console.log(`Checking ${dependencies.length} direct dependencies…`)
+
+  const result = evaluateDeprecations({
+    dependencies,
+    deprecations: await fetchDeprecations(dependencies),
+    allowlist: parseAllowlist(readJson(ALLOWLIST_PATH)),
+  })
+
+  console.log(formatReport(result))
+  if (result.violations.length > 0 || result.unchecked.length > 0) {
+    process.exitCode = 1
+  }
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  await main()
+}

--- a/test/check-deprecated-deps.test.mjs
+++ b/test/check-deprecated-deps.test.mjs
@@ -1,0 +1,344 @@
+import { load } from 'js-yaml'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import {
+  ALLOWLIST_PATH,
+  collectDirectDependencies,
+  evaluateDeprecations,
+  fetchDeprecations,
+  formatReport,
+  parseAllowlist,
+} from '../scripts/check-deprecated-deps.mjs'
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)))
+
+function readJson(relativePath) {
+  return JSON.parse(readFileSync(join(rootDir, relativePath), 'utf8'))
+}
+
+test('collectDirectDependencies resolves declared ranges to locked versions', () => {
+  const dependencies = collectDirectDependencies({
+    manifests: [
+      { path: '', manifest: { devDependencies: { prettier: '^3.9.5' } } },
+      { path: 'packages/app', manifest: { dependencies: { luxon: '^3.7.2' } } },
+    ],
+    lockfile: {
+      packages: {
+        'node_modules/prettier': { version: '3.9.5' },
+        'node_modules/luxon': { version: '3.7.2' },
+      },
+    },
+  })
+
+  assert.deepEqual(dependencies, [
+    { name: 'luxon', version: '3.7.2', dependents: ['packages/app'] },
+    { name: 'prettier', version: '3.9.5', dependents: ['.'] },
+  ])
+})
+
+test('collectDirectDependencies covers optional dependencies too', () => {
+  const dependencies = collectDirectDependencies({
+    manifests: [
+      { path: '', manifest: { optionalDependencies: { fsevents: '^2.3.3' } } },
+    ],
+    lockfile: { packages: { 'node_modules/fsevents': { version: '2.3.3' } } },
+  })
+
+  assert.deepEqual(dependencies, [
+    { name: 'fsevents', version: '2.3.3', dependents: ['.'] },
+  ])
+})
+
+test('collectDirectDependencies merges the dependents of a shared version', () => {
+  const dependencies = collectDirectDependencies({
+    manifests: [
+      { path: 'packages/a', manifest: { dependencies: { luxon: '^3.7.2' } } },
+      { path: 'packages/b', manifest: { dependencies: { luxon: '^3.0.0' } } },
+    ],
+    lockfile: { packages: { 'node_modules/luxon': { version: '3.7.2' } } },
+  })
+
+  assert.deepEqual(dependencies, [
+    {
+      name: 'luxon',
+      version: '3.7.2',
+      dependents: ['packages/a', 'packages/b'],
+    },
+  ])
+})
+
+// A workspace that pins its own copy installs it under its own node_modules,
+// and that copy — not the hoisted one — is what the deprecation notice applies
+// to, so both versions have to be queried.
+test('collectDirectDependencies prefers a nested install over the hoisted one', () => {
+  const dependencies = collectDirectDependencies({
+    manifests: [
+      { path: '', manifest: { devDependencies: { nanoid: '^5.1.6' } } },
+      { path: 'packages/a', manifest: { dependencies: { nanoid: '^3.3.11' } } },
+    ],
+    lockfile: {
+      packages: {
+        'node_modules/nanoid': { version: '5.1.6' },
+        'packages/a/node_modules/nanoid': { version: '3.3.11' },
+      },
+    },
+  })
+
+  assert.deepEqual(dependencies, [
+    { name: 'nanoid', version: '3.3.11', dependents: ['packages/a'] },
+    { name: 'nanoid', version: '5.1.6', dependents: ['.'] },
+  ])
+})
+
+test('collectDirectDependencies skips workspace-internal links', () => {
+  const dependencies = collectDirectDependencies({
+    manifests: [
+      {
+        path: 'packages/app',
+        manifest: { dependencies: { 'streamwall-shared': '^0.0.0' } },
+      },
+    ],
+    lockfile: {
+      packages: {
+        'node_modules/streamwall-shared': {
+          resolved: 'packages/streamwall-shared',
+          link: true,
+        },
+      },
+    },
+  })
+
+  assert.deepEqual(dependencies, [])
+})
+
+test('collectDirectDependencies rejects a dependency missing from the lockfile', () => {
+  assert.throws(
+    () =>
+      collectDirectDependencies({
+        manifests: [
+          { path: '', manifest: { dependencies: { ghost: '^1.0.0' } } },
+        ],
+        lockfile: { packages: {} },
+      }),
+    /ghost.*package-lock\.json/s,
+  )
+})
+
+test('parseAllowlist indexes tolerated deprecations by package name', () => {
+  const allowlist = parseAllowlist({
+    allow: [
+      {
+        package: 'dank-twitch-irc',
+        reason: 'Migration in progress',
+        issue: 'https://github.com/NilsR0711/streamwall/issues/406',
+      },
+    ],
+  })
+
+  assert.deepEqual([...allowlist.keys()], ['dank-twitch-irc'])
+  assert.equal(allowlist.get('dank-twitch-irc').reason, 'Migration in progress')
+})
+
+test('parseAllowlist accepts an empty allowlist', () => {
+  assert.equal(parseAllowlist({ allow: [] }).size, 0)
+})
+
+test('parseAllowlist rejects a missing "allow" array', () => {
+  assert.throws(() => parseAllowlist({}), /"allow" array/)
+})
+
+test('parseAllowlist rejects an entry without a tracking issue', () => {
+  assert.throws(
+    () => parseAllowlist({ allow: [{ package: 'foo', reason: 'later' }] }),
+    /"issue"/,
+  )
+})
+
+test('parseAllowlist rejects an entry without a reason', () => {
+  assert.throws(
+    () => parseAllowlist({ allow: [{ package: 'foo', issue: 'https://x/1' }] }),
+    /"reason"/,
+  )
+})
+
+test('parseAllowlist rejects duplicate packages', () => {
+  assert.throws(
+    () =>
+      parseAllowlist({
+        allow: [
+          { package: 'foo', reason: 'a', issue: 'https://x/1' },
+          { package: 'foo', reason: 'b', issue: 'https://x/2' },
+        ],
+      }),
+    /listed twice/,
+  )
+})
+
+const luxon = { name: 'luxon', version: '3.7.2', dependents: ['.'] }
+const abandoned = { name: 'abandoned', version: '1.0.0', dependents: ['.'] }
+
+test('evaluateDeprecations reports a deprecated dependency as a violation', () => {
+  const result = evaluateDeprecations({
+    dependencies: [luxon, abandoned],
+    deprecations: new Map([
+      ['luxon@3.7.2', null],
+      ['abandoned@1.0.0', 'no longer maintained'],
+    ]),
+    allowlist: new Map(),
+  })
+
+  assert.deepEqual(result.violations, [
+    { ...abandoned, message: 'no longer maintained' },
+  ])
+  assert.deepEqual(result.tolerated, [])
+  assert.deepEqual(result.stale, [])
+})
+
+test('evaluateDeprecations downgrades an allowlisted deprecation', () => {
+  const entry = {
+    package: 'abandoned',
+    reason: 'Migration tracked',
+    issue: 'https://x/1',
+  }
+  const result = evaluateDeprecations({
+    dependencies: [abandoned],
+    deprecations: new Map([['abandoned@1.0.0', 'no longer maintained']]),
+    allowlist: new Map([['abandoned', entry]]),
+  })
+
+  assert.deepEqual(result.violations, [])
+  assert.deepEqual(result.tolerated, [
+    { ...abandoned, message: 'no longer maintained', allowance: entry },
+  ])
+  assert.deepEqual(result.stale, [])
+})
+
+// An allowlist entry that outlives the migration it covers would silently
+// tolerate a future deprecation of the same package.
+test('evaluateDeprecations reports an allowance that no longer applies as stale', () => {
+  const entry = { package: 'gone', reason: 'Migration', issue: 'https://x/1' }
+  const result = evaluateDeprecations({
+    dependencies: [luxon],
+    deprecations: new Map([['luxon@3.7.2', null]]),
+    allowlist: new Map([['gone', entry]]),
+  })
+
+  assert.deepEqual(result.stale, [entry])
+  assert.deepEqual(result.violations, [])
+})
+
+test('evaluateDeprecations reports a dependency without a registry answer as unchecked', () => {
+  const result = evaluateDeprecations({
+    dependencies: [luxon],
+    deprecations: new Map(),
+    allowlist: new Map(),
+  })
+
+  assert.equal(result.violations.length, 0)
+  assert.deepEqual(result.unchecked, [luxon])
+})
+
+test('formatReport annotates violations as errors and stale allowances as warnings', () => {
+  const report = formatReport({
+    violations: [{ ...abandoned, message: 'no longer maintained' }],
+    tolerated: [],
+    stale: [{ package: 'gone', reason: 'Migration', issue: 'https://x/1' }],
+    unchecked: [],
+  })
+
+  assert.match(report, /^::error::.*abandoned@1\.0\.0.*no longer maintained/m)
+  assert.match(report, /^::warning::.*gone/m)
+})
+
+test('formatReport reports an all-clear run without annotations', () => {
+  const report = formatReport({
+    violations: [],
+    tolerated: [],
+    stale: [],
+    unchecked: [],
+  })
+
+  assert.doesNotMatch(report, /^::(error|warning)::/m)
+})
+
+test('formatReport names the allowlist entry behind a tolerated deprecation', () => {
+  const report = formatReport({
+    violations: [],
+    tolerated: [
+      {
+        ...abandoned,
+        message: 'no longer maintained',
+        allowance: {
+          package: 'abandoned',
+          reason: 'Migration tracked',
+          issue: 'https://x/1',
+        },
+      },
+    ],
+    stale: [],
+    unchecked: [],
+  })
+
+  assert.match(report, /^::notice::.*abandoned.*Migration tracked/m)
+})
+
+test('fetchDeprecations keys registry answers by name and version', async () => {
+  const deprecations = await fetchDeprecations([luxon, abandoned], {
+    concurrency: 2,
+    lookUp: async ({ name, version }) =>
+      name === 'abandoned' ? `${name}@${version} is dead` : null,
+  })
+
+  assert.deepEqual(
+    [...deprecations.entries()].sort(),
+    [
+      ['abandoned@1.0.0', 'abandoned@1.0.0 is dead'],
+      ['luxon@3.7.2', null],
+    ].sort(),
+  )
+})
+
+// A registry error must not read as "not deprecated": the entry is left out,
+// which `evaluateDeprecations` surfaces as an unchecked dependency.
+test('fetchDeprecations omits dependencies whose lookup failed', async () => {
+  const deprecations = await fetchDeprecations([luxon, abandoned], {
+    concurrency: 1,
+    lookUp: async ({ name }) => {
+      if (name === 'luxon') {
+        throw new Error('registry unreachable')
+      }
+      return null
+    },
+  })
+
+  assert.deepEqual([...deprecations.keys()], ['abandoned@1.0.0'])
+})
+
+test('the committed allowlist is valid', () => {
+  assert.doesNotThrow(() => parseAllowlist(readJson(ALLOWLIST_PATH)))
+})
+
+test('the deprecation check runs on a schedule and can be dispatched manually', () => {
+  const workflow = load(
+    readFileSync(
+      join(rootDir, '.github/workflows/deprecated-deps.yml'),
+      'utf8',
+    ),
+  )
+  const triggers = Object.keys(workflow.on)
+
+  assert.ok(triggers.includes('schedule'), 'must run on a schedule')
+  assert.ok(
+    triggers.includes('workflow_dispatch'),
+    'must be dispatchable so a migration can be verified on demand',
+  )
+  assert.ok(
+    !triggers.includes('pull_request'),
+    'must not run on pull requests: an upstream deprecation would then block ' +
+      'every unrelated change',
+  )
+})


### PR DESCRIPTION
## Summary

`npm ci` prints npm's deprecation notices, but they scroll past in the install
log without failing or annotating anything, and Dependabot only opens PRs for
version bumps and advisories — never for a package that was simply abandoned.
That is how `dank-twitch-irc` stayed in the tree long after its maintainer had
announced it would receive no further dependency or security updates (#406),
and it was only noticed by chance during an unrelated audit.

This adds a check that surfaces that on its own, while migrating is still cheap.

**`scripts/check-deprecated-deps.mjs`**

- Resolves the *direct* dependencies of the root manifest and of every
  workspace (`dependencies`, `devDependencies`, `optionalDependencies`) to
  their locked versions, then asks the registry
  (`npm view <name>@<version> deprecated --json`) about each one.
- Transitive dependencies are deliberately out of scope: those deprecations are
  frequent, rarely actionable from here, and would make the check noisy enough
  to be ignored.
- Exits non-zero on any deprecation that is not allowlisted, and on any
  dependency whose registry lookup failed — a failed lookup must not read as
  "not deprecated".

**`.github/workflows/deprecated-deps.yml`** — Mondays 06:23 UTC plus manual
dispatch, mirroring the weekly packaging workflow (#425).

**`.github/deprecated-dependencies-allowlist.json`** — currently empty.
Deprecations whose migration is already tracked can be parked here; every entry
requires a `reason` and an `issue`, and entries that no longer apply are
reported as stale warnings so the file does not silently accumulate.

## Architecture decisions

- **Manifests + `package-lock.json` instead of `npm ls`.** The issue suggested
  `npm ls --json --depth 0 --workspaces`. That reports the *installed* tree,
  which flattens workspace links in with real dependencies and — in a git
  worktree nested inside the main checkout — is polluted with `extraneous`
  packages resolved from the parent's `node_modules` (verified locally). The
  committed manifests plus the lockfile are the install-independent source of
  truth, so the workflow can skip `npm ci` entirely and runs in seconds.
- **Nested installs are queried separately.** A workspace that pins its own
  copy of a package installs it under its own `node_modules`; the deprecation
  notice applies to that exact version, so both it and the hoisted one are
  looked up.
- **Outside the `ci-ok` gate.** An upstream deprecation lands independently of
  any change in a PR, so gating PRs on it would block unrelated work on someone
  else's release, and each run costs a registry round-trip per dependency.

## How was this tested?

- New `test/check-deprecated-deps.test.mjs` (23 cases, `node --test`) covers
  dependency collection (hoisted vs. nested installs, shared versions, optional
  deps, workspace links, lockfile drift), allowlist validation (missing
  `allow`, missing `reason`/`issue`, duplicates), the evaluation verdicts
  (violation / tolerated / stale / unchecked), report formatting, and the
  lookup pool — including that a failing lookup is omitted rather than counted
  as clean. It also asserts the committed allowlist parses and that the
  workflow is scheduled + dispatchable but not `pull_request`-triggered.
- Ran the script against the real registry: 84 direct dependencies, ~6s, clean.
- Verified detection end-to-end against two known-deprecated packages
  (`request@2.88.2`, `dank-twitch-irc@4.2.0`) — both reported as `::error::`
  with the registry's message.
- `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm test`, and
  `actionlint` all pass locally.

## Risks

Low: nothing in the PR gate changes. Worst case the weekly job is red on a
deprecation that cannot be acted on immediately, which the allowlist covers.

Closes #494

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests (or this PR explains why none apply)
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments
