### PR TITLE
docs(readme): drop the stale CodeQL badge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,10 @@ else:
   builds, packaging, E2E, the control-server Docker build, dependency review,
   workflow linting and **CodeQL**
   all report through it — CodeQL runs as a job of `ci.yml` rather than as a
-  standalone workflow precisely so that its failures block a merge.
+  standalone workflow precisely so that its failures block a merge. Because a
+  reusable-workflow call produces no run of its own, the README carries no
+  separate CodeQL badge — the `CI` badge already reflects the analysis that ran
+  on the latest commit on `main`.
 - `Conventional Commits title` — `.github/workflows/pr-title.yml`.
 
 Adding a job to `ci.yml` therefore also means adding it to the `ci-ok` gate's

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Release](https://img.shields.io/github/v/release/NilsR0711/streamwall?include_prereleases&sort=semver&label=release)](https://github.com/NilsR0711/streamwall/releases/latest)
 [![CI](https://github.com/NilsR0711/streamwall/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/NilsR0711/streamwall/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/NilsR0711/streamwall/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/NilsR0711/streamwall/actions/workflows/codeql.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 ![Platforms](https://img.shields.io/badge/platforms-macOS%20%7C%20Windows%20%7C%20Linux-lightgrey.svg)
 


### PR DESCRIPTION
## Problem

Since #403, CodeQL runs as a reusable workflow called from `ci.yml`, and `codeql.yml` itself only triggers on its weekly `schedule`. A reusable-workflow invocation creates no workflow run of its own, so the README badge pointed at `codeql.yml` reflected nothing but the Monday 03:30 UTC scan — up to a week stale relative to `main`.

## Solution

Remove the separate CodeQL badge. The `CI` badge already tracks `ci.yml`, which contains the CodeQL job that analyses every push to `main`, so no information is lost. `CONTRIBUTING.md` now states why there is no dedicated CodeQL badge, so the badge does not get reinstated later.

The alternative — adding `push: branches: [main]` back to `codeql.yml` — was rejected because it would run a second, redundant full analysis on every push to `main` purely to feed a badge.

## Testing

Docs-only change with no testable behaviour; no tests added. `npx prettier --check README.md CONTRIBUTING.md` passes, and CI's format job checks Markdown repo-wide.

## Risks

None. Merge gating is unaffected — `CI OK` still covers the per-PR CodeQL analysis, and the weekly scheduled scan is untouched.

Closes #475