### PR TITLE
feat(release): publish the control-server image to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,6 +239,66 @@ jobs:
           WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
         run: npm -w streamwall run publish
 
+  # The self-hosting image (#478). CI already builds and boots this Dockerfile
+  # on every PR that touches it, but throws the result away, so operators had
+  # to clone the repo and run the whole toolchain build on their own host with
+  # no immutable artifact to pin or roll back to. Publishing it here makes
+  # `docker compose pull` the update path and every release an addressable
+  # version tag.
+  #
+  # Runs alongside the desktop publish matrix rather than after it: the two
+  # ship unrelated artifacts, and a registry outage should not hold back the
+  # binaries (or the other way round). Both wait for the same quality gate.
+  docker-image:
+    name: Publish (control-server image)
+    needs: [checks, test, build, make, e2e, licenses]
+    # Only a tag carries the version to publish under; a workflow_dispatch run
+    # would otherwise move `latest` to an unreleased commit.
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write # pushing to ghcr.io/<owner>/streamwall-control-server
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Derived from the owner rather than hardcoded so a repository transfer
+      # does not silently keep publishing under the old account. The action
+      # lowercases the image name, which GHCR requires.
+      - name: Derive image tags and labels
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/streamwall-control-server
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      # linux/amd64 only: an emulated arm64 leg would run `npm ci` plus the
+      # control-client build under QEMU and dominate the release time. Native
+      # arm64 runners are tracked separately.
+      - name: Build and push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: packages/streamwall-control-server/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
   # electron-forge's GitHub publisher creates the release for the tag but leaves
   # its body empty. The changelog section for that version — generated from the
   # Conventional Commit subjects by release-please.yml — is exactly the release

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -18,6 +18,12 @@ STREAMWALL_ACME_EMAIL=you@example.com
 
 # --- streamwall-control-server ------------------------------------------
 
+# Released image tag to run (see the GHCR package linked from the repository).
+# `latest` follows every release; pin an exact version here to control when
+# you move, and to roll back by setting the previous one and re-running
+# `docker compose up -d`. Ignored when you build locally with `--build`.
+#STREAMWALL_IMAGE_TAG=latest
+
 # Public base URL of the control server. Must use https:// -- this drives
 # secure-cookie and Content-Security-Policy behaviour (see
 # packages/streamwall-control-server/README.md). Keep the domain in sync

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -4,10 +4,15 @@
 #
 # Usage (from this directory):
 #   cp .env.example .env   # then fill in STREAMWALL_DOMAIN etc.
-#   docker compose up -d --build
+#   docker compose up -d          # pulls the published image
+#   docker compose up -d --build  # builds from this checkout instead
 
 services:
   control-server:
+    # Released image (pin a version with STREAMWALL_IMAGE_TAG in .env). It is
+    # also the tag `--build` writes to locally, so both paths use one service
+    # definition and switching between them needs no compose-file edit.
+    image: ghcr.io/nilsr0711/streamwall-control-server:${STREAMWALL_IMAGE_TAG:-latest}
     build:
       context: ..
       dockerfile: packages/streamwall-control-server/Dockerfile

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -26,11 +26,12 @@ cd streamwall/deploy
 cp .env.example .env
 # edit .env: set STREAMWALL_DOMAIN, STREAMWALL_ACME_EMAIL, and
 # STREAMWALL_CONTROL_URL to match your domain (see comments in the file)
-docker compose up -d --build
+docker compose up -d
 ```
 
-This builds [`packages/streamwall-control-server/Dockerfile`](../packages/streamwall-control-server/Dockerfile)
-and starts two containers, wired together by
+This pulls the control-server image published for the latest release
+(`ghcr.io/nilsr0711/streamwall-control-server:latest`) and starts two
+containers, wired together by
 [`deploy/docker-compose.yml`](../deploy/docker-compose.yml):
 
 - **`control-server`** — the Fastify backend, not published to the host
@@ -40,6 +41,25 @@ and starts two containers, wired together by
   for `STREAMWALL_DOMAIN` and forwards traffic to `control-server`. Caddy was
   chosen over nginx/Traefik for this specifically because it needs no manual
   ACME/cert configuration — see [`deploy/Caddyfile`](../deploy/Caddyfile).
+
+To pin a specific release instead of following `latest` — recommended for
+anything you depend on, since it makes an update (and a rollback) an explicit
+change — set the tag in `.env`:
+
+```sh
+STREAMWALL_IMAGE_TAG=0.9.1
+```
+
+To run code that has not been released yet (or a local modification), build
+the image from this checkout instead of pulling it:
+
+```sh
+docker compose up -d --build
+```
+
+That builds [`packages/streamwall-control-server/Dockerfile`](../packages/streamwall-control-server/Dockerfile)
+and tags the result as the same image name, so the two paths stay
+interchangeable without editing the compose file.
 
 Auth-token storage (`storage.json`) lives on the `control-server-data` named
 volume, so it survives container restarts/rebuilds; back that volume up like
@@ -183,6 +203,18 @@ update is available — so checking no longer requires shelling into the host
 or querying `/admin/status` by hand. Every other role sees neither.
 
 ## Updating
+
+```sh
+cd streamwall/deploy
+docker compose pull
+docker compose up -d
+```
+
+That fetches the image published for the newest release. If you pinned
+`STREAMWALL_IMAGE_TAG`, set it to the new version first (and set it back to
+the previous one to roll back — every released version stays available).
+
+If you build from source instead, update the checkout first:
 
 ```sh
 cd streamwall

