### PR TITLE
fix(control-client): validate the patched state on the WebSocket delta path

### DIFF
--- a/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.test.tsx
+++ b/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.test.tsx
@@ -13,6 +13,7 @@ const { FakeSocket, instances } = vi.hoisted(() => {
     options: unknown
     binaryType = ''
     closed = false
+    reconnectCount = 0
     listeners = new Map<string, Set<Listener>>()
 
     constructor(url: string, _protocols: unknown, options: unknown) {
@@ -36,6 +37,10 @@ const { FakeSocket, instances } = vi.hoisted(() => {
 
     close() {
       this.closed = true
+    }
+
+    reconnect() {
+      this.reconnectCount++
     }
 
     dispatch(type: string, ev: unknown = {}) {
@@ -75,10 +80,26 @@ const minimalState: StreamwallState = {
   dataSourceHealth: [],
 }
 
-function stateMessage() {
+function stateMessage(state: StreamwallState = minimalState) {
   return {
-    data: JSON.stringify({ type: 'state', state: minimalState }),
+    data: JSON.stringify({ type: 'state', state }),
   }
+}
+
+function deltaMessage(delta: unknown) {
+  return {
+    data: JSON.stringify({ type: 'state-delta', delta }),
+  }
+}
+
+/**
+ * jsondiffpatch encodes a replaced scalar as `[oldValue, newValue]`. The
+ * deltas below are written out rather than derived via `stateDiff.diff` so a
+ * test can express an invalid target state without the differ having to build
+ * a diff for one.
+ */
+function setCols(from: number, to: number) {
+  return { config: { cols: [from, to] } }
 }
 
 const createInviteCommand: ControlCommand = {
@@ -325,6 +346,122 @@ describe('useStreamwallWebsocketConnection', () => {
 
       expect(getConnection().isConnected).toBe(true)
       expect(getConnection().sharedState?.views['0']?.streamId).toBe('fresh')
+    })
+  })
+
+  // Deltas are applied blind onto the last-known state, so a malformed or
+  // out-of-order one used to poison `lastStateData` and compound across every
+  // later delta. The patched result is validated against the same schema the
+  // IPC and uplink boundaries enforce (issue #488).
+  describe('state-delta validation (issue #488)', () => {
+    // Every rejected delta logs; silence it so the expected warnings don't
+    // look like test noise.
+    let warn: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+      warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      warn.mockRestore()
+    })
+
+    function connectedSocket() {
+      const mounted = mount()
+      const socket = instances[0]!
+      act(() => {
+        socket.dispatch('message', stateMessage())
+      })
+      return { ...mounted, socket }
+    }
+
+    it('applies a delta that patches into a valid state', () => {
+      const { getConnection, socket } = connectedSocket()
+
+      act(() => {
+        socket.dispatch('message', deltaMessage(setCols(1, 2)))
+      })
+
+      expect(getConnection().config?.cols).toBe(2)
+      expect(socket.reconnectCount).toBe(0)
+    })
+
+    it('drops a delta that patches into an invalid state and keeps the last-known state', () => {
+      const { getConnection, socket } = connectedSocket()
+
+      act(() => {
+        // Below GRID_MIN, so the patched snapshot fails the schema.
+        socket.dispatch('message', deltaMessage(setCols(1, 0)))
+      })
+
+      expect(getConnection().config).toEqual(minimalState.config)
+      expect(warn).toHaveBeenCalled()
+    })
+
+    it('forces a resync so the client recovers instead of drifting', () => {
+      const { socket } = connectedSocket()
+
+      act(() => {
+        socket.dispatch('message', deltaMessage(setCols(1, 0)))
+      })
+
+      expect(socket.reconnectCount).toBe(1)
+    })
+
+    it('ignores further deltas while desynced, so the poisoned base cannot compound', () => {
+      const { getConnection, socket } = connectedSocket()
+
+      act(() => {
+        socket.dispatch('message', deltaMessage(setCols(1, 0)))
+      })
+      act(() => {
+        socket.dispatch('message', deltaMessage(setCols(0, 3)))
+      })
+
+      expect(getConnection().config).toEqual(minimalState.config)
+    })
+
+    it('resumes applying deltas once a full state message resyncs the client', () => {
+      const { getConnection, socket } = connectedSocket()
+
+      act(() => {
+        socket.dispatch('message', deltaMessage(setCols(1, 0)))
+      })
+      act(() => {
+        socket.dispatch('message', stateMessage())
+      })
+      act(() => {
+        socket.dispatch('message', deltaMessage(setCols(1, 4)))
+      })
+
+      expect(getConnection().config?.cols).toBe(4)
+    })
+
+    it('survives a malformed delta payload that the patcher itself rejects', () => {
+      const { getConnection, socket } = connectedSocket()
+
+      act(() => {
+        // An array-diff op aimed at an object: the patcher throws on it.
+        socket.dispatch(
+          'message',
+          deltaMessage({ config: { _t: 'a', _0: ['', 0, 0] } }),
+        )
+      })
+
+      expect(getConnection().config).toEqual(minimalState.config)
+      expect(socket.reconnectCount).toBe(1)
+    })
+
+    it('drops a delta that arrives before any full state, since there is no base to patch', () => {
+      const { getConnection } = mount()
+      const socket = instances[0]!
+
+      act(() => {
+        socket.dispatch('message', deltaMessage(setCols(1, 2)))
+      })
+
+      expect(getConnection().config).toBeUndefined()
+      expect(socket.reconnectCount).toBe(1)
     })
   })
 

--- a/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.ts
+++ b/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.ts
@@ -1,3 +1,4 @@
+import type { Delta } from 'jsondiffpatch'
 import { useMemo, useRef } from 'preact/hooks'
 import ReconnectingWebSocket from 'reconnecting-websocket'
 import {
@@ -10,7 +11,51 @@ import {
   parseDisconnectReason,
   stateDiff,
   type StreamwallState,
+  streamwallStateSchema,
 } from 'streamwall-shared'
+
+/**
+ * Applies a server `state-delta` to the last-known snapshot and gates the
+ * result on the same schema the IPC and uplink boundaries enforce (issues #409
+ * / #387). Unlike a full snapshot, a bad delta is not a one-off: the patched
+ * object becomes the base for every later delta, so an unchecked one keeps
+ * compounding. Returns `undefined` when the delta cannot be trusted.
+ *
+ * The base is cloned before patching because `stateDiff.patch` mutates its
+ * target in place - patching `lastStateData` directly would corrupt it even
+ * when the caller then discards the result (issue #488).
+ */
+function patchState(
+  lastStateData: StreamwallState | undefined,
+  delta: unknown,
+): StreamwallState | undefined {
+  if (lastStateData === undefined) {
+    console.warn('Ignored Streamwall state delta received before a snapshot')
+    return undefined
+  }
+  let patched: unknown
+  try {
+    // Cloning also gives the updated object a fresh identity, which is what
+    // triggers React renders downstream. The cast is deliberate: the payload
+    // came off the wire unvalidated, and `patch` has no total signature for
+    // untrusted input - hence the catch below.
+    patched = stateDiff.patch(stateDiff.clone(lastStateData), delta as Delta)
+  } catch (err) {
+    console.warn('Ignored unpatchable Streamwall state delta:', err)
+    return undefined
+  }
+  const result = streamwallStateSchema.safeParse(patched)
+  if (!result.success) {
+    console.warn(
+      'Ignored Streamwall state delta patching into an invalid state:',
+      result.error.issues[0]?.message,
+    )
+    return undefined
+  }
+  // Return the patched object rather than the parsed copy: validation is a
+  // gate here, not a transform, so fields the schema does not model survive.
+  return patched as StreamwallState
+}
 
 interface WsRef {
   ws: ReconnectingWebSocket
@@ -73,6 +118,11 @@ function useWebsocketCollabTransport(wsEndpoint: string): CollabTransport {
 
       connect(events) {
         let lastStateData: StreamwallState | undefined
+        // Set once a delta is rejected: the server has already advanced past
+        // what we last accepted, so every following delta is a diff against a
+        // state we do not have. Further deltas are dropped until a full
+        // snapshot resyncs us.
+        let desynced = false
         const ws = new ReconnectingWebSocket(wsEndpoint, [], {
           maxReconnectionDelay: 5000,
           minReconnectionDelay: 1000 + Math.random() * 500,
@@ -122,16 +172,23 @@ function useWebsocketCollabTransport(wsEndpoint: string): CollabTransport {
               responseMap.delete(msg.id)
               responseCb(msg)
             }
-          } else if (msg.type === 'state' || msg.type === 'state-delta') {
-            let state: StreamwallState
-            if (msg.type === 'state') {
-              state = msg.state
-              events.onConnected()
-            } else {
-              // Clone so the updated object triggers React renders
-              state = stateDiff.clone(
-                stateDiff.patch(lastStateData, msg.delta),
-              ) as StreamwallState
+          } else if (msg.type === 'state') {
+            desynced = false
+            lastStateData = msg.state
+            events.onConnected()
+            events.onState(msg.state)
+          } else if (msg.type === 'state-delta') {
+            if (desynced) {
+              return
+            }
+            const state = patchState(lastStateData, msg.delta)
+            if (!state) {
+              // Keep `lastStateData` on the last snapshot we trust and ask the
+              // server for a fresh one: it only pushes a full `state` on
+              // (re)connect, so reconnecting is how a client resyncs.
+              desynced = true
+              ws.reconnect()
+              return
             }
             lastStateData = state
             events.onState(state)


### PR DESCRIPTION
## Problem

After #409 (PR #481) the Electron IPC boundary validates full `StreamwallState`
snapshots, and the control server validates uplink snapshots the same way
(#387). The `state-delta` path in the web control client was the last
`StreamwallState` boundary without a gate: `msg.delta` was patched onto
`lastStateData` and the result cast rather than validated.

That is worse than an unchecked snapshot. The patched object becomes the base
for every following delta, so one malformed or out-of-order delta poisoned
`lastStateData` and kept compounding until the next full `state` message.

## Solution

`packages/streamwall-control-client/src/useStreamwallWebsocketConnection.ts`:

- The patched result is validated with `streamwallStateSchema` — the same
  contract the IPC gate in `ipcCollabTransport.ts` enforces. As there, the
  patched object (not the parsed copy) is forwarded: validation is a gate,
  not a transform.
- The base is **cloned before** patching. `stateDiff.patch` mutates its target
  in place, so patching `lastStateData` directly corrupted it even when the
  result was then discarded — "drop the delta" would not have held without
  this.
- `patch` itself is wrapped in `try`/`catch`: a delta whose ops do not fit the
  target (e.g. an array op aimed at an object) throws rather than returning
  something checkable.
- A rejected delta leaves `lastStateData` on the last trusted snapshot and
  sets a `desynced` flag; the client calls `ws.reconnect()`. The server only
  pushes a full `state` on (re)connect, so reconnecting *is* the resync
  protocol here. While desynced, further deltas are dropped — they are diffs
  against a state the client never accepted, so patching them would be exactly
  the drift this fixes. A full `state` clears the flag and deltas resume.
- A delta arriving before any snapshot is dropped the same way: there is no
  base to patch.

## Architecture decisions

- **Always validate, no sampling.** The issue asked to weigh per-delta
  validation cost against a validate-on-failure scheme. A parse only happens
  per delta *received*, deltas are already throttled by the server's diff
  (nothing sent when nothing changed), and the state is a small object graph
  — the whole `streamwall-control-client` suite (23 tests, many driving this
  path) runs in ~50 ms. An adaptive scheme would add a second, harder-to-test
  code path for no measured win.
- **Reconnect instead of a new "resync" request message.** No client-initiated
  resync exists in the protocol, and adding one would mean a server-side
  change plus a new message type. The socket already resyncs on connect, and
  `ReconnectingWebSocket` handles the backoff.

## Testing

`npm test` (all workspaces), `npm run lint`, `npm run typecheck`,
`npm run format:check` — all green.

New tests in `useStreamwallWebsocketConnection.test.tsx` (verified failing
against the previous implementation, for the right reasons):

- a valid delta still applies, without triggering a reconnect
- a delta patching into an invalid state is dropped, last-known state kept
- a rejected delta forces a resync
- further deltas are ignored while desynced (no compounding)
- deltas resume after a full `state` message
- a delta the patcher itself rejects does not crash the client
- a delta arriving before any snapshot is dropped

## Risks

Low. Behaviour is unchanged for well-formed deltas. A client that does hit an
invalid delta now takes one reconnect round-trip (full `state` + Yjs doc)
instead of silently rendering drifting state; the shared doc-reset policy on
close already covers that path (#37 / #283).

## Follow-ups

- #539 — a *string-valued* delta property makes `jsondiffpatch.patch` allocate
  until the heap dies, before this gate can run. Found while writing these
  tests (it OOM-killed a test worker). Needs delta-payload validation ahead of
  `patch`, which is its own piece of work.

Closes #488
