### PR TITLE
fix(deps): bump transitive fast-uri to 3.1.4 to patch host confusion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9695,9 +9695,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Problem

Dependabot alert #22 (high) is open on `main`: `fast-uri` before 3.1.3 is vulnerable to host confusion via failed IDN canonicalization (GHSA-4c8g-83qw-93j6). The package is not a direct dependency — it enters the tree exclusively through Fastify's schema-compilation stack in `streamwall-control-server` (`@fastify/ajv-compiler`, `ajv`, `ajv-formats`, `fast-json-stringify`) and through `ajv` in the packaging tooling.

## Solution

`npm update fast-uri` resolves the patched 3.1.4 inside the existing `^3` ranges declared by those dependents, so the fix is a lockfile-only bump. No `overrides` entry is required — an override would only pin what semver already selects and would add maintenance noise the next time the range moves.

`npm audit` now reports 0 vulnerabilities; every `fast-uri` node in the tree resolves to 3.1.4.

## Testing

No tests were added: this is a dependency lockfile bump with no behavior of ours to exercise. Verified locally:

- `npm run format:check`, `npm run lint`, `npm run typecheck` — clean
- `npm test` — all workspaces green
- `npm audit` — 0 vulnerabilities
- `npm ls fast-uri` — all nodes at 3.1.4

## Risks

Patch-level bump of a transitive URI parser; no API surface change. The alert should close automatically once this lands on `main`.

Closes #503