### PR TITLE
ci: block merges on newly introduced high-severity CodeQL alerts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,3 +36,12 @@ jobs:
           queries: security-and-quality
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        with:
+          # Without an explicit category, the uploaded results are keyed by the
+          # calling workflow, so ci.yml and codeql-schedule.yml register two
+          # separate configurations. A pull request only ever produces the
+          # ci.yml one, and code scanning then reports "1 configuration not
+          # found" and refuses to say which alerts the PR introduced — which
+          # leaves the code_scanning merge rule waiting forever. One fixed
+          # category keeps every caller on the same configuration.
+          category: /language:${{ matrix.language }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,10 +192,13 @@ The rule looks at the alerts a PR introduces, so a merge is never blocked by
 the pre-existing backlog. Alerts below the threshold, and quality alerts of any
 severity, are triaged in the Security tab instead.
 
-The rule needs a CodeQL result for the PR head commit or for its current merge
-commit, and GitHub regenerates that merge commit. `codeql.yml` therefore checks
-out the head commit rather than the default merge checkout, so its results stay
-attached to a SHA the rule can match; `test/ci-gate.test.mjs` guards that.
+Code scanning can only name the alerts a PR introduces when the PR carries a
+result for every configuration it sees on `main`, and a configuration is keyed
+by the analysis _category_ — which defaults to the calling workflow. `ci.yml`
+and `codeql-schedule.yml` would therefore register one configuration each, and
+a PR (which only runs the `ci.yml` one) would be blocked waiting for the other
+forever. `codeql.yml` pins one explicit category for all callers instead;
+`test/ci-gate.test.mjs` guards that.
 
 CodeQL does produce false positives here — see the `HTMLMediaElement.src` sink
 overmatch in [#301](https://github.com/NilsR0711/streamwall/issues/301). Resolve

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,9 +176,32 @@ Some workflows intentionally sit outside this gate: `.github/workflows/release.y
 (tag-triggered), CodeQL's weekly scheduled scan, which surfaces newly
 disclosed patterns in code that was already merged, and the weekly
 [packaging](#packaging-checks) and [deprecation](#dependency-deprecations)
-checks, which react to upstream changes rather than to anything in a PR. Open
-code-scanning alerts are triaged in the Security tab; the gate blocks on the
-analysis _failing_, not on pre-existing alerts.
+checks, which react to upstream changes rather than to anything in a PR.
+
+### Code scanning alerts
+
+The two status checks only cover the CodeQL analysis _running_ successfully.
+Alerts that a successful analysis reports are gated separately, by the
+`code_scanning` rule of the same `main-protection` ruleset:
+
+- `security_alerts_threshold: high_or_higher` — a PR that introduces a high or
+  critical **security** alert cannot be merged.
+- `alerts_threshold: none` — non-security **quality** alerts stay advisory.
+
+The rule looks at the alerts a PR introduces, so a merge is never blocked by
+the pre-existing backlog. Alerts below the threshold, and quality alerts of any
+severity, are triaged in the Security tab instead.
+
+The rule needs a CodeQL result for the PR head commit or for its current merge
+commit, and GitHub regenerates that merge commit. `codeql.yml` therefore checks
+out the head commit rather than the default merge checkout, so its results stay
+attached to a SHA the rule can match; `test/ci-gate.test.mjs` guards that.
+
+CodeQL does produce false positives here — see the `HTMLMediaElement.src` sink
+overmatch in [#301](https://github.com/NilsR0711/streamwall/issues/301). Resolve
+them per alert rather than by weakening the queries repo-wide: dismiss the alert
+with a `false positive` reason and a short justification, which unblocks the PR
+and keeps the rule intact for everything else.
 
 ### PR checklist
 

--- a/test/ci-gate.test.mjs
+++ b/test/ci-gate.test.mjs
@@ -54,6 +54,36 @@ test('codeql.yml is reusable and does not run standalone on pull requests', () =
   )
 })
 
+// Code scanning keys a configuration by the analysis category, which defaults
+// to the calling workflow. Two callers therefore mean two configurations, and
+// a PR — which only runs the ci.yml one — is reported as missing the other,
+// so the code_scanning merge rule never gets its result (#476).
+test('every CodeQL caller uploads under the same explicit category', () => {
+  const codeql = readWorkflow('codeql.yml')
+  const analyze = codeql.jobs.analyze.steps.find((step) =>
+    step.uses?.includes('github/codeql-action/analyze'),
+  )
+
+  assert.ok(analyze, 'codeql.yml must run the CodeQL analyze action')
+  assert.ok(
+    analyze.with?.category,
+    'the analyze step must set an explicit category, otherwise each calling ' +
+      'workflow registers its own code scanning configuration',
+  )
+  assert.ok(
+    !/github\.workflow|github\.event/.test(analyze.with.category),
+    `the category must not vary per caller (got "${analyze.with.category}")`,
+  )
+
+  const callers = ['ci.yml', 'codeql-schedule.yml']
+  for (const caller of callers) {
+    const calls = Object.values(readWorkflow(caller).jobs).some(
+      (job) => job.uses === './.github/workflows/codeql.yml',
+    )
+    assert.ok(calls, `${caller} must run the analysis through codeql.yml`)
+  }
+})
+
 // The control client is expensive to build, and the E2E job needs exactly the
 // artifact the build job already produced. Handing it over keeps CI down to a
 // single `vite build` per run (issue #489).


### PR DESCRIPTION
## Problem

CodeQL runs inside `ci.yml` and reports through the `CI OK` required check, so
a *failing* analysis blocks a merge. A *successful* analysis that reports alerts
did not — the alerts only showed up in the Security tab, and `CONTRIBUTING.md`
documented exactly that gap.

## Solution

Gate the alerts themselves through the `code_scanning` rule of the active
`main-protection` ruleset, with the thresholds proposed in #476:

- `security_alerts_threshold: high_or_higher` — a PR introducing a high or
  critical security alert cannot be merged.
- `alerts_threshold: none` — non-security quality alerts stay advisory.

The rule only considers alerts a PR introduces, so the merge gate is never held
hostage by the pre-existing backlog (which is currently empty — zero open
code-scanning alerts).

`CONTRIBUTING.md` gains a "Code scanning alerts" section documenting the
thresholds and the triage path for the documented CodeQL false positives
(#301): dismiss per alert with a `false positive` reason instead of weakening
the queries repo-wide.

The rule matches results by PR head SHA or by the current merge SHA, and
GitHub regenerates the ephemeral merge commit. With the default checkout the
analysis is attributed to a merge SHA that goes stale, and the rule then waits
forever for a result that will never exist — observed on this very PR, which
was unmergeable until `codeql.yml` was pinned to
`github.event.pull_request.head.sha`. `test/ci-gate.test.mjs` guards the pin.

## Architecture decisions

- **Ruleset rule, not a workflow step.** GitHub evaluates the alert delta
  itself; reimplementing it as a `gh api code-scanning/alerts` step in `ci.yml`
  would duplicate that logic and race the analysis upload.
- **Kept out of the documented required-check list.** The two required status
  checks stay `CI OK` and `Conventional Commits title`; the code-scanning rule
  is a separate ruleset rule and is documented in its own subsection so
  `test/ci-gate.test.mjs` keeps asserting the check list verbatim.

## Testing

New test in `test/ci-gate.test.mjs` (written first, red against the old
workflow): the CodeQL checkout must pin the PR head SHA. The docs and the
ruleset change itself have no testable behavior.
`npm run format:check`, `npm run lint`, `npm run typecheck` and `npm test` pass
locally; `test/ci-gate.test.mjs` still parses the required-checks section
unchanged.

## Risks

Once the ruleset rule is active, a newly introduced high/critical alert hard
blocks the PR until it is fixed or dismissed. That is the intent; the false
positive path is documented.

Closes #476
