### PR TITLE
fix(data): log a chokidar watcher error only once

### DIFF
--- a/packages/streamwall/src/main/data.test.ts
+++ b/packages/streamwall/src/main/data.test.ts
@@ -174,6 +174,36 @@ link = "https://b.example/s"
     }
   })
 
+  test('logs a watcher error exactly once', async () => {
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {})
+    const file = writeTomlFile(`
+[[streams]]
+link = "https://a.example/s"
+`)
+    const gen = watchDataFile(file)
+    try {
+      await gen.next()
+      const watcher = fakeWatcher!
+
+      const next = gen.next()
+      await waitForListener(watcher, 'all')
+      // Both the permanent 'error' listener and the `once(watcher, 'all')`
+      // race promise observe this emission; only one of them may log it.
+      watcher.emit('error', new Error('EPERM'))
+      watcher.emit('all', 'change', file)
+      await next
+
+      expect(
+        warnSpy.mock.calls.filter(
+          ([message]) => message === 'error watching data file',
+        ),
+      ).toHaveLength(1)
+    } finally {
+      await gen.return(undefined)
+      warnSpy.mockRestore()
+    }
+  })
+
   test('keeps the last known-good streams when a read fails after a successful read', async () => {
     const dir = mkdtempSync(path.join(tmpdir(), 'sw-data-'))
     const file = path.join(dir, 'streams.toml')

--- a/packages/streamwall/src/main/data.ts
+++ b/packages/streamwall/src/main/data.ts
@@ -113,17 +113,18 @@ export function watchDataFile(
         const eventP = once(watcher, 'all')
         // Pure unhandled-rejection guard for the race loser. `once(watcher,
         // 'all')` rejects on a watcher 'error', which is already logged by the
-        // persistent 'error' listener above (and, when this promise wins the
-        // race, by the catch below) -- so re-logging here would just duplicate
-        // an already-surfaced breadcrumb (issue #392).
+        // persistent 'error' listener above -- so re-logging here would just
+        // duplicate an already-surfaced breadcrumb (issue #392).
         eventP.catch(() => {})
         try {
           const result = await Promise.race([eventP, stop])
           if (result === undefined) {
             return
           }
-        } catch (err) {
-          log.warn('error watching data file', path, err)
+        } catch {
+          // A watcher 'error' rejected the race; the persistent 'error'
+          // listener above is the single source of truth for logging it
+          // (issue #464). Swallow it here and keep watching.
         }
       }
     } finally {


### PR DESCRIPTION
## Problem

`watchDataFile` (`packages/streamwall/src/main/data.ts`) emitted **two identical** `error watching data file` warnings for every single chokidar `'error'` event:

1. the permanent `watcher.on('error')` listener that keeps the watcher (and the Repeater) alive, and
2. the `catch` around `Promise.race([eventP, stop])` — `once(watcher, 'all')` attaches its own one-shot error listener and rejects on the same emission.

Purely log noise, but it doubles the apparent error volume when eyeballing logs.

## Solution

Make the permanent `'error'` listener the single source of truth for watcher-error logging. The race `catch` remains for control flow only (swallow the rejection, keep watching) and no longer re-logs. The existing `eventP.catch(() => {})` unhandled-rejection guard from #392 is untouched; its comment was updated so it no longer references the now-removed second log site.

## Testing

- New regression test `watchDataFile > logs a watcher error exactly once`: spies on `log.warn`, emits a watcher `'error'` followed by a `'change'`, and asserts exactly one `error watching data file` line. Verified red before the fix (2 calls) and green after.
- The existing "does not crash and keeps watching after a watcher error" test still passes, so the control-flow behaviour is unchanged.
- Full local quality gate green: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (337 tests).

## Risks / breaking changes

None. Log-output-only change; no behavioural or API change.

Closes #464