--- a/test/release-docker.test.mjs
+++ b/test/release-docker.test.mjs
@@ -1,0 +1,125 @@
+import { load } from 'js-yaml'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)))
+
+function readYaml(relativePath) {
+  return load(readFileSync(join(rootDir, relativePath), 'utf8'))
+}
+
+function readText(relativePath) {
+  return readFileSync(join(rootDir, relativePath), 'utf8')
+}
+
+const IMAGE_REPOSITORY = 'streamwall-control-server'
+
+function dockerJob() {
+  const job = readYaml('.github/workflows/release.yml').jobs['docker-image']
+  assert.ok(job, 'release.yml is missing a docker-image job')
+  return job
+}
+
+// Self-hosters otherwise have to clone the repo and run the full toolchain
+// build on their own host, with no immutable artifact to pin or roll back to
+// (#478).
+test('the release publishes the control-server image to GHCR', () => {
+  const steps = dockerJob().steps
+
+  const login = steps.find((step) =>
+    step.uses?.startsWith('docker/login-action@'),
+  )
+  assert.ok(login, 'the docker-image job must log in to a registry')
+  assert.equal(login.with.registry, 'ghcr.io')
+
+  const push = steps.find((step) =>
+    step.uses?.startsWith('docker/build-push-action@'),
+  )
+  assert.ok(push, 'the docker-image job must build and push the image')
+  assert.equal(push.with.push, true)
+  assert.equal(
+    push.with.file,
+    `packages/${IMAGE_REPOSITORY}/Dockerfile`,
+    'the published image must come from the self-hosting Dockerfile',
+  )
+  assert.equal(
+    push.with.context,
+    '.',
+    'the Dockerfile needs the repository root as its build context',
+  )
+})
+
+// A GITHUB_TOKEN without `packages: write` fails at push time, after the whole
+// image has been built.
+test('the docker-image job is granted package write access', () => {
+  assert.equal(dockerJob().permissions.packages, 'write')
+})
+
+// Both the version tag (to pin or roll back to) and `latest` (what the
+// documented compose stack resolves by default) have to exist for every
+// release.
+test('the published image is tagged with the version and latest', () => {
+  const meta = dockerJob().steps.find((step) =>
+    step.uses?.startsWith('docker/metadata-action@'),
+  )
+  assert.ok(meta, 'the docker-image job must derive its tags from the ref')
+  assert.match(
+    meta.with.images,
+    new RegExp(`^ghcr\\.io/.+/${IMAGE_REPOSITORY}$`),
+  )
+  assert.match(meta.with.tags, /type=semver,pattern=\{\{version\}\}/)
+  assert.match(meta.with.tags, /type=raw,value=latest/)
+})
+
+// The image must not ship code that would have failed a pull request, and a
+// `latest` tag pointing at an untested build is worse than no image at all.
+test('the image publish waits for the release quality gate', () => {
+  const release = readYaml('.github/workflows/release.yml')
+
+  for (const job of release.jobs.publish.needs) {
+    assert.ok(
+      release.jobs['docker-image'].needs.includes(job),
+      `release.yml job "${job}" gates the binaries but not the image`,
+    )
+  }
+})
+
+// Only a tag carries a version to publish under; a manual workflow_dispatch
+// run would otherwise move `latest` to an unreleased commit.
+test('the image is only published for a version tag', () => {
+  assert.match(dockerJob().if, /refs\/tags\/v/)
+})
+
+// `docker compose pull` needs an image reference; keeping `build:` alongside
+// it preserves the documented local-build path (`up -d --build`).
+test('the compose stack can pull the published image', () => {
+  const service = readYaml('deploy/docker-compose.yml').services[
+    'control-server'
+  ]
+
+  assert.match(
+    service.image,
+    new RegExp(`^ghcr\\.io/.+/${IMAGE_REPOSITORY}:\\$\\{`),
+    'the compose service must reference the published image with an ' +
+      'overridable tag so a deployment can be pinned',
+  )
+  assert.ok(
+    service.build,
+    'the local-build path must keep working for unreleased changes',
+  )
+})
+
+test('self-hosting documents pulling and pinning the image', () => {
+  const doc = readText('docs/self-hosting.md')
+
+  assert.match(doc, /docker compose pull/)
+  assert.match(doc, /STREAMWALL_IMAGE_TAG/)
+  assert.match(
+    readText('deploy/.env.example'),
+    /STREAMWALL_IMAGE_TAG/,
+    '.env.example must document the tag the compose stack resolves',
+  )
+})


