### PR TITLE
ci(workflows): report scheduled workflow failures in the issue tracker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,7 @@ jobs:
 
   # Static security analysis. Runs here — instead of standing alone — so that
   # a CodeQL failure fails the single `CI OK` check branch protection requires.
-  # The same analysis runs weekly from codeql.yml's schedule.
+  # The same analysis runs weekly from codeql-schedule.yml.
   codeql:
     name: CodeQL
     needs: changes

--- a/.github/workflows/codeql-schedule.yml
+++ b/.github/workflows/codeql-schedule.yml
@@ -1,0 +1,44 @@
+name: CodeQL (weekly)
+
+# The periodic CodeQL scan, catching patterns that were only disclosed after
+# the code was last touched. The analysis itself lives in codeql.yml, which
+# ci.yml calls for pushes and pull requests.
+#
+# It is a workflow of its own rather than a second trigger on codeql.yml so
+# that the reporting job below can hold `issues: write`: a called workflow is
+# capped at the permissions of its caller, and ci.yml — the other caller —
+# neither has nor should have that scope (#514).
+on:
+  schedule:
+    # Mondays, 03:30 UTC.
+    - cron: '30 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-schedule-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  analyze:
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    uses: ./.github/workflows/codeql.yml
+
+  # A failing weekly run is invisible without this: nobody is emailed about a
+  # scheduled run, so the report goes into the issue tracker instead (#514).
+  report:
+    needs: [analyze]
+    if: always()
+    permissions:
+      issues: write
+    uses: ./.github/workflows/scheduled-report.yml
+    with:
+      result: >-
+        ${{ contains(needs.*.result, 'failure') && 'failure'
+         || contains(needs.*.result, 'success') && 'success'
+         || 'none' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,13 +1,13 @@
 name: CodeQL
 
-# Push and pull-request analysis is driven by ci.yml, which calls this
-# workflow as a job of the `CI OK` gate — that is what makes a CodeQL failure
-# block a merge. Only the periodic scan is triggered here.
+# The analysis itself, with no trigger of its own. ci.yml calls it as a job of
+# the `CI OK` gate — that is what makes a CodeQL failure block a merge — and
+# codeql-schedule.yml calls it for the weekly scan. The schedule lives there
+# rather than here because a caller can never grant a called workflow more
+# permissions than it holds itself, so the weekly run's `issues: write`
+# reporting job would otherwise have to be granted by ci.yml as well.
 on:
   workflow_call:
-  schedule:
-    # Weekly scan (Mondays 03:30 UTC) to catch newly disclosed patterns.
-    - cron: '30 3 * * 1'
 
 permissions:
   contents: read

--- a/.github/workflows/deprecated-deps.yml
+++ b/.github/workflows/deprecated-deps.yml
@@ -46,3 +46,17 @@ jobs:
 
       - name: Check for deprecated direct dependencies
         run: node scripts/check-deprecated-deps.mjs
+
+  # A failing weekly run is invisible without this: nobody is emailed about a
+  # scheduled run, so the report goes into the issue tracker instead (#514).
+  report:
+    needs: [check]
+    if: always()
+    permissions:
+      issues: write
+    uses: ./.github/workflows/scheduled-report.yml
+    with:
+      result: >-
+        ${{ contains(needs.*.result, 'failure') && 'failure'
+         || contains(needs.*.result, 'success') && 'success'
+         || 'none' }}

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -84,3 +84,19 @@ jobs:
             exit 1
           fi
           find "$make_dir" -type f -print | sort
+
+  # A failing weekly run is invisible without this: nobody is emailed about a
+  # scheduled run, so the report goes into the issue tracker instead (#514).
+  # `fail-fast: false` above means one red leg still leaves the others' verdict
+  # intact, and `needs.*.result` aggregates the matrix into a single one.
+  report:
+    needs: [make]
+    if: always()
+    permissions:
+      issues: write
+    uses: ./.github/workflows/scheduled-report.yml
+    with:
+      result: >-
+        ${{ contains(needs.*.result, 'failure') && 'failure'
+         || contains(needs.*.result, 'success') && 'success'
+         || 'none' }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -49,3 +49,18 @@ jobs:
 
       - name: Check the release version is tagged
         run: node scripts/check-release-tag.mjs
+
+  # A failing scheduled run is invisible without this: nobody is emailed about
+  # one, so the report goes into the issue tracker instead (#514) — which is
+  # also where a forgotten tag belongs.
+  report:
+    needs: [check]
+    if: always()
+    permissions:
+      issues: write
+    uses: ./.github/workflows/scheduled-report.yml
+    with:
+      result: >-
+        ${{ contains(needs.*.result, 'failure') && 'failure'
+         || contains(needs.*.result, 'success') && 'success'
+         || 'none' }}

--- a/.github/workflows/scheduled-report.yml
+++ b/.github/workflows/scheduled-report.yml
@@ -1,0 +1,87 @@
+name: Scheduled report
+
+# Reports the verdict of a scheduled workflow into the issue tracker (#514).
+#
+# GitHub only emails the user whose commit triggered a run, and a `schedule`
+# run has no such user, so a red weekly job produces no signal at all beyond an
+# entry in the Actions tab. The weekly workflows exist to surface problems that
+# arrive from upstream between PRs, which is exactly the kind of failure nobody
+# is watching for — so each of them calls this workflow to file its own report.
+#
+# One issue per calling workflow, reused: a persistent failure adds a comment
+# rather than a new issue, and the next green run closes it, so the tracker
+# always reflects the current state instead of a pile of weekly duplicates.
+on:
+  workflow_call:
+    inputs:
+      result:
+        description: >-
+          Aggregated result of the calling workflow's jobs: `failure` files or
+          updates the report, `success` closes it, anything else (cancelled,
+          skipped) is ignored.
+        required: true
+        type: string
+
+# Granted per job below; the caller has to grant `issues: write` as well, since
+# a reusable workflow can never exceed the permissions it was called with.
+permissions: {}
+
+jobs:
+  report:
+    name: Report scheduled run
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      # No checkout: everything below talks to the API, and the token stays out
+      # of a working copy that way.
+      - name: File, update or close the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RESULT: ${{ inputs.result }}
+          # In a reusable workflow these name and link the *calling* workflow.
+          WORKFLOW: ${{ github.workflow }}
+          TITLE: 'Scheduled workflow failing: ${{ github.workflow }}'
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "$RESULT" != 'failure' ] && [ "$RESULT" != 'success' ]; then
+            echo "Result is '$RESULT' — nothing to report."
+            exit 0
+          fi
+
+          # Matched on the exact title rather than through issue search: the
+          # search index lags behind by minutes, which is long enough for two
+          # runs of the same workflow to each open their own issue.
+          issue=$(gh issue list --state open --limit 100 --json number,title \
+            --jq 'map(select(.title == env.TITLE)) | .[0].number // empty')
+
+          if [ "$RESULT" = 'failure' ]; then
+            if [ -n "$issue" ]; then
+              gh issue comment "$issue" --body "Still failing: $RUN_URL"
+              echo "Commented on #$issue."
+            else
+              gh issue create --title "$TITLE" --label ci-cd --body \
+          "The scheduled workflow \`$WORKFLOW\` failed: $RUN_URL
+
+          Scheduled runs notify nobody, so this issue is the notification. It is
+          reused for every further failure and closed automatically once the
+          workflow runs green again, so please leave it open until then.
+
+          Filed by \`.github/workflows/scheduled-report.yml\`."
+              echo 'Filed a new report.'
+            fi
+            exit 0
+          fi
+
+          if [ -n "$issue" ]; then
+            gh issue close "$issue" --reason completed --comment \
+              "Green again: $RUN_URL"
+            echo "Closed #$issue."
+          else
+            echo 'Green, and no open report to close.'
+          fi

--- a/test/scheduled-reports.test.mjs
+++ b/test/scheduled-reports.test.mjs
@@ -1,0 +1,147 @@
+import { load } from 'js-yaml'
+import assert from 'node:assert/strict'
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)))
+const workflowDir = join(rootDir, '.github/workflows')
+const reporterPath = './.github/workflows/scheduled-report.yml'
+
+function readWorkflow(fileName) {
+  return load(readFileSync(join(workflowDir, fileName), 'utf8'))
+}
+
+function scheduledWorkflows() {
+  return readdirSync(workflowDir)
+    .filter((fileName) => fileName.endsWith('.yml'))
+    .map((fileName) => [fileName, readWorkflow(fileName)])
+    .filter(([, workflow]) => workflow.on?.schedule)
+}
+
+// A scheduled run has no triggering user, so GitHub emails nobody when it goes
+// red — the failure only exists as an entry in the Actions tab (#514). Every
+// workflow that runs on a schedule therefore has to report its own verdict.
+test('every scheduled workflow reports its result', () => {
+  const workflows = scheduledWorkflows()
+  assert.ok(workflows.length > 0, 'expected at least one scheduled workflow')
+
+  for (const [fileName, workflow] of workflows) {
+    const entries = Object.entries(workflow.jobs)
+    const reporters = entries.filter(([, job]) => job.uses === reporterPath)
+    assert.equal(
+      reporters.length,
+      1,
+      `${fileName} must call ${reporterPath} exactly once`,
+    )
+
+    const [reporterName, reporter] = reporters[0]
+    const workJobs = entries
+      .map(([name]) => name)
+      .filter((name) => name !== reporterName)
+
+    for (const name of workJobs) {
+      assert.ok(
+        reporter.needs?.includes(name),
+        `${fileName} job "${name}" is missing from the reporting job's needs, ` +
+          'so its failure would go unreported',
+      )
+    }
+
+    // Without `always()` the reporter inherits the default "only on success"
+    // condition and is skipped by exactly the runs it exists to report.
+    assert.match(
+      String(reporter.if ?? ''),
+      /always\(\)/,
+      `${fileName}'s reporting job must run with always()`,
+    )
+
+    // `needs.*.result` covers every upstream job, including matrix legs, so a
+    // new job in the workflow cannot silently fall out of the verdict.
+    assert.match(
+      String(reporter.with?.result ?? ''),
+      /needs\.\*\.result/,
+      `${fileName} must derive the reported result from needs.*.result`,
+    )
+
+    // The reusable workflow can only use permissions the caller granted.
+    assert.equal(
+      reporter.permissions?.issues,
+      'write',
+      `${fileName}'s reporting job must grant issues: write`,
+    )
+    assert.equal(
+      reporter.permissions?.contents,
+      undefined,
+      `${fileName}'s reporting job must not grant contents access`,
+    )
+  }
+})
+
+// A called workflow is capped at the permissions of its caller, and that cap
+// is validated when the run is created — before any job-level `if` is
+// evaluated. So a workflow that is both called and scheduled cannot grow a
+// reporting job with `issues: write` without failing every caller's run at
+// startup; the schedule belongs in a wrapper of its own instead.
+test('a workflow another workflow calls does not also run on a schedule', () => {
+  const called = new Set(
+    readdirSync(workflowDir)
+      .filter((fileName) => fileName.endsWith('.yml'))
+      .flatMap((fileName) => Object.values(readWorkflow(fileName).jobs))
+      .map((job) => job.uses)
+      .filter((uses) => uses?.startsWith('./.github/workflows/')),
+  )
+  assert.ok(called.size > 0, 'expected at least one reusable workflow call')
+
+  for (const path of called) {
+    const workflow = readWorkflow(path.split('/').pop())
+    assert.equal(
+      workflow.on?.schedule,
+      undefined,
+      `${path} is called by another workflow and must not also be scheduled`,
+    )
+  }
+})
+
+test('the reporter is reusable only and keeps its permissions scoped', () => {
+  const reporter = readWorkflow('scheduled-report.yml')
+
+  assert.deepEqual(
+    Object.keys(reporter.on),
+    ['workflow_call'],
+    'scheduled-report.yml must only be callable from another workflow',
+  )
+  assert.deepEqual(
+    reporter.permissions,
+    {},
+    'scheduled-report.yml must start from no permissions at all',
+  )
+
+  const [job] = Object.values(reporter.jobs)
+  assert.deepEqual(
+    job.permissions,
+    { issues: 'write' },
+    'the reporting job needs issues: write and nothing else',
+  )
+})
+
+// Reusing one issue per workflow is what keeps a persistent failure from
+// filing a fresh report every week, and closing it on the next green run is
+// what keeps the tracker honest about the current state.
+test('the reporter reuses one issue per workflow and closes it when green', () => {
+  const reporter = readWorkflow('scheduled-report.yml')
+  const script = Object.values(reporter.jobs)
+    .flatMap((job) => job.steps)
+    .map((step) => step.run ?? '')
+    .join('\n')
+
+  assert.match(
+    script,
+    /gh issue list/,
+    'the reporter must look for an existing issue before opening one',
+  )
+  assert.match(script, /gh issue create/)
+  assert.match(script, /gh issue comment/)
+  assert.match(script, /gh issue close/)
+})


### PR DESCRIPTION
## Problem

`packaging.yml` (weekly `electron-forge make`) and `deprecated-deps.yml` (weekly
npm deprecation check) run only on a schedule, outside the `CI OK` merge gate.
A `schedule` run has no triggering user, so GitHub emails nobody when one turns
red: the only signal is an entry in the Actions tab. Both workflows exist to
surface problems that arrive from upstream between PRs — precisely the failures
nobody is watching for — so a red weekly job could sit unnoticed for weeks.

The same applies to `codeql.yml`, which also runs a weekly scan in addition to
being called from `ci.yml`.

## Solution

A new reusable workflow `.github/workflows/scheduled-report.yml`:

- takes an aggregated `result` input and does nothing unless it is
  `failure` or `success`;
- on failure, looks for an open issue titled
  `Scheduled workflow failing: <workflow>` and **comments** on it, or files it
  if none exists — so a persistent failure never spams the tracker;
- on success, closes that issue with a "green again" comment, so the tracker
  reflects the current state;
- declares `permissions: {}` at workflow level and `issues: write` on the single
  job, and does no checkout.

The three scheduled workflows call it from a `report` job with
`if: always()`, `needs` on their work jobs and `permissions: issues: write`
(a reusable workflow can never exceed the caller's permissions). The result is
derived via `contains(needs.*.result, …)`, which aggregates the packaging matrix
into one verdict and keeps working when a job is added.

### Decisions

- **Reusable workflow rather than a duplicated step** — three call sites, one
  place for the issue-reuse logic.
- **Matched on the exact issue title, not issue search** — the search index lags
  by minutes, long enough for two runs to each open their own issue.
- **The weekly CodeQL scan moved into its own `codeql-schedule.yml`** —
  `codeql.yml` was both called by `ci.yml` and scheduled. A called workflow is
  capped at its caller's permissions, and that cap is validated when the run is
  created, before any job-level `if` is evaluated: adding an `issues: write`
  reporting job to `codeql.yml` failed *every* CI run at startup. `codeql.yml`
  is now call-only and owns nothing but the analysis; the wrapper owns the cron
  and the reporting. A test pins the invariant so this cannot come back.
- **`packaging`/`deprecated-deps` also report on `workflow_dispatch`** — those
  workflows have no other trigger, and a manual re-run is how a fix gets
  verified, so it should be able to close the report.

## Testing

New `test/scheduled-reports.test.mjs` derives the requirement from the workflow
files themselves: it enumerates every workflow with an `on.schedule` trigger and
asserts each calls the reporter exactly once, needs every other job, runs with
`always()`, derives the result from `needs.*.result` and grants `issues: write`
and nothing else. It also pins the reporter to `workflow_call` only, to empty
top-level permissions, and to the create/comment/close behaviour. A future
scheduled workflow that skips reporting fails this test.

Full quality gate green locally: format, lint, typecheck, `npm run test`
(162 root + workspace suites, 337 control-ui tests), `actionlint` clean.

## Risks

Workflow-only change; nothing in the app or the merge gate is touched. The
reporting jobs cannot run on `pull_request`, so this PR's own CI does not
exercise them — the first real proof is next Monday's scheduled run (or a
`workflow_dispatch` of `Packaging` / `Deprecated dependencies`).

Closes #514
