### PR TITLE
ci(release): publish a linux/arm64 control-server image alongside amd64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,17 +249,33 @@ jobs:
   # Runs alongside the desktop publish matrix rather than after it: the two
   # ship unrelated artifacts, and a registry outage should not hold back the
   # binaries (or the other way round). Both wait for the same quality gate.
+  # Both architectures build natively, one runner each (`ubuntu-24.04-arm` is
+  # free for public repositories). Emulating the arm64 leg with QEMU instead
+  # would run `npm ci` for four workspaces plus the Vite control-client build
+  # under emulation and dominate the release wall-clock time (#524).
+  #
+  # Because the two legs cannot push the same tag without racing, each pushes
+  # an untagged, digest-addressed image (`push-by-digest`) and hands the digest
+  # to `docker-manifest` below, which merges them into one multi-arch manifest
+  # that the `<version>` and `latest` tags then point at.
   docker-image:
-    name: Publish (control-server image)
+    name: Publish (control-server image, ${{ matrix.platform.arch }})
     needs: [checks, test, build, make, e2e, licenses]
     # Only a tag carries the version to publish under; a workflow_dispatch run
     # would otherwise move `latest` to an unreleased commit.
     if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform.runner }}
     timeout-minutes: 30
     permissions:
       contents: read
       packages: write # pushing to ghcr.io/<owner>/streamwall-control-server
+    strategy:
+      # One broken architecture must not hide the state of the other.
+      fail-fast: false
+      matrix:
+        platform:
+          - { arch: amd64, runner: ubuntu-latest }
+          - { arch: arm64, runner: ubuntu-24.04-arm }
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -275,29 +291,128 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # Derived from the owner rather than hardcoded so a repository transfer
-      # does not silently keep publishing under the old account. The action
-      # lowercases the image name, which GHCR requires.
-      - name: Derive image tags and labels
+      # does not silently keep publishing under the old account. Lowercased
+      # here because GHCR rejects uppercase image names and `push-by-digest`
+      # takes the name verbatim (unlike `metadata-action`, which lowercases it
+      # for the tags in the manifest job below).
+      - name: Derive the image name
+        id: image
+        env:
+          OWNER: ${{ github.repository_owner }}
+        run: echo "name=ghcr.io/${OWNER,,}/streamwall-control-server" >> "$GITHUB_OUTPUT"
+
+      - name: Derive image labels
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
-          images: ghcr.io/${{ github.repository_owner }}/streamwall-control-server
-          tags: |
-            type=semver,pattern={{version}}
-            type=raw,value=latest
+          images: ${{ steps.image.outputs.name }}
 
-      # linux/amd64 only: an emulated arm64 leg would run `npm ci` plus the
-      # control-client build under QEMU and dominate the release time. Native
-      # arm64 runners are tracked separately.
-      - name: Build and push
+      # No `tags:` — a digest-addressed push must stay untagged, or both legs
+      # would fight over the same tag and the last one to finish would win.
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: packages/streamwall-control-server/Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/${{ matrix.platform.arch }}
           labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=true
+
+      # The digest travels as an empty file named after it: artifact names have
+      # to differ per leg, but their *contents* merge into one directory for
+      # the manifest job.
+      - name: Export the digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/digests"
+          touch "$RUNNER_TEMP/digests/${DIGEST#sha256:}"
+
+      - name: Upload the digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: control-server-image-digest-${{ matrix.platform.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Merges the per-architecture digests pushed above into the single multi-arch
+  # manifest that `<version>` and `latest` resolve to, so `docker compose pull`
+  # keeps referencing one tag and Docker picks the right architecture.
+  docker-manifest:
+    name: Publish (control-server image manifest)
+    needs: docker-image
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write # tagging the merged manifest in GHCR
+    steps:
+      # `merge-multiple` flattens both leg artifacts into one directory, one
+      # empty file per digest.
+      - name: Download the digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: control-server-image-digest-*
+          merge-multiple: true
+          path: ${{ runner.temp }}/digests
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive the image name
+        id: image
+        env:
+          OWNER: ${{ github.repository_owner }}
+        run: echo "name=ghcr.io/${OWNER,,}/streamwall-control-server" >> "$GITHUB_OUTPUT"
+
+      - name: Derive image tags
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ steps.image.outputs.name }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Create the multi-arch manifest
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          IMAGE_NAME: ${{ steps.image.outputs.name }}
+        run: |
+          # One `-t <tag>` pair per tag, one image reference per digest file.
+          mapfile -t tags < <(jq -r '.tags[] | "-t", .' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          refs=()
+          for digest in *; do
+            refs+=("$IMAGE_NAME@sha256:$digest")
+          done
+          docker buildx imagetools create "${tags[@]}" "${refs[@]}"
+
+      # A manifest that silently lost an architecture (a leg that pushed
+      # nothing, a digest artifact that never arrived) is indistinguishable
+      # from a good one until an arm64 host tries to pull it, so assert both
+      # platforms are actually in the published manifest.
+      - name: Verify both platforms are published
+        env:
+          IMAGE_REF: ${{ steps.image.outputs.name }}:${{ steps.meta.outputs.version }}
+        run: |
+          platforms=$(docker buildx imagetools inspect "$IMAGE_REF" \
+            --format '{{json .Manifest}}' \
+            | jq -r '.manifests[].platform | select(.os != "unknown") | .os + "/" + .architecture')
+          echo "$platforms"
+          for expected in linux/amd64 linux/arm64; do
+            if ! grep -qx "$expected" <<< "$platforms"; then
+              echo "::error::$IMAGE_REF is missing $expected"
+              exit 1
+            fi
+          done
 
   # electron-forge's GitHub publisher creates the release for the tag but leaves
   # its body empty. The changelog section for that version — generated from the

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -42,6 +42,10 @@ containers, wired together by
   chosen over nginx/Traefik for this specifically because it needs no manual
   ACME/cert configuration — see [`deploy/Caddyfile`](../deploy/Caddyfile).
 
+The image is published for **`linux/amd64` and `linux/arm64`**, so the same
+tag runs natively on a Raspberry Pi 4/5 or an Ampere/Graviton VPS as it does
+on an x86 host — Docker picks the matching architecture on `pull`.
+
 To pin a specific release instead of following `latest` — recommended for
 anything you depend on, since it makes an update (and a rollback) an explicit
 change — set the tag in `.env`:

--- a/test/release-docker.test.mjs
+++ b/test/release-docker.test.mjs
@@ -17,10 +17,27 @@ function readText(relativePath) {
 
 const IMAGE_REPOSITORY = 'streamwall-control-server'
 
-function dockerJob() {
-  const job = readYaml('.github/workflows/release.yml').jobs['docker-image']
-  assert.ok(job, 'release.yml is missing a docker-image job')
+function releaseJob(name) {
+  const job = readYaml('.github/workflows/release.yml').jobs[name]
+  assert.ok(job, `release.yml is missing a ${name} job`)
   return job
+}
+
+function dockerJob() {
+  return releaseJob('docker-image')
+}
+
+function manifestJob() {
+  return releaseJob('docker-manifest')
+}
+
+// Both jobs address the same repository: the build legs push digests into it,
+// the manifest job tags them. A mismatch would publish tags that resolve to
+// nothing.
+function imageNameStep(job, jobName) {
+  const step = job.steps.find((candidate) => candidate.id === 'image')
+  assert.ok(step, `the ${jobName} job must derive the image name`)
+  return step.run
 }
 
 // Self-hosters otherwise have to clone the repo and run the full toolchain
@@ -39,7 +56,11 @@ test('the release publishes the control-server image to GHCR', () => {
     step.uses?.startsWith('docker/build-push-action@'),
   )
   assert.ok(push, 'the docker-image job must build and push the image')
-  assert.equal(push.with.push, true)
+  assert.match(
+    push.with.outputs,
+    /push=true/,
+    'the build legs must push their layers, not just build them',
+  )
   assert.equal(
     push.with.file,
     `packages/${IMAGE_REPOSITORY}/Dockerfile`,
@@ -52,6 +73,72 @@ test('the release publishes the control-server image to GHCR', () => {
   )
 })
 
+// arm64 self-hosting targets (Raspberry Pi, Ampere/Graviton) otherwise get a
+// failed pull or slow QEMU emulation (#524). Each architecture builds on a
+// runner of its own kind, because emulating the arm64 leg would dominate the
+// release wall-clock time.
+test('the image is built natively for amd64 and arm64', () => {
+  const job = dockerJob()
+  const platforms = job.strategy.matrix.platform
+
+  assert.deepEqual(
+    platforms.map((platform) => platform.arch).sort(),
+    ['amd64', 'arm64'],
+    'the image must be published for both architectures',
+  )
+  for (const { arch, runner } of platforms) {
+    assert.match(
+      runner,
+      arch === 'arm64' ? /-arm$/ : /^ubuntu-latest$/,
+      `the ${arch} leg must build on a native ${arch} runner`,
+    )
+  }
+
+  const push = job.steps.find((step) =>
+    step.uses?.startsWith('docker/build-push-action@'),
+  )
+  assert.equal(
+    push.with.platforms,
+    'linux/${{ matrix.platform.arch }}',
+    'each leg must build only its own architecture',
+  )
+  assert.ok(
+    !job.steps.some((step) => step.uses?.includes('setup-qemu-action')),
+    'a native matrix must not fall back to QEMU emulation',
+  )
+})
+
+// The legs cannot share a tag without racing, so each pushes an untagged,
+// digest-addressed image and hands the digest to the manifest job.
+test('each architecture is pushed by digest and handed on', () => {
+  const steps = dockerJob().steps
+
+  const push = steps.find((step) =>
+    step.uses?.startsWith('docker/build-push-action@'),
+  )
+  assert.match(push.with.outputs, /push-by-digest=true/)
+  assert.ok(
+    !push.with.tags,
+    'a digest-addressed push must stay untagged, or the legs overwrite ' +
+      'each other',
+  )
+
+  const upload = steps.find((step) =>
+    step.uses?.startsWith('actions/upload-artifact@'),
+  )
+  assert.ok(upload, 'each leg must publish its digest for the manifest job')
+  assert.match(
+    upload.with.name,
+    /\$\{\{ matrix\.platform\.arch \}\}/,
+    'the digest artifacts need per-architecture names to coexist',
+  )
+  assert.equal(
+    upload.with['if-no-files-found'],
+    'error',
+    'a missing digest must fail the leg, not the manifest merge',
+  )
+})
+
 // A GITHUB_TOKEN without `packages: write` fails at push time, after the whole
 // image has been built.
 test('the docker-image job is granted package write access', () => {
@@ -60,18 +147,61 @@ test('the docker-image job is granted package write access', () => {
 
 // Both the version tag (to pin or roll back to) and `latest` (what the
 // documented compose stack resolves by default) have to exist for every
-// release.
-test('the published image is tagged with the version and latest', () => {
-  const meta = dockerJob().steps.find((step) =>
+// release, and they must point at the merged multi-arch manifest rather than
+// at one architecture's digest.
+test('the published manifest is tagged with the version and latest', () => {
+  const job = manifestJob()
+
+  assert.equal(
+    job.permissions.packages,
+    'write',
+    'tagging the merged manifest is a registry write',
+  )
+  assert.ok(
+    job.needs.includes('docker-image'),
+    'the manifest can only be merged once both legs have pushed',
+  )
+
+  const meta = job.steps.find((step) =>
     step.uses?.startsWith('docker/metadata-action@'),
   )
-  assert.ok(meta, 'the docker-image job must derive its tags from the ref')
-  assert.match(
-    meta.with.images,
-    new RegExp(`^ghcr\\.io/.+/${IMAGE_REPOSITORY}$`),
-  )
+  assert.ok(meta, 'the docker-manifest job must derive its tags from the ref')
   assert.match(meta.with.tags, /type=semver,pattern=\{\{version\}\}/)
   assert.match(meta.with.tags, /type=raw,value=latest/)
+
+  const imageName = imageNameStep(job, 'docker-manifest')
+  assert.match(imageName, new RegExp(`ghcr\\.io/.+/${IMAGE_REPOSITORY}`))
+  assert.equal(
+    imageName,
+    imageNameStep(dockerJob(), 'docker-image'),
+    'the tags must be applied to the repository the legs pushed into',
+  )
+})
+
+// A manifest that silently lost an architecture looks identical to a good one
+// until an arm64 host tries to pull it.
+test('the multi-arch manifest is merged and verified', () => {
+  const runs = manifestJob()
+    .steps.map((step) => step.run)
+    .filter(Boolean)
+    .join('\n')
+
+  assert.match(
+    runs,
+    /docker buildx imagetools create/,
+    'the per-architecture digests must be merged into one manifest',
+  )
+  assert.match(
+    runs,
+    /docker buildx imagetools inspect/,
+    'the published manifest must be inspected before the release is done',
+  )
+  for (const platform of ['linux/amd64', 'linux/arm64']) {
+    assert.ok(
+      runs.includes(platform),
+      `the verification must assert ${platform} is in the manifest`,
+    )
+  }
 })
 
 // The image must not ship code that would have failed a pull request, and a
@@ -117,6 +247,11 @@ test('self-hosting documents pulling and pinning the image', () => {
 
   assert.match(doc, /docker compose pull/)
   assert.match(doc, /STREAMWALL_IMAGE_TAG/)
+  assert.match(
+    doc,
+    /linux\/arm64/,
+    'self-hosters on arm64 need to know the published image covers them',
+  )
   assert.match(
     readText('deploy/.env.example'),
     /STREAMWALL_IMAGE_TAG/,


### PR DESCRIPTION
## Problem

The `docker-image` job added in #478 publishes `ghcr.io/<owner>/streamwall-control-server` on every `v*` tag, but built `linux/amd64` only.

A fair share of cheap self-hosting targets are arm64 (Raspberry Pi 4/5, Ampere/Graviton VPS instances). On those hosts `docker compose pull` either fails or silently falls back to slow QEMU emulation, so the local-build path stayed the only realistic option — exactly the friction the published image was meant to remove.

## Solution

Build both architectures **natively**, one runner each (`ubuntu-latest` and `ubuntu-24.04-arm`, the latter free for public repositories). Adding `platforms: linux/arm64` to the existing single job instead would emulate `npm ci` across four workspaces plus the Vite control-client build under QEMU and dominate the release wall-clock time.

Two legs cannot push the same tag without racing, so the pipeline is split:

- **`docker-image`** — a 2-leg matrix. Each leg builds its own architecture and pushes an untagged, digest-addressed image (`outputs: type=image,push-by-digest=true,name-canonical=true,push=true`), then uploads its digest as a per-arch artifact.
- **`docker-manifest`** (new) — downloads both digests (`merge-multiple`), merges them with `docker buildx imagetools create`, and applies the `<version>` and `latest` tags to the merged manifest, so both stay single references that Docker resolves per architecture.

### Architecture decisions

- **Verification is part of the job, not an afterthought.** A manifest that silently lost an architecture (a leg that pushed nothing, a digest artifact that never arrived) is indistinguishable from a good one until an arm64 host tries to pull it, so the manifest job asserts both `linux/amd64` and `linux/arm64` are present via `imagetools inspect` and fails the release otherwise.
- **The image name is lowercased explicitly.** `push-by-digest` takes the name verbatim and GHCR rejects uppercase names; previously `metadata-action` lowercased it implicitly. It is still derived from `github.repository_owner` rather than hardcoded, so a repository transfer cannot silently keep publishing under the old account.
- **`fail-fast: false`** on the matrix, matching the `make` and `publish` matrices: one broken architecture must not hide the state of the other. A leg that fails leaves only untagged digests behind, which no tag resolves to.

## Testing

`test/release-docker.test.mjs` already pinned the shape of this job; it was extended for the new topology and verified to fail against the pre-change workflow (6 failing tests) before the implementation landed:

- both architectures are built, each on a native runner of its own kind, and no `setup-qemu-action` sneaks back in
- each leg pushes by digest, stays untagged, and uploads a per-arch digest artifact with `if-no-files-found: error`
- the manifest job gates on `docker-image`, holds `packages: write`, and tags the merged manifest with the version and `latest`
- both jobs derive the *same* image repository — tags that point at a repository the legs never pushed into would resolve to nothing
- the merge step runs `imagetools create` and the verification asserts both platforms
- `docs/self-hosting.md` states the published architectures

Full quality gate green locally: Prettier, ESLint, `tsc`, `npm test` (162 tests), `actionlint` 1.7.12 (incl. shellcheck on the new `run` blocks) and the dependency license check.

## Risks

- The multi-arch path can only be exercised end-to-end by an actual tag — GHCR pushes do not happen on a PR. The failure mode is contained: the legs push untagged digests, and if the merge or verification fails, no tag moves, so `latest` keeps pointing at the previous good manifest.
- `ubuntu-24.04-arm` requires the repository to stay public for free runner minutes.
- No breaking changes for consumers: the tags self-hosters already pull are unchanged, they just resolve to a manifest list now.

## Follow-ups

- #545 — PR CI still builds the image for amd64 only, so an arm64-breaking Dockerfile change is only caught at release time.

Closes #524