### PR TITLE
ci(release-please): start the required checks on the release PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+  # release-please.yml dispatches this workflow for the release PR, whose
+  # `pull_request` events GitHub never delivers (#521).
+  workflow_dispatch:
 
 # Least privilege: read-only by default. Jobs opt into more where needed.
 permissions:
@@ -18,6 +21,10 @@ concurrency:
 jobs:
   # Classify the change so docs-only edits skip the heavy jobs. Downstream
   # jobs skip based on these outputs; the ci-ok gate treats skipped as OK.
+  #
+  # A dispatched run (the release PR, see the trigger above) has no base to
+  # diff against, and a release is the last place to narrow the gate — so it
+  # skips the filter and runs everything.
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
@@ -26,20 +33,22 @@ jobs:
       contents: read
       pull-requests: read # paths-filter lists changed files via the PR API
     outputs:
-      code: ${{ steps.filter.outputs.code }}
-      dependencies: ${{ steps.filter.outputs.dependencies }}
-      docker: ${{ steps.filter.outputs.docker }}
-      workflows: ${{ steps.filter.outputs.workflows }}
+      code: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.code }}
+      dependencies: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.dependencies }}
+      docker: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.docker }}
+      workflows: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.workflows }}
       # Runner matrix for the package smoke job. macOS is the expensive leg
       # and the only one that ad-hoc re-signs the app, so it joins only when
-      # the PR actually touches a packaging input (#538).
-      package_os: ${{ steps.filter.outputs.packaging == 'true' && '["ubuntu-latest", "macos-latest"]' || '["ubuntu-latest"]' }}
+      # the PR actually touches a packaging input (#538) — or when the run was
+      # dispatched, which cuts a release and takes the whole matrix.
+      package_os: ${{ (github.event_name == 'workflow_dispatch' || steps.filter.outputs.packaging == 'true') && '["ubuntu-latest", "macos-latest"]' || '["ubuntu-latest"]' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
+        if: github.event_name != 'workflow_dispatch'
         with:
           filters: |
             # Anything that can influence lint/typecheck/test/build results.

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -5,6 +5,15 @@ name: PR title
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
+  # release-please.yml dispatches this workflow for the release PR, whose
+  # `pull_request` events GitHub never delivers (#521). A dispatched run gets
+  # no pull request payload, hence the number.
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: 'Number of the pull request whose title to check'
+        required: true
+        type: string
 
 permissions: {}
 
@@ -13,11 +22,20 @@ jobs:
     name: Conventional Commits title
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      pull-requests: read # reads the title a dispatched run has no payload for
     steps:
       - name: Check PR title
         env:
           TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ inputs.pr-number }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
+          if [[ -z "$TITLE" ]]; then
+            TITLE="$(gh pr view "$PR_NUMBER" --json title --jq .title)"
+            echo "Checking the title of #$PR_NUMBER."
+          fi
           regex='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9./-]+\))?!?: .+'
           if [[ "$TITLE" =~ $regex ]]; then
             echo "PR title OK: $TITLE"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,9 +29,34 @@ jobs:
     permissions:
       contents: write # commits the version bump and changelog to the release branch
       pull-requests: write # opens, updates and labels the release PR
+      actions: write # dispatches the required checks for the release PR
     steps:
-      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+      - id: release-please
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           skip-github-release: true
+
+      # The PR above was opened with this workflow's GITHUB_TOKEN, and GitHub
+      # raises no `pull_request` events for it — so neither `CI OK` nor
+      # `Conventional Commits title` starts, and branch protection blocks the
+      # merge. `workflow_dispatch` is the documented exception: GitHub always
+      # creates a run for it, GITHUB_TOKEN included. Dispatching both workflows
+      # against the release branch attaches their checks to its head commit,
+      # which is what branch protection looks at (#521).
+      #
+      # This replaces closing and reopening the PR by hand, and re-runs on
+      # every push to `main`, because release-please rewrites the branch head
+      # each time it folds a new commit into the pending release.
+      - name: Run the required checks on the release PR
+        if: steps.release-please.outputs.pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ steps.release-please.outputs.pr }}
+        run: |
+          branch="$(jq -er '.headBranchName' <<< "$PR")"
+          number="$(jq -er '.number' <<< "$PR")"
+          echo "Dispatching the required checks for #$number ($branch)."
+          gh workflow run ci.yml --ref "$branch"
+          gh workflow run pr-title.yml --ref "$branch" -f pr-number="$number"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -375,12 +375,14 @@ breaking change bumps the minor version.
    manifests, their `package-lock.json` entries and the `CHANGELOG.md` section
    for the pending release. Its description previews the release notes;
    anything merged afterwards updates the PR.
