### PR TITLE
fix(preload): keep rescanning iframes for a late-appearing player

### DIFF
--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -358,6 +358,164 @@ describe('mediaPreload iframe video extraction (issue #413)', () => {
   })
 })
 
+describe('mediaPreload late iframe rescanning (issue #485)', () => {
+  // Must match INITIAL_TIMEOUT in mediaPreload.ts; the search gives up once it
+  // elapses, so every late insertion under test happens before it.
+  const INITIAL_TIMEOUT_MS = 10 * 1000
+  // Must match SCAN_THROTTLE in mediaPreload.ts: long enough for the throttled
+  // rescan to run, short enough that these assertions land well before the
+  // timeout would have triggered a one-shot scan on its own.
+  const SCAN_THROTTLE_MS = 500
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.resetModules()
+    invoke.mockClear()
+    send.mockClear()
+    on.mockClear()
+    exposeInMainWorld.mockClear()
+    document.body.innerHTML = ''
+  })
+
+  function viewErrorCalls() {
+    return send.mock.calls.filter(([channel]) => channel === 'view-error')
+  }
+
+  async function loadVideoContent() {
+    invoke.mockResolvedValueOnce({
+      content: { kind: 'video', link: 'https://example.com/stream' },
+      options: {},
+      volume: 1,
+    })
+    await import('./mediaPreload')
+    document.dispatchEvent(new Event('DOMContentLoaded'))
+    process.emit('loaded' as never)
+    await vi.advanceTimersByTimeAsync(0)
+  }
+
+  // happy-dom's HTMLVideoElement never implements videoWidth, so give it a
+  // truthy value to skip findMedia's "wait for playing" branch.
+  function playableVideo(doc: Document): HTMLVideoElement {
+    const video = doc.createElement('video')
+    ;(video as unknown as { videoWidth: number }).videoWidth = 100
+    return video
+  }
+
+  // An empty same-origin frame whose player arrives later.
+  function appendEmptyIframe(): {
+    iframe: HTMLIFrameElement
+    frameDocument: Document
+  } {
+    const iframe = document.createElement('iframe')
+    iframe.srcdoc = '<html><head></head><body></body></html>'
+    document.body.appendChild(iframe)
+    const frameDocument = iframe.contentDocument
+    if (!frameDocument) {
+      throw new Error('test fixture: iframe has no document')
+    }
+    return { iframe, frameDocument }
+  }
+
+  it('acquires an iframe-embedded video without waiting out the initial timeout', async () => {
+    const { iframe, frameDocument } = appendEmptyIframe()
+    frameDocument.body.appendChild(playableVideo(frameDocument))
+
+    await loadVideoContent()
+    await vi.advanceTimersByTimeAsync(SCAN_THROTTLE_MS)
+
+    expect(viewErrorCalls()).toEqual([])
+    expect(send).toHaveBeenCalledWith('view-loaded')
+    expect(iframe.className).toBe('__video__')
+  })
+
+  it('acquires a video from an iframe inserted after the page settled', async () => {
+    await loadVideoContent()
+    await vi.advanceTimersByTimeAsync(INITIAL_TIMEOUT_MS / 2)
+
+    // A slow SPA bootstrap finally inserts its player iframe. The embedder's
+    // MutationObserver sees the insertion, so the scan must run again rather
+    // than only once at the very end of the initial wait.
+    const { iframe, frameDocument } = appendEmptyIframe()
+    frameDocument.body.appendChild(playableVideo(frameDocument))
+
+    await vi.advanceTimersByTimeAsync(SCAN_THROTTLE_MS)
+
+    expect(viewErrorCalls()).toEqual([])
+    expect(send).toHaveBeenCalledWith('view-loaded')
+    expect(iframe.className).toBe('__video__')
+  })
+
+  it('rescans an already-present iframe once it fires load with its player', async () => {
+    // The frame exists from the start but is still empty (a consent gate, a
+    // lazily navigated player). Its own document is outside the embedder's
+    // observed tree, so only the frame's load event can announce the change.
+    const { iframe, frameDocument } = appendEmptyIframe()
+
+    await loadVideoContent()
+    await vi.advanceTimersByTimeAsync(INITIAL_TIMEOUT_MS / 2)
+
+    frameDocument.body.appendChild(playableVideo(frameDocument))
+    iframe.dispatchEvent(new Event('load'))
+
+    await vi.advanceTimersByTimeAsync(SCAN_THROTTLE_MS)
+
+    expect(viewErrorCalls()).toEqual([])
+    expect(send).toHaveBeenCalledWith('view-loaded')
+    expect(iframe.className).toBe('__video__')
+  })
+
+  it('scans iframes during an unbounded re-acquisition, which never reaches a timeout', async () => {
+    const video = playableVideo(document)
+    document.body.appendChild(video)
+
+    await loadVideoContent()
+    expect(send).toHaveBeenCalledWith('view-loaded')
+
+    // The stream is replaced by an iframe-embedded player. The 'emptied'
+    // handler re-acquires with an unbounded timeout, so a scan that only runs
+    // when the search times out would never run at all here.
+    video.remove()
+    const { iframe, frameDocument } = appendEmptyIframe()
+    frameDocument.body.appendChild(playableVideo(frameDocument))
+    video.dispatchEvent(new Event('emptied'))
+
+    await vi.advanceTimersByTimeAsync(INITIAL_TIMEOUT_MS * 3)
+
+    expect(viewErrorCalls()).toEqual([])
+    expect(
+      send.mock.calls.filter(([channel]) => channel === 'view-loaded'),
+    ).toHaveLength(2)
+    expect(iframe.className).toBe('__video__')
+  })
+
+  it('still reports the cross-origin cause when the frame stays unreachable for the whole search', async () => {
+    await loadVideoContent()
+    await vi.advanceTimersByTimeAsync(INITIAL_TIMEOUT_MS / 2)
+
+    const iframe = document.createElement('iframe')
+    document.body.appendChild(iframe)
+    Object.defineProperty(iframe, 'contentDocument', { value: null })
+
+    await vi.advanceTimersByTimeAsync(INITIAL_TIMEOUT_MS)
+
+    expect(viewErrorCalls()).toEqual([
+      [
+        'view-error',
+        {
+          error: expect.objectContaining({
+            message:
+              'could not find video: it may be inside a cross-origin iframe, which is unsupported',
+          }),
+        },
+      ],
+    ])
+  })
+})
+
 describe('mediaPreload MutationObserver lifecycle (issue #412)', () => {
   // Records every observer the module creates so the tests can assert on how
   // many are still connected at a given point. Deliberately inert: it never

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -279,15 +279,110 @@ async function waitForQuery(
   })
 }
 
