### PR TITLE
fix(streamwall): stage each packaging run in its own temp directory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -278,6 +278,13 @@ in two other places:
   tab (optionally with the `debug` input for verbose Forge logging) after a
   Forge/maker dependency bump.
 
+Two packaging runs can share a machine: `packagerConfig.tmpdir` points each
+run at a directory of its own (`forge.tmpdir.ts`). @electron/packager
+otherwise stages every run under the same `<tmpdir>/electron-packager` and
+deletes that directory when a run starts, which used to break a concurrent run
+with a misleading `Ad-hoc codesign failed with status: 1` from the fuses
+plugin (#510).
+
 ### Dependency deprecations
 
 `.github/workflows/deprecated-deps.yml` asks the npm registry every Monday

--- a/packages/streamwall/forge.config.test.ts
+++ b/packages/streamwall/forge.config.test.ts
@@ -4,6 +4,12 @@ import { describe, expect, it, vi } from 'vitest'
 const runTypecheck = vi.fn()
 vi.mock('./forge.typecheck', () => ({ runTypecheck: () => runTypecheck() }))
 
+const removePackagingTmpdir = vi.fn()
+vi.mock('./forge.tmpdir', () => ({
+  createPackagingTmpdir: () => '/tmp/streamwall-packager-test',
+  removePackagingTmpdir: (dir: string) => removePackagingTmpdir(dir),
+}))
+
 const { default: config }: { default: ForgeConfig } =
   await import('./forge.config')
 
@@ -24,6 +30,27 @@ describe('forge prePackage hook', () => {
 
     await expect(config.hooks?.prePackage?.(config, '', '')).rejects.toThrow(
       /typecheck failed/,
+    )
+  })
+})
+
+// @electron/packager wipes its base temp directory when a run starts, so two
+// packaging runs sharing the default base delete each other's staging tree
+// mid-run (#510). Every run therefore stages in its own directory.
+describe('forge packaging temp directory', () => {
+  it('stages the app in a directory of its own', () => {
+    expect(config.packagerConfig.tmpdir).toBe('/tmp/streamwall-packager-test')
+  })
+
+  it('removes that directory once packaging is done', async () => {
+    await config.hooks?.postPackage?.(config, {
+      platform: 'darwin',
+      arch: 'arm64',
+      outputPaths: [],
+    })
+
+    expect(removePackagingTmpdir).toHaveBeenCalledWith(
+      '/tmp/streamwall-packager-test',
     )
   })
 })

--- a/packages/streamwall/forge.config.ts
+++ b/packages/streamwall/forge.config.ts
@@ -13,6 +13,7 @@ import {
   getWindowsSigningConfig,
   isSigningConfigured,
 } from './forge.signing'
+import { createPackagingTmpdir, removePackagingTmpdir } from './forge.tmpdir'
 import { runTypecheck } from './forge.typecheck'
 import { appendUpdateMetadata } from './forge.updateMetadata'
 import packageJson from './package.json'
@@ -21,6 +22,7 @@ const macSigning = getMacSigningConfig(process.env)
 const windowsSigning = getWindowsSigningConfig(process.env)
 const signingConfigured = isSigningConfigured(process.env)
 const publishRepository = parseGithubRepository(packageJson.repository)
+const packagingTmpdir = createPackagingTmpdir()
 
 const config: ForgeConfig = {
   packagerConfig: {
@@ -29,6 +31,10 @@ const config: ForgeConfig = {
     // executable to match. The Linux makers still install a lowercase
     // `streamwall` command via their `bin` option below.
     asar: true,
+    // Stage in a directory of this run's own: packager wipes its base temp
+    // directory on start, so runs sharing the default base kill each other
+    // (#510, see forge.tmpdir.ts).
+    tmpdir: packagingTmpdir,
     ...macSigning,
   },
   rebuildConfig: {},
@@ -61,6 +67,9 @@ const config: ForgeConfig = {
     // command that produces a distributable; `start` stays unchecked to keep
     // the dev loop fast (`npm run typecheck` still covers it in CI).
     prePackage: async () => runTypecheck(),
+    // The staged app has been moved to `out/` by now, so the run's private
+    // temp directory is only an empty shell (#510).
+    postPackage: async () => removePackagingTmpdir(packagingTmpdir),
     // latest.yml / latest-mac.yml for electron-updater (#432); uploaded to
     // the release alongside the installers by the GitHub publisher.
     postMake: async (_forgeConfig, makeResults) =>

--- a/packages/streamwall/forge.tmpdir.test.ts
+++ b/packages/streamwall/forge.tmpdir.test.ts
@@ -1,0 +1,83 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  createPackagingTmpdir,
+  PACKAGING_TMPDIR_PREFIX,
+  removePackagingTmpdir,
+} from './forge.tmpdir'
+
+const created: string[] = []
+
+function create(): string {
+  const dir = createPackagingTmpdir()
+  created.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  for (const dir of created.splice(0)) {
+    removePackagingTmpdir(dir)
+  }
+})
+
+describe('createPackagingTmpdir', () => {
+  it('creates an empty directory inside the system temp directory', () => {
+    const dir = create()
+
+    expect(existsSync(dir)).toBe(true)
+    expect(readdirSync(dir)).toEqual([])
+    expect(path.dirname(dir)).toBe(os.tmpdir())
+  })
+
+  it('gives every packaging run its own directory', () => {
+    // The whole point of #510: @electron/packager wipes its base temp
+    // directory when a run starts, so two runs must never share one.
+    expect(create()).not.toBe(create())
+  })
+})
+
+describe('removePackagingTmpdir', () => {
+  it('removes the directory and everything staged inside it', () => {
+    const dir = create()
+    writeFileSync(path.join(dir, 'staged'), '')
+
+    removePackagingTmpdir(dir)
+
+    expect(existsSync(dir)).toBe(false)
+  })
+
+  it('does nothing when the directory is already gone', () => {
+    const dir = create()
+    removePackagingTmpdir(dir)
+
+    expect(() => removePackagingTmpdir(dir)).not.toThrow()
+  })
+
+  it('refuses to delete a directory it did not create', () => {
+    const foreign = mkdtempSync(path.join(os.tmpdir(), 'not-a-packaging-run-'))
+
+    try {
+      expect(() => removePackagingTmpdir(foreign)).toThrow(
+        /not a packaging temp directory/i,
+      )
+      expect(existsSync(foreign)).toBe(true)
+    } finally {
+      rmSync(foreign, { recursive: true, force: true })
+    }
+  })
+
+  it('accepts the prefix the helper stages under', () => {
+    expect(path.basename(create())).toMatch(
+      new RegExp(`^${PACKAGING_TMPDIR_PREFIX}`),
+    )
+  })
+})

--- a/packages/streamwall/forge.tmpdir.ts
+++ b/packages/streamwall/forge.tmpdir.ts
@@ -1,0 +1,36 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+/**
+ * Keeps every packaging run's staging directory to itself (#510).
+ *
+ * @electron/packager stages the app under `<tmpdir>/electron-packager` and
+ * deletes that entire base directory when a run starts, so two runs on the
+ * same machine - a second worktree, a `make` next to a `package` - wipe each
+ * other's staging tree mid-run. The victim fails once the fuses plugin
+ * re-signs the app it can no longer find ("Ad-hoc codesign failed with status:
+ * 1"), which reads like a macOS signing problem but is a plain temp-directory
+ * collision. Pointing `packagerConfig.tmpdir` at a fresh directory per run
+ * keeps that wipe private to the run performing it.
+ */
+
+export const PACKAGING_TMPDIR_PREFIX = 'streamwall-packager-'
+
+/** Creates the base directory a single packaging run stages in. */
+export function createPackagingTmpdir(): string {
+  return mkdtempSync(path.join(os.tmpdir(), PACKAGING_TMPDIR_PREFIX))
+}
+
+/**
+ * Removes a directory created by {@link createPackagingTmpdir}. The prefix
+ * check keeps a recursive delete from ever reaching a directory this module
+ * did not create.
+ */
+export function removePackagingTmpdir(dir: string): void {
+  if (!path.basename(dir).startsWith(PACKAGING_TMPDIR_PREFIX)) {
+    throw new Error(`Refusing to remove ${dir}: not a packaging temp directory`)
+  }
+
+  rmSync(dir, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary

`npm -w streamwall run package` aborted with a misleading macOS signing error
whenever a second packaging run was active on the same machine:

```
/var/folders/.../electron-packager/tmp-XXXXXX/Electron.app: No such file or directory
Error: Ad-hoc codesign failed with status: 1
    at flipFuses (node_modules/@electron/fuses/dist/index.js:149:19)
```

Root cause is not signing at all: `@electron/packager` stages every run under
`<tmpdir>/electron-packager` and deletes that entire base directory when a run
starts (`Packager.ensureTempDir()` → `fs.remove(this.tempBase)`). A second run
therefore wipes the staging tree of the first one mid-run, and the fuses plugin
then ad-hoc re-signs an `Electron.app` that no longer exists. On a machine with
several worktrees this happens easily; a single run in isolation always
succeeded, which is why the report looked environment-specific.

Reproduced deterministically on macOS 26.5 / arm64 by removing
`$TMPDIR/electron-packager` while a run was in its "Copying files" phase — the
failure is byte-for-byte the one reported in #510.

## Technical solution

- New `packages/streamwall/forge.tmpdir.ts`: `createPackagingTmpdir()` creates a
  fresh `streamwall-packager-*` base per run, `removePackagingTmpdir()` deletes
  it again behind a prefix guard so a recursive delete can never escape.
- `forge.config.ts` sets `packagerConfig.tmpdir` to that directory and drops it
  in a new `postPackage` hook — by then packager has moved the staged app to
  `out/`, so only an empty shell is left.

Alternative considered: `tmpdir: false` (stage straight into `out/`). Rejected
because an aborted run would leave a half-built `.app` behind in the output
directory that the makers operate on.

## How was this tested?

- `npx vitest run forge.tmpdir.test.ts forge.config.test.ts -w packages/streamwall`
  — new unit tests for the helper (own directory per run, recursive removal,
  idempotent removal, foreign-path guard) and for the forge wiring.
- `npm run lint`, `npm run format`, `npm run typecheck`, `npm test` — all green.
- Manual verification on macOS 26.5 / arm64: with the fix in place, deleting
  `$TMPDIR/electron-packager` mid-run no longer affects the run; packaging
  finishes, `out/Streamwall-darwin-arm64/Streamwall.app` is ad-hoc signed with
  the expected fuses flipped, and the run's temp directory is gone afterwards.

## Risks / breaking changes

None for CI or releases: the packager option is documented and platform
independent, and the smoke/make jobs keep running unchanged. Worst case a
crashed run leaves an empty `streamwall-packager-*` directory in the system temp
directory, which the OS cleans up.

Closes #510