-2. Merge the release PR when you want to cut the release. It arrives without
-   status checks: a pull request opened by a workflow's `GITHUB_TOKEN` does not
-   trigger other workflows, so neither `CI OK` nor `Conventional Commits title`
-   starts on its own. **Close and immediately reopen the release PR** — the
-   reopen comes from your account and starts both required checks. Wait for them
-   to pass before merging; release-please reuses the same branch afterwards.
+2. Merge the release PR when you want to cut the release. A pull request opened
+   by a workflow's `GITHUB_TOKEN` raises no `pull_request` events, so neither
+   `CI OK` nor `Conventional Commits title` would start on its own. Instead,
+   `release-please.yml` dispatches both workflows against the release branch
+   after every update — `workflow_dispatch` is the one event GitHub still
+   delivers for that token. Wait for the two checks to pass before merging.
+   Because a dispatched run has nothing to diff against, it always runs the
+   full gate rather than the change-scaled subset.
 3. Tag the merge commit and push the tag:
 
    ```sh

--- a/test/release-please.test.mjs
+++ b/test/release-please.test.mjs
@@ -149,6 +149,98 @@ test('the release-please workflow maintains the release PR on main', () => {
   assert.equal(step.with['skip-github-release'], true)
 })
 
+// A pull request opened with a workflow's GITHUB_TOKEN raises no
+// `pull_request` events, so the release PR arrives without the two checks
+// branch protection requires. `workflow_dispatch` is the one event GitHub
+// still delivers for that token, so release-please starts both checks itself
+// instead of a maintainer closing and reopening the PR by hand (#521).
+test('release-please starts the required checks on the release PR', () => {
+  const workflow = readWorkflow('release-please.yml')
+  const job = workflow.jobs['release-please']
+
+  assert.equal(
+    job.permissions.actions,
+    'write',
+    'dispatching a workflow run needs the actions: write scope',
+  )
+
+  const action = job.steps.find((candidate) =>
+    candidate.uses?.startsWith('googleapis/release-please-action@'),
+  )
+  assert.ok(action.id, 'the release-please step must expose its outputs via id')
+
+  const dispatch = job.steps.find((candidate) =>
+    candidate.run?.includes('gh workflow run'),
+  )
+  assert.ok(
+    dispatch,
+    'release-please.yml must dispatch the required checks for the release PR',
+  )
+  assert.match(
+    dispatch.if ?? '',
+    new RegExp(`steps\\.${action.id}\\.outputs\\.pr`),
+    'the dispatch must be skipped on pushes that leave no release PR',
+  )
+  for (const required of ['ci.yml', 'pr-title.yml']) {
+    assert.match(
+      dispatch.run,
+      new RegExp(`gh workflow run ${required.replace('.', '\\.')}`),
+      `${required} produces a required check and must be dispatched`,
+    )
+  }
+  assert.match(
+    dispatch.run,
+    /--ref/,
+    'the checks must run against the release branch, not the default branch',
+  )
+})
+
+// Both workflows are dispatched by name from release-please.yml; without the
+// trigger the dispatch fails and the release PR stays unmergeable.
+test('the required checks can be dispatched for the release branch', () => {
+  for (const fileName of ['ci.yml', 'pr-title.yml']) {
+    assert.ok(
+      'workflow_dispatch' in readWorkflow(fileName).on,
+      `${fileName} must be dispatchable so the release PR can run it`,
+    )
+  }
+})
+
+// A dispatched run carries no pull request payload, so the check has to look
+// the title up from the number it was dispatched with.
+test('the PR title check resolves the title of a dispatched release PR', () => {
+  const workflow = readWorkflow('pr-title.yml')
+  const input = workflow.on.workflow_dispatch?.inputs?.['pr-number']
+
+  assert.ok(input, 'pr-title.yml must accept the PR number as a dispatch input')
+  assert.equal(input.required, true)
+
+  const job = workflow.jobs['conventional-title']
+  assert.equal(
+    job.permissions['pull-requests'],
+    'read',
+    'reading the title of a dispatched PR needs the pull-requests: read scope',
+  )
+
+  const step = job.steps.find((candidate) => candidate.run?.includes('regex='))
+  assert.match(
+    step.run,
+    /gh pr view/,
+    'the dispatched run must fetch the title it cannot read from the event',
+  )
+  assert.equal(step.env.PR_NUMBER, '${{ inputs.pr-number }}')
+})
+
+test('the release documentation drops the close/reopen workaround', () => {
+  const contributing = readFileSync(join(rootDir, 'CONTRIBUTING.md'), 'utf8')
+
+  assert.doesNotMatch(
+    contributing,
+    /reopen the release PR/i,
+    'release-please.yml starts the checks itself now (#521)',
+  )
+})
+
 test('release.yml turns the changelog section into the release notes', () => {
   const release = readWorkflow('release.yml')
   const job = release.jobs['release-notes']


### PR DESCRIPTION
## Summary

Since #457, release-please opens the release PR with the workflow's
`GITHUB_TOKEN`. GitHub raises no `pull_request` events for that token, so the
release PR arrived with **no checks at all** — neither `CI OK` nor
`Conventional Commits title`, both of which branch protection requires. Every
release needed the close/reopen dance #520 documented before it could be
merged.

`workflow_dispatch` is the one documented exception: GitHub
[always creates a run for it](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow),
`GITHUB_TOKEN` included. `release-please.yml` now dispatches both required
workflows against the release branch right after the action updates the PR, so
their checks attach to the branch head — which is the commit branch protection
looks at. The dispatch repeats on every push to `main`, because release-please
rewrites the branch head each time it folds a new commit into the pending
release.

Closes #521

## Technical solution

- **`release-please.yml`** — the action step gained an `id`, the job gained the
  `actions: write` scope, and a follow-up step runs
  `gh workflow run ci.yml` / `gh workflow run pr-title.yml --ref <release
  branch>`. It is gated on `steps.release-please.outputs.pr`, so a push that
  leaves no release PR dispatches nothing. Branch and PR number are read from
  that output with `jq -e` rather than hardcoded, and both reach the shell as
  environment variables.
- **`ci.yml`** — added the `workflow_dispatch` trigger. A dispatched run has no
  base to diff against, so the `changes` job skips `dorny/paths-filter` and
  reports every filter as `true`: a release is the last place to narrow the
  gate, and it avoids depending on undefined paths-filter behaviour outside
  `push`/`pull_request`. `dependency-review` stays skipped (it is
  `pull_request`-only) and `ci-ok` treats skipped as OK, unchanged.
- **`pr-title.yml`** — added `workflow_dispatch` with a required `pr-number`
  input plus the `pull-requests: read` scope. A dispatched run has no pull
  request payload, so the step falls back to `gh pr view --json title`. The
  regex and the error messages are untouched, and both PR titles and the
  dispatch input stay in environment variables (no expression interpolation
  into `run:`).
- **`CONTRIBUTING.md`** — the "Releasing" step no longer tells maintainers to
  close and reopen the PR.

### Architecture decisions

The issue offered a fine-grained PAT / GitHub App token as the alternative. It
is the cleaner end state — it would also retire the manual `vX.Y.Z` tag push
(#515) — but it needs a secret to be provisioned and rotated by hand, and the
release PR stays blocked until that happens. The dispatch shim needs no secret,
lives entirely in the repository and is covered by tests, so it ships first;
the token migration is filed as a follow-up (#549) and can remove this shim
when it lands.

One consequence worth naming: the dispatch targets the workflow files **as they
exist on the release branch**. The currently open release PR #518 branched
before this change, so it still needs one manual close/reopen; from the next
release-please run onwards the branch carries the new triggers and starts its
own checks.

## How was this tested?

New assertions in `test/release-please.test.mjs` (red before the change, green
after) cover:

- `release-please.yml` holds `actions: write`, gives the action step an `id`,
  and dispatches both `ci.yml` and `pr-title.yml` with `--ref`, gated on the
  `pr` output.
- `ci.yml` and `pr-title.yml` are dispatchable at all — without the trigger the
  dispatch fails and the release PR stays unmergeable.
- `pr-title.yml` takes a required `pr-number` input, holds `pull-requests:
  read`, and resolves the title via `gh pr view` from `$PR_NUMBER`.
- `CONTRIBUTING.md` no longer documents the close/reopen workaround.

Full local gate: `npm run format:check`, `npm run lint`, `npm run typecheck`,
`npm test` (106 root + 162 streamwall + 343 control-ui tests) and
`actionlint 1.7.12` all pass.

## Risks / breaking changes

None for consumers. The `workflow_dispatch` trigger on `ci.yml` also lets
anyone with write access re-run the full gate on an arbitrary branch, which is
a capability rather than a regression. The shim can be deleted wholesale once
#549 lands.

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests (or this PR explains why none apply)
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments

