### PR TITLE
fix(shared): validate state deltas before patching them

### DIFF
--- a/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.test.tsx
+++ b/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.test.tsx
@@ -452,6 +452,44 @@ describe('useStreamwallWebsocketConnection', () => {
       expect(socket.reconnectCount).toBe(1)
     })
 
+    // A string where a nested delta belongs makes jsondiffpatch allocate
+    // until the heap dies, so the payload has to be rejected before `patch`
+    // ever sees it (issue #539). These deltas are written out literally: a
+    // rejected one must never reach the patcher, not even in a test.
+    it('drops a string-valued delta property before the patcher hangs on it', () => {
+      const { getConnection, socket } = connectedSocket()
+
+      act(() => {
+        socket.dispatch('message', deltaMessage({ config: 'not-a-delta' }))
+      })
+
+      expect(getConnection().config).toEqual(minimalState.config)
+      expect(socket.reconnectCount).toBe(1)
+      expect(warn).toHaveBeenCalled()
+    })
+
+    it('drops a number-valued delta property', () => {
+      const { getConnection, socket } = connectedSocket()
+
+      act(() => {
+        socket.dispatch('message', deltaMessage({ config: 42 }))
+      })
+
+      expect(getConnection().config).toEqual(minimalState.config)
+      expect(socket.reconnectCount).toBe(1)
+    })
+
+    it('drops a delta that is not an object at all', () => {
+      const { getConnection, socket } = connectedSocket()
+
+      act(() => {
+        socket.dispatch('message', deltaMessage('nope'))
+      })
+
+      expect(getConnection().config).toEqual(minimalState.config)
+      expect(socket.reconnectCount).toBe(1)
+    })
+
     it('drops a delta that arrives before any full state, since there is no base to patch', () => {
       const { getConnection } = mount()
       const socket = instances[0]!

--- a/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.ts
+++ b/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.ts
@@ -1,4 +1,3 @@
-import type { Delta } from 'jsondiffpatch'
 import { useMemo, useRef } from 'preact/hooks'
 import ReconnectingWebSocket from 'reconnecting-websocket'
 import {
@@ -9,6 +8,7 @@ import {
 import {
   isSocketOpen,
   parseDisconnectReason,
+  stateDeltaSchema,
   stateDiff,
   type StreamwallState,
   streamwallStateSchema,
@@ -24,6 +24,10 @@ import {
  * The base is cloned before patching because `stateDiff.patch` mutates its
  * target in place - patching `lastStateData` directly would corrupt it even
  * when the caller then discards the result (issue #488).
+ *
+ * The delta itself is validated first: some malformed shapes - a string where
+ * a nested delta belongs - make `patch` allocate until the heap dies, which no
+ * `try`/`catch` around it can contain (issue #539).
  */
 function patchState(
   lastStateData: StreamwallState | undefined,
@@ -33,13 +37,17 @@ function patchState(
     console.warn('Ignored Streamwall state delta received before a snapshot')
     return undefined
   }
+  const deltaResult = stateDeltaSchema.safeParse(delta)
+  if (!deltaResult.success) {
+    console.warn('Ignored malformed Streamwall state delta')
+    return undefined
+  }
   let patched: unknown
   try {
     // Cloning also gives the updated object a fresh identity, which is what
-    // triggers React renders downstream. The cast is deliberate: the payload
-    // came off the wire unvalidated, and `patch` has no total signature for
-    // untrusted input - hence the catch below.
-    patched = stateDiff.patch(stateDiff.clone(lastStateData), delta as Delta)
+    // triggers React renders downstream. A well-formed delta can still fail to
+    // apply against this particular base - hence the catch below.
+    patched = stateDiff.patch(stateDiff.clone(lastStateData), deltaResult.data)
   } catch (err) {
     console.warn('Ignored unpatchable Streamwall state delta:', err)
     return undefined

--- a/packages/streamwall-shared/src/stateDiff.test.ts
+++ b/packages/streamwall-shared/src/stateDiff.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { stateDiff } from './stateDiff.ts'
+import { stateDeltaSchema, stateDiff } from './stateDiff.ts'
 import type { StreamData, StreamwallState, ViewState } from './types.ts'
 
 function makeStream(
@@ -61,6 +61,9 @@ function makeState(overrides: Partial<StreamwallState> = {}): StreamwallState {
 // `patch` mutates a clone of `prev` in place using the delta from `diff`.
 function expectRoundTrip(prev: unknown, next: unknown) {
   const delta = stateDiff.diff(prev, next)
+  // Everything the differ emits has to survive the wire-level delta gate,
+  // otherwise the gate would drop legitimate updates (issue #539).
+  expect(stateDeltaSchema.safeParse(delta).success).toBe(true)
   const patched = stateDiff.patch(structuredClone(prev), delta)
   expect(patched).toEqual(next)
   return delta
@@ -201,5 +204,93 @@ describe('stateDiff round-trips', () => {
       },
     })
     expectRoundTrip(prev, next)
+  })
+})
+
+// `stateDiff.patch` has no total signature for untrusted input, and some
+// malformed shapes are not even catchable: a string where a nested delta
+// belongs makes jsondiffpatch enumerate the string as an index collection,
+// which allocates until the heap dies. Deltas therefore have to be checked
+// *before* they are patched (issue #539).
+//
+// None of these tests may call `stateDiff.patch` on a rejected delta - doing
+// so would hang the test worker, which is exactly the bug being guarded.
+describe('stateDeltaSchema (issue #539)', () => {
+  it('accepts an added, modified, deleted and moved op', () => {
+    const delta = {
+      identity: [{ role: 'admin' }],
+      fullscreenViewIdx: [null, 1],
+      auth: [0, 0, 0],
+      streams: { _t: 'a', _2: ['', 0, 3] },
+    }
+    expect(stateDeltaSchema.safeParse(delta).success).toBe(true)
+  })
+
+  it('accepts a nested delta', () => {
+    const delta = { views: { _t: 'a', 0: { context: { volume: [1, 0] } } } }
+    expect(stateDeltaSchema.safeParse(delta).success).toBe(true)
+  })
+
+  it('rejects a string where a nested delta belongs', () => {
+    expect(stateDeltaSchema.safeParse({ config: 'not-a-delta' }).success).toBe(
+      false,
+    )
+  })
+
+  it('rejects a number where a nested delta belongs', () => {
+    expect(stateDeltaSchema.safeParse({ config: 42 }).success).toBe(false)
+  })
+
+  it('rejects a nested string deeper in the tree', () => {
+    expect(
+      stateDeltaSchema.safeParse({ views: { _t: 'a', 0: 'boom' } }).success,
+    ).toBe(false)
+  })
+
+  it('rejects a null or boolean value', () => {
+    expect(stateDeltaSchema.safeParse({ config: null }).success).toBe(false)
+    expect(stateDeltaSchema.safeParse({ config: true }).success).toBe(false)
+  })
+
+  it('rejects an array container marker other than "a"', () => {
+    expect(
+      stateDeltaSchema.safeParse({ streams: { _t: 'nope' } }).success,
+    ).toBe(false)
+  })
+
+  it('rejects an op with more than three elements', () => {
+    expect(stateDeltaSchema.safeParse({ config: [1, 2, 3, 4] }).success).toBe(
+      false,
+    )
+  })
+
+  it('rejects an empty op', () => {
+    expect(stateDeltaSchema.safeParse({ config: [] }).success).toBe(false)
+  })
+
+  it('rejects a three-element op that is neither a deletion nor a move', () => {
+    expect(stateDeltaSchema.safeParse({ config: [1, 2, 9] }).success).toBe(
+      false,
+    )
+  })
+
+  it('rejects a text diff, which this stateDiff instance cannot patch', () => {
+    expect(
+      stateDeltaSchema.safeParse({ label: ['@@ -1 +1 @@', 0, 2] }).success,
+    ).toBe(false)
+  })
+
+  it('rejects a delta that is not an object', () => {
+    expect(stateDeltaSchema.safeParse('nope').success).toBe(false)
+    expect(stateDeltaSchema.safeParse([1, 2]).success).toBe(false)
+    expect(stateDeltaSchema.safeParse(undefined).success).toBe(false)
+  })
+
+  it('rejects nesting deeper than the patcher ever needs', () => {
+    let delta: Record<string, unknown> = { config: [1, 2] }
+    for (let i = 0; i < 64; i++) {
+      delta = { nested: delta }
+    }
+    expect(stateDeltaSchema.safeParse(delta).success).toBe(false)
   })
 })

--- a/packages/streamwall-shared/src/stateDiff.ts
+++ b/packages/streamwall-shared/src/stateDiff.ts
@@ -1,6 +1,72 @@
+import type { Delta } from 'jsondiffpatch'
 import * as jsondiffpatch from 'jsondiffpatch'
+import { z } from 'zod'
 
 export const stateDiff = jsondiffpatch.create({
   objectHash: (obj, idx) => (obj as { _id?: string })._id || `$$index:${idx}`,
   omitRemovedValues: true,
 })
+
+/**
+ * Deepest delta nesting accepted. The state tree is only a handful of levels
+ * deep, so anything beyond this is malformed - and bounding the recursion
+ * keeps a hostile payload from blowing the stack while it is validated.
+ */
+const MAX_DELTA_DEPTH = 20
+
+/**
+ * A delta value that is an array is a leaf operation. jsondiffpatch encodes
+ * these as `[newValue]` (added), `[oldValue, newValue]` (modified),
+ * `[oldValue, 0, 0]` (deleted) and `['', destIndex, 3]` (moved).
+ *
+ * Text diffs (`[oldText, 0, 2]`) are rejected: `stateDiff` is created without
+ * a diff-match-patch instance, so it never emits them and `patch` would throw
+ * on one anyway.
+ */
+function isDeltaOp(op: unknown[]): boolean {
+  switch (op.length) {
+    case 1:
+    case 2:
+      return true
+    case 3:
+      return (
+        (op[1] === 0 && op[2] === 0) ||
+        (op[0] === '' && typeof op[1] === 'number' && op[2] === 3)
+      )
+    default:
+      return false
+  }
+}
+
+function isDeltaNode(node: unknown, depth: number): boolean {
+  if (Array.isArray(node)) {
+    return isDeltaOp(node)
+  }
+  if (typeof node !== 'object' || node === null) {
+    return false
+  }
+  if (depth >= MAX_DELTA_DEPTH) {
+    return false
+  }
+  return Object.entries(node).every(([key, child]) =>
+    // `_t: 'a'` marks an object delta as describing an array; every other key
+    // carries a nested delta or a leaf operation.
+    key === '_t' ? child === 'a' : isDeltaNode(child, depth + 1),
+  )
+}
+
+/**
+ * Validates a jsondiffpatch delta that came off the wire *before* it is
+ * handed to `stateDiff.patch`.
+ *
+ * Patching untrusted input is not merely error-prone, it is unbounded: a
+ * string where a nested delta belongs makes jsondiffpatch enumerate the
+ * string as an index collection, allocating until the heap is exhausted. That
+ * happens inside `patch`, so `try`/`catch` around it cannot contain it and a
+ * single crafted `state-delta` frame can freeze an operator's browser tab
+ * (issue #539). The shape has to be checked first.
+ */
+export const stateDeltaSchema = z.custom<Delta>(
+  (value) => !Array.isArray(value) && isDeltaNode(value, 0),
+  { message: 'Invalid state delta' },
+)


### PR DESCRIPTION
## Summary

`stateDiff.patch` (jsondiffpatch) does not terminate when a delta property
holds a **string** where a nested delta belongs: the string is enumerated as
an index collection and the call allocates until the JS heap is exhausted.
Reproduced against the repo's own `stateDiff` instance — the call ran ~100s at
a 4 GB heap before `FATAL ERROR: Ineffective mark-compacts near heap limit`.

The patched-state validation added in #488 runs *after* `patch`, so neither it
nor the surrounding `try`/`catch` can contain this: the control server, or
anything able to inject a `state-delta` frame on the socket, can freeze an
operator's browser tab.

The delta payload is now validated *before* it is patched:

- `stateDeltaSchema` (new, next to `stateDiff` in `streamwall-shared`) models
  jsondiffpatch's wire format — leaf operations as 1/2/3-element arrays
  (`[new]`, `[old, new]`, `[old, 0, 0]`, `['', destIdx, 3]`), nested object
  deltas, and `_t: 'a'` array containers — and rejects everything else,
  notably a bare string or number where a nested delta is expected.
- The web client gates `state-delta` messages on it before `stateDiff.patch`
  runs, reusing the existing drop-and-resync path from #488.

Closes #539

## Architecture decisions

- The schema lives next to `stateDiff` rather than in `schemas.ts`: it models
  the differ's encoding, not Streamwall's domain state, and only makes sense
  paired with that specific `stateDiff` instance.
- Text-diff operations (`[oldText, 0, 2]`) are rejected. `stateDiff` is created
  without a diff-match-patch instance, so it never emits them and `patch`
  throws on them anyway.
- Nesting is capped at 20 levels. The state tree is a handful of levels deep,
  and bounding the recursion keeps a hostile payload from blowing the stack
  during validation.
- Validation is a gate, not a transform: the patcher still receives the
  original delta object.

## How was this tested?

- `packages/streamwall-shared/src/stateDiff.test.ts`: accepted operation
  shapes, nested deltas, and rejection of string-valued, number-valued, null,
  boolean, over-long, empty, bogus 3-element and text-diff payloads, plus an
  over-deep delta. The existing round-trip helper now also asserts that every
  delta `stateDiff.diff` emits passes the schema, so the gate cannot start
  dropping legitimate updates unnoticed.
- `packages/streamwall-control-client/src/useStreamwallWebsocketConnection.test.tsx`:
  a string-valued, a number-valued and a non-object delta are dropped, the
  last-known state is kept, and a resync is forced.
- Rejected deltas are written out literally in the tests and never reach
  `stateDiff.patch` — patching one would hang the test worker, which is the
  bug under guard.
- `npm run lint`, `npm run format`, `npm run typecheck`, `npm test` all pass
  locally.

## Risks / breaking changes

None expected. The schema accepts everything this `stateDiff` instance emits
(covered by the round-trip assertion); an unexpectedly rejected delta degrades
to the existing resync path rather than to data loss.

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments
