### PR TITLE
fix(control-ui): derive the grid focus ring from the tile colour

### DIFF
--- a/packages/streamwall-control-ui/src/GridInput.test.tsx
+++ b/packages/streamwall-control-ui/src/GridInput.test.tsx
@@ -1,10 +1,13 @@
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
+import { Color, idColor } from 'streamwall-shared'
+import { StyleSheetManager } from 'styled-components'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 
-import { GridInput } from './GridInput.tsx'
+import { focusRingColors, GridInput, tileColor } from './GridInput.tsx'
 
 let container: HTMLDivElement | undefined
+let styleTarget: HTMLDivElement | undefined
 
 afterEach(() => {
   if (container) {
@@ -12,6 +15,11 @@ afterEach(() => {
     container.remove()
     container = undefined
   }
+  styleTarget?.remove()
+  styleTarget = undefined
+  document
+    .querySelectorAll('style[data-styled]')
+    .forEach((style) => style.remove())
 })
 
 function renderInput(
@@ -19,24 +27,41 @@ function renderInput(
 ): HTMLDivElement {
   container = document.createElement('div')
   document.body.appendChild(container)
+  // Own styled-components target per render: the sheet remembers what it
+  // already injected, so without it only the first test would see the CSS.
+  styleTarget = document.createElement('div')
+  document.head.appendChild(styleTarget)
   act(() => {
     render(
-      <GridInput
-        style={{}}
-        idx={0}
-        onChangeSpace={() => {}}
-        spaceValue=""
-        isHighlighted={false}
-        role="admin"
-        onPointerDown={() => {}}
-        onFocus={() => {}}
-        onBlur={() => {}}
-        {...props}
-      />,
+      <StyleSheetManager target={styleTarget}>
+        <GridInput
+          style={{}}
+          idx={0}
+          onChangeSpace={() => {}}
+          spaceValue=""
+          isHighlighted={false}
+          role="admin"
+          onPointerDown={() => {}}
+          onFocus={() => {}}
+          onBlur={() => {}}
+          {...props}
+        />
+      </StyleSheetManager>,
       container!,
     )
   })
   return container
+}
+
+function collectCss(): string {
+  return Array.from(document.querySelectorAll('style'))
+    .map((style) => style.textContent)
+    .join('\n')
+}
+
+/** The rule the focused tile draws its ring from, or undefined if there is none. */
+function focusVisibleRule(css: string): string | undefined {
+  return /:focus-visible[^{}]*{([^}]*)}/.exec(css)?.[1]
 }
 
 describe('GridInput', () => {
@@ -71,5 +96,75 @@ describe('GridInput', () => {
 
     expect(input.getAttribute('data-testid')).toBe('grid-cell')
     expect(input.getAttribute('data-idx')).toBe('3')
+  })
+})
+
+// The tile ring used to be a hardcoded `1px solid black` behind a plain
+// `:focus`, so it also appeared on pointer interaction and could disappear
+// against a dark tile (#531). It now follows the shared affordance from
+// globalStyle.tsx in shape and trigger, but derives its colour from the tile
+// instead of using --accent: the tile hue comes from the stream id, so a fixed
+// accent hue can land next to a near-identical one.
+describe('GridInput focus affordance', () => {
+  test('draws the ring only for keyboard focus, not for every :focus', () => {
+    renderInput({ spaceValue: 'stream-1' })
+
+    const css = collectCss()
+
+    expect(focusVisibleRule(css)).toBeDefined()
+    // `:focus-visible` itself contains `:focus`, hence the lookahead.
+    expect(css).not.toMatch(/:focus(?![-\w])/)
+  })
+
+  test('replaces the hardcoded black ring with a 2px ring derived from the tile', () => {
+    const spaceValue = 'stream-1'
+    renderInput({ spaceValue })
+
+    const rule = focusVisibleRule(collectCss())
+
+    expect(rule).toBeDefined()
+    expect(rule).not.toMatch(/black/)
+    const ring = /outline:\s*2px solid ([^;]+);/.exec(rule!)?.[1]
+    expect(ring).toBeDefined()
+    expect(
+      Color(ring!.trim()).contrast(tileColor(idColor(spaceValue))),
+    ).toBeGreaterThanOrEqual(3)
+  })
+
+  test('keeps the ring inside the tile so neighbouring tiles cannot clip it', () => {
+    renderInput({ spaceValue: 'stream-1' })
+
+    expect(focusVisibleRule(collectCss())).toMatch(/outline-offset:\s*-2px/)
+  })
+
+  test('pairs the ring with a halo it contrasts against, so both edges stay legible', () => {
+    renderInput({ spaceValue: 'stream-1' })
+
+    const rule = focusVisibleRule(collectCss())!
+    const ring = /outline:\s*2px solid ([^;]+);/.exec(rule)![1].trim()
+    const halo = /box-shadow:[^;]*?(#[0-9a-fA-F]{3,8})\s+inset/.exec(rule)![1]
+
+    expect(Color(ring).contrast(Color(halo))).toBeGreaterThanOrEqual(3)
+  })
+})
+
+describe('focusRingColors', () => {
+  test('clears WCAG 2.4.11 contrast against every tile colour the grid can paint', () => {
+    const ids = ['', ...Array.from({ length: 64 }, (_, i) => `stream-${i}`)]
+
+    for (const id of ids) {
+      for (const isHighlighted of [false, true]) {
+        const tile = tileColor(idColor(id), isHighlighted)
+        const { ring, halo } = focusRingColors(tile)
+
+        expect(Color(ring).contrast(tile)).toBeGreaterThanOrEqual(3)
+        expect(Color(ring).contrast(Color(halo))).toBeGreaterThanOrEqual(3)
+      }
+    }
+  })
+
+  test('flips to a light ring on a dark tile instead of hardcoding black', () => {
+    expect(focusRingColors(Color('#111111')).ring).toBe(Color('white').hex())
+    expect(focusRingColors(Color('#eeeeee')).ring).toBe(Color('black').hex())
   })
 })

--- a/packages/streamwall-control-ui/src/GridInput.tsx
+++ b/packages/streamwall-control-ui/src/GridInput.tsx
@@ -10,6 +10,37 @@ const StyledGridInputContainer = styled.div`
   touch-action: none;
 `
 
+/**
+ * The colour a tile actually paints for its stream colour: the same hue, but
+ * lightened so the value stays readable on top of it (and lightened further
+ * while the tile is a drag/resize highlight).
+ */
+export function tileColor(color: ColorInstance, isHighlighted = false) {
+  return Color(color).lightness(isHighlighted ? 90 : 75)
+}
+
+/**
+ * Ring and halo colours for the focused tile.
+ *
+ * The rest of the control UI takes its keyboard ring from the shared
+ * `:focus-visible` rule in globalStyle.tsx, which draws `--accent` on the
+ * neutral surface tokens. A tile's hue comes from the stream id, so a fixed
+ * accent hue can land on a near-identical one and drop below the 3:1 that
+ * WCAG 2.4.11 asks for. The colours are therefore derived from the tile:
+ * whichever of black/white contrasts more becomes the ring, the other one the
+ * halo just inside it, so the pair reads on any tile the grid can paint
+ * (#531).
+ */
+export function focusRingColors(tile: ColorInstance) {
+  const black = Color('black')
+  const white = Color('white')
+  const ringIsBlack = tile.contrast(black) >= tile.contrast(white)
+  return {
+    ring: (ringIsBlack ? black : white).hex(),
+    halo: (ringIsBlack ? white : black).hex(),
+  }
+}
+
 const StyledGridInput = styled(LazyChangeInput)<{
   $color: ColorInstance
   $isHighlighted?: boolean
@@ -20,16 +51,25 @@ const StyledGridInput = styled(LazyChangeInput)<{
   border: none;
   padding: 0;
   background: ${({ $color, $isHighlighted }) =>
-    $isHighlighted
-      ? Color($color).lightness(90).hsl().string()
-      : Color($color).lightness(75).hsl().string()};
+    tileColor($color, $isHighlighted).hsl().string()};
   font-size: 20px;
   text-align: center;
 
-  &:focus {
-    outline: 1px solid black;
-    box-shadow: 0 0 5px black inset;
-    z-index: 100;
+  /* Matches the shared affordance from globalStyle.tsx in shape and trigger -
+     a 2px ring plus a halo, keyboard focus only - but with tile-derived
+     colours (see focusRingColors). The ring is drawn inwards
+     (outline-offset: -2px) because the tiles are laid out edge to edge inside
+     an overflow: hidden layer, where an outset ring would be overlapped by
+     its neighbours and clipped at the grid border. */
+  &:focus-visible {
+    outline: 2px solid
+      ${({ $color, $isHighlighted }) =>
+        focusRingColors(tileColor($color, $isHighlighted)).ring};
+    outline-offset: -2px;
+    box-shadow: 0 0 0 4px
+      ${({ $color, $isHighlighted }) =>
+        focusRingColors(tileColor($color, $isHighlighted)).halo}
+      inset;
   }
 `
 


### PR DESCRIPTION
## Problem

`GridInput` styled its focus state with a hardcoded, non-token affordance:

```css
&:focus {
  outline: 1px solid black;
  box-shadow: 0 0 5px black inset;
  z-index: 100;
}
```

Two defects: it triggers on `:focus`, so the ring also appears on pointer
interaction — unlike the shared affordance added in #508 / #528 — and its
colour is fixed, so contrast depends on whichever tile colour it lands on.
The rule also outranks the shared `:focus-visible` rule on specificity, so the
grid could never inherit it.

## Solution

The rule now matches the shared affordance from `globalStyle.tsx` in **shape
and trigger** — a 2px ring plus a halo, keyboard focus only — but keeps its own
colours.

Adopting `--accent` outright was evaluated and rejected: a tile's hue is
derived from the stream id (`idColor`), so the accent red can land on a
near-identical light red and fall below the 3:1 that WCAG 2.4.11 asks for. The
new `focusRingColors()` therefore takes the issue's second option and derives
the colours from the tile — whichever of black/white contrasts more becomes the
ring, the other one the halo just inside it — so the pair reads on every tile
the grid can paint.

The ring is drawn inwards (`outline-offset: -2px`) rather than outwards: the
tiles are laid out edge to edge inside an `overflow: hidden` layer, where an
outset ring would be overlapped by its neighbours and clipped at the grid
border. That also retires the `z-index: 100` the old rule carried, which never
had an effect — the input is statically positioned, so `z-index` was ignored.

`tileColor()` is extracted so the background and the ring derive from the same
value instead of repeating the lightness maths.

## Testing

`GridInput.test.tsx` gains component tests that inspect the emitted CSS
(the `globalStyle.test.tsx` `StyleSheetManager` pattern) plus unit tests for
the derivation:

- the rule is `:focus-visible` and no bare `:focus` rule remains
- the ring is 2px, contains no `black`, and clears 3:1 against its tile
- `outline-offset: -2px` keeps the ring inside the tile
- ring and halo contrast against each other
- `focusRingColors()` clears 3:1 against every tile colour the grid can paint
  (65 stream ids × both highlight states) and flips to a light ring on a dark
  tile

Full quality gate green locally: `npm run lint`, `npm run format:check`,
`npm run typecheck`, `npm test`.

## Risks

Visual only, scoped to the grid cells. The ring is now thicker and sits inside
the tile edge instead of on it.

## Follow-up

- #551 — keyboard focus in the grid is still invisible because the cell layer
  renders at `opacity: 0` unless hovered. Out of scope here (it is a separate
  rule in `ControlGrid.tsx` with its own design decision), but it gates whether
  this ring can be seen at all without a pointer.

Closes #531