### PR TITLE
test(control-server): stop the node:test timeout cancelling whole test files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,15 @@ the same runner:
 To run a single package's tests, target its workspace, e.g.
 `npm -w streamwall-control-server test`.
 
+`node --test` applies `--test-timeout` to every test _including the implicit
+file-level test_ it wraps each file in, so the value has to clear the slowest
+whole file, not the slowest single test. When a file exceeds it, the run
+reports `# fail 0` alongside `# cancelled 1` and still exits non-zero — an
+easily misread symptom, so check the `cancelled` counter before hunting for a
+failing assertion. `test/workspace-metadata.test.mjs` keeps the configured
+timeout above a floor that leaves the live-server WebSocket suites room to
+finish under load.
+
 ### End-to-end tests
 
 The E2E smoke tests need a browser that is not installed by `npm ci`. They are

--- a/packages/streamwall-control-server/package.json
+++ b/packages/streamwall-control-server/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "tsx ./src/index.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "test": "node --import tsx --test --test-concurrency=1 --test-force-exit --test-timeout=20000 \"src/**/*.test.ts\""
+    "test": "node --import tsx --test --test-concurrency=1 --test-force-exit --test-timeout=60000 \"src/**/*.test.ts\""
   },
   "repository": "github:NilsR0711/streamwall",
   "author": "Nils Reeh <info@nilsreeh.de>",

--- a/test/workspace-metadata.test.mjs
+++ b/test/workspace-metadata.test.mjs
@@ -84,6 +84,38 @@ test('every workspace that packages with electron-forge typechecks first', () =>
   }
 })
 
+// `--test-timeout` bounds *every* node:test test — including the implicit
+// file-level test the runner wraps each file in. A file of live-server
+// WebSocket integration tests therefore races the same budget as a single
+// test: `wsValidation.test.ts` alone needs 6-13s locally, so the former 20s
+// value cancelled the whole file on a loaded machine. A cancelled file reports
+// `# fail 0` with a non-zero exit, which reads as an unexplained flake. The
+// floor keeps the timeout a hang detector rather than a per-file budget.
+// Issue #492.
+const NODE_TEST_TIMEOUT_FLOOR_MS = 60_000
+
+test('node:test workspaces leave room for whole-file runtime in --test-timeout', () => {
+  for (const relativePath of workspacePackageJsonPaths()) {
+    const { scripts = {} } = readPackageJson(relativePath)
+    const testScript = scripts.test
+    if (!testScript?.includes('--test')) {
+      continue
+    }
+
+    const configured = testScript.match(/--test-timeout=(\d+)/)
+    assert.ok(
+      configured,
+      `${relativePath} runs node:test without an explicit --test-timeout`,
+    )
+    assert.ok(
+      Number(configured[1]) >= NODE_TEST_TIMEOUT_FLOOR_MS,
+      `${relativePath} sets --test-timeout=${configured[1]}, below the ` +
+        `${NODE_TEST_TIMEOUT_FLOOR_MS}ms floor that keeps whole test files ` +
+        'from being cancelled under load',
+    )
+  }
+})
+
 // The E2E suite deliberately has no `test` script (it needs a browser, so it
 // stays out of the `npm test` workspace fan-out), which means the only way to
 // discover it is a root-level entry point. Issue #411.


### PR DESCRIPTION
## Problem

`npm -w packages/streamwall-control-server test` failed intermittently on an
unmodified tree, reporting `# fail 0` yet exiting non-zero, with fewer subtests
than a passing run.

Reproduced locally (1 failure in 6 consecutive runs). The captured output shows
the actual cause:

```
# Subtest: src/wsValidation.test.ts
not ok 23 - src/wsValidation.test.ts
  duration_ms: 20002.976417
  failureType: 'testTimeoutFailure'
  error: 'test timed out after 20000ms'
# pass 155
# fail 0
# cancelled 1
```

`node --test` applies `--test-timeout` to **every** test — including the
implicit file-level test it wraps each file in. `src/wsValidation.test.ts` boots
eleven live servers (each: fastify listen, two scrypt-hashed tokens, an uplink
and a client WebSocket handshake) and needs 6–13 s locally, so the whole file
raced the same 20 s budget that was meant to bound a single test. On a loaded
machine it lost, and the file was cancelled mid-run — taking its remaining
subtests with it. A cancelled test counts under `cancelled`, not `fail`, which
is exactly why the summary read `fail 0` next to a non-zero exit.

The 20 s value dates back to #102, where it was introduced to bound individual
slow WebSocket tests; the file-level effect was never intended.

## Solution

- Raise the control-server `--test-timeout` to 60 s, so it detects a genuine
  hang instead of acting as a per-file budget (≈5× headroom over the slowest
  observed file).
- Add a `test/workspace-metadata.test.mjs` guard that fails if a node:test
  workspace configures a timeout below that floor, so the value cannot silently
  drift back to a file-cancelling one.
- Document the mechanism in `CONTRIBUTING.md`, including that a cancelled file
  reports `# fail 0` with a non-zero exit — the symptom that made this hard to
  triage.

Deliberately not done: shaving per-test cost (scrypt work factor, fixed
handshake `delay()`s). Both would trade security or determinism for a second or
two and neither removes the structural coupling between the per-test and
per-file budget. Follow-up: #536.

## Testing

- Red first: the new guard fails against the 20 s value, then passes at 60 s.
- Full quality gate green locally: `format:check`, `lint`, `typecheck`, `npm test`.
- Stability: 6 consecutive control-server runs after the change, all
  `162 pass / 0 fail / 0 cancelled` (the same loop reproduced the flake before).

## Risks

Low. No production code changes. A genuinely hung test file now takes 60 s
instead of 20 s to fail; individual tests still fail fast through their own
`waitFor` (2 s) and `AbortSignal.timeout` guards.

Closes #492

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments
