### PR TITLE
ci(release): bump the package-lock workspace entries with release-please

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -321,9 +321,9 @@ breaking change bumps the minor version.
 
 1. release-please keeps a release PR open (title: `chore(main): release x.y.z`)
    containing the version bump for the root manifest, both release-tracking
-   manifests and the `CHANGELOG.md` section for the pending release. Its
-   description previews the release notes; anything merged afterwards updates
-   the PR.
+   manifests, their `package-lock.json` entries and the `CHANGELOG.md` section
+   for the pending release. Its description previews the release notes;
+   anything merged afterwards updates the PR.
 2. Merge the release PR when you want to cut the release. It arrives without
    status checks: a pull request opened by a workflow's `GITHUB_TOKEN` does not
    trigger other workflows, so neither `CI OK` nor `Conventional Commits title`

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -32,6 +32,16 @@
           "type": "json",
           "path": "packages/streamwall-control-server/package.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "package-lock.json",
+          "jsonpath": "$.packages['packages/streamwall'].version"
+        },
+        {
+          "type": "json",
+          "path": "package-lock.json",
+          "jsonpath": "$.packages['packages/streamwall-control-server'].version"
         }
       ]
     }

--- a/test/release-please.test.mjs
+++ b/test/release-please.test.mjs
@@ -46,15 +46,37 @@ test('release-please keeps the pre-1.0 bump strategy', () => {
 // Only the release-tracking workspaces may be bumped: the other manifests are
 // deliberately pinned (see CONTRIBUTING "Cutting a release").
 test('release-please bumps exactly the release-tracked manifests', () => {
-  const extraFiles = rootPackage['extra-files']
+  const manifestFiles = rootPackage['extra-files'].filter(
+    (file) => file.path !== 'package-lock.json',
+  )
 
   assert.deepEqual(
-    extraFiles.map((file) => file.path),
+    manifestFiles.map((file) => file.path),
     RELEASE_TRACKED_WORKSPACES.map((workspace) => `${workspace}/package.json`),
   )
-  for (const file of extraFiles) {
+  for (const file of manifestFiles) {
     assert.equal(file.type, 'json')
     assert.equal(file.jsonpath, '$.version')
+  }
+})
+
+// The `node` release type rewrites the root entries of package-lock.json but
+// not the workspace entries `extra-files` bumps, so without these the lock
+// keeps the previous version until an unrelated `npm install` rewrites it.
+// Issue #513.
+test('release-please bumps the workspace entries of package-lock.json', () => {
+  const lockFiles = rootPackage['extra-files'].filter(
+    (file) => file.path === 'package-lock.json',
+  )
+
+  assert.deepEqual(
+    lockFiles.map((file) => file.jsonpath),
+    RELEASE_TRACKED_WORKSPACES.map(
+      (workspace) => `$.packages['${workspace}'].version`,
+    ),
+  )
+  for (const file of lockFiles) {
+    assert.equal(file.type, 'json')
   }
 })
 
@@ -75,6 +97,27 @@ test('the release-please manifest matches every release-tracked version', () => 
       readJson(`${workspace}/package.json`).version,
       version,
       `${workspace}/package.json must stay on the root release version`,
+    )
+  }
+})
+
+// A lock entry left behind by a release surfaces as an unrelated diff in some
+// later PR, so catch the drift here rather than in an unsuspecting review.
+// Issue #513.
+test('package-lock.json records the release version for every tracked workspace', () => {
+  const lockPackages = readJson('package-lock.json').packages
+  const version = readJson('package.json').version
+
+  assert.equal(
+    lockPackages[''].version,
+    version,
+    'the root entry of package-lock.json must stay on the root release version',
+  )
+  for (const workspace of RELEASE_TRACKED_WORKSPACES) {
+    assert.equal(
+      lockPackages[workspace].version,
+      version,
+      `package-lock.json entry "${workspace}" must stay on the root release version`,
     )
   }
 })


### PR DESCRIPTION
## Problem

`release-please` releases the repository root with `release-type: node`, which
rewrites the root version entries of `package-lock.json`, and patches
`packages/streamwall/package.json` and
`packages/streamwall-control-server/package.json` through `extra-files`.

`extra-files` only touches the manifests, not the matching lock entries
(`packages["packages/streamwall"].version` and
`packages["packages/streamwall-control-server"].version`). After every automated
release those two entries kept the previous version until an unrelated
`npm install` rewrote them, producing a stray diff in some later PR. `npm ci`
tolerates the drift, so this was noise rather than a failure.

## Solution

- Added one `extra-files` entry per release-tracked workspace pointing at its
  `package-lock.json` entry, using bracketed keys
  (`$.packages['packages/streamwall'].version`).
- Added a drift guard so a lock entry that falls behind its manifest fails the
  test suite deliberately instead of surfacing as an unrelated diff.

## Architecture decisions

Both suggested fixes from the issue were taken rather than one: the config
change stops the drift, the test catches it if release-please ever stops
resolving those paths. The workflow-side `npm install --package-lock-only`
option was rejected — it would need the release branch amended from CI, which is
more moving parts than a declarative config entry.

Verified against the real lockfile that `jsonpath-plus` (the resolver
release-please's generic JSON updater uses) resolves both bracketed paths and
rewrites exactly those two `version` fields. release-please merges several
updaters for the same path into a `CompositeUpdater`, so these entries compose
with the built-in `package-lock.json` updater instead of replacing it.

## Testing

- `test/release-please.test.mjs`: new assertion that the config carries a lock
  entry per release-tracked workspace (confirmed red against the previous
  config), plus a drift guard comparing every tracked lock entry — including the
  root entry — against the root `package.json` version.
- `node --test test/*.test.mjs`: 77 passing.
- `npm run format:check` clean. `npm run lint` reports three pre-existing
  `@twurple/*` resolution errors in this worktree (missing optional install),
  unrelated to this change.

## Risks

None at runtime — the change only affects what the release PR rewrites. If
release-please were to stop resolving the bracketed paths, the new drift guard
turns that into a failing test on the release PR rather than silent noise.

Closes #513
