### PR TITLE
ci(workflows): run the PR package smoke on macOS for packaging changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
       dependencies: ${{ steps.filter.outputs.dependencies }}
       docker: ${{ steps.filter.outputs.docker }}
       workflows: ${{ steps.filter.outputs.workflows }}
+      # Runner matrix for the package smoke job. macOS is the expensive leg
+      # and the only one that ad-hoc re-signs the app, so it joins only when
+      # the PR actually touches a packaging input (#538).
+      package_os: ${{ steps.filter.outputs.packaging == 'true' && '["ubuntu-latest", "macos-latest"]' || '["ubuntu-latest"]' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -64,6 +68,14 @@ jobs:
               - 'package.json'
               - 'package-lock.json'
               - '.dockerignore'
+              - '.github/workflows/ci.yml'
+            # Inputs to `electron-forge package`: the desktop workspace with
+            # its Forge/Vite config, the manifests that pin Electron and the
+            # native modules, and this workflow.
+            packaging:
+              - 'packages/streamwall/**'
+              - 'package.json'
+              - 'package-lock.json'
               - '.github/workflows/ci.yml'
             workflows:
               - '.github/workflows/**'
@@ -140,16 +152,27 @@ jobs:
   # `package` only, not `make`: it exercises the Vite builds, asar packing
   # and native rebuild without paying for the maker-specific installer
   # steps (NSIS, darwin zip, deb, rpm). Those are covered outside of PR CI
-  # by the weekly `.github/workflows/packaging.yml` matrix. Ubuntu alone is
-  # enough for a smoke test — the shared failure modes are OS-independent.
-  # Runtime: ~45 seconds (measured on ubuntu-latest, cached npm), and it runs
-  # in parallel with the other jobs, so wall-clock CI time is unchanged.
+  # by the weekly `.github/workflows/packaging.yml` matrix.
+  #
+  # Ubuntu covers the OS-independent failure modes on every code change and
+  # runs in parallel with the other jobs (~45 seconds, cached npm), so
+  # wall-clock CI time is unchanged. macOS joins only for changes that touch
+  # a packaging input, because it is the one platform whose `package` step
+  # ad-hoc re-signs the app (fuses plugin) and produces the `.app` bundle the
+  # darwin zip maker consumes — a regression there used to stay hidden until
+  # the weekly matrix or a release (#538). Gating it on the `packaging` filter
+  # keeps the extra macOS minutes off PRs that cannot break packaging.
   package:
-    name: Package smoke (Electron app)
+    name: Package smoke (${{ matrix.os }})
     needs: changes
     if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
+    strategy:
+      # One broken platform must not hide the state of the other.
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(needs.changes.outputs.package_os) }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -276,9 +276,18 @@ app itself is distributed, via GitHub Releases.
 
 ### Packaging checks
 
-PR CI runs `electron-forge package` (Ubuntu only) as a smoke test. The
-installer makers themselves — NSIS, the macOS zip, deb and rpm — are exercised
-in two other places:
+PR CI runs `electron-forge package` as a smoke test. Ubuntu covers every code
+change; macOS is added whenever the PR touches a packaging input — the
+`packages/streamwall` workspace (including `forge.config.ts`), the root
+manifests or `.github/workflows/ci.yml`. macOS is the only platform whose
+`package` step ad-hoc re-signs the app and produces the `.app` bundle the
+darwin zip maker consumes, so a macOS-specific regression is caught on the PR
+that introduces it instead of a week later. The `packaging` filter in the
+`Detect changes` job keeps those extra runner minutes off PRs that cannot
+break packaging.
+
+The installer makers themselves — NSIS, the macOS zip, deb and rpm — are
+exercised in two other places:
 
 - `.github/workflows/release.yml` gates every tag on an `electron-forge make`
   run that builds the deb and rpm installers natively and cross-builds the


### PR DESCRIPTION
## Problem

`Package smoke (Electron app)` in `.github/workflows/ci.yml` ran on
`ubuntu-latest` only. The macOS packaging path — the only one that ad-hoc
re-signs the app in `@electron-forge/plugin-fuses`, and the one that produces
the `.app` bundle the darwin zip maker consumes — was exercised on a schedule
instead, by the weekly `.github/workflows/packaging.yml` matrix. A
macOS-specific packaging regression therefore surfaced up to a week after the
PR that introduced it, or at release time.

## Solution

Option 1 from the issue, with the change-detection gate it was made
conditional on.

- A new `packaging` filter in the `Detect changes` job classifies the inputs
  to `electron-forge package`: the `packages/streamwall` workspace (including
  `forge.config.ts`), the root `package.json`/`package-lock.json` that pin
  Electron and the native modules, and `ci.yml` itself.
- `Detect changes` exposes a `package_os` output — a JSON runner list that is
  `["ubuntu-latest", "macos-latest"]` when that filter matches and
  `["ubuntu-latest"]` otherwise.
- The `package` job consumes it via `fromJSON` as its `os` matrix
  (`fail-fast: false`, so one platform cannot hide the other's verdict).

Ubuntu therefore still covers the OS-independent failure modes on every code
change, and PRs that cannot break packaging pay no extra macOS minutes.

### Architecture decisions

- **Dynamic matrix instead of a second job.** A conditional extra job would
  duplicate the steps and add another entry to the `ci-ok` `needs` list; a
  matrix computed in `changes` keeps one job definition and one gate entry.
- **Output name `package_os`, not `package-os`.** GitHub expressions treat
  `-` as an operator; an underscore removes the ambiguity entirely.
- **`ci.yml` in the `packaging` filter**, mirroring how the `docker` filter
  already lists it: a change to the job definition should exercise the job.
  As a side effect this PR runs its own macOS leg.
- **Job name is now `Package smoke (${{ matrix.os }})`.** Branch protection
  requires only the aggregate `CI OK` check, so no required check changes.

## Testing

No automated tests: this is a CI workflow change with no testable runtime
behavior. Verified instead by

- `actionlint` (clean) and `npm run format:check` (clean) locally, the same
  checks CI runs;
- `npm -w streamwall run package` executed locally on macOS (arm64, darwin) —
  exit 0, packaging and the `postPackage` hook complete — confirming the new
  matrix leg has a working command to run;
- this PR touching `ci.yml`, which is a `packaging` input, so the
  `Package smoke (macos-latest)` leg runs on this very PR.

## Risks

Low. The added leg is opt-in per change and cannot make an existing leg fail.
Worst case is extra runner minutes on packaging-touching PRs; `package` runs
in parallel with the other jobs, so wall-clock CI time is unaffected.

Closes #538
