### PR TITLE
fix(control-ui): adopt the shared focus-visible ring for grid cells

### DIFF
--- a/packages/streamwall-control-ui/src/GridInput.test.tsx
+++ b/packages/streamwall-control-ui/src/GridInput.test.tsx
@@ -1,10 +1,13 @@
-import { render } from 'preact'
+import { type ComponentChildren, render } from 'preact'
 import { act } from 'preact/test-utils'
+import { StyleSheetManager } from 'styled-components'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 
 import { GridInput } from './GridInput.tsx'
+import { GlobalStyle } from './globalStyle.tsx'
 
 let container: HTMLDivElement | undefined
+let styleTarget: HTMLDivElement | undefined
 
 afterEach(() => {
   if (container) {
@@ -12,31 +15,91 @@ afterEach(() => {
     container.remove()
     container = undefined
   }
+  styleTarget?.remove()
+  styleTarget = undefined
+  document
+    .querySelectorAll('style[data-styled]')
+    .forEach((style) => style.remove())
 })
 
-function renderInput(
-  props: Partial<Parameters<typeof GridInput>[0]> = {},
-): HTMLDivElement {
+/**
+ * Renders into a fresh container with its own styled-components target, so the
+ * emitted CSS can be inspected. The dedicated target matters: styled-components
+ * remembers what it already injected, so without a new sheet per test only the
+ * first render would emit any CSS at all.
+ */
+function renderWithStyles(node: ComponentChildren): HTMLDivElement {
   container = document.createElement('div')
   document.body.appendChild(container)
+  styleTarget = document.createElement('div')
+  document.head.appendChild(styleTarget)
+
   act(() => {
     render(
-      <GridInput
-        style={{}}
-        idx={0}
-        onChangeSpace={() => {}}
-        spaceValue=""
-        isHighlighted={false}
-        role="admin"
-        onPointerDown={() => {}}
-        onFocus={() => {}}
-        onBlur={() => {}}
-        {...props}
-      />,
+      <StyleSheetManager target={styleTarget}>{node}</StyleSheetManager>,
       container!,
     )
   })
   return container
+}
+
+function gridInput(
+  props: Partial<Parameters<typeof GridInput>[0]> = {},
+): ComponentChildren {
+  return (
+    <GridInput
+      style={{}}
+      idx={0}
+      onChangeSpace={() => {}}
+      spaceValue=""
+      isHighlighted={false}
+      role="admin"
+      onPointerDown={() => {}}
+      onFocus={() => {}}
+      onBlur={() => {}}
+      {...props}
+    />
+  )
+}
+
+function renderInput(
+  props: Partial<Parameters<typeof GridInput>[0]> = {},
+): HTMLDivElement {
+  return renderWithStyles(gridInput(props))
+}
+
+function collectCss(): string {
+  return Array.from(document.querySelectorAll('style'))
+    .map((style) => style.textContent)
+    .join('\n')
+}
+
+type FocusVisibleRule = { selectors: string[]; body: string }
+
+/**
+ * Extracts every `:focus-visible` rule and reduces its selectors to the plain-
+ * element part, so a test can check which elements a rule matches
+ * (`:focus-visible` itself never matches in a non-interactive DOM). Rules whose
+ * selector also carries `:not(:focus-visible)` are the idle-state rules and are
+ * skipped.
+ */
+function focusVisibleRules(css: string): FocusVisibleRule[] {
+  return Array.from(css.matchAll(/([^{}]*:focus-visible[^{}]*){([^}]*)}/g))
+    .filter(([, selector]) => !selector.includes(':not(:focus-visible)'))
+    .map(([, selector, body]) => ({
+      selectors: selector
+        .split(',')
+        .map((one) => one.replaceAll(':focus-visible', '').trim())
+        .map((one) => one || '*'),
+      body,
+    }))
+}
+
+/** The single `:focus-visible` rule the component itself contributes. */
+function ownFocusVisibleRule(css: string): FocusVisibleRule | undefined {
+  const rules = focusVisibleRules(css)
+  expect(rules).toHaveLength(1)
+  return rules[0]
 }
 
 describe('GridInput', () => {
@@ -71,5 +134,74 @@ describe('GridInput', () => {
 
     expect(input.getAttribute('data-testid')).toBe('grid-cell')
     expect(input.getAttribute('data-idx')).toBe('3')
+  })
+
+  // The cell used to draw its own hardcoded `outline: 1px solid black` /
+  // `box-shadow: ... black inset` on `:focus`, which fired on pointer
+  // interaction too and out-specified the shared `:focus-visible` ring added
+  // in #508 - leaving the grid as the one place in the control UI with a
+  // different, non-token keyboard affordance (#531).
+  describe('keyboard focus affordance', () => {
+    test('does not style a bare :focus, so pointer interaction draws no keyboard ring', () => {
+      renderInput()
+
+      // `:focus` not followed by `-visible`.
+      expect(collectCss()).not.toMatch(/:focus(?!-visible)/)
+    })
+
+    test('does not hardcode a focus colour, leaving the shared accent ring to apply', () => {
+      renderInput()
+
+      const rule = ownFocusVisibleRule(collectCss())
+
+      expect(rule).toBeDefined()
+      expect(rule!.body).not.toMatch(/black/)
+      expect(rule!.body).not.toMatch(/outline:/)
+      expect(rule!.body).not.toMatch(/box-shadow:/)
+    })
+
+    test('confines the idle cell border to :not(:focus-visible) so it cannot beat the shared ring', () => {
+      renderInput()
+
+      // Both the component class and the global `:focus-visible` rule are
+      // single-pseudo-class selectors, so an unscoped `outline` on the class
+      // would win or lose purely by injection order.
+      expect(collectCss()).toMatch(
+        /:not\(:focus-visible\)\s*{[^}]*outline:\s*1px solid/,
+      )
+    })
+
+    test('raises the focused cell above its neighbours so the ring is not clipped', () => {
+      renderInput()
+
+      const rule = ownFocusVisibleRule(collectCss())
+
+      expect(rule).toBeDefined()
+      // `z-index` only applies to positioned elements; the input itself is
+      // static, so it needs `position` alongside it to actually stack.
+      expect(rule!.body).toMatch(/position:\s*relative/)
+      expect(rule!.body).toMatch(/z-index:\s*100/)
+    })
+
+    test('is covered by the shared accent ring from GlobalStyle', () => {
+      renderWithStyles(
+        <>
+          <GlobalStyle />
+          {gridInput()}
+        </>,
+      )
+
+      const input = container!.querySelector('input')!
+      const rule = focusVisibleRules(collectCss()).find(({ body }) =>
+        body.includes('--accent'),
+      )
+
+      expect(rule).toBeDefined()
+      expect(rule!.body).toMatch(/outline:\s*2px solid var\(--accent\)/)
+      expect(rule!.body).toMatch(/var\(--accent-soft\)/)
+      expect(rule!.selectors.some((selector) => input.matches(selector))).toBe(
+        true,
+      )
+    })
   })
 })

--- a/packages/streamwall-control-ui/src/GridInput.tsx
+++ b/packages/streamwall-control-ui/src/GridInput.tsx
@@ -16,7 +16,6 @@ const StyledGridInput = styled(LazyChangeInput)<{
 }>`
   width: 100%;
   height: 100%;
-  outline: 1px solid rgba(0, 0, 0, 0.5);
   border: none;
   padding: 0;
   background: ${({ $color, $isHighlighted }) =>
@@ -26,9 +25,20 @@ const StyledGridInput = styled(LazyChangeInput)<{
   font-size: 20px;
   text-align: center;
 
-  &:focus {
-    outline: 1px solid black;
-    box-shadow: 0 0 5px black inset;
+  /* The cell divider. Scoped to :not(:focus-visible) so it cannot compete with
+     the shared focus ring in globalStyle.tsx: both are single-class /
+     single-pseudo-class selectors, so an unscoped outline here would win or
+     lose purely by stylesheet injection order (see #531). */
+  &:not(:focus-visible) {
+    outline: 1px solid rgba(0, 0, 0, 0.5);
+  }
+
+  /* The shared ring is drawn outside the cell (outline-offset plus a halo), so
+     the focused cell has to rise above its neighbours or the ring gets clipped
+     by them. z-index only applies to positioned elements, hence the
+     position. */
+  &:focus-visible {
+    position: relative;
     z-index: 100;
   }
 `


### PR DESCRIPTION
## Problem

`GridInput` styled its focus state with a hardcoded, non-token affordance:

```css
&:focus {
  outline: 1px solid black;
  box-shadow: 0 0 5px black inset;
  z-index: 100;
}
```

Two issues (#531):

- It matched `:focus`, not `:focus-visible`, so the keyboard ring also appeared on plain pointer interaction — unlike the shared affordance added in #508 / PR #528.
- The colours were hardcoded `black` instead of the `--accent` / `--accent-soft` tokens, and because the rule sat on the component class it out-specified the shared global `:focus-visible` rule. The grid was the last place in the control UI with a divergent keyboard affordance.

## Solution

`GridInput` now adopts the shared affordance and contributes no focus colours of its own. Two details make that work:

- **The idle cell divider is scoped to `:not(:focus-visible)`.** The component class rule and the global `:focus-visible` rule are both single-class / single-pseudo-class selectors, so specificity ties — an unscoped `outline: 1px solid rgba(0,0,0,.5)` would win or lose purely by stylesheet injection order. Scoping it out of the focused state removes the ambiguity instead of relying on ordering luck.
- **The `:focus-visible` block keeps `z-index: 100` and gains `position: relative`.** The shared ring is drawn *outside* the control (`outline-offset: 2px` plus a 4px halo), so a focused cell has to rise above its neighbouring tiles or the ring is clipped. The pre-existing `z-index: 100` never actually applied — `z-index` only affects positioned elements, and the input is `static` (only its wrapper is absolute). Adding `position: relative` fixes that latent no-op.

## Architecture decisions

- **Adopt rather than re-derive.** The issue offered an alternative: derive a contrast-safe outline colour from the tile colour. Not needed here — the tile background is always `lightness(75)` (or `90` when highlighted), i.e. reliably light, so the `--accent` ring (`#d6402a` light / `#f24d2e` dark) has ample contrast against every tile. Deriving a per-tile colour would reintroduce the divergence the issue is about.
- **No duplication of the shared ring declarations** in the component — the whole point is a single source of truth in `globalStyle.tsx`.

## Testing

New `GridInput` component tests covering the emitted CSS (same approach as the existing `globalStyle.test.tsx` rules):

- no bare `:focus` rule is emitted, so pointer interaction draws no keyboard ring
- the component's `:focus-visible` block declares no `outline` / `box-shadow` / `black`, leaving the shared ring to apply
- the idle divider is confined to `:not(:focus-visible)` so it cannot beat the shared rule
- the focused cell gets both `position: relative` and `z-index: 100`
- with `GlobalStyle` mounted, the accent ring rule matches the grid-cell input

Full quality gate green locally: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (510 tests across all workspaces).

## Risks / breaking changes

None functionally. Visual change only: the focus ring in the grid becomes the accent ring instead of a black outline, and no longer appears on click. The `data-testid` / `data-idx` E2E hooks are untouched, and no E2E test asserts on focus styling.

Closes #531