### PR TITLE
fix(control-ui): announce the server update notice politely

### DIFF
--- a/packages/streamwall-control-ui/src/ServerUpdateBanner.test.tsx
+++ b/packages/streamwall-control-ui/src/ServerUpdateBanner.test.tsx
@@ -56,6 +56,37 @@ describe('ServerUpdateBanner', () => {
     expect(el.querySelector('.server-update-banner')).toBeNull()
   })
 
+  // `aria-live` only guarantees an announcement for content that changes
+  // inside an already-present region, so the region stays mounted (empty)
+  // while there is no update - otherwise the notice, which appears without
+  // any user action once `GET /admin/status` resolves, can go unannounced
+  // (WCAG 4.1.3, issue #502).
+  test('keeps the live region mounted while there is no update', () => {
+    const el = renderBanner({ ...AVAILABLE_STATUS, updateAvailable: false })
+    const region = el.querySelector('[role="status"]')
+    expect(region).not.toBeNull()
+    expect(region?.getAttribute('aria-live')).toBe('polite')
+    expect(el.textContent).toBe('')
+  })
+
+  test('reuses the same live region element when the notice appears', () => {
+    const el = renderBanner({ ...AVAILABLE_STATUS, updateAvailable: false })
+    const regionWithoutUpdate = el.querySelector('[role="status"]')
+    act(() => {
+      render(<ServerUpdateBanner status={AVAILABLE_STATUS} />, container!)
+    })
+    expect(el.querySelector('[role="status"]')).toBe(regionWithoutUpdate)
+    expect(regionWithoutUpdate?.textContent).toContain('1.0.0')
+  })
+
+  test('announces an available update politely to assistive technology', () => {
+    const el = renderBanner(AVAILABLE_STATUS)
+    const region = el.querySelector('[role="status"]')
+    expect(region).not.toBeNull()
+    expect(region?.getAttribute('aria-live')).toBe('polite')
+    expect(region?.textContent).toContain('1.0.0')
+  })
+
   test('shows a notice linking to the release when an update is available', () => {
     const el = renderBanner(AVAILABLE_STATUS)
     const banner = el.querySelector('.server-update-banner')

--- a/packages/streamwall-control-ui/src/ServerUpdateBanner.tsx
+++ b/packages/streamwall-control-ui/src/ServerUpdateBanner.tsx
@@ -9,6 +9,12 @@ const StyledServerUpdateBanner = styled.div`
   font-size: 12px;
   color: var(--text-dim);
 
+  .server-update-banner {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+
   a {
     color: inherit;
   }
@@ -38,6 +44,15 @@ function readDismissedKey(): string | null {
  * Dismissible "a newer release is available" notice for admins, sourced
  * from `GET /admin/status` (#436). Dismissal is keyed on `latestVersion` so
  * dismissing one release doesn't hide the next one.
+ *
+ * The live region itself stays mounted while there is no update and only its
+ * contents are swapped: `aria-live` announcements are only reliable for
+ * changes inside a region that already exists in the accessibility tree, so
+ * mounting the region together with the notice risks losing exactly that
+ * announcement - and the notice appears without any user action, once
+ * `GET /admin/status` resolves (WCAG 4.1.3, issue #502). The
+ * `server-update-banner` class therefore sits on the notice, which is still
+ * present only while an update is pending.
  */
 export function ServerUpdateBanner({
   status,
@@ -47,43 +62,40 @@ export function ServerUpdateBanner({
   const releaseKey = status?.latestVersion ?? status?.version ?? null
   const [dismissedKey, setDismissedKey] = useState(readDismissedKey)
 
-  if (
-    status == null ||
-    !status.checkEnabled ||
-    !status.updateAvailable ||
-    releaseKey == null ||
-    dismissedKey === releaseKey
-  ) {
-    return null
-  }
-  // Reassign into a freshly-typed `const` (`string`, not `string | null`):
-  // TypeScript doesn't carry the `releaseKey == null` narrowing above into
-  // the nested `handleDismiss` closure.
-  const confirmedReleaseKey: string = releaseKey
-
-  function handleDismiss() {
-    setDismissedKey(confirmedReleaseKey)
+  function handleDismiss(releaseToDismiss: string) {
+    setDismissedKey(releaseToDismiss)
     try {
-      localStorage.setItem(DISMISSED_STORAGE_KEY, confirmedReleaseKey)
+      localStorage.setItem(DISMISSED_STORAGE_KEY, releaseToDismiss)
     } catch {
       // ignore (e.g. storage disabled)
     }
   }
 
+  const hasUpdate =
+    status != null &&
+    releaseKey != null &&
+    status.checkEnabled &&
+    status.updateAvailable &&
+    dismissedKey !== releaseKey
+
   return (
-    <StyledServerUpdateBanner className="server-update-banner">
-      <span>
-        A Streamwall update is available: {status.latestVersion} (you're on{' '}
-        {status.version}).
-      </span>
-      {status.releaseUrl && (
-        <a href={status.releaseUrl} target="_blank" rel="noreferrer">
-          Release notes
-        </a>
+    <StyledServerUpdateBanner role="status" aria-live="polite">
+      {hasUpdate && (
+        <span className="server-update-banner">
+          <span>
+            A Streamwall update is available: {status.latestVersion} (you're on{' '}
+            {status.version}).
+          </span>
+          {status.releaseUrl && (
+            <a href={status.releaseUrl} target="_blank" rel="noreferrer">
+              Release notes
+            </a>
+          )}
+          <button type="button" onClick={() => handleDismiss(releaseKey)}>
+            Dismiss
+          </button>
+        </span>
       )}
-      <button type="button" onClick={handleDismiss}>
-        Dismiss
-      </button>
     </StyledServerUpdateBanner>
   )
 }


### PR DESCRIPTION
## Problem

`ServerUpdateBanner` is part of the `ControlBanners` stack but, unlike its three siblings, carried no `role` and no `aria-live`. The notice appears asynchronously once `GET /admin/status` resolves — without any user action — so a screen reader user got no indication that a new banner had appeared above the wall (WCAG 4.1.3 Status Messages).

## Solution

Follow the pattern established in #463/#500: the banner now renders a persistent `role="status" aria-live="polite"` container that stays mounted (empty) while there is no update, and only its contents are swapped. Mounting the region together with its first message is unreliable — `aria-live` only guarantees announcements for changes inside a region already present in the accessibility tree.

The `server-update-banner` class moved from the region onto the inner notice, so it remains present only while an update is pending; existing selectors in `ServerUpdateBanner.test.tsx` and `serverStatusGating.test.tsx` keep their meaning unchanged. The dismissal closure now takes the release key as an argument instead of relying on an early-return narrowing that no longer exists.

## Testing

- New unit tests: the region is mounted while there is no update (and renders no text), the same element is reused when the notice appears, and the notice is announced politely.
- `npm run test` (all packages), `npm run typecheck`, `npm run format` green locally. `npm run lint` reports three pre-existing `@twurple/*` resolution errors in `packages/streamwall/src/main/TwitchBot.ts` caused by an incomplete `node_modules` in this worktree — unrelated to this change.

## Risks

None functional: the visible markup is unchanged apart from one extra wrapper span; the banner's gating, dismissal and persistence behaviour is untouched.

Closes #502