### PR TITLE
ci(release): make the darwin installers before the publish matrix

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -6,9 +6,10 @@ name: Packaging
 # major bump, a missing packaging tool on a runner image, a bad NSIS icon
 # path — is caught here rather than on release day.
 #
-# release.yml gates every tag on its own `make` smoke as the backstop (#453),
-# but that one is Ubuntu-only: it cross-builds the Windows NSIS installer and
-# cannot run the darwin-only zip maker at all, which stays this matrix's job.
+# release.yml gates every tag on its own `make` smoke as the backstop (#453,
+# #517), but that one runs on Linux and macOS only — the Windows NSIS
+# installer is cross-built there, so a native Windows `make` stays this
+# matrix's job.
 #
 # Deliberately not part of PR CI: `make` costs several minutes per platform,
 # while the failure modes shared by every platform (Vite/Forge config, asar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,13 +78,30 @@ jobs:
   #
   # `make`, not just `package`: the weekly `packaging.yml` matrix (#425)
   # exercises the makers too, but it is up to a week stale and does not gate
-  # the tag. Only the darwin ZIP stays uncovered here — MakerZIP is
-  # darwin-only and cannot be cross-built — so the macOS publish leg remains
-  # the first place it runs.
+  # the tag.
+  #
+  # Two legs, because MakerZIP is darwin-only and cannot be cross-built: the
+  # Linux runner covers deb/rpm natively plus the cross-built Windows NSIS
+  # installer, and a macOS runner covers the ZIP and the `latest-mac.yml`
+  # half of the update-metadata hook, which would otherwise run for the first
+  # time inside the macOS publish leg (#517).
   make:
-    name: Installer smoke (makers)
-    runs-on: ubuntu-latest
+    name: Installer smoke (${{ matrix.leg.name }} makers)
+    runs-on: ${{ matrix.leg.os }}
     timeout-minutes: 30
+    strategy:
+      # One broken platform must not hide the state of the other.
+      fail-fast: false
+      matrix:
+        leg:
+          # `artifacts` is the whitespace-separated list of kinds only this
+          # runner can produce; the verification step below asserts each one.
+          - name: linux + windows
+            os: ubuntu-latest
+            artifacts: '*.deb *.rpm *-setup-*.exe latest.yml'
+          - name: macos
+            os: macos-latest
+            artifacts: '*.zip latest-mac.yml'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -94,18 +111,21 @@ jobs:
       # MakerRpm shells out to `rpmbuild`, MakerDeb to `dpkg`/`fakeroot`.
       # Only the latter two ship on the GitHub Ubuntu runner image.
       - name: Install Linux maker tooling
+        if: matrix.leg.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends rpm fakeroot
 
-      - name: Make (linux installers)
+      # Host-platform makers: deb/rpm on Linux, the darwin ZIP on macOS.
+      - name: Make (host installers)
         run: npm -w streamwall run make
 
       # The NSIS maker and the `latest.yml` half of the update-metadata hook
       # only run for win32. electron-builder bundles makensis for every host
-      # OS, so the expensive Windows-only path is verified from this runner
-      # rather than trusting the Windows publish leg.
+      # OS, so the expensive Windows-only path is verified from the Linux
+      # runner rather than trusting the Windows publish leg.
       - name: Make (windows NSIS, cross-built)
+        if: matrix.leg.os == 'ubuntu-latest'
         run: npm -w streamwall run make -- --platform=win32
 
       # A maker that is silently skipped (unsupported-platform detection, a
@@ -113,10 +133,12 @@ jobs:
       # the expected artifact kinds are asserted explicitly.
       - name: Verify installer artifacts
         shell: bash
+        env:
+          EXPECTED_ARTIFACTS: ${{ matrix.leg.artifacts }}
         run: |
           make_dir=packages/streamwall/out/make
           find "$make_dir" -type f -print | sort
-          for pattern in '*.deb' '*.rpm' '*-setup-*.exe' 'latest.yml'; do
+          for pattern in $EXPECTED_ARTIFACTS; do
             if [ -z "$(find "$make_dir" -type f -name "$pattern" -print -quit)" ]; then
               echo "::error::No $pattern artifact found in $make_dir"
               exit 1

--- a/test/ci-gate.test.mjs
+++ b/test/ci-gate.test.mjs
@@ -171,3 +171,61 @@ test('the release quality gate makes installers before publishing', () => {
       'the update-metadata hook are exercised before publishing',
   )
 })
+
+// MakerZIP is darwin-only and cannot be cross-built from Linux, so a
+// Linux-only gate leaves the macOS zip and the latest-mac.yml half of the
+// postMake hook to run for the first time inside the publish matrix — the
+// exact half-published release the gate exists to prevent (#517).
+test('the release quality gate makes the darwin artifacts on a macOS leg', () => {
+  const make = readWorkflow('release.yml').jobs.make
+  const legs = make.strategy?.matrix?.leg
+
+  assert.ok(
+    Array.isArray(legs),
+    'the make gate must fan out over a `leg` matrix so the darwin makers ' +
+      'get a macOS runner of their own',
+  )
+
+  const legsByOs = new Map(legs.map((leg) => [leg.os, leg]))
+  const expectedArtifacts = {
+    'ubuntu-latest': ['*.deb', '*.rpm', '*-setup-*.exe', 'latest.yml'],
+    'macos-latest': ['*.zip', 'latest-mac.yml'],
+  }
+
+  for (const [os, patterns] of Object.entries(expectedArtifacts)) {
+    const leg = legsByOs.get(os)
+    assert.ok(leg, `release.yml is missing a ${os} leg of the make gate`)
+    assert.deepEqual(
+      String(leg.artifacts).split(/\s+/).filter(Boolean),
+      patterns,
+      `the ${os} make leg must assert exactly the artifacts only that ` +
+        'runner can produce',
+    )
+  }
+
+  // Per-leg patterns are useless unless the assertion step reads them.
+  const verify = make.steps.find(
+    (step) => step.name === 'Verify installer artifacts',
+  )
+  assert.ok(verify, 'the make gate must verify the artifacts it produced')
+  assert.equal(verify.env?.EXPECTED_ARTIFACTS, '${{ matrix.leg.artifacts }}')
+  assert.ok(
+    verify.run.includes('EXPECTED_ARTIFACTS'),
+    'the verification step must iterate the leg-specific pattern list',
+  )
+
+  // The rpm/fakeroot install and the NSIS cross-build only make sense on the
+  // Linux leg; unguarded they would fail the macOS one.
+  for (const stepName of [
+    'Install Linux maker tooling',
+    'Make (windows NSIS, cross-built)',
+  ]) {
+    const step = make.steps.find(({ name }) => name === stepName)
+    assert.ok(step, `the make gate is missing the "${stepName}" step`)
+    assert.match(
+      step.if ?? '',
+      /ubuntu-latest/,
+      `"${stepName}" must be restricted to the Linux leg`,
+    )
+  }
+})


### PR DESCRIPTION
## Problem

The release quality gate runs `electron-forge make` before the publish matrix (#453 / #498), but only from an Ubuntu runner. `MakerZIP` is configured darwin-only and cannot be cross-built from Linux, so the macOS ZIP — and with it the `latest-mac.yml` half of the `postMake` update-metadata hook in `forge.updateMetadata.ts` — still ran for the first time inside the macOS publish leg. A regression there lands in exactly the situation the gate exists to prevent: a partially populated release for the tag, requiring the tag to be redone.

The weekly `packaging.yml` matrix covers the darwin makers, but it is up to a week stale and does not gate the tag.

## Solution

Fan the `make` gate out over a two-leg matrix:

| Leg | Runner | Makers exercised | Asserted artifacts |
| --- | --- | --- | --- |
| `linux + windows` | `ubuntu-latest` | deb, rpm (native) + NSIS (cross-built `--platform=win32`) | `*.deb *.rpm *-setup-*.exe latest.yml` |
| `macos` | `macos-latest` | darwin ZIP | `*.zip latest-mac.yml` |

The artifact assertion is now per-leg: each matrix entry carries the whitespace-separated list of artifact kinds only that runner can produce, passed to the verification step through the `EXPECTED_ARTIFACTS` env var. The `rpm`/`fakeroot` install and the NSIS cross-build are gated to the Linux leg with step-level `if:` conditions.

`publish` already needs `make`, and a matrix job gates as a whole, so no change to the dependency wiring was required.

The stale note in `packaging.yml` ("release.yml … is Ubuntu-only … cannot run the darwin-only zip maker at all") is corrected: a native Windows `make` is now the only thing that weekly matrix uniquely covers.

## Architecture decisions

- **Matrix over a second job.** A separate `make-macos` job would have to be added to `publish.needs` by hand, and the existing `ci-gate` test that walks every make-running job would treat them independently. One matrix keeps a single gate name and a single set of steps.
- **Patterns as matrix data, not a shell `case`.** Putting the expected artifact kinds next to the runner that produces them keeps the "what does this leg prove" question answerable from the matrix block alone, and makes it assertable from the test.

## Testing

- New `test/ci-gate.test.mjs` case: asserts the `make` job fans out over a `leg` matrix containing an `ubuntu-latest` and a `macos-latest` entry, that each leg declares exactly the artifact kinds only that runner can produce, that the verification step actually consumes `matrix.leg.artifacts`, and that the Linux-only steps carry an `if:` restricting them to that leg. Confirmed red before the workflow change (`the make gate must fan out over a leg matrix…`), green after.
- Full local quality gate: Prettier, ESLint, `tsc`, the complete test suite (162 node:test + 337 vitest, all passing), `actionlint` on both edited workflows.

## Risks

One additional macOS runner per release (`make` is roughly the same cost as the macOS publish leg that follows it). `fail-fast: false` keeps one broken platform from hiding the state of the other. No change to what gets published.

Closes #517