-async function waitForVideo(
-  kind: 'video' | 'audio',
-  timeoutMs = INITIAL_TIMEOUT,
-): Promise<{
+type MediaSearchResult = {
   video?: HTMLMediaElement
   iframe?: HTMLIFrameElement
   iframeDocument?: Document
   crossOriginIframe?: boolean
-}> {
+}
+
+// One pass over the top-level document and every iframe embedded in it.
+//
+// Some pages embed their player in an iframe. Its document is only reachable
+// when it is same-origin: a cross-origin frame has an opaque origin, so
+// `contentDocument` reads as null and no amount of waiting will ever make the
+// <video> inside visible from here. Report that case so findMedia can name it
+// instead of reporting a generic missing video.
+function scanForMedia(kind: 'video' | 'audio'): MediaSearchResult {
+  const video = document.querySelector(kind)
+  if (video instanceof HTMLMediaElement) {
+    return { video }
+  }
+
+  let crossOriginIframe = false
+  for (const iframe of document.querySelectorAll('iframe')) {
+    const iframeDocument = iframe.contentDocument
+    if (!iframeDocument) {
+      crossOriginIframe = true
+      continue
+    }
+    const framedVideo = iframeDocument.querySelector(kind)
+    if (framedVideo instanceof HTMLMediaElement) {
+      return { video: framedVideo, iframe, iframeDocument }
+    }
+  }
+  return { crossOriginIframe }
+}
+
+// Resolves with the first media element found in the document or in any
+// same-origin iframe, or with the last scan's outcome if `signal` aborts
+// first. Both places are covered by the same retry loop: scanning iframes
+// only once, after the top-level wait had run out, meant a frame inserted (or
+// filled) later was never re-examined, and an unbounded search -- which never
+// times out -- never scanned them at all (#485).
+async function waitForMedia(
+  kind: 'video' | 'audio',
+  signal: AbortSignal,
+): Promise<MediaSearchResult> {
+  console.log(`waiting for '${kind}'...`)
+  // The abort has to cut this wait short too, not just the observing below:
+  // a page that never reaches DOMContentLoaded (a stalled or dead stream
+  // page) would otherwise leave the caller's timeout with nothing to settle.
+  await Promise.race([pageReady, aborted(signal)])
+  if (signal.aborted) {
+    return {}
+  }
+  return new Promise((resolve) => {
+    // Iframes already wired for their own 'load' event. A frame's document is
+    // outside the tree observed below, so mutations in the embedder never
+    // report the moment a frame finishes loading the player it contains.
+    const watchedIframes = new Set<HTMLIFrameElement>()
+    const rescan = () => scan()
+
+    const scan = throttle(() => {
+      const result = scanForMedia(kind)
+      for (const iframe of document.querySelectorAll('iframe')) {
+        if (watchedIframes.has(iframe)) {
+          continue
+        }
+        watchedIframes.add(iframe)
+        iframe.addEventListener('load', rescan)
+      }
+      if (result.video) {
+        console.log(`found '${kind}'`)
+        stop()
+        resolve(result)
+      }
+    }, SCAN_THROTTLE)
+
+    const stopObserving = observeBody(scan)
+    const stop = () => {
+      for (const iframe of watchedIframes) {
+        iframe.removeEventListener('load', rescan)
+      }
+      watchedIframes.clear()
+      stopObserving()
+    }
+
+    signal.addEventListener(
+      'abort',
+      () => {
+        stop()
+        // The teardown just cancelled whatever trailing scan the throttle was
+        // holding, so take one final look before giving up -- and report the
+        // freshest cross-origin verdict rather than an early scan's.
+        resolve(scanForMedia(kind))
+      },
+      { once: true },
+    )
+    scan()
+  })
+}
+
+async function waitForVideo(
+  kind: 'video' | 'audio',
+  timeoutMs = INITIAL_TIMEOUT,
+): Promise<MediaSearchResult> {
   lockdownMediaTags()
 
   // One search, bounded by its own abort timer. Racing a search against a
@@ -298,34 +393,11 @@ async function waitForVideo(
     timeoutMs === Infinity
       ? undefined
       : setTimeout(() => search.abort(), timeoutMs)
-  let video: Element | null | undefined
   try {
-    video = await waitForQuery(kind, search.signal)
+    return await waitForMedia(kind, search.signal)
   } finally {
     clearTimeout(searchTimeout)
   }
-  if (video instanceof HTMLMediaElement) {
-    return { video }
-  }
-
-  // Some pages embed their player in an iframe. Its document is only
-  // reachable when it is same-origin: a cross-origin frame has an opaque
-  // origin, so `contentDocument` reads as null and no amount of waiting will
-  // ever make the <video> inside visible from here. Remember that case so
-  // findMedia can name it instead of reporting a generic missing video.
-  let crossOriginIframe = false
-  for (const iframe of document.querySelectorAll('iframe')) {
-    const iframeDocument = iframe.contentDocument
-    if (!iframeDocument) {
-      crossOriginIframe = true
-      continue
-    }
-    video = iframeDocument.querySelector(kind)
-    if (video instanceof HTMLMediaElement) {
-      return { video, iframe, iframeDocument }
-    }
-  }
-  return { crossOriginIframe }
 }
 
 const igHacks = {


### PR DESCRIPTION
## Problem

`waitForVideo()` watched the top-level document with a `MutationObserver`, but the iframe fallback ran exactly once — after the top-level wait lost its race against `INITIAL_TIMEOUT`. A page that inserts its player iframe later (slow SPA bootstrap, consent gate, lazy player) had that frame scanned at a single moment only, so the tile failed with a generic `could not find video`.

Two further consequences of the one-shot placement:

- An **unbounded** search (`acquireMedia(Infinity)`, used by the `emptied` re-acquisition) never times out, so the iframe scan never ran *at all* — an iframe-embedded player could never be re-acquired.
- Even when the frame was present from the start, its video was only picked up after the full 10 s timeout had elapsed.

## Solution

The iframe scan is folded into the same retry loop as the top-level query:

- `scanForMedia()` does one pass over the document *and* every embedded iframe, returning the media element or the cross-origin verdict.
- `waitForMedia()` drives that scan from the existing throttled `MutationObserver` on `document.body`, plus a `load` listener on every iframe it sees — a frame's own document lies outside the observed tree, so mutations in the embedder never announce that a frame finished loading its player.
- On abort (timeout) the loop takes one final scan before giving up, so a player that appeared inside the throttle window is still found and the reported `crossOriginIframe` verdict is the freshest one rather than an early scan's.
- Teardown removes the iframe `load` listeners alongside disconnecting the observer, keeping the leak discipline established in #412.

`waitForQuery()` is unchanged and still serves `igHacks`.

## Testing

New tests in `mediaPreload.test.ts` (`issue #485`), all red before the fix:

- an iframe-embedded video is acquired without waiting out the initial timeout
- a video from an iframe inserted after the page settled is acquired
- an already-present iframe is rescanned once it fires `load` with its player
- an unbounded re-acquisition scans iframes at all
- the cross-origin cause is still reported when the frame stays unreachable for the whole search

Full quality gate green locally: Prettier, ESLint, tsc, full test suite (all workspaces).

## Risks

No behavioural change for pages whose video is in the top-level document. Iframe-embedded players are now acquired sooner rather than later; the per-scan cost grows by one `querySelector` per iframe every 500 ms, which is negligible for stream pages.

Follow-up from #413 / #479.

Closes #485