### PR TITLE
feat(control-server): route remaining startup output through the structured logger

### DIFF
--- a/packages/streamwall-control-server/README.md
+++ b/packages/streamwall-control-server/README.md
@@ -115,10 +115,12 @@ identifiable session metadata never reaches them:
 - The `role` is logged, since authorization decisions are unreadable without
   it and a role is not identifying on its own.
 
-The startup banner (server version, uplink endpoint, admin invite link) is
-written directly to stdout rather than through the logger, so it stays visible
-regardless of `LOG_LEVEL`. It is the one place credentials are printed on
-purpose — see [Running](#running).
+The credential banner (uplink endpoint, admin invite link) is written directly
+to stdout rather than through the logger, so it stays visible regardless of
+`LOG_LEVEL`. It is the only output that bypasses the logger, and the one place
+credentials are printed on purpose — see [Running](#running). Everything else,
+including the startup diagnostics and the update-available announcement, is a
+structured entry on the JSON stream.
 
 ### Telemetry
 

--- a/packages/streamwall-control-server/src/bootstrap.ts
+++ b/packages/streamwall-control-server/src/bootstrap.ts
@@ -2,6 +2,7 @@ import { inviteLink } from 'streamwall-shared'
 import type { Auth } from './auth.ts'
 import { resolveListenPort } from './config.ts'
 import { type AppOptions, initApp } from './index.ts'
+import type { LogLevel } from './logger.ts'
 import type { StorageDB } from './storage.ts'
 import { SERVER_VERSION, type UpdateChecker } from './updateCheck.ts'
 
@@ -129,12 +130,18 @@ export default async function runServer({
   baseURL,
   clientStaticPath,
   db: injectedDb,
+  logLevel,
+  logStream,
   updateChecker: injectedUpdateChecker,
 }: AppOptions & {
   hostname?: string
   port?: string
   /** Test-only override so specs can exercise the real listen() path without touching disk. */
   db?: StorageDB
+  /** Overrides the level from `LOG_LEVEL` (used by tests to silence or widen output). */
+  logLevel?: LogLevel
+  /** Test-only sink for log output; defaults to pino's stdout destination. */
+  logStream?: { write(line: string): void }
   /** Test-only override so specs can exercise the real listen() path without reaching GitHub. */
   updateChecker?: UpdateChecker
 }) {
@@ -142,14 +149,23 @@ export default async function runServer({
   const hostname = overrideHostname ?? url.hostname
   const port = resolveListenPort(baseURL, overridePort)
 
-  console.log(`Starting streamwall-control-server ${SERVER_VERSION}`)
-  console.debug('Initializing web server:', { hostname, port })
+  // The startup diagnostics below run *after* `initApp` purely so they can go
+  // through `app.log`: they belong in the structured stream like every other
+  // server diagnostic, and the logger only exists once Fastify does (#493).
   const { app, db, auth, updateChecker } = await initApp({
     baseURL,
     clientStaticPath,
     db: injectedDb,
+    logLevel,
+    logStream,
     updateChecker: injectedUpdateChecker,
   })
+
+  app.log.info(
+    { version: SERVER_VERSION },
+    'Starting streamwall-control-server',
+  )
+  app.log.debug({ hostname, port }, 'Initializing web server')
 
   const bootstrap = await initialInviteCodes({ db, auth, baseURL })
   logBootstrap(bootstrap)

--- a/packages/streamwall-control-server/src/index.test.ts
+++ b/packages/streamwall-control-server/src/index.test.ts
@@ -6,7 +6,7 @@ import runServer, {
   resolveListenPort,
   SESSION_COOKIE_NAME,
 } from './index.ts'
-import { inMemoryDb } from './testHelpers.ts'
+import { captureLogs, inMemoryDb } from './testHelpers.ts'
 import type { UpdateChecker, UpdateStatus } from './updateCheck.ts'
 
 const ONE_YEAR_IN_SECONDS = 365 * 24 * 60 * 60
@@ -138,6 +138,54 @@ describe('runServer', () => {
       server.listening,
       'server should be listening after runServer resolves',
     )
+  })
+
+  test('writes its startup diagnostics to the structured logger (issue #493)', async () => {
+    const logs = captureLogs()
+    const consoleCalls: unknown[][] = []
+    const originalLog = console.log
+    const originalDebug = console.debug
+    console.log = (...args: unknown[]) => {
+      consoleCalls.push(args)
+    }
+    console.debug = (...args: unknown[]) => {
+      consoleCalls.push(args)
+    }
+    let server: { close(): void }
+    try {
+      ;({ server } = await runServer({
+        baseURL: 'http://127.0.0.1:0',
+        clientStaticPath: import.meta.dirname,
+        db: inMemoryDb(),
+        logLevel: 'trace',
+        logStream: logs.stream,
+        updateChecker: fakeUpdateChecker(),
+      }))
+    } finally {
+      console.log = originalLog
+      console.debug = originalDebug
+    }
+    after(() => server.close())
+
+    const starting = logs.entries.find(
+      (e) => e.msg === 'Starting streamwall-control-server',
+    )
+    assert.ok(starting, 'the startup banner must be a structured entry')
+    assert.equal(typeof starting.version, 'string')
+
+    const initializing = logs.entries.find(
+      (e) => e.msg === 'Initializing web server',
+    )
+    assert.ok(initializing, 'the listen diagnostics must be a structured entry')
+    assert.equal(initializing.hostname, '127.0.0.1')
+    assert.equal(typeof initializing.port, 'number')
+
+    // The credential banner (`logBootstrap`) stays on `console` by design, so
+    // only the two startup diagnostics must have moved off it.
+    const startupOnConsole = consoleCalls.filter((args) =>
+      String(args[0]).match(/Starting streamwall-control-server|web server/),
+    )
+    assert.deepEqual(startupOnConsole, [])
   })
 })
 

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -88,11 +88,12 @@ export async function initApp({
 
   const db = injectedDb ?? (await loadStorage())
   const auth = new Auth(db.data.auth, app.log)
-  const updateChecker = injectedUpdateChecker ?? createUpdateChecker()
+  const updateChecker =
+    injectedUpdateChecker ?? createUpdateChecker({ log: app.log })
 
   // Opt-in crash reporting (see sentry.ts for why there is no default DSN).
   // Must be wired up before routes are registered so their errors are covered.
-  const sentryEnabled = injectedSentryEnabled ?? initSentry()
+  const sentryEnabled = injectedSentryEnabled ?? initSentry(app.log)
   if (sentryEnabled) {
     Sentry.setupFastifyErrorHandler(app)
   }

--- a/packages/streamwall-control-server/src/sentry.test.ts
+++ b/packages/streamwall-control-server/src/sentry.test.ts
@@ -8,6 +8,7 @@ import {
   getSentryConfig,
   initSentry,
 } from './sentry.ts'
+import { recordingLogger } from './testHelpers.ts'
 
 describe('getSentryConfig', () => {
   const originalEnabled = process.env[SENTRY_ENABLED_ENV]
@@ -78,11 +79,17 @@ describe('initSentry', () => {
 
   test('does nothing when disabled', () => {
     const client = fakeClient()
+    const logger = recordingLogger()
 
-    const result = initSentry({ enabled: false, dsn: undefined }, client)
+    const result = initSentry(
+      logger.log,
+      { enabled: false, dsn: undefined },
+      client,
+    )
 
     assert.equal(result, false)
     assert.equal(client.calls.length, 0)
+    assert.equal(logger.entries.length, 0)
     assert.equal(warnCalls.length, 0)
   })
 
@@ -90,6 +97,7 @@ describe('initSentry', () => {
     const client = fakeClient()
 
     const result = initSentry(
+      recordingLogger().log,
       { enabled: true, dsn: 'https://example@o0.ingest.sentry.io/1' },
       client,
     )
@@ -100,15 +108,31 @@ describe('initSentry', () => {
     ])
   })
 
-  test('warns and skips initialization when enabled without a DSN', () => {
+  test('warns through the structured logger and skips initialization when enabled without a DSN', () => {
     const client = fakeClient()
+    const logger = recordingLogger()
 
-    const result = initSentry({ enabled: true, dsn: undefined }, client)
+    const result = initSentry(
+      logger.log,
+      { enabled: true, dsn: undefined },
+      client,
+    )
 
     assert.equal(result, false)
     assert.equal(client.calls.length, 0)
-    assert.equal(warnCalls.length, 1)
-    assert.match(String(warnCalls[0][0]), new RegExp(SENTRY_DSN_ENV))
+    assert.equal(logger.entries.length, 1)
+    const [entry] = logger.entries
+    assert.equal(entry.level, 'warn')
+    assert.deepEqual(entry.fields, {
+      enabledEnv: SENTRY_ENABLED_ENV,
+      dsnEnv: SENTRY_DSN_ENV,
+    })
+    assert.match(String(entry.msg), new RegExp(SENTRY_DSN_ENV))
+    assert.equal(
+      warnCalls.length,
+      0,
+      'the warning must not bypass the structured logger (issue #493)',
+    )
   })
 })
 

--- a/packages/streamwall-control-server/src/sentry.ts
+++ b/packages/streamwall-control-server/src/sentry.ts
@@ -1,5 +1,7 @@
 import * as Sentry from '@sentry/node'
 
+import type { Logger } from './logger.ts'
+
 /**
  * Unlike the Electron app (which ships a DSN for the maintainer's own Sentry
  * project), this server is self-hosted by independent operators. There is no
@@ -28,11 +30,20 @@ export interface SentryClient {
 }
 
 /**
+ * The slice of the structured logger this module needs. Taken as the first
+ * (required) parameter rather than defaulting to `console`, so the
+ * misconfiguration warning honours `LOG_LEVEL` like every other server
+ * diagnostic (issue #493).
+ */
+export type SentryLogger = Pick<Logger, 'warn'>
+
+/**
  * Initializes Sentry crash reporting if enabled and configured. Returns
  * whether initialization happened, so callers can decide whether to also wire
  * up framework-specific error capture (e.g. Fastify's error handler).
  */
 export function initSentry(
+  log: SentryLogger,
   config: SentryConfig = getSentryConfig(),
   client: SentryClient = Sentry,
 ): boolean {
@@ -40,8 +51,9 @@ export function initSentry(
     return false
   }
   if (!config.dsn) {
-    console.warn(
-      `${SENTRY_ENABLED_ENV} is set but ${SENTRY_DSN_ENV} is missing; skipping Sentry initialization.`,
+    log.warn(
+      { enabledEnv: SENTRY_ENABLED_ENV, dsnEnv: SENTRY_DSN_ENV },
+      `${SENTRY_ENABLED_ENV} is set but ${SENTRY_DSN_ENV} is missing; skipping Sentry initialization`,
     )
     return false
   }

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -73,6 +73,35 @@ export function captureLogs(): LogCapture {
   }
 }
 
+/** One entry a unit under test wrote through an injected structured logger. */
+export interface RecordedLogEntry {
+  level: 'info' | 'warn'
+  fields: Record<string, unknown>
+  msg: string | undefined
+}
+
+/**
+ * A stand-in for the structured logger, recording what a unit under test would
+ * have written. For units that take a logger by injection rather than reaching
+ * for `console` (see `captureLogs` for asserting on a live server's output).
+ */
+export function recordingLogger() {
+  const entries: RecordedLogEntry[] = []
+  const record =
+    (level: RecordedLogEntry['level']) =>
+    (fields: unknown, msg?: string): void => {
+      entries.push({
+        level,
+        fields: (fields ?? {}) as Record<string, unknown>,
+        msg,
+      })
+    }
+  return {
+    entries,
+    log: { info: record('info'), warn: record('warn') },
+  }
+}
+
 /**
  * Builds a fully-wired app instance backed by in-memory storage and throwaway
  * static assets, ready for `app.inject()` or `app.listen()` in tests.

--- a/packages/streamwall-control-server/src/updateCheck.test.ts
+++ b/packages/streamwall-control-server/src/updateCheck.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { describe, test } from 'node:test'
 
+import { recordingLogger } from './testHelpers.ts'
 import {
   createUpdateChecker,
   isUpdateCheckEnabled,
@@ -47,6 +48,7 @@ describe('isUpdateCheckEnabled', () => {
 describe('createUpdateChecker', () => {
   test('reports the running version and no update before the first check', () => {
     const checker = createUpdateChecker({
+      log: recordingLogger().log,
       currentVersion: '0.9.1',
       fetchImpl: async () => jsonResponse({}),
     })
@@ -63,6 +65,7 @@ describe('createUpdateChecker', () => {
 
   test('flags an available update after a check', async () => {
     const checker = createUpdateChecker({
+      log: recordingLogger().log,
       currentVersion: '0.9.1',
       fetchImpl: async () =>
         jsonResponse({
@@ -82,6 +85,7 @@ describe('createUpdateChecker', () => {
 
   test('reports no update when the latest release is the running version', async () => {
     const checker = createUpdateChecker({
+      log: recordingLogger().log,
       currentVersion: '1.0.0',
       fetchImpl: async () =>
         jsonResponse({
@@ -97,10 +101,10 @@ describe('createUpdateChecker', () => {
   })
 
   test('logs once per newly discovered version, not on every check', async () => {
-    const logged: string[] = []
+    const logger = recordingLogger()
     const checker = createUpdateChecker({
+      log: logger.log,
       currentVersion: '0.9.1',
-      log: (msg) => logged.push(msg),
       fetchImpl: async () =>
         jsonResponse({
           tag_name: 'v1.0.0',
@@ -111,13 +115,52 @@ describe('createUpdateChecker', () => {
     await checker.checkNow()
     await checker.checkNow()
 
-    assert.equal(logged.length, 1)
-    assert.match(logged[0], /1\.0\.0/)
+    assert.equal(logger.entries.length, 1)
+  })
+
+  test('announces the update as a structured info entry, not a console line', async () => {
+    const logger = recordingLogger()
+    const consoleCalls: unknown[][] = []
+    const originalLog = console.log
+    console.log = (...args: unknown[]) => {
+      consoleCalls.push(args)
+    }
+    try {
+      const checker = createUpdateChecker({
+        log: logger.log,
+        currentVersion: '0.9.1',
+        fetchImpl: async () =>
+          jsonResponse({
+            tag_name: 'v1.0.0',
+            html_url: 'https://example.test/r',
+          }),
+      })
+
+      await checker.checkNow()
+    } finally {
+      console.log = originalLog
+    }
+
+    assert.equal(logger.entries.length, 1)
+    const [entry] = logger.entries
+    assert.equal(entry.level, 'info')
+    assert.deepEqual(entry.fields, {
+      latestVersion: '1.0.0',
+      currentVersion: '0.9.1',
+      releaseUrl: 'https://example.test/r',
+    })
+    assert.match(String(entry.msg), /newer streamwall-control-server release/)
+    assert.equal(
+      consoleCalls.length,
+      0,
+      'the announcement must not bypass the structured logger (issue #493)',
+    )
   })
 
   test('keeps the last known result when a check fails', async () => {
     let failNext = false
     const checker = createUpdateChecker({
+      log: recordingLogger().log,
       currentVersion: '0.9.1',
       fetchImpl: async () => {
         if (failNext) {
@@ -142,6 +185,7 @@ describe('createUpdateChecker', () => {
   test('never performs a request when disabled', async () => {
     let calls = 0
     const checker = createUpdateChecker({
+      log: recordingLogger().log,
       currentVersion: '0.9.1',
       enabled: false,
       fetchImpl: async () => {
@@ -162,6 +206,7 @@ describe('createUpdateChecker', () => {
     let calls = 0
     const timers: { fn: () => void; ms: number }[] = []
     const checker = createUpdateChecker({
+      log: recordingLogger().log,
       currentVersion: '0.9.1',
       intervalMs: 1000,
       fetchImpl: async () => {
@@ -190,6 +235,7 @@ describe('createUpdateChecker', () => {
   test('start() is idempotent (no duplicate intervals)', async () => {
     const timers: unknown[] = []
     const checker = createUpdateChecker({
+      log: recordingLogger().log,
       currentVersion: '0.9.1',
       fetchImpl: async () =>
         jsonResponse({ tag_name: 'v0.9.1', html_url: 'https://x.test' }),
@@ -212,6 +258,7 @@ describe('createUpdateChecker', () => {
   test('start() does not schedule anything when disabled', async () => {
     let scheduled = 0
     const checker = createUpdateChecker({
+      log: recordingLogger().log,
       currentVersion: '0.9.1',
       enabled: false,
       fetchImpl: async () => jsonResponse({}),

--- a/packages/streamwall-control-server/src/updateCheck.ts
+++ b/packages/streamwall-control-server/src/updateCheck.ts
@@ -8,6 +8,8 @@ import {
   type LatestRelease,
 } from 'streamwall-shared'
 
+import type { Logger } from './logger.ts'
+
 /**
  * Update *notification* for self-hosted deployments (issue #382).
  *
@@ -80,13 +82,21 @@ export interface UpdateChecker {
   stop(): void
 }
 
+/**
+ * The slice of the structured logger this module needs. Required rather than
+ * defaulted to `console`, so an update announcement can never bypass
+ * `LOG_LEVEL` or land in the JSON stream unstructured (issue #493).
+ */
+export type UpdateCheckLogger = Pick<Logger, 'info'>
+
 export interface UpdateCheckerOptions {
+  /** Structured logger the update announcement is written to, at `info`. */
+  log: UpdateCheckLogger
   currentVersion?: string
   enabled?: boolean
   intervalMs?: number
   fetchImpl?: GithubReleaseFetchImpl
   url?: string
-  log?: (message: string) => void
   setIntervalImpl?: (fn: () => void, ms: number) => unknown
   clearIntervalImpl?: (handle: unknown) => void
 }
@@ -102,15 +112,15 @@ function defaultSetInterval(fn: () => void, ms: number): unknown {
 }
 
 export function createUpdateChecker({
+  log,
   currentVersion = SERVER_VERSION,
   enabled = isUpdateCheckEnabled(process.env.STREAMWALL_UPDATE_CHECK),
   intervalMs = DEFAULT_CHECK_INTERVAL_MS,
   fetchImpl = fetch as GithubReleaseFetchImpl,
   url = RELEASES_API_URL,
-  log = console.log,
   setIntervalImpl = defaultSetInterval,
   clearIntervalImpl = (handle) => clearInterval(handle as NodeJS.Timeout),
-}: UpdateCheckerOptions = {}): UpdateChecker {
+}: UpdateCheckerOptions): UpdateChecker {
   let latest: LatestRelease | null = null
   let lastCheckedAt: string | null = null
   let announcedVersion: string | null = null
@@ -150,8 +160,13 @@ export function createUpdateChecker({
       status.latestVersion !== announcedVersion
     ) {
       announcedVersion = status.latestVersion
-      log(
-        `⬆️  streamwall-control-server ${status.latestVersion} is available (running ${currentVersion}): ${status.releaseUrl}`,
+      log.info(
+        {
+          latestVersion: status.latestVersion,
+          currentVersion,
+          releaseUrl: status.releaseUrl,
+        },
+        'A newer streamwall-control-server release is available',
       )
     }
     return status


### PR DESCRIPTION
## Problem

#410 moved every request and WebSocket hot path onto Fastify's pino logger, but three call sites were left on `console`: the update-available announcement (`updateCheck.ts`), the Sentry misconfiguration warning (`sentry.ts`) and the two startup diagnostics in `runServer` (`bootstrap.ts`). They bypassed `LOG_LEVEL` entirely and showed up as unparseable noise in a log aggregator ingesting the JSON stream.

## Solution

- `createUpdateChecker` takes the structured logger as a **required** option (`log: Pick<Logger, 'info'>`) instead of defaulting to `console.log`. `initApp` passes `app.log`. The announcement is now an `info` entry carrying `latestVersion`, `currentVersion` and `releaseUrl` as fields.
- `initSentry(log, config?, client?)` takes the logger as its first parameter and warns through it. The logger comes first because the two existing parameters are optional and a required parameter cannot follow them.
- `runServer` emits its two startup diagnostics *after* `initApp` so they can go through `app.log` — no second pino instance and no new dependency needed. `Starting streamwall-control-server` is `info` with a `version` field, `Initializing web server` is `debug` with `hostname`/`port`.
- `runServer` gained the same test-only `logLevel` / `logStream` overrides `initApp` already had, so a spec can capture what a real `listen()` run logs.

Making the logger a required injection (rather than defaulting to a module-level pino instance) keeps the "no logging singletons" rule the server already codes by: every entry inherits the instance it belongs to.

The credential banner in `logBootstrap` deliberately stays on `console` — it must remain visible whatever `LOG_LEVEL` is set to. The server README's logging section was updated to say that it is now the *only* output bypassing the logger.

## Testing

- `updateCheck.test.ts`: new spec asserts the announcement is a structured `info` entry with the expected fields and that `console.log` is not called at all; the existing once-per-version spec now asserts on recorded entries.
- `sentry.test.ts`: the missing-DSN spec asserts a `warn` entry with `enabledEnv`/`dsnEnv` fields and that `console.warn` stays untouched.
- `index.test.ts`: `runServer` is booted for real with a capturing log stream and asserts both startup lines appear as JSON entries while `console` sees neither.
- New shared `recordingLogger()` helper in `testHelpers.ts` for units that take a logger by injection.
- Full gate green locally: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (162 control-server tests, all workspaces pass).

## Risks

Both `createUpdateChecker` and `initSentry` have breaking signature changes, but neither is exported outside the control-server package and every call site is updated in this PR.

Closes #493