### PR TITLE
fix(preload): observe same-origin iframe documents while searching for media

### DIFF
--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -516,6 +516,134 @@ describe('mediaPreload late iframe rescanning (issue #485)', () => {
   })
 })
 
+describe('mediaPreload in-frame document observation (issue #534)', () => {
+  // Must match INITIAL_TIMEOUT in mediaPreload.ts; every insertion under test
+  // happens well before it, so a scan that only runs when the search gives up
+  // cannot be what finds the player.
+  const INITIAL_TIMEOUT_MS = 10 * 1000
+  // Must match SCAN_THROTTLE in mediaPreload.ts.
+  const SCAN_THROTTLE_MS = 500
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.resetModules()
+    invoke.mockClear()
+    send.mockClear()
+    on.mockClear()
+    exposeInMainWorld.mockClear()
+    document.body.innerHTML = ''
+  })
+
+  function viewErrorCalls() {
+    return send.mock.calls.filter(([channel]) => channel === 'view-error')
+  }
+
+  async function loadVideoContent() {
+    invoke.mockResolvedValueOnce({
+      content: { kind: 'video', link: 'https://example.com/stream' },
+      options: {},
+      volume: 1,
+    })
+    await import('./mediaPreload')
+    document.dispatchEvent(new Event('DOMContentLoaded'))
+    process.emit('loaded' as never)
+    await vi.advanceTimersByTimeAsync(0)
+  }
+
+  // happy-dom's HTMLVideoElement never implements videoWidth, so give it a
+  // truthy value to skip findMedia's "wait for playing" branch.
+  function playableVideo(doc: Document): HTMLVideoElement {
+    const video = doc.createElement('video')
+    ;(video as unknown as { videoWidth: number }).videoWidth = 100
+    return video
+  }
+
+  function appendEmptyIframe(): {
+    iframe: HTMLIFrameElement
+    frameDocument: Document
+  } {
+    const iframe = document.createElement('iframe')
+    iframe.srcdoc = '<html><head></head><body></body></html>'
+    document.body.appendChild(iframe)
+    const frameDocument = iframe.contentDocument
+    if (!frameDocument) {
+      throw new Error('test fixture: iframe has no document')
+    }
+    return { iframe, frameDocument }
+  }
+
+  it('acquires a video inserted by the frame itself after it finished loading', async () => {
+    const { iframe, frameDocument } = appendEmptyIframe()
+
+    await loadVideoContent()
+    // The frame is loaded and empty: neither a further embedder mutation nor
+    // another 'load' event will announce what its own scripts do next.
+    await vi.advanceTimersByTimeAsync(SCAN_THROTTLE_MS)
+    expect(send).not.toHaveBeenCalledWith('view-loaded')
+
+    frameDocument.body.appendChild(playableVideo(frameDocument))
+    await vi.advanceTimersByTimeAsync(SCAN_THROTTLE_MS)
+
+    expect(viewErrorCalls()).toEqual([])
+    expect(send).toHaveBeenCalledWith('view-loaded')
+    expect(iframe.className).toBe('__video__')
+  })
+
+  it('observes the replacement document after the frame navigates', async () => {
+    const { iframe } = appendEmptyIframe()
+    const initialDocument = iframe.contentDocument
+    if (!initialDocument) {
+      throw new Error('test fixture: iframe has no document')
+    }
+
+    await loadVideoContent()
+    await vi.advanceTimersByTimeAsync(SCAN_THROTTLE_MS)
+
+    // A navigation inside the frame discards the observed document, so the
+    // observer has to be re-attached to the new one when 'load' announces it.
+    const nextDocument = document.implementation.createHTMLDocument()
+    Object.defineProperty(iframe, 'contentDocument', {
+      configurable: true,
+      get: () => nextDocument,
+    })
+    iframe.dispatchEvent(new Event('load'))
+    await vi.advanceTimersByTimeAsync(SCAN_THROTTLE_MS)
+    expect(send).not.toHaveBeenCalledWith('view-loaded')
+
+    nextDocument.body.appendChild(playableVideo(nextDocument))
+    await vi.advanceTimersByTimeAsync(SCAN_THROTTLE_MS)
+
+    expect(viewErrorCalls()).toEqual([])
+    expect(send).toHaveBeenCalledWith('view-loaded')
+    expect(iframe.className).toBe('__video__')
+  })
+
+  it('keeps reporting the cross-origin cause for frames it cannot observe', async () => {
+    const iframe = document.createElement('iframe')
+    document.body.appendChild(iframe)
+    Object.defineProperty(iframe, 'contentDocument', { value: null })
+
+    await loadVideoContent()
+    await vi.advanceTimersByTimeAsync(INITIAL_TIMEOUT_MS)
+
+    expect(viewErrorCalls()).toEqual([
+      [
+        'view-error',
+        {
+          error: expect.objectContaining({
+            message:
+              'could not find video: it may be inside a cross-origin iframe, which is unsupported',
+          }),
+        },
+      ],
+    ])
+  })
+})
+
 describe('mediaPreload MutationObserver lifecycle (issue #412)', () => {
   // Records every observer the module creates so the tests can assert on how
   // many are still connected at a given point. Deliberately inert: it never
@@ -588,6 +716,19 @@ describe('mediaPreload MutationObserver lifecycle (issue #412)', () => {
 
   it('disconnects the element-search observer when the acquisition times out', async () => {
     // No <video> in the document, so findMedia's search runs to its timeout.
+    await loadVideoContent()
+    await vi.advanceTimersByTimeAsync(10 * 1000)
+
+    expect(connectedObservers()).toHaveLength(1)
+  })
+
+  it('disconnects the observers watching frame documents when the acquisition times out', async () => {
+    // A same-origin frame gets an observer of its own (issue #534), which the
+    // search must tear down along with the embedder's.
+    const iframe = document.createElement('iframe')
+    iframe.srcdoc = '<html><head></head><body></body></html>'
+    document.body.appendChild(iframe)
+
     await loadVideoContent()
     await vi.advanceTimersByTimeAsync(10 * 1000)
 

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -177,9 +177,9 @@ type ScanCallback = (() => void) & { cancel(): void }
 // firing its throttled callback for the rest of the page's life -- see #412.
 const observerTeardowns = new Set<() => void>()
 
-function observeBody(scan: ScanCallback): () => void {
+function observeSubtree(root: Node, scan: ScanCallback): () => void {
   const observer = new MutationObserver(scan)
-  observer.observe(document.body, { subtree: true, childList: true })
+  observer.observe(root, { subtree: true, childList: true })
   const stop = () => {
     observer.disconnect()
     scan.cancel()
@@ -187,6 +187,10 @@ function observeBody(scan: ScanCallback): () => void {
   }
   observerTeardowns.add(stop)
   return stop
+}
+
+function observeBody(scan: ScanCallback): () => void {
+  return observeSubtree(document.body, scan)
 }
 
 // Nothing in the page world outlives its document, so once it goes away even
@@ -339,14 +343,41 @@ async function waitForMedia(
     const watchedIframes = new Set<HTMLIFrameElement>()
     const rescan = () => scan()
 
+    // Observers watching the documents of reachable frames, keyed by frame.
+    // A same-origin frame may insert its player from its own scripts long
+    // after it finished loading (a player bootstrapped in-frame, a consent
+    // gate resolved, an ad pre-roll swapped out): that mutation happens in a
+    // tree the embedder's observer does not cover, and no further 'load'
+    // event announces it either -- so watch each frame's document as well
+    // (#534). The observed body is kept so a navigation, which replaces the
+    // frame's document, re-attaches rather than leaving a stale observer.
+    const frameObservers = new Map<
+      HTMLIFrameElement,
+      { body: HTMLElement; stop: () => void }
+    >()
+    const observeFrameDocument = (iframe: HTMLIFrameElement) => {
+      const body = iframe.contentDocument?.body
+      const observed = frameObservers.get(iframe)
+      if (observed?.body === body) {
+        return
+      }
+      observed?.stop()
+      if (!body) {
+        // Cross-origin, or a document that has no body (yet).
+        frameObservers.delete(iframe)
+        return
+      }
+      frameObservers.set(iframe, { body, stop: observeSubtree(body, scan) })
+    }
+
     const scan = throttle(() => {
       const result = scanForMedia(kind)
       for (const iframe of document.querySelectorAll('iframe')) {
-        if (watchedIframes.has(iframe)) {
-          continue
+        if (!watchedIframes.has(iframe)) {
+          watchedIframes.add(iframe)
+          iframe.addEventListener('load', rescan)
         }
-        watchedIframes.add(iframe)
-        iframe.addEventListener('load', rescan)
+        observeFrameDocument(iframe)
       }
       if (result.video) {
         console.log(`found '${kind}'`)
@@ -361,6 +392,10 @@ async function waitForMedia(
         iframe.removeEventListener('load', rescan)
       }
       watchedIframes.clear()
+      for (const { stop: stopFrameObserver } of frameObservers.values()) {
+        stopFrameObserver()
+      }
+      frameObservers.clear()
       stopObserving()
     }
 


### PR DESCRIPTION
## Summary

`waitForMedia()` observed only the embedder's `document.body` plus each iframe's
`load` event. A same-origin frame that inserts its `<video>` from its own scripts
*after* it finished loading — an in-frame player bootstrap, a resolved consent
gate, an ad pre-roll swapped for the player — mutates a tree neither signal
covers, so such a player was found only if it happened to appear inside the
throttle window before the search's final scan; otherwise the view failed with
`could not find video` even though the element became reachable seconds later.

Each scan now attaches a `MutationObserver` to every reachable frame's
`contentDocument.body`, feeding the same throttled scan callback. Detection is
driven by an actual signal instead of scan timing.

Technical notes:

- `observeBody()` was generalized to `observeSubtree(root, scan)` so frame
  bodies register through the same `observerTeardowns` discipline (#412); the
  search's `stop()` disconnects the frame observers along with the embedder's,
  and `pagehide` still catches anything left.
- The observed body is remembered per frame, so a navigation — which replaces
  the frame's document — re-attaches on the next scan (triggered by the frame's
  `load` event) rather than leaving a stale observer behind.
- Cross-origin frames stay unobservable and keep producing the specific
  "may be inside a cross-origin iframe" failure.

Follow-up from #485.

Closes #534

## How was this tested?

`npm run lint`, `npm run format:check`, `npm run typecheck`, `npm test` — all
green. New tests in `packages/streamwall/src/preload/mediaPreload.test.ts`:

- a video inserted by the frame itself after it finished loading is acquired
  within one throttle window instead of waiting out the initial timeout
- after the frame navigates, the replacement document is observed and a video
  inserted there is still acquired
- an unreachable (cross-origin) frame still yields the specific error message
- the frame-document observers are disconnected when the acquisition times out
  (observer-lifecycle suite for #412)

The first two fail on `main`.

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests (or this PR explains why none apply)
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments
