### PR TITLE
feat(control-ui): surface paused views in the control UI and wall overlay

### DIFF
--- a/packages/streamwall-control-ui/src/GridPreviewBox.test.tsx
+++ b/packages/streamwall-control-ui/src/GridPreviewBox.test.tsx
@@ -31,6 +31,7 @@ function renderBox(
         isSmall={false}
         isError={false}
         errorReason={null}
+        isPaused={false}
         orientation={null}
         source="Example Source"
         city={undefined}
@@ -73,6 +74,21 @@ describe('GridPreviewBox', () => {
     expect(box.querySelector('svg')).toBeNull()
   })
 
+  test('renders the paused badge for a parked view whose playback is paused (#490)', () => {
+    const box = renderBox({ isPaused: true })
+
+    const badge = box.querySelector('[data-testid="grid-paused-badge"]')
+    expect(badge).not.toBeNull()
+    expect(badge!.textContent).toContain('Paused')
+    expect(badge!.querySelector('svg')).not.toBeNull()
+  })
+
+  test('does not render the paused badge for a playing view (#490)', () => {
+    const box = renderBox({ isPaused: false })
+
+    expect(box.querySelector('[data-testid="grid-paused-badge"]')).toBeNull()
+  })
+
   test('marks the info panel as small so the reason text collapses on small cells', () => {
     const box = renderBox({ isSmall: true })
 
@@ -80,7 +96,7 @@ describe('GridPreviewBox', () => {
   })
 
   test('does not leak custom styled-component props onto the DOM node (#152)', () => {
-    const box = renderBox({ isError: true, isListening: true })
+    const box = renderBox({ isError: true, isListening: true, isPaused: true })
 
     for (const el of box.querySelectorAll('*')) {
       for (const propName of [
@@ -90,6 +106,7 @@ describe('GridPreviewBox', () => {
         'windowheight',
         'islistening',
         'iserror',
+        'ispaused',
       ]) {
         expect(
           el.hasAttribute(propName),

--- a/packages/streamwall-control-ui/src/GridPreviewBox.tsx
+++ b/packages/streamwall-control-ui/src/GridPreviewBox.tsx
@@ -1,5 +1,5 @@
 import { type JSX } from 'preact'
-import { FaExclamationTriangle } from 'react-icons/fa'
+import { FaExclamationTriangle, FaPause } from 'react-icons/fa'
 import { Color, type ViewPos } from 'streamwall-shared'
 import { styled } from 'styled-components'
 import { type ColorInstance } from './colorTypes.ts'
@@ -106,6 +106,31 @@ const StyledGridError = styled.div`
   }
 `
 
+const StyledGridPaused = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  margin-top: 6px;
+  padding: 3px 8px;
+  border-radius: 8px;
+  max-width: 100%;
+  font-size: 12px;
+  font-weight: 600;
+  color: white;
+  background: ${Color('black').alpha(0.55).string()};
+
+  svg {
+    flex-shrink: 0;
+  }
+
+  ${StyledGridInfo}.small & {
+    span {
+      display: none;
+    }
+  }
+`
+
 // Extracted from the ControlUI grid preview loop so the error badge markup
 // can be rendered and tested in isolation.
 export function GridPreviewBox({
@@ -118,6 +143,7 @@ export function GridPreviewBox({
   isSmall,
   isError,
   errorReason,
+  isPaused,
   orientation,
   source,
   city,
@@ -133,6 +159,7 @@ export function GridPreviewBox({
   isSmall: boolean
   isError: boolean
   errorReason: string | null | undefined
+  isPaused: boolean
   orientation: 'V' | 'H' | null | undefined
   source: string | undefined
   city: string | undefined
@@ -170,6 +197,15 @@ export function GridPreviewBox({
             <FaExclamationTriangle />
             <span>{errorReason ?? 'Stream error'}</span>
           </StyledGridError>
+        )}
+        {isPaused && (
+          <StyledGridPaused
+            data-testid="grid-paused-badge"
+            title="Playback paused while this view is parked"
+          >
+            <FaPause />
+            <span>Paused</span>
+          </StyledGridPaused>
         )}
       </StyledGridInfo>
     </StyledGridPreviewBox>

--- a/packages/streamwall-control-ui/src/GridViewIdentity.test.tsx
+++ b/packages/streamwall-control-ui/src/GridViewIdentity.test.tsx
@@ -76,6 +76,7 @@ function makeView(streamIdx: number, spaces: number[]): ViewInfo {
     isListening: false,
     isBackgroundListening: false,
     isBlurred: false,
+    isPaused: false,
     volume: 1,
     spaces,
   }

--- a/packages/streamwall-control-ui/src/components/ControlGrid.tsx
+++ b/packages/streamwall-control-ui/src/components/ControlGrid.tsx
@@ -181,7 +181,7 @@ export function ControlGrid({
         })}
       </div>
       <StyledGridPreview>
-        {views.map(({ state, isListening }) => {
+        {views.map(({ state, isListening, isPaused }) => {
           const { pos } = state.context
           if (pos == null) {
             return null
@@ -217,6 +217,7 @@ export function ControlGrid({
               isSmall={isSmall}
               isError={isError}
               errorReason={errorReason}
+              isPaused={isPaused}
               orientation={data?.orientation ?? null}
               source={data?.source}
               city={data?.city}

--- a/packages/streamwall-control-ui/src/gridFullscreen.test.tsx
+++ b/packages/streamwall-control-ui/src/gridFullscreen.test.tsx
@@ -85,6 +85,7 @@ function makeView(streamId: string, spaces: number[]): ViewInfo {
     isListening: false,
     isBackgroundListening: false,
     isBlurred: false,
+    isPaused: false,
     volume: 1,
     spaces,
   }

--- a/packages/streamwall-control-ui/src/hooks/useControlHotkeys.test.tsx
+++ b/packages/streamwall-control-ui/src/hooks/useControlHotkeys.test.tsx
@@ -53,6 +53,7 @@ function makeViewInfo(
     isListening: false,
     isBackgroundListening: false,
     isBlurred: false,
+    isPaused: false,
     volume: 1,
     spaces,
     ...overrides,

--- a/packages/streamwall-control-ui/src/streamwallState.test.tsx
+++ b/packages/streamwall-control-ui/src/streamwallState.test.tsx
@@ -1,0 +1,98 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import type { StreamwallState, ViewState } from 'streamwall-shared'
+import { afterEach, describe, expect, test } from 'vitest'
+import { useStreamwallState } from './streamwallState.tsx'
+
+let container: HTMLDivElement | undefined
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+function makeViewState(
+  pause: 'paused' | 'unpaused',
+  overrides: Partial<ViewState['context']> = {},
+): ViewState {
+  return {
+    state: {
+      displaying: {
+        running: {
+          playback: 'playing',
+          video: 'normal',
+          audio: 'muted',
+          pause,
+          swap: 'idle',
+        },
+      },
+    },
+    context: {
+      id: 1,
+      content: null,
+      info: null,
+      pos: { x: 0, y: 0, width: 100, height: 100, spaces: [0] },
+      error: null,
+      volume: 1,
+      ...overrides,
+    },
+  }
+}
+
+function makeState(views: ViewState[]): StreamwallState {
+  return {
+    identity: { role: 'admin' },
+    config: {
+      cols: 1,
+      rows: 1,
+      width: 100,
+      height: 100,
+      frameless: false,
+      fullscreen: false,
+      activeColor: '#fff',
+      backgroundColor: '#000',
+    },
+    streams: [],
+    customStreams: [],
+    views,
+    fullscreenViewIdx: null,
+    streamdelay: null,
+    layoutPresets: [],
+    favorites: [],
+    dataSourceHealth: [],
+  }
+}
+
+function renderState(state: StreamwallState) {
+  let result: ReturnType<typeof useStreamwallState> | undefined
+  function Probe() {
+    result = useStreamwallState(state)
+    return null
+  }
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    render(<Probe />, container!)
+  })
+  return result!
+}
+
+describe('useStreamwallState', () => {
+  test('derives isPaused for a view whose media playback is paused', () => {
+    const { views, stateIdxMap } = renderState(
+      makeState([makeViewState('paused')]),
+    )
+
+    expect(views[0]!.isPaused).toBe(true)
+    expect(stateIdxMap.get(0)!.isPaused).toBe(true)
+  })
+
+  test('leaves isPaused false while the view keeps playing', () => {
+    const { views } = renderState(makeState([makeViewState('unpaused')]))
+
+    expect(views[0]!.isPaused).toBe(false)
+  })
+})

--- a/packages/streamwall-control-ui/src/streamwallState.tsx
+++ b/packages/streamwall-control-ui/src/streamwallState.tsx
@@ -21,6 +21,12 @@ export interface ViewInfo {
   isListening: boolean
   isBackgroundListening: boolean
   isBlurred: boolean
+  /**
+   * Media playback is paused because the view is parked behind a fullscreen
+   * expansion and the wall runs with `--park.pause` (issue #374). Purely
+   * informational here: there is no control command to toggle it.
+   */
+  isPaused: boolean
   volume: number
   spaces: number[]
 }
@@ -109,12 +115,17 @@ export function useStreamwallState(state: StreamwallState | undefined) {
         'displaying.running.video.blurred',
         viewState.state,
       )
+      const isPaused = matchesState(
+        'displaying.running.pause.paused',
+        viewState.state,
+      )
       const spaces = pos?.spaces ?? []
       const viewInfo = {
         state: viewState,
         isListening,
         isBackgroundListening,
         isBlurred,
+        isPaused,
         volume: viewState.context.volume,
         spaces,
       }

--- a/packages/streamwall/src/renderer/OverlayRoot.tsx
+++ b/packages/streamwall/src/renderer/OverlayRoot.tsx
@@ -43,6 +43,7 @@ export function Overlay({
           'displaying.running.video.blurred',
           state,
         )
+        const isPaused = matchesState('displaying.running.pause.paused', state)
         const isLoading =
           matchesState('displaying.loading', state) ||
           matchesState('displaying.running.playback.stalled', state)
@@ -65,6 +66,7 @@ export function Overlay({
               isBackgroundListening={isBackgroundListening}
               isBlurred={isBlurred}
               isLoading={isLoading}
+              isPaused={isPaused}
               activeColor={activeColor}
             />
           </SpaceBorder>

--- a/packages/streamwall/src/renderer/OverlayViewTile.test.tsx
+++ b/packages/streamwall/src/renderer/OverlayViewTile.test.tsx
@@ -31,6 +31,7 @@ function renderTile(
         isBackgroundListening={false}
         isBlurred={false}
         isLoading={false}
+        isPaused={false}
         activeColor="#fff"
         {...props}
       />,
@@ -117,6 +118,30 @@ describe('OverlayViewTile', () => {
     expect(getComputedStyle(spinner!).visibility).toBe('hidden')
   })
 
+  test('renders the paused badge for a parked view whose playback is paused (#490)', () => {
+    const tile = renderTile({ isPaused: true })
+
+    const badge = tile.querySelector('[data-testid="overlay-paused-badge"]')
+    expect(badge).not.toBeNull()
+    expect(badge!.textContent).toContain('Paused')
+    expect(badge!.querySelector('svg')).not.toBeNull()
+  })
+
+  test('does not render the paused badge for a playing view (#490)', () => {
+    const tile = renderTile({ isPaused: false })
+
+    expect(
+      tile.querySelector('[data-testid="overlay-paused-badge"]'),
+    ).toBeNull()
+  })
+
+  test('desaturates the tile while it is paused (#490)', () => {
+    const tile = renderTile({ isPaused: true })
+
+    const cover = tile.firstElementChild as HTMLElement
+    expect(getComputedStyle(cover).backdropFilter).toContain('grayscale')
+  })
+
   test('does not leak custom styled-component props onto the DOM nodes (#152)', () => {
     const data: StreamData = {
       _id: 'a',
@@ -134,6 +159,7 @@ describe('OverlayViewTile', () => {
       isListening: true,
       isBlurred: true,
       isLoading: true,
+      isPaused: true,
       activeColor: '#f00',
     })
 
@@ -145,6 +171,7 @@ describe('OverlayViewTile', () => {
         'isvisible',
         'isblurred',
         'isdesaturated',
+        'ispaused',
       ]) {
         expect(
           el.hasAttribute(propName),

--- a/packages/streamwall/src/renderer/OverlayViewTile.tsx
+++ b/packages/streamwall/src/renderer/OverlayViewTile.tsx
@@ -4,6 +4,7 @@ import {
   FaFacebook,
   FaInstagram,
   FaMapMarkerAlt,
+  FaPause,
   FaTiktok,
   FaTwitch,
   FaVolumeUp,
@@ -25,6 +26,7 @@ export function OverlayViewTile({
   isBackgroundListening,
   isBlurred,
   isLoading,
+  isPaused,
   activeColor,
 }: {
   url: string
@@ -35,6 +37,12 @@ export function OverlayViewTile({
   isBackgroundListening: boolean
   isBlurred: boolean
   isLoading: boolean
+  /**
+   * Media playback is paused because this view is parked behind a fullscreen
+   * expansion and the wall runs with `--park.pause` (issue #374). Marked so a
+   * frozen tile doesn't read as a broken stream (issue #490).
+   */
+  isPaused: boolean
   activeColor: string
 }) {
   const hasTitle = data && (data.label || data.source)
@@ -58,7 +66,10 @@ export function OverlayViewTile({
 
   return (
     <>
-      <FilterCover $isBlurred={isBlurred} $isDesaturated={isLoading} />
+      <FilterCover
+        $isBlurred={isBlurred}
+        $isDesaturated={isLoading || isPaused}
+      />
       {hasTitle && (
         <StreamTitle
           $position={position}
@@ -77,6 +88,12 @@ export function OverlayViewTile({
             {data.city} {data.state}
           </span>
         </StreamLocation>
+      )}
+      {isPaused && (
+        <PausedBadge data-testid="overlay-paused-badge">
+          <FaPause />
+          <span>Paused</span>
+        </PausedBadge>
       )}
       <LoadingSpinner $isVisible={isLoading} />
     </>
@@ -200,6 +217,36 @@ const StreamLocation = styled.div`
 
   svg {
     flex-shrink: 0;
+  }
+`
+
+const PausedBadge = styled.div`
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  padding: 6px 14px;
+  font-weight: 700;
+  font-size: 18px;
+  letter-spacing: -0.025em;
+  color: white;
+  text-shadow: 0 0 4px black;
+  background: ${Color('black').alpha(0.5).toString()};
+  border-radius: 6px;
+  backdrop-filter: blur(10px);
+
+  svg {
+    width: 1em;
+    height: 1em;
+    filter: drop-shadow(0 0 4px black);
+
+    path {
+      fill: white;
+    }
   }
 `
 


### PR DESCRIPTION
## Problem

Views parked behind a fullscreen expansion have their media playback paused
since #383 added the opt-in `--park.pause` flag, and #484 made the
`displaying.running.pause` region survive `viewStateValueSchema` so it finally
reaches clients.

Neither surface rendered it. `streamwallState.tsx` and `OverlayRoot.tsx` derive
per-view flags for `audio.listening`, `audio.background`, `video.blurred` and
`playback.stalled`, but nothing for `pause.paused`. An operator running with
`--park.pause` therefore could not tell a paused, parked view from a live one —
the tile just looked normal, or looked stalled once the video froze, which is
easy to misread as a broken stream.

## Solution

Derive an `isPaused` flag from `displaying.running.pause.paused` alongside the
existing ones and surface it on both surfaces:

- **Control UI** — `ViewInfo.isPaused` is derived in `useStreamwallState` (so it
  is available on both `views` and `stateIdxMap`), threaded through
  `ControlGrid` and rendered by `GridPreviewBox` as a "Paused" badge modelled on
  the existing error badge: same layout, neutral black background instead of
  red, and the same `.small` rule that collapses the label text on short cells.
- **Wall overlay** — `OverlayRoot` derives the flag and `OverlayViewTile`
  renders a centred "Paused" pill plus desaturation, reusing the existing
  `FilterCover` `$isDesaturated` path that already marks loading tiles.

### Architecture decisions

- **No protocol or schema change.** The `pause` region is already part of the
  broadcast state since #484; this is purely a rendering change.
- **Read-only flag.** Unlike `isBlurred`, `isPaused` has no toggle control: it
  is owned by the park/fullscreen logic, not the operator, so it is surfaced as
  an indicator rather than a button. This is noted in the `ViewInfo` doc comment
  so a future reader doesn't wire up a command for it.
- **Badges, not a new visual language.** Both surfaces reuse the styling already
  established for error/loading states so the wall keeps one consistent way of
  marking a non-live tile.
- **Desaturation only on the overlay.** The control UI grid preview draws
  synthetic colour tiles rather than live video, so desaturating there would
  carry no meaning; the badge alone is the signal.

## Testing

- New `streamwallState.test.tsx` covers the flag derivation for both a paused
  and a playing view, on `views` and on `stateIdxMap`.
- New `GridPreviewBox` tests: badge rendered with icon and label when paused,
  absent when playing.
- New `OverlayViewTile` tests: badge rendered when paused, absent when playing,
  and the tile desaturated while paused.
- Both existing "does not leak custom styled-component props onto the DOM"
  regression tests (#152) extended to cover the new paused state.
- Full quality gate green locally: `npm run format:check`, `npm run lint`,
  `npm run typecheck`, `npm run test` (all packages), and
  `npm -w streamwall-control-client run build`.

## Risks / breaking changes

None. `ViewInfo` gains a required field, which is internal to
`streamwall-control-ui`; all in-repo fixtures were updated. No public API,
protocol, or persisted format changes.

Closes #490
