### PR TITLE
docs(contributing): explain how to start CI on the release PR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -321,7 +321,12 @@ breaking change bumps the minor version.
    manifests and the `CHANGELOG.md` section for the pending release. Its
    description previews the release notes; anything merged afterwards updates
    the PR.
-2. Merge the release PR when you want to cut the release.
+2. Merge the release PR when you want to cut the release. It arrives without
+   status checks: a pull request opened by a workflow's `GITHUB_TOKEN` does not
+   trigger other workflows, so neither `CI OK` nor `Conventional Commits title`
+   starts on its own. **Close and immediately reopen the release PR** — the
+   reopen comes from your account and starts both required checks. Wait for them
+   to pass before merging; release-please reuses the same branch afterwards.
 3. Tag the merge commit and push the tag:
 
    ```sh


### PR DESCRIPTION
## Summary

Follow-up to #505 / #457, found by watching the first real release-please run.

The release PR release-please opens (#518) arrives with **no status checks**:
GitHub does not trigger workflows for pull requests created with a workflow's
`GITHUB_TOKEN`, so neither `CI OK` nor `Conventional Commits title` starts.
Branch protection requires both, so the release PR is unmergeable until a human
action re-triggers them.

Documents the workaround — close and immediately reopen the release PR, which
fires `pull_request` events from the maintainer's account — in the release
steps, so the flow described in CONTRIBUTING actually completes.

Closes # (none — docs follow-up)

## How was this tested?

Docs-only: no behavior to test. `npm test`, `npm run format:check` pass locally.
The underlying observation is from run
https://github.com/NilsR0711/streamwall/actions/runs/29869119161 and PR #518,
which shows "no checks reported".

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] Docs-only change, no tests apply
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments