### PR TITLE
ci(release): check that the release tag produced usable assets

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -50,6 +50,16 @@ jobs:
       - name: Check the release version is tagged
         run: node scripts/check-release-tag.mjs
 
+      # A tag alone proves nothing: the publish matrix may have failed
+      # half-way through, or never run for the tag at all (#533). Runs even
+      # when the step above failed — the two report different halves of the
+      # same pipeline, and one missing tag must not hide a broken release.
+      - name: Check the newest tag produced a complete release
+        if: ${{ !cancelled() }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/check-release-assets.mjs
+
   # A failing scheduled run is invisible without this: nobody is emailed about
   # one, so the report goes into the issue tracker instead (#514) — which is
   # also where a forgotten tag belongs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -374,6 +374,19 @@ up to date. Run it from the Actions tab, or locally:
 node scripts/check-release-tag.mjs
 ```
 
+The same job then checks what that tag actually produced: a tag can exist while
+its release is still broken — a publish leg of `release.yml` failed and left a
+partially populated release behind (#453), the workflow never ran for the tag,
+or the release was never taken out of draft. The check asks the GitHub API for
+the release of the version on `main` and asserts the artifact kinds the `make`
+job builds (`*.deb`, `*.rpm`, `*-setup-*.exe`, `latest.yml`, `*.zip`,
+`latest-mac.yml`). Releases before v0.9.2 carry Squirrel's artifact names and
+are skipped.
+
+```sh
+node scripts/check-release-assets.mjs
+```
+
 `test/changelog.test.mjs` and `test/release-please.test.mjs` run as part of
 `npm test` and fail if `CHANGELOG.md` is missing a heading for the version
 currently in `packages/streamwall/package.json`, if a hand-maintained

--- a/scripts/check-release-assets.mjs
+++ b/scripts/check-release-assets.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+// Fails when the `vX.Y.Z` tag of the version on `main` did not produce an
+// installable release (#533).
+//
+// `check-release-tag.mjs` only asserts that the tag for the version on `main`
+// exists; it never looks at what the tag produced. A tag can exist while the
+// release behind it is unusable:
+//
+//   - one leg of `release.yml`'s three-platform publish matrix failed, so the
+//     GitHub Release is missing that platform's installers (#453),
+//   - `release.yml` never ran for the tag at all — pushed from a workflow
+//     token, or the run was cancelled — so there is no release behind the tag.
+//
+// Both point self-hosters and the app's updater at a release that cannot be
+// installed, and neither shows up anywhere. The expected artifact kinds are
+// the ones the `make` job in `release.yml` already asserts on the runner,
+// checked here against what actually reached the release.
+import { execFile } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)))
+
+// Mirrors the `artifacts` lists of `release.yml`'s `make` matrix: deb/rpm from
+// the Linux publish leg, the NSIS installer plus `latest.yml` from the Windows
+// leg, the ZIP plus `latest-mac.yml` from the macOS leg. `latest*.yml` is what
+// electron-updater reads, so a release without it silently stops updating
+// installed apps.
+export const EXPECTED_ASSET_PATTERNS = [
+  '*.deb',
+  '*.rpm',
+  '*-setup-*.exe',
+  'latest.yml',
+  '*.zip',
+  'latest-mac.yml',
+]
+
+function assetPatternToRegExp(pattern) {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&')
+  // Anchored, so `*.zip` is not satisfied by `installer.zip.blockmap`.
+  return new RegExp(`^${escaped.replace(/\*/g, '.*')}$`)
+}
+
+// v0.9.1 and everything before it was published with Squirrel, which names
+// its installer `Streamwall-<version>.Setup.exe` and ships `RELEASES` plus a
+// `.nupkg` instead of the `latest*.yml` electron-updater reads (#454). Those
+// releases can no longer be rebuilt, so judging them by the current artifact
+// list would leave the daily run permanently red.
+export const FIRST_CHECKED_VERSION = '0.9.2'
+
+function isBefore(version, floor) {
+  // Only the release numbers are compared: a prerelease of the floor version
+  // is already built by the current pipeline and belongs in the check.
+  const parse = (value) => value.split('-')[0].split('.').map(Number)
+  const left = parse(version)
+  const right = parse(floor)
+
+  for (let index = 0; index < right.length; index += 1) {
+    if (left[index] !== right[index]) {
+      return left[index] < right[index]
+    }
+  }
+  return false
+}
+
+// The release to inspect is the one `main` currently claims, not simply the
+// highest tag: the repository still carries `v2.0.0-pre*` tags from the
+// project it started as, which sort above the current release line but never
+// had a GitHub Release here.
+//
+// A version whose tag was never pushed is `check-release-tag.mjs`'s finding,
+// so it is skipped here rather than reported a second time.
+export function selectReleaseTag({ version, tags }) {
+  const tag = `v${version}`
+
+  if (isBefore(version, FIRST_CHECKED_VERSION)) {
+    return { status: 'legacy', tag }
+  }
+  if (!tags.includes(tag)) {
+    return { status: 'no-tag', tag: null }
+  }
+  return { status: 'check', tag }
+}
+
+export function parseRepository(remoteUrl) {
+  const match = /github\.com[/:]([^/]+\/[^/]+?)(?:\.git)?\/?$/.exec(
+    remoteUrl.trim(),
+  )
+  if (!match) {
+    throw new Error(
+      `Could not read a GitHub repository from the remote "${remoteUrl.trim()}".`,
+    )
+  }
+  return match[1]
+}
+
+export function evaluateReleaseAssets({ tag, release }) {
+  if (release === null) {
+    return { status: 'no-release', tag, missing: [...EXPECTED_ASSET_PATTERNS] }
+  }
+
+  // GitHub lists an asset as soon as its upload starts; only `uploaded` ones
+  // can actually be downloaded.
+  const names = (release.assets ?? [])
+    .filter((asset) => asset.state === 'uploaded')
+    .map((asset) => asset.name)
+  const missing = EXPECTED_ASSET_PATTERNS.filter((pattern) => {
+    const matcher = assetPatternToRegExp(pattern)
+    return !names.some((name) => matcher.test(name))
+  })
+
+  if (release.draft) {
+    return { status: 'draft', tag, missing }
+  }
+  return {
+    status: missing.length === 0 ? 'complete' : 'incomplete',
+    tag,
+    missing,
+  }
+}
+
+export function formatReport({ status, tag, missing }) {
+  if (status === 'no-tag') {
+    return (
+      '::notice::The version on main has no tag yet, so there is no release ' +
+      'to check — see the release tag check above.'
+    )
+  }
+  if (status === 'legacy') {
+    return (
+      `::notice::${tag} predates ${FIRST_CHECKED_VERSION}, the first version ` +
+      'built with electron-updater, so its artifact names are not the ones ' +
+      'this check knows about.'
+    )
+  }
+  if (status === 'complete') {
+    return `${tag} has a published release with every expected artifact kind.`
+  }
+  if (status === 'no-release') {
+    return (
+      `::error::${tag} has no GitHub Release, so the tag shipped no ` +
+      'installers. Re-run release.yml for the tag (Actions → Release → Run ' +
+      `workflow) or delete and re-push ${tag}.`
+    )
+  }
+  if (status === 'draft') {
+    return (
+      `::error::The release for ${tag} is still a draft, so neither the ` +
+      'updater nor a self-hoster can see it. Publish it in the releases UI.'
+    )
+  }
+  return (
+    `::error::The release for ${tag} is missing ${missing.join(', ')} — a ` +
+    'publish leg of release.yml failed, so the release is only partially ' +
+    'populated. Re-run the failed leg and check the release assets.'
+  )
+}
+
+async function git(args) {
+  const { stdout } = await execFileAsync('git', args, { cwd: rootDir })
+  return stdout
+}
+
+// The releases endpoint answers 404 both for an unknown tag and for a draft
+// release that the token may not read — hence the token, which the workflow
+// passes in and which also lifts the anonymous rate limit.
+async function fetchReleaseByTag({ repository, tag, token }) {
+  const response = await fetch(
+    `https://api.github.com/repos/${repository}/releases/tags/${tag}`,
+    {
+      headers: {
+        accept: 'application/vnd.github+json',
+        'x-github-api-version': '2022-11-28',
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+      },
+    },
+  )
+
+  if (response.status === 404) {
+    return null
+  }
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API returned ${response.status} for the release of ${tag}.`,
+    )
+  }
+  return response.json()
+}
+
+async function main() {
+  const { version } = JSON.parse(
+    readFileSync(join(rootDir, 'package.json'), 'utf8'),
+  )
+  const selected = selectReleaseTag({
+    version,
+    tags: (await git(['tag', '--list', 'v*']))
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line !== ''),
+  })
+
+  if (selected.status !== 'check') {
+    console.log(formatReport({ ...selected, missing: [] }))
+    return
+  }
+  const { tag } = selected
+
+  const repository =
+    process.env.GITHUB_REPOSITORY ||
+    parseRepository(await git(['remote', 'get-url', 'origin']))
+
+  const result = evaluateReleaseAssets({
+    tag,
+    release: await fetchReleaseByTag({
+      repository,
+      tag,
+      token: process.env.GH_TOKEN || process.env.GITHUB_TOKEN,
+    }),
+  })
+
+  console.log(formatReport(result))
+  if (result.status !== 'complete') {
+    process.exitCode = 1
+  }
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  await main()
+}

--- a/test/check-release-assets.test.mjs
+++ b/test/check-release-assets.test.mjs
@@ -1,0 +1,255 @@
+import { load } from 'js-yaml'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import {
+  EXPECTED_ASSET_PATTERNS,
+  FIRST_CHECKED_VERSION,
+  evaluateReleaseAssets,
+  formatReport,
+  parseRepository,
+  selectReleaseTag,
+} from '../scripts/check-release-assets.mjs'
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)))
+
+function uploaded(...names) {
+  return names.map((name) => ({ name, state: 'uploaded' }))
+}
+
+// The full set a healthy release carries — one artifact per expected kind.
+function completeAssets() {
+  return uploaded(
+    'streamwall_0.9.1_amd64.deb',
+    'streamwall-0.9.1-1.x86_64.rpm',
+    'streamwall-0.9.1-setup-x64.exe',
+    'latest.yml',
+    'streamwall-darwin-arm64-0.9.1.zip',
+    'latest-mac.yml',
+  )
+}
+
+test('selectReleaseTag picks the tag of the version main is on', () => {
+  assert.deepEqual(
+    selectReleaseTag({ version: '1.0.0', tags: ['v0.9.1', 'v1.0.0'] }),
+    { status: 'check', tag: 'v1.0.0' },
+  )
+})
+
+// The repository carries tags inherited from the project it started as
+// (`v2.0.0-pre3`), which sort above the current release line but never had a
+// GitHub Release here. Anchoring on the version `main` claims skips them.
+test('selectReleaseTag ignores tags outside the current release line', () => {
+  assert.deepEqual(
+    selectReleaseTag({ version: '1.0.0', tags: ['v1.0.0', 'v2.0.0-pre3'] }),
+    { status: 'check', tag: 'v1.0.0' },
+  )
+})
+
+// A version whose tag was never pushed is what check-release-tag.mjs reports;
+// repeating it here would raise the same problem twice.
+test('selectReleaseTag skips a version that has no tag', () => {
+  assert.deepEqual(selectReleaseTag({ version: '1.0.0', tags: ['v0.9.1'] }), {
+    status: 'no-tag',
+    tag: null,
+  })
+})
+
+// Releases built before the electron-updater switch (#454) carry Squirrel's
+// artifact names and no `latest*.yml` at all; judging them by the current
+// artifact list would keep the daily run red over a release nobody can fix.
+test('selectReleaseTag skips releases predating the expected artifact set', () => {
+  assert.deepEqual(selectReleaseTag({ version: '0.9.1', tags: ['v0.9.1'] }), {
+    status: 'legacy',
+    tag: 'v0.9.1',
+  })
+})
+
+test('selectReleaseTag checks a prerelease of the first checked version', () => {
+  const { status } = selectReleaseTag({
+    version: `${FIRST_CHECKED_VERSION}-rc.1`,
+    tags: [`v${FIRST_CHECKED_VERSION}-rc.1`],
+  })
+
+  assert.equal(status, 'check')
+})
+
+test('parseRepository reads the slug from an HTTPS remote', () => {
+  assert.equal(
+    parseRepository('https://github.com/streamwallhq/streamwall.git\n'),
+    'streamwallhq/streamwall',
+  )
+})
+
+test('parseRepository reads the slug from an SSH remote', () => {
+  assert.equal(
+    parseRepository('git@github.com:streamwallhq/streamwall.git'),
+    'streamwallhq/streamwall',
+  )
+})
+
+test('parseRepository rejects a remote that is not on GitHub', () => {
+  assert.throws(
+    () => parseRepository('https://gitlab.com/streamwallhq/streamwall.git'),
+    /GitHub/,
+  )
+})
+
+test('evaluateReleaseAssets accepts a release carrying every artifact kind', () => {
+  const result = evaluateReleaseAssets({
+    tag: 'v0.9.1',
+    release: { draft: false, assets: completeAssets() },
+  })
+
+  assert.equal(result.status, 'complete')
+  assert.deepEqual(result.missing, [])
+})
+
+// `release.yml` never ran for the tag: pushed from a workflow token, or the
+// run was cancelled.
+test('evaluateReleaseAssets reports a tag without a release', () => {
+  const result = evaluateReleaseAssets({ tag: 'v0.9.1', release: null })
+
+  assert.equal(result.status, 'no-release')
+  assert.deepEqual(result.missing, EXPECTED_ASSET_PATTERNS)
+})
+
+// A draft is invisible to the updater and to `docker compose pull` alike.
+test('evaluateReleaseAssets reports a release that stayed a draft', () => {
+  const result = evaluateReleaseAssets({
+    tag: 'v0.9.1',
+    release: { draft: true, assets: completeAssets() },
+  })
+
+  assert.equal(result.status, 'draft')
+})
+
+// The partially populated release of #453: one leg of the publish matrix
+// failed, so a platform's installers never made it into the release.
+test('evaluateReleaseAssets lists the artifact kinds a failed publish leg left out', () => {
+  const result = evaluateReleaseAssets({
+    tag: 'v0.9.1',
+    release: {
+      draft: false,
+      assets: uploaded(
+        'streamwall_0.9.1_amd64.deb',
+        'streamwall-0.9.1-1.x86_64.rpm',
+        'streamwall-darwin-arm64-0.9.1.zip',
+        'latest-mac.yml',
+      ),
+    },
+  })
+
+  assert.equal(result.status, 'incomplete')
+  assert.deepEqual(result.missing, ['*-setup-*.exe', 'latest.yml'])
+})
+
+// An asset whose upload never finished is listed by the API but cannot be
+// downloaded, so it must not count as present.
+test('evaluateReleaseAssets ignores assets that are not fully uploaded', () => {
+  const assets = completeAssets()
+  assets.find((asset) => asset.name === 'latest.yml').state = 'starting'
+
+  const result = evaluateReleaseAssets({
+    tag: 'v0.9.1',
+    release: { draft: false, assets },
+  })
+
+  assert.equal(result.status, 'incomplete')
+  assert.deepEqual(result.missing, ['latest.yml'])
+})
+
+// `*.zip` must not be satisfied by a Windows installer or a source archive.
+test('evaluateReleaseAssets anchors the artifact patterns to the whole name', () => {
+  const result = evaluateReleaseAssets({
+    tag: 'v0.9.1',
+    release: {
+      draft: false,
+      assets: uploaded(
+        'streamwall_0.9.1_amd64.deb.sha256',
+        'notes-setup-x64.exe.blockmap',
+      ),
+    },
+  })
+
+  assert.deepEqual(result.missing, EXPECTED_ASSET_PATTERNS)
+})
+
+test('formatReport annotates a missing release as an error naming the tag', () => {
+  const report = formatReport({
+    status: 'no-release',
+    tag: 'v0.9.1',
+    missing: EXPECTED_ASSET_PATTERNS,
+  })
+
+  assert.match(report, /^::error::/m)
+  assert.match(report, /v0\.9\.1/)
+})
+
+test('formatReport lists every missing artifact kind of an incomplete release', () => {
+  const report = formatReport({
+    status: 'incomplete',
+    tag: 'v0.9.1',
+    missing: ['*-setup-*.exe', 'latest.yml'],
+  })
+
+  assert.match(report, /^::error::/m)
+  assert.match(report, /\*-setup-\*\.exe/)
+  assert.match(report, /latest\.yml/)
+})
+
+test('formatReport annotates a draft release as an error', () => {
+  const report = formatReport({ status: 'draft', tag: 'v0.9.1', missing: [] })
+
+  assert.match(report, /^::error::/m)
+  assert.match(report, /draft/)
+})
+
+test('formatReport stays quiet for a complete release', () => {
+  const report = formatReport({
+    status: 'complete',
+    tag: 'v0.9.1',
+    missing: [],
+  })
+
+  assert.doesNotMatch(report, /::error::/)
+  assert.match(report, /v0\.9\.1/)
+})
+
+// check-release-tag.mjs owns the untagged case; reporting it here as well
+// would raise the same problem twice in the same run.
+test('formatReport notes an untagged version without failing the run', () => {
+  const report = formatReport({ status: 'no-tag', tag: null, missing: [] })
+
+  assert.doesNotMatch(report, /::error::/)
+  assert.match(report, /^::notice::/m)
+})
+
+test('formatReport notes a release predating the check without failing', () => {
+  const report = formatReport({ status: 'legacy', tag: 'v0.9.1', missing: [] })
+
+  assert.doesNotMatch(report, /::error::/)
+  assert.match(report, /^::notice::/m)
+  assert.match(report, /v0\.9\.1/)
+})
+
+test('the release tag workflow also checks the release assets', () => {
+  const workflow = load(
+    readFileSync(join(rootDir, '.github/workflows/release-tag.yml'), 'utf8'),
+  )
+  const job = workflow.jobs.check
+  const step = job.steps.find((candidate) =>
+    candidate.run?.includes('scripts/check-release-assets.mjs'),
+  )
+
+  assert.ok(step, 'release-tag.yml must run the release asset check')
+  // The asset check must still report when the tag check above it failed.
+  assert.match(step.if ?? '', /cancelled/)
+  assert.ok(
+    step.env?.GH_TOKEN,
+    'the GitHub API call needs a token to stay within the API rate limit',
+  )
+})


### PR DESCRIPTION
## Problem

`release-tag.yml` (#515) checks only that the version on `main` has a matching
`vX.Y.Z` tag — it never looks at what the tag produced. A tag can exist while
the release behind it is unusable:

- a leg of `release.yml`'s three-platform publish matrix failed, so the release
  is missing that platform's installers (the partially populated release of
  #453),
- `release.yml` never ran for the tag (pushed from a workflow token, or the run
  was cancelled), so there is no release behind it,
- the release was never taken out of draft, so neither the updater nor a
  self-hoster can see it.

All three point the app's updater and self-hosters at a release that cannot be
installed, and none of them were reported anywhere.

## Solution

`scripts/check-release-assets.mjs` asks the GitHub API for the release of the
version on `main` and asserts the artifact kinds the `make` job in `release.yml`
already builds: `*.deb`, `*.rpm`, `*-setup-*.exe`, `latest.yml`, `*.zip`,
`latest-mac.yml`. It runs as a second step of the daily `release-tag.yml` job,
with `if: ${{ !cancelled() }}` so a missing tag cannot hide a broken release.

### Decisions

- **Anchored on the version `main` claims, not on the highest tag.** The issue
  suggested "the newest `v*` tag", but the repository still carries
  `v2.0.0-pre1..3` from the project this started as; those sort above the
  current release line and never had a GitHub Release here, so the newest-tag
  reading reports a permanent false failure. The version on `main` is the
  release that matters and is the same anchor `check-release-tag.mjs` uses.
- **A version without a tag is skipped**, because that is exactly what
  `check-release-tag.mjs` reports — raising it twice in one run would be noise.
- **Releases before 0.9.2 are skipped.** v0.9.1 and earlier were published with
  Squirrel (`Streamwall-0.9.1.Setup.exe`, `RELEASES`, `.nupkg`) and have no
  `latest*.yml` at all (#454, and the upgrade notice in `CONTRIBUTING.md`).
  They cannot be rebuilt, so checking them would leave the daily run
  permanently red over something nobody can fix.
- **Assets still uploading do not count.** GitHub lists an asset as soon as its
  upload starts; only `state: "uploaded"` ones can be downloaded.
- **Patterns are anchored**, so `*.zip` is not satisfied by
  `installer.zip.blockmap`.

## Testing

- `test/check-release-assets.test.mjs` (21 tests): tag selection incl. the
  inherited `v2.0.0-pre*` tags and the legacy floor, the four release verdicts
  (complete / no release / draft / incomplete), partially uploaded assets,
  pattern anchoring, remote-URL parsing, every report shape, and a workflow
  assertion that the step runs with a token and survives a failing tag check.
- `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` and
  `actionlint` all pass locally.
- Ran against the live repository at three stages: it correctly reported
  `v2.0.0-pre3` as having no release, reported `v0.9.1` as missing the NSIS and
  `latest*.yml` artifacts before the legacy floor was added, and is quiet on
  `main` today.

## Risks

None at runtime — the script only reads. The first release from 0.9.2 onwards
is the first one this actually inspects; if its artifact list ever diverges
from `release.yml`'s `make` matrix, `EXPECTED_ASSET_PATTERNS` has to follow.

Closes #533