### PR TITLE
feat(control-ui): add a shared focus-visible affordance for buttons

### DIFF
--- a/packages/streamwall-control-ui/src/StyledButton.tsx
+++ b/packages/streamwall-control-ui/src/StyledButton.tsx
@@ -36,10 +36,8 @@ export const StyledButton = styled.button<{
       color: #fff;
     `};
 
-  &:focus {
-    outline: none;
-    box-shadow: 0 0 0 2px var(--accent-soft);
-  }
+  /* No local :focus override - it would suppress the shared :focus-visible
+     outline from GlobalStyle, which is the stronger affordance (see #508). */
 
   svg {
     width: 20px;

--- a/packages/streamwall-control-ui/src/globalStyle.test.tsx
+++ b/packages/streamwall-control-ui/src/globalStyle.test.tsx
@@ -1,9 +1,12 @@
-import { render } from 'preact'
+import { type ComponentChildren, render } from 'preact'
 import { act } from 'preact/test-utils'
+import { StyleSheetManager } from 'styled-components'
 import { afterEach, describe, expect, test } from 'vitest'
+import { StreamList } from './Sidebar.tsx'
 import { GlobalStyle } from './globalStyle.tsx'
 
 let container: HTMLDivElement | undefined
+let styleTarget: HTMLDivElement | undefined
 
 afterEach(() => {
   if (container) {
@@ -11,10 +14,32 @@ afterEach(() => {
     container.remove()
     container = undefined
   }
+  styleTarget?.remove()
+  styleTarget = undefined
   document
     .querySelectorAll('style[data-styled]')
     .forEach((style) => style.remove())
 })
+
+/**
+ * Renders into a fresh container with its own styled-components target. The
+ * dedicated target matters: styled-components remembers what it already
+ * injected, so without a new sheet per test only the first render would emit
+ * the global CSS these tests inspect.
+ */
+function renderWithStyles(node: ComponentChildren) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  styleTarget = document.createElement('div')
+  document.head.appendChild(styleTarget)
+
+  act(() => {
+    render(
+      <StyleSheetManager target={styleTarget}>{node}</StyleSheetManager>,
+      container!,
+    )
+  })
+}
 
 // The browser default 8px body margin is never reset, so the flex shell (sized
 // to the viewport) ends up wider than the viewport once that margin is added -
@@ -29,18 +54,82 @@ afterEach(() => {
 // floor so `body` actually shrinks to fit the viewport.
 describe('GlobalStyle', () => {
   test('resets the default body margin and min-width so the shell cannot exceed the viewport width', () => {
-    container = document.createElement('div')
-    document.body.appendChild(container)
+    renderWithStyles(<GlobalStyle />)
 
-    act(() => {
-      render(<GlobalStyle />, container!)
-    })
-
-    const css = Array.from(document.querySelectorAll('style'))
-      .map((style) => style.textContent)
-      .join('\n')
+    const css = collectCss()
 
     expect(css).toMatch(/html,\s*body\s*{[^}]*margin:\s*0/)
     expect(css).toMatch(/html,\s*body\s*{[^}]*min-width:\s*0/)
   })
+
+  // Inputs have carried an accent focus ring since the design system landed,
+  // but buttons had none and fell back to the user-agent ring - which is
+  // easily lost on the custom-coloured controls (sidebar handle, favorite
+  // star, grid preset buttons); see #508. One shared `:focus-visible` rule
+  // covers every focusable element instead.
+  test('defines a shared focus-visible affordance built from the accent tokens', () => {
+    renderWithStyles(<GlobalStyle />)
+
+    const rule = focusVisibleRule(collectCss())
+
+    expect(rule).toBeDefined()
+    expect(rule!.body).toMatch(/outline:\s*2px solid var\(--accent\)/)
+    expect(rule!.body).toMatch(/outline-offset:/)
+    expect(rule!.body).toMatch(/var\(--accent-soft\)/)
+  })
+
+  test('applies that affordance to a custom-styled button such as the sidebar stream handle', () => {
+    renderWithStyles(
+      <>
+        <GlobalStyle />
+        <StreamList
+          rows={[
+            {
+              _id: 'abc',
+              _dataSource: 'example',
+              kind: 'video',
+              link: 'https://example.com/stream',
+            },
+          ]}
+          disabled={false}
+          onClickId={() => {}}
+          favorites={new Set()}
+        />
+      </>,
+    )
+
+    const handle = container!.querySelector('button')
+    expect(handle).not.toBeNull()
+
+    const rule = focusVisibleRule(collectCss())
+    expect(rule).toBeDefined()
+    expect(rule!.selectors.some((selector) => handle!.matches(selector))).toBe(
+      true,
+    )
+  })
 })
+
+function collectCss(): string {
+  return Array.from(document.querySelectorAll('style'))
+    .map((style) => style.textContent)
+    .join('\n')
+}
+
+/**
+ * Extracts the shared `:focus-visible` rule and reduces its selectors to the
+ * plain-element part, so a test can check which elements the rule matches
+ * (`:focus-visible` itself never matches in a non-interactive DOM).
+ */
+function focusVisibleRule(
+  css: string,
+): { selectors: string[]; body: string } | undefined {
+  const match = /([^{}]*:focus-visible[^{}]*){([^}]*)}/.exec(css)
+  if (!match) {
+    return undefined
+  }
+  const selectors = match[1]
+    .split(',')
+    .map((selector) => selector.replaceAll(':focus-visible', '').trim())
+    .map((selector) => selector || '*')
+  return { selectors, body: match[2] }
+}

--- a/packages/streamwall-control-ui/src/globalStyle.tsx
+++ b/packages/streamwall-control-ui/src/globalStyle.tsx
@@ -97,6 +97,19 @@ export const GlobalStyle = createGlobalStyle`
 
   * { box-sizing: border-box; }
 
+  /* Shared keyboard focus affordance. Text inputs get their accent ring from
+     the .stream-list rules below, but the custom-coloured buttons (sidebar
+     stream handle, favorite star, grid preset buttons) used to fall back to
+     the user-agent ring, which is easily lost against their own background
+     (see #508). The outline sits outside the control - so it stays visible
+     whatever the control's colours are - and the soft halo matches the ring
+     the inputs draw. */
+  :focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    box-shadow: 0 0 0 4px var(--accent-soft);
+  }
+
   /* ---- Sidebar (stream list / custom streams / access) ---- */
   .stream-list h2 {
     font-family: var(--font-display);


### PR DESCRIPTION
## Problem

`globalStyle.tsx` defined an accent focus ring for `.stream-list input:focus` / `select:focus`, but nothing equivalent for buttons. Custom-coloured buttons (sidebar stream handle, favorite stars, grid preset buttons) therefore relied on the user-agent focus ring, which can be low-contrast or invisible against their own background — a WCAG 2.4.7 / 2.4.11 risk and an inconsistent keyboard affordance.

## Solution

- One shared `:focus-visible` rule in `GlobalStyle`, built from the existing `--accent` / `--accent-soft` tokens: a 2px accent outline with `outline-offset: 2px` (so it sits outside the control and stays visible whatever the control's own colours are) plus the soft halo the inputs already draw. It matches the affordance `ResizeHandles` had introduced locally.
- Removed the local `&:focus { outline: none; box-shadow: … }` block in `StyledButton`, which has higher specificity and would otherwise suppress the shared outline on the grid tile buttons. `:focus-visible` also means the ring no longer appears on mouse clicks.

Element-specific rules with higher specificity (`.stream-list input:focus`, `GridInput`) keep their existing styling — those already had a deliberate affordance.

## Testing

- `globalStyle.test.tsx`: asserts the shared rule exists and is built from the accent tokens, and that it actually matches a custom-styled button (the sidebar stream handle) by extracting the rule from the injected CSS and matching its selector against the rendered element.
- The existing tests needed a per-test styled-components target (`StyleSheetManager`): the sheet remembers what it injected, so without it only the first render in the file emits the global CSS.
- Verified red before / green after; full quality gate (format, lint, typecheck, tests) green locally. The three pre-existing `@twurple/*` `import-x/no-unresolved` lint errors are a worktree dependency artifact, unrelated to this change.

## Risks

Low, CSS only. The affordance is now applied globally, so any element without a more specific focus rule gets the accent outline instead of the browser default.

Closes #508