### PR DESCRIPTION
## Summary

CI has built and booted `packages/streamwall-control-server/Dockerfile` on every PR that touches it since #401, but the image was thrown away. Self-hosters therefore had to clone the repo and run the full toolchain build on their own host, updating meant `git pull` + rebuild, and there was no immutable, versioned artifact to pin or roll back to.

This publishes the image on release and makes the documented self-hosting stack use it.

**Release workflow** — a new `docker-image` job:

- waits for the same quality gate as the desktop publish matrix (`checks`, `test`, `build`, `make`, `e2e`, `licenses`), so `latest` can never point at a build that would have failed a PR;
- runs only for `refs/tags/v*`, so a manual `workflow_dispatch` run cannot move `latest` to an unreleased commit;
- logs in to GHCR with the workflow `GITHUB_TOKEN` (`packages: write`) and pushes `ghcr.io/${{ github.repository_owner }}/streamwall-control-server`, tagged with the released version and `latest`, plus the OCI labels `docker/metadata-action` derives.

It runs alongside the binary publish matrix rather than after it: the two ship unrelated artifacts, so a registry outage should not hold back the installers (or the other way round).

**Compose stack** — `deploy/docker-compose.yml` now carries `image: ghcr.io/nilsr0711/streamwall-control-server:${STREAMWALL_IMAGE_TAG:-latest}` *next to* its existing `build:` section. That single service definition serves both paths: `docker compose up -d` pulls the released image, `up -d --build` builds from the checkout and tags the result identically, and `STREAMWALL_IMAGE_TAG` (documented in `.env.example`) pins a version or rolls one back. Purely additive — nothing about the local-build path changes.

**Docs** — `docs/self-hosting.md` leads with the pull-based quick start, documents pinning, and the update section is now `docker compose pull && docker compose up -d`, with the source-build variant kept below it.

### Architecture decisions

- **Image name derived from `github.repository_owner`** rather than hardcoded, so a repository transfer does not silently keep publishing under the old account. `docker/metadata-action` lowercases the name, which GHCR requires.
- **`linux/amd64` only.** An emulated arm64 leg would run `npm ci` plus the control-client build under QEMU and dominate the release time. Native arm64 runners with a manifest merge are tracked in #524.
- **`image` + `build` in one service** instead of a second compose file, which would have duplicated the Caddy service and the volume wiring.

## How was this tested?

- New `test/release-docker.test.mjs` (7 tests, node:test + js-yaml, same shape as the existing workflow tests): the job pushes to `ghcr.io` from the self-hosting Dockerfile with the repository root as context, holds `packages: write`, tags both the semver version and `latest`, inherits every gate job the binary publish waits for, is tag-gated, and the compose service keeps both an overridable image reference and its build section — plus the docs/`.env.example` assertions. Red before the change, green after.
- `npm run format`, `npm run lint`, `npm run typecheck`, `npm test` — all green locally.
- `actionlint` (the pinned 1.7.12 image CI uses) clean on the changed workflow.
- `docker compose config` in `deploy/` with `.env.example` renders `image: ghcr.io/nilsr0711/streamwall-control-server:latest`; CI's `Docker build (control server)` job re-runs that validation plus the build/boot smoke test on this PR.

## Risks / breaking changes

None for existing deployments: `docker compose up -d --build` behaves exactly as before. The pull path only starts working once the first tag runs the new job — until then, self-hosters follow the documented `--build` variant. The first push also creates the GHCR package, which starts out private; it has to be flipped to public once (package settings) before anonymous `docker compose pull` works.

## Follow-ups

- #524 — publish a `linux/arm64` image alongside amd64 via native runners and a manifest merge.

Closes #478

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests (or this PR explains why none apply)
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments