### PR TITLE
ci(release): warn when the version on main was never tagged

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,51 @@
+name: Release tag
+
+# Checks that the version `main` claims has a matching `vX.Y.Z` tag, and fails
+# the run when it has not had one for a day (#515).
+#
+# Pushing that tag is the one manual step left in the release: release-please
+# runs with `skip-github-release`, because a tag created with a workflow's
+# GITHUB_TOKEN does not trigger other workflows and would never start
+# `release.yml`. Until now nothing noticed when the step was forgotten — `main`
+# then advertises a version with no GitHub Release and no installers, while the
+# control server's update check keeps telling self-hosters they are current.
+#
+# Daily rather than on `push: [main]`: the tag follows the release PR merge by
+# minutes, so a push-triggered run would report the normal flow as a failure.
+# The script's grace period covers the same window for the scheduled run.
+on:
+  schedule:
+    # 07:23 UTC — off the hour, to avoid GitHub's scheduling peak.
+    - cron: '23 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-tag-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Check the release version is tagged
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          # `git tag --list` and the commit date of the version bump both need
+          # the full history; the default shallow clone has neither.
+          fetch-depth: 0
+
+      # No `npm ci` and no Node setup beyond the runner default: the script
+      # reads the committed manifest and shells out to git.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Check the release version is tagged
+        run: node scripts/check-release-tag.mjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -338,6 +338,18 @@ breaking change bumps the minor version.
    electron-forge, and then copies the `CHANGELOG.md` section for that version
    into the GitHub Release body (`scripts/changelog-section.mjs`).
 
+Because that tag is the one manual step,
+[`.github/workflows/release-tag.yml`](.github/workflows/release-tag.yml) checks
+every morning that the version on `main` has a matching `vX.Y.Z` tag and fails
+the run when it has been missing for more than a day — otherwise a forgotten
+tag stays invisible: `main` advertises a version with no GitHub Release and no
+installers, while the control server's update check tells self-hosters they are
+up to date. Run it from the Actions tab, or locally:
+
+```sh
+node scripts/check-release-tag.mjs
+```
+
 `test/changelog.test.mjs` and `test/release-please.test.mjs` run as part of
 `npm test` and fail if `CHANGELOG.md` is missing a heading for the version
 currently in `packages/streamwall/package.json`, if a hand-maintained

--- a/scripts/check-release-tag.mjs
+++ b/scripts/check-release-tag.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+// Fails when `main` claims a release version that was never tagged (#515).
+//
+// release-please runs with `skip-github-release` (#457): it opens the release
+// PR with the version bump and the changelog, but pushing the `vX.Y.Z` tag
+// stays a manual step, because a tag created with a workflow's GITHUB_TOKEN
+// does not trigger other workflows and would therefore never start
+// `release.yml`. Nothing used to notice when that last step was forgotten:
+// `main` then advertises a version that has no GitHub Release and no
+// installers, and the control server's update check — which compares its own
+// version against the release tags — keeps telling self-hosters that they are
+// up to date.
+//
+// A tag is pushed by hand moments after the release PR merges, so a freshly
+// bumped version without a tag is normal for a while; only a version that has
+// been sitting untagged past the grace period is reported.
+import { execFile } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)))
+
+// The version bump lands on `main` with the release PR merge; a day is long
+// enough for the maintainer who merged it to push the tag.
+export const GRACE_PERIOD_HOURS = 24
+
+// Mirrors the version format release-please writes into the manifests; the tag
+// is that version with a `v` prefix (`include-v-in-tag`).
+const SEMVER_PATTERN =
+  /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/
+
+export function parseTags(stdout) {
+  return stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '')
+}
+
+export function evaluateReleaseTag({ version, tags, versionCommittedAt, now }) {
+  if (!SEMVER_PATTERN.test(version)) {
+    throw new Error(`"${version}" is not a valid semantic version.`)
+  }
+
+  const committedAt = new Date(versionCommittedAt)
+  if (Number.isNaN(committedAt.getTime())) {
+    throw new Error(
+      `Could not read the commit date of the release version ` +
+        `("${versionCommittedAt}") — is this a shallow clone?`,
+    )
+  }
+
+  const tag = `v${version}`
+  const ageHours = (now.getTime() - committedAt.getTime()) / (60 * 60 * 1000)
+
+  if (tags.includes(tag)) {
+    return { status: 'tagged', tag, version, ageHours }
+  }
+  return {
+    status: ageHours < GRACE_PERIOD_HOURS ? 'pending' : 'missing',
+    tag,
+    version,
+    ageHours,
+  }
+}
+
+export function formatReport({ status, tag, version, ageHours }) {
+  const hours = Math.round(ageHours)
+
+  if (status === 'tagged') {
+    return `main is on ${version} and ${tag} exists.`
+  }
+  if (status === 'pending') {
+    return (
+      `::notice::main is on ${version} but ${tag} does not exist yet ` +
+      `(bumped ${hours}h ago, within the ${GRACE_PERIOD_HOURS}h grace ` +
+      'period).'
+    )
+  }
+  return (
+    `::error::main has claimed ${version} for ${hours}h without a ${tag} ` +
+    'tag, so no GitHub Release and no installers were ever built. Push the ' +
+    `tag to run release.yml: git checkout main && git pull && git tag ${tag} ` +
+    `&& git push origin ${tag}`
+  )
+}
+
+async function git(args) {
+  const { stdout } = await execFileAsync('git', args, { cwd: rootDir })
+  return stdout
+}
+
+async function main() {
+  const { version } = JSON.parse(
+    readFileSync(join(rootDir, 'package.json'), 'utf8'),
+  )
+
+  // The release-please manifest changes in exactly the commits that move the
+  // release line, so its last commit dates the version currently on `main` —
+  // unlike package.json, which any dependency bump touches.
+  const result = evaluateReleaseTag({
+    version,
+    tags: parseTags(await git(['tag', '--list', 'v*'])),
+    versionCommittedAt: (
+      await git([
+        'log',
+        '-1',
+        '--format=%cI',
+        '--',
+        '.release-please-manifest.json',
+      ])
+    ).trim(),
+    now: new Date(),
+  })
+
+  console.log(formatReport(result))
+  if (result.status === 'missing') {
+    process.exitCode = 1
+  }
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  await main()
+}

--- a/test/check-release-tag.test.mjs
+++ b/test/check-release-tag.test.mjs
@@ -1,0 +1,175 @@
+import { load } from 'js-yaml'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import {
+  evaluateReleaseTag,
+  formatReport,
+  GRACE_PERIOD_HOURS,
+  parseTags,
+} from '../scripts/check-release-tag.mjs'
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)))
+
+const NOW = new Date('2026-07-21T12:00:00Z')
+
+function hoursAgo(hours) {
+  return new Date(NOW.getTime() - hours * 60 * 60 * 1000).toISOString()
+}
+
+test('parseTags splits the tag listing and drops blank lines', () => {
+  assert.deepEqual(parseTags('v0.9.0\nv0.9.1\n\n'), ['v0.9.0', 'v0.9.1'])
+})
+
+test('parseTags returns an empty list for a repository without tags', () => {
+  assert.deepEqual(parseTags('\n'), [])
+})
+
+test('evaluateReleaseTag accepts a version that has its tag', () => {
+  const result = evaluateReleaseTag({
+    version: '0.9.1',
+    tags: ['v0.9.0', 'v0.9.1'],
+    versionCommittedAt: hoursAgo(72),
+    now: NOW,
+  })
+
+  assert.equal(result.status, 'tagged')
+  assert.equal(result.tag, 'v0.9.1')
+})
+
+// The tag is pushed by hand right after the release PR merges, so a run that
+// lands in between must not cry wolf.
+test('evaluateReleaseTag tolerates a missing tag inside the grace period', () => {
+  const result = evaluateReleaseTag({
+    version: '0.9.2',
+    tags: ['v0.9.1'],
+    versionCommittedAt: hoursAgo(GRACE_PERIOD_HOURS - 1),
+    now: NOW,
+  })
+
+  assert.equal(result.status, 'pending')
+  assert.equal(result.tag, 'v0.9.2')
+})
+
+test('evaluateReleaseTag reports a tag that stayed missing past the grace period', () => {
+  const result = evaluateReleaseTag({
+    version: '0.9.2',
+    tags: ['v0.9.1'],
+    versionCommittedAt: hoursAgo(GRACE_PERIOD_HOURS + 1),
+    now: NOW,
+  })
+
+  assert.equal(result.status, 'missing')
+  assert.equal(result.tag, 'v0.9.2')
+  assert.equal(Math.round(result.ageHours), GRACE_PERIOD_HOURS + 1)
+})
+
+test('evaluateReleaseTag rejects a version that is not a semantic version', () => {
+  assert.throws(
+    () =>
+      evaluateReleaseTag({
+        version: 'v0.9.2',
+        tags: [],
+        versionCommittedAt: hoursAgo(1),
+        now: NOW,
+      }),
+    /not a valid semantic version/,
+  )
+})
+
+// A shallow clone reports neither tags nor commit dates; failing loudly beats
+// reporting a missing tag that is only missing from the local checkout.
+test('evaluateReleaseTag rejects an unusable commit timestamp', () => {
+  assert.throws(
+    () =>
+      evaluateReleaseTag({
+        version: '0.9.2',
+        tags: [],
+        versionCommittedAt: '',
+        now: NOW,
+      }),
+    /commit date/,
+  )
+})
+
+test('formatReport annotates a missing tag as an error with the push command', () => {
+  const report = formatReport({
+    status: 'missing',
+    tag: 'v0.9.2',
+    version: '0.9.2',
+    ageHours: 30,
+  })
+
+  assert.match(report, /^::error::/m)
+  assert.match(report, /git tag v0\.9\.2/)
+})
+
+test('formatReport stays quiet for a tagged version', () => {
+  const report = formatReport({
+    status: 'tagged',
+    tag: 'v0.9.1',
+    version: '0.9.1',
+    ageHours: 72,
+  })
+
+  assert.doesNotMatch(report, /::error::/)
+  assert.match(report, /v0\.9\.1/)
+})
+
+test('formatReport notes a pending tag without failing the run', () => {
+  const report = formatReport({
+    status: 'pending',
+    tag: 'v0.9.2',
+    version: '0.9.2',
+    ageHours: 2,
+  })
+
+  assert.doesNotMatch(report, /::error::/)
+  assert.match(report, /^::notice::/m)
+})
+
+test('the release tag check runs on a schedule and can be dispatched manually', () => {
+  const workflow = load(
+    readFileSync(join(rootDir, '.github/workflows/release-tag.yml'), 'utf8'),
+  )
+  const triggers = Object.keys(workflow.on)
+
+  assert.ok(triggers.includes('schedule'), 'must run on a schedule')
+  assert.ok(
+    triggers.includes('workflow_dispatch'),
+    'must be dispatchable so a maintainer can verify a fresh tag on demand',
+  )
+  assert.ok(
+    !triggers.includes('pull_request'),
+    'must not run on pull requests: an untagged release would then block ' +
+      'every unrelated change',
+  )
+})
+
+// `git tag --list` only sees what the checkout fetched, so a shallow clone
+// would report every release as untagged.
+test('the release tag check checks out the full history including tags', () => {
+  const workflow = load(
+    readFileSync(join(rootDir, '.github/workflows/release-tag.yml'), 'utf8'),
+  )
+  const job = workflow.jobs.check
+  const checkout = job.steps.find((step) =>
+    step.uses?.startsWith('actions/checkout@'),
+  )
+
+  assert.ok(checkout, 'release-tag.yml must check the repository out')
+  assert.match(
+    checkout.uses,
+    /@[0-9a-f]{40}$/,
+    'actions must be pinned to a commit SHA',
+  )
+  assert.equal(checkout.with['fetch-depth'], 0)
+  assert.equal(job.permissions.contents, 'read')
+  assert.match(
+    job.steps.map((step) => step.run ?? '').join('\n'),
+    /scripts\/check-release-tag\.mjs/,
+  )
+})


### PR DESCRIPTION
## Problem

Since #457 (PR #505) release-please runs with `skip-github-release`: it opens the
release PR with the version bump and the changelog, but pushing the `vX.Y.Z` tag
stays a manual step, because a tag created with a workflow's `GITHUB_TOKEN` does
not trigger other workflows and would therefore never start `release.yml`.

Nothing noticed when a maintainer merged the release PR and then forgot the tag.
`main` then advertises a version that has no GitHub Release and no installers,
and the control server's update check — which compares its own version against
the release tags — keeps telling self-hosters that they are up to date.

## Solution

`scripts/check-release-tag.mjs` compares the version in the root manifest
against the `v*` tags and reports a missing tag with the exact command that
fixes it. `.github/workflows/release-tag.yml` runs it daily (07:23 UTC) and on
manual dispatch, and fails the run when the tag is missing.

Decisions:

- **Daily schedule, not `push: [main]`.** The tag follows the release PR merge
  by minutes, so a push-triggered run would flag the normal flow as a failure.
- **24 h grace period.** The check dates the current version by the last commit
  that touched `.release-please-manifest.json` — that file moves in exactly the
  commits that move the release line, unlike `package.json`, which every
  dependency bump touches. Inside the window a missing tag is a `::notice::`,
  after it an `::error::` that fails the job.
- **Fail the run rather than open an issue**, matching `deprecated-deps.yml`,
  the repo's other scheduled hygiene check.
- **`fetch-depth: 0`.** `git tag --list` and the commit date both need the full
  history; a shallow clone would report every release as untagged. An unusable
  commit date throws instead of silently reporting a missing tag.

## Testing

`test/check-release-tag.test.mjs` (12 cases, TDD): tag listing parsing, tagged /
pending / missing classification around the grace-period boundary, rejection of
a non-semver version and of an unreadable commit date, the report annotations,
plus the workflow wiring (schedule + dispatch, never `pull_request`, SHA-pinned
checkout with `fetch-depth: 0`, `contents: read`).

Full quality gate green locally: Prettier, ESLint, `tsc`, `npm test`,
`npm run licenses:check`, `actionlint`. The script also ran against this
checkout (`main is on 0.9.1 and v0.9.1 exists.`).

## Risks

None for the product: the workflow is scheduled only, reads the repository and
touches no release artifacts. Worst case is a false alarm if a release version
is ever bumped without release-please.

Closes #515
