### PR TITLE
refactor(control-ui): type stateIdxMap and separate the view-id / cell-index axes

### DIFF
--- a/packages/streamwall-control-ui/src/GridControls.test.tsx
+++ b/packages/streamwall-control-ui/src/GridControls.test.tsx
@@ -2,6 +2,7 @@ import { render } from 'preact'
 import { act } from 'preact/test-utils'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { GridControls } from './GridControls.tsx'
+import { asCellIdx, asViewId } from './viewAddressing.ts'
 
 // react-icons renders through preact/compat's Context.Consumer, which
 // currently crashes under this package's happy-dom test environment
@@ -35,8 +36,8 @@ function renderControls(
   act(() => {
     render(
       <GridControls
-        idx={0}
-        viewId={0}
+        idx={asCellIdx(0)}
+        viewId={asViewId(0)}
         streamId="abc"
         style={{}}
         isDisplaying={true}
@@ -85,7 +86,12 @@ describe('GridControls volume slider', () => {
     const onSetVolume = vi.fn()
     // viewId deliberately differs from idx to prove the command carries the
     // stable view id, not the grid cell index (issue #397).
-    const box = renderControls({ idx: 0, viewId: 3, volume: 1, onSetVolume })
+    const box = renderControls({
+      idx: asCellIdx(0),
+      viewId: asViewId(3),
+      volume: 1,
+      onSetVolume,
+    })
     const slider = box.querySelector('input[type="range"]') as HTMLInputElement
 
     act(() => {
@@ -100,7 +106,11 @@ describe('GridControls volume slider', () => {
 describe('GridControls double-click to toggle fullscreen', () => {
   test('toggles fullscreen for this tile when its open area is double-clicked', () => {
     const onToggleFullscreen = vi.fn()
-    const box = renderControls({ idx: 0, viewId: 4, onToggleFullscreen })
+    const box = renderControls({
+      idx: asCellIdx(0),
+      viewId: asViewId(4),
+      onToggleFullscreen,
+    })
     const controls = box.firstElementChild as HTMLElement
 
     act(() => {

--- a/packages/streamwall-control-ui/src/GridControls.tsx
+++ b/packages/streamwall-control-ui/src/GridControls.tsx
@@ -16,6 +16,7 @@ import {
   StyledSmallButton,
   StyledVolumeSlider,
 } from './StyledButton.tsx'
+import { type CellIdx, type ViewId } from './viewAddressing.ts'
 
 const StyledGridButtons = styled.div<{ $side?: 'left' | 'right' }>`
   display: flex;
@@ -66,11 +67,11 @@ export function GridControls({
 }: {
   // Grid cell index of this tile's top-left space. Used only for position-based
   // operations (swap/drag) that intentionally target the cell, not the view.
-  idx: number
+  idx: CellIdx
   // Stable identity of the view actor currently in this tile. View-state
   // commands (listen/blur/volume/reload/devtools/fullscreen) address the view
   // by this id so a concurrent grid resize can't misroute them (issue #397).
-  viewId: number
+  viewId: ViewId
   streamId: string
   style: JSX.HTMLAttributes['style']
   isDisplaying: boolean
@@ -81,20 +82,20 @@ export function GridControls({
   isSwapping: boolean
   showDebug: boolean
   role: StreamwallRole | null
-  onSetListening: (viewId: number, isListening: boolean) => void
+  onSetListening: (viewId: ViewId, isListening: boolean) => void
   onSetBackgroundListening: (
-    viewId: number,
+    viewId: ViewId,
     isBackgroundListening: boolean,
   ) => void
-  onSetBlurred: (viewId: number, isBlurred: boolean) => void
-  onSetVolume: (viewId: number, volume: number) => void
-  onReloadView: (viewId: number) => void
-  onSwapView: (idx: number) => void
+  onSetBlurred: (viewId: ViewId, isBlurred: boolean) => void
+  onSetVolume: (viewId: ViewId, volume: number) => void
+  onReloadView: (viewId: ViewId) => void
+  onSwapView: (idx: CellIdx) => void
   onRotateView: (streamId: string) => void
   onBrowse: (streamId: string) => void
-  onDevTools: (viewId: number) => void
+  onDevTools: (viewId: ViewId) => void
   onPointerDown: JSX.PointerEventHandler<HTMLDivElement>
-  onToggleFullscreen: (viewId: number) => void
+  onToggleFullscreen: (viewId: ViewId) => void
 }) {
   const handleListeningClick = useCallback<
     JSX.MouseEventHandler<HTMLButtonElement>

--- a/packages/streamwall-control-ui/src/GridInput.test.tsx
+++ b/packages/streamwall-control-ui/src/GridInput.test.tsx
@@ -3,6 +3,7 @@ import { act } from 'preact/test-utils'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 
 import { GridInput } from './GridInput.tsx'
+import { asCellIdx } from './viewAddressing.ts'
 
 let container: HTMLDivElement | undefined
 
@@ -23,7 +24,7 @@ function renderInput(
     render(
       <GridInput
         style={{}}
-        idx={0}
+        idx={asCellIdx(0)}
         onChangeSpace={() => {}}
         spaceValue=""
         isHighlighted={false}
@@ -66,7 +67,7 @@ describe('GridInput', () => {
   // hooks instead of styled-components class names, so a markup/styling
   // refactor can't silently break it (issue #344).
   test('exposes a stable data-testid and data-idx for E2E cell targeting', () => {
-    const box = renderInput({ idx: 3 })
+    const box = renderInput({ idx: asCellIdx(3) })
     const input = box.querySelector('input')!
 
     expect(input.getAttribute('data-testid')).toBe('grid-cell')

--- a/packages/streamwall-control-ui/src/GridInput.tsx
+++ b/packages/streamwall-control-ui/src/GridInput.tsx
@@ -4,6 +4,7 @@ import { Color, idColor, roleCan, type StreamwallRole } from 'streamwall-shared'
 import { styled } from 'styled-components'
 import { type ColorInstance } from './colorTypes.ts'
 import { LazyChangeInput } from './LazyChangeInput.tsx'
+import { type CellIdx } from './viewAddressing.ts'
 
 const StyledGridInputContainer = styled.div`
   position: absolute;
@@ -46,13 +47,13 @@ export function GridInput({
 }: {
   style: JSX.HTMLAttributes['style']
   onPointerDown: JSX.PointerEventHandler<HTMLInputElement>
-  idx: number
-  onChangeSpace: (idx: number, value: string) => void
+  idx: CellIdx
+  onChangeSpace: (idx: CellIdx, value: string) => void
   spaceValue: string
   isHighlighted: boolean
   role: StreamwallRole | null
-  onFocus: (idx: number) => void
-  onBlur: (idx: number) => void
+  onFocus: (idx: CellIdx) => void
+  onBlur: (idx: CellIdx) => void
 }) {
   const handleFocus = useCallback(() => {
     onFocus(idx)

--- a/packages/streamwall-control-ui/src/GridViewIdentity.test.tsx
+++ b/packages/streamwall-control-ui/src/GridViewIdentity.test.tsx
@@ -12,6 +12,7 @@ import {
   type StreamwallConnection,
   type ViewInfo,
 } from './index.tsx'
+import { asCellIdx, asCellIdxs, type CellIdx } from './viewAddressing.ts'
 
 vi.mock('react-icons/fa', () => ({
   FaExchangeAlt: () => null,
@@ -78,7 +79,7 @@ function makeView(streamIdx: number, spaces: number[]): ViewInfo {
     isBlurred: false,
     isPaused: false,
     volume: 1,
-    spaces,
+    spaces: asCellIdxs(spaces),
   }
 }
 
@@ -107,8 +108,8 @@ function makeConnection(viewCount: number): StreamwallConnection {
     makeStream(`s${i}`),
   )
   const views = Array.from({ length: viewCount }, (_, i) => makeView(i, [i]))
-  const stateIdxMap = new Map<number, ViewInfo>()
-  views.forEach((v, i) => stateIdxMap.set(i, v))
+  const stateIdxMap = new Map<CellIdx, ViewInfo>()
+  views.forEach((v, i) => stateIdxMap.set(asCellIdx(i), v))
 
   return {
     isConnected: true,
@@ -173,7 +174,7 @@ describe('grid view identity across a shrinking view list', () => {
       // Simulate the first cell's view disappearing (e.g. it's stream
       // stopped): only the second view remains, now at array position 0.
       connection.views = [connection.views[1]]
-      connection.stateIdxMap = new Map([[1, connection.views[0]]])
+      connection.stateIdxMap = new Map([[asCellIdx(1), connection.views[0]]])
       render(<ControlUI connection={connection} />, root)
     })
 

--- a/packages/streamwall-control-ui/src/components/ControlGrid.tsx
+++ b/packages/streamwall-control-ui/src/components/ControlGrid.tsx
@@ -15,6 +15,13 @@ import { ResizeHandles } from '../ResizeHandles.tsx'
 import { type ViewInfo } from '../streamwallState.tsx'
 import { type useTileDrag } from '../useTileDrag.ts'
 import { type useTileResize } from '../useTileResize.ts'
+import {
+  asCellIdx,
+  asCellIdxs,
+  asViewId,
+  type CellIdx,
+  type ViewId,
+} from '../viewAddressing.ts'
 import { resolveAnchorIdx } from '../viewPlacement.ts'
 
 /**
@@ -59,23 +66,23 @@ export function ControlGrid({
   showDebug: boolean
   sharedState: CollabData | undefined
   views: ViewInfo[]
-  stateIdxMap: Map<number, ViewInfo>
+  stateIdxMap: Map<CellIdx, ViewInfo>
   streams: StreamData[]
-  fullscreenViewIdx: number | null
+  fullscreenViewIdx: CellIdx | null
   tileDrag: ReturnType<typeof useTileDrag>
   tileResize: ReturnType<typeof useTileResize>
-  onSetView: (idx: number, streamId: string) => void
-  onFocusInput: (idx: number) => void
+  onSetView: (idx: CellIdx, streamId: string) => void
+  onFocusInput: (idx: CellIdx) => void
   onBlurInput: () => void
-  onToggleFullscreen: (viewId: number) => void
-  onSetListening: (viewId: number, listening: boolean) => void
-  onSetBackgroundListening: (viewId: number, listening: boolean) => void
-  onSetBlurred: (viewId: number, blurred: boolean) => void
-  onSetVolume: (viewId: number, volume: number) => void
-  onReloadView: (viewId: number) => void
+  onToggleFullscreen: (viewId: ViewId) => void
+  onSetListening: (viewId: ViewId, listening: boolean) => void
+  onSetBackgroundListening: (viewId: ViewId, listening: boolean) => void
+  onSetBlurred: (viewId: ViewId, blurred: boolean) => void
+  onSetVolume: (viewId: ViewId, volume: number) => void
+  onReloadView: (viewId: ViewId) => void
   onRotateView: (streamId: string) => void
   onBrowse: (streamId: string) => void
-  onDevTools: (viewId: number) => void
+  onDevTools: (viewId: ViewId) => void
 }) {
   const {
     hoveringIdx,
@@ -101,7 +108,7 @@ export function ControlGrid({
       <StyledGridInputs>
         {range(0, rows).map((y) =>
           range(0, cols).map((x) => {
-            const idx = cols * y + x
+            const idx = asCellIdx(cols * y + x)
             const { streamId } = sharedState?.views?.[idx] ?? {}
             const isMoveHighlight =
               moveStart != null &&
@@ -228,7 +235,7 @@ export function ControlGrid({
       </StyledGridPreview>
       {views.map(
         ({ state, isListening, isBackgroundListening, isBlurred, volume }) => {
-          const { id: viewId, pos } = state.context
+          const { pos } = state.context
           if (!pos) {
             return null
           }
@@ -239,11 +246,14 @@ export function ControlGrid({
           if (!streamId) {
             return null
           }
+          // The overlay addresses its view by id for the control commands and
+          // by anchor cell for the swap gesture — two distinct axes (#507).
+          const [anchorIdx] = asCellIdxs(pos.spaces)
           return (
             <GridControls
               key={pos.spaces[0]}
-              idx={pos.spaces[0]}
-              viewId={viewId}
+              idx={anchorIdx}
+              viewId={asViewId(state.context.id)}
               streamId={streamId}
               onToggleFullscreen={onToggleFullscreen}
               style={{

--- a/packages/streamwall-control-ui/src/gridDragMoveRoleGating.test.tsx
+++ b/packages/streamwall-control-ui/src/gridDragMoveRoleGating.test.tsx
@@ -13,6 +13,7 @@ import {
   type StreamwallConnection,
   type ViewInfo,
 } from './index.tsx'
+import { asCellIdx, asCellIdxs, type CellIdx } from './viewAddressing.ts'
 
 // react-icons renders through preact/compat's Context.Consumer, which
 // currently crashes under this package's happy-dom test environment
@@ -95,9 +96,9 @@ function renderControlUI(role: StreamwallRole | null): {
     state: 'idle',
   }
 
-  const stateIdxMap = new Map<number, ViewInfo>([
-    [0, { spaces: [0] } as ViewInfo],
-    [1, { spaces: [1] } as ViewInfo],
+  const stateIdxMap = new Map<CellIdx, ViewInfo>([
+    [asCellIdx(0), { spaces: asCellIdxs([0]) } as ViewInfo],
+    [asCellIdx(1), { spaces: asCellIdxs([1]) } as ViewInfo],
   ])
 
   const connection: StreamwallConnection = {

--- a/packages/streamwall-control-ui/src/gridFullscreen.test.tsx
+++ b/packages/streamwall-control-ui/src/gridFullscreen.test.tsx
@@ -12,6 +12,7 @@ import {
   type StreamwallConnection,
   type ViewInfo,
 } from './index.tsx'
+import { asCellIdx, asCellIdxs } from './viewAddressing.ts'
 
 vi.mock('react-icons/fa', () => ({
   FaExchangeAlt: () => null,
@@ -87,7 +88,7 @@ function makeView(streamId: string, spaces: number[]): ViewInfo {
     isBlurred: false,
     isPaused: false,
     volume: 1,
-    spaces,
+    spaces: asCellIdxs(spaces),
   }
 }
 
@@ -175,7 +176,7 @@ describe('ControlUI double-click fullscreen', () => {
       baseConnection({
         send: (msg) => sent.push(msg),
         views: [makeView('s1', [0, 1])],
-        fullscreenViewIdx: 1,
+        fullscreenViewIdx: asCellIdx(1),
       }),
     )
 
@@ -199,7 +200,7 @@ describe('ControlUI double-click fullscreen', () => {
     const root = renderControlUI(
       baseConnection({
         views: [makeView('s1', [0, 1])],
-        fullscreenViewIdx: 1,
+        fullscreenViewIdx: asCellIdx(1),
       }),
     )
 

--- a/packages/streamwall-control-ui/src/hooks/useControlHotkeys.test.tsx
+++ b/packages/streamwall-control-ui/src/hooks/useControlHotkeys.test.tsx
@@ -4,6 +4,12 @@ import type { ViewState } from 'streamwall-shared'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { hotkeyTriggers } from '../hotkeyLabel.ts'
 import type { ViewInfo } from '../streamwallState.tsx'
+import {
+  asCellIdx,
+  asCellIdxs,
+  type CellIdx,
+  type ViewId,
+} from '../viewAddressing.ts'
 import { useControlHotkeys } from './useControlHotkeys.ts'
 
 const useHotkeysMock = vi.hoisted(() => vi.fn())
@@ -55,14 +61,14 @@ function makeViewInfo(
     isBlurred: false,
     isPaused: false,
     volume: 1,
-    spaces,
+    spaces: asCellIdxs(spaces),
     ...overrides,
   }
 }
 
-function renderHotkeys(stateIdxMap: Map<number, ViewInfo>) {
-  const handleSetListening = vi.fn<(viewId: number, on: boolean) => void>()
-  const handleSetBlurred = vi.fn<(viewId: number, on: boolean) => void>()
+function renderHotkeys(stateIdxMap: Map<CellIdx, ViewInfo>) {
+  const handleSetListening = vi.fn<(viewId: ViewId, on: boolean) => void>()
+  const handleSetBlurred = vi.fn<(viewId: ViewId, on: boolean) => void>()
   function Probe() {
     useControlHotkeys({
       stateIdxMap,
@@ -108,9 +114,9 @@ describe('useControlHotkeys view addressing (#470)', () => {
   // cell, while `viewId` is the Electron `webContents.id`. The fixtures below
   // deliberately keep the two apart so a regression cannot pass by coincidence.
   test('audio-listen hotkey dispatches the view id, not the cell index', () => {
-    const stateIdxMap = new Map<number, ViewInfo>([
-      [0, makeViewInfo(42, [0])],
-      [1, makeViewInfo(43, [1])],
+    const stateIdxMap = new Map<CellIdx, ViewInfo>([
+      [asCellIdx(0), makeViewInfo(42, [0])],
+      [asCellIdx(1), makeViewInfo(43, [1])],
     ])
     const { handleSetListening } = renderHotkeys(stateIdxMap)
 
@@ -120,8 +126,8 @@ describe('useControlHotkeys view addressing (#470)', () => {
   })
 
   test('audio-listen hotkey toggles off using the view id', () => {
-    const stateIdxMap = new Map<number, ViewInfo>([
-      [0, makeViewInfo(42, [0], { isListening: true })],
+    const stateIdxMap = new Map<CellIdx, ViewInfo>([
+      [asCellIdx(0), makeViewInfo(42, [0], { isListening: true })],
     ])
     const { handleSetListening } = renderHotkeys(stateIdxMap)
 
@@ -131,8 +137,11 @@ describe('useControlHotkeys view addressing (#470)', () => {
   })
 
   test('second audio layer offsets by 20 cells and still sends the view id', () => {
-    const stateIdxMap = new Map<number, ViewInfo>([
-      [hotkeyTriggers.length, makeViewInfo(77, [hotkeyTriggers.length])],
+    const stateIdxMap = new Map<CellIdx, ViewInfo>([
+      [
+        asCellIdx(hotkeyTriggers.length),
+        makeViewInfo(77, [hotkeyTriggers.length]),
+      ],
     ])
     const { handleSetListening } = renderHotkeys(stateIdxMap)
 
@@ -142,9 +151,9 @@ describe('useControlHotkeys view addressing (#470)', () => {
   })
 
   test('blur hotkey dispatches the view id, not the cell index', () => {
-    const stateIdxMap = new Map<number, ViewInfo>([
-      [0, makeViewInfo(42, [0])],
-      [1, makeViewInfo(43, [1], { isBlurred: true })],
+    const stateIdxMap = new Map<CellIdx, ViewInfo>([
+      [asCellIdx(0), makeViewInfo(42, [0])],
+      [asCellIdx(1), makeViewInfo(43, [1], { isBlurred: true })],
     ])
     const { handleSetBlurred } = renderHotkeys(stateIdxMap)
 
@@ -154,9 +163,9 @@ describe('useControlHotkeys view addressing (#470)', () => {
   })
 
   test('second blur layer offsets by 20 cells and still sends the view id', () => {
-    const stateIdxMap = new Map<number, ViewInfo>([
+    const stateIdxMap = new Map<CellIdx, ViewInfo>([
       [
-        hotkeyTriggers.length + 2,
+        asCellIdx(hotkeyTriggers.length + 2),
         makeViewInfo(88, [hotkeyTriggers.length + 2]),
       ],
     ])

--- a/packages/streamwall-control-ui/src/hooks/useControlHotkeys.ts
+++ b/packages/streamwall-control-ui/src/hooks/useControlHotkeys.ts
@@ -8,6 +8,12 @@ import {
   hotkeyTriggers,
 } from '../hotkeyLabel.ts'
 import { type ViewInfo } from '../streamwallState.tsx'
+import {
+  asCellIdx,
+  asViewId,
+  type CellIdx,
+  type ViewId,
+} from '../viewAddressing.ts'
 
 /**
  * Registers ControlUI's global keyboard shortcuts: the two-layer alt-key
@@ -27,26 +33,28 @@ export function useControlHotkeys({
   handleSwapView,
   undoManager,
 }: {
-  stateIdxMap: Map<number, ViewInfo>
-  focusedInputIdx: number | undefined
+  stateIdxMap: Map<CellIdx, ViewInfo>
+  focusedInputIdx: CellIdx | undefined
   role: StreamwallRole | null
-  handleSetListening: (viewId: number, listening: boolean) => void
-  handleSetBlurred: (viewId: number, blurred: boolean) => void
+  handleSetListening: (viewId: ViewId, listening: boolean) => void
+  handleSetBlurred: (viewId: ViewId, blurred: boolean) => void
   setStreamCensored: (isCensored: boolean) => void
-  handleSwapView: (idx: number) => void
+  handleSwapView: (idx: CellIdx) => void
   undoManager: Y.UndoManager | undefined
 }) {
   // The hotkeys are addressed by grid cell, but the commands take a stable
   // view id (`webContents.id`, see #397/#467) - resolve one into the other via
-  // the cell's view instead of passing the index through (issue #470). An
-  // empty cell has no view to toggle, so the keypress is a no-op.
+  // the cell's view instead of passing the index through (issue #470). The two
+  // axes are distinct types, so the compiler now rejects that mix-up outright
+  // (issue #507). An empty cell has no view to toggle, so the keypress is a
+  // no-op.
   const toggleListening = useCallback(
-    (idx: number) => {
+    (idx: CellIdx) => {
       const view = stateIdxMap.get(idx)
       if (!view) {
         return
       }
-      handleSetListening(view.state.context.id, !view.isListening)
+      handleSetListening(asViewId(view.state.context.id), !view.isListening)
     },
     [stateIdxMap, handleSetListening],
   )
@@ -56,7 +64,9 @@ export function useControlHotkeys({
     hotkeyLayerBindings[0],
     (ev, { hotkey }) => {
       ev.preventDefault()
-      toggleListening(hotkeyTriggers.indexOf(hotkey[hotkey.length - 1]))
+      toggleListening(
+        asCellIdx(hotkeyTriggers.indexOf(hotkey[hotkey.length - 1])),
+      )
     },
     { enableOnFormTags: true },
     [toggleListening],
@@ -68,8 +78,10 @@ export function useControlHotkeys({
     (ev, { hotkey }) => {
       ev.preventDefault()
       toggleListening(
-        hotkeyTriggers.length +
-          hotkeyTriggers.indexOf(hotkey[hotkey.length - 1]),
+        asCellIdx(
+          hotkeyTriggers.length +
+            hotkeyTriggers.indexOf(hotkey[hotkey.length - 1]),
+        ),
       )
     },
     { enableOnFormTags: true },
@@ -77,12 +89,12 @@ export function useControlHotkeys({
   )
   // Same cell-index -> view-id resolution as `toggleListening` above (#470).
   const toggleBlurred = useCallback(
-    (idx: number) => {
+    (idx: CellIdx) => {
       const view = stateIdxMap.get(idx)
       if (!view) {
         return
       }
-      handleSetBlurred(view.state.context.id, !view.isBlurred)
+      handleSetBlurred(asViewId(view.state.context.id), !view.isBlurred)
     },
     [stateIdxMap, handleSetBlurred],
   )
@@ -91,7 +103,9 @@ export function useControlHotkeys({
     blurHotkeyLayerBindings[0],
     (ev, { hotkey }) => {
       ev.preventDefault()
-      toggleBlurred(hotkeyTriggers.indexOf(hotkey[hotkey.length - 1]))
+      toggleBlurred(
+        asCellIdx(hotkeyTriggers.indexOf(hotkey[hotkey.length - 1])),
+      )
     },
     [toggleBlurred],
   )
@@ -102,8 +116,10 @@ export function useControlHotkeys({
     (ev, { hotkey }) => {
       ev.preventDefault()
       toggleBlurred(
-        hotkeyTriggers.length +
-          hotkeyTriggers.indexOf(hotkey[hotkey.length - 1]),
+        asCellIdx(
+          hotkeyTriggers.length +
+            hotkeyTriggers.indexOf(hotkey[hotkey.length - 1]),
+        ),
       )
     },
     [toggleBlurred],

--- a/packages/streamwall-control-ui/src/hooks/useGridCommands.test.tsx
+++ b/packages/streamwall-control-ui/src/hooks/useGridCommands.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest'
 import * as Y from 'yjs'
 import { type CollabData } from '../collabData.ts'
 import { type Invite } from '../invite.ts'
+import { asCellIdx, asViewId, type CellIdx } from '../viewAddressing.ts'
 import { useGridCommands } from './useGridCommands.ts'
 
 type Commands = ReturnType<typeof useGridCommands>
@@ -28,8 +29,8 @@ interface Overrides {
   stateDoc?: Y.Doc
   cols?: number | null
   rows?: number | null
-  fullscreenViewIdx?: number | null
-  focusedInputIdx?: number | undefined
+  fullscreenViewIdx?: CellIdx | null
+  focusedInputIdx?: CellIdx | undefined
   favoritesSet?: ReadonlySet<string>
   onInvite?: (invite: Invite) => void
   onError?: (message: string) => void
@@ -90,37 +91,37 @@ function renderCommands(overrides: Overrides = {}) {
 describe('useGridCommands', () => {
   test('dispatches view commands through send', () => {
     const { commands, send } = renderCommands()
-    act(() => commands.handleSetListening(3, true))
+    act(() => commands.handleSetListening(asViewId(3), true))
     expect(send).toHaveBeenLastCalledWith({
       type: 'set-listening-view',
       viewId: 3,
     })
-    act(() => commands.handleSetListening(3, false))
+    act(() => commands.handleSetListening(asViewId(3), false))
     expect(send).toHaveBeenLastCalledWith({
       type: 'set-listening-view',
       viewId: null,
     })
-    act(() => commands.handleSetVolume(1, 0.5))
+    act(() => commands.handleSetVolume(asViewId(1), 0.5))
     expect(send).toHaveBeenLastCalledWith({
       type: 'set-view-volume',
       viewId: 1,
       volume: 0.5,
     })
-    act(() => commands.handleReloadView(2))
+    act(() => commands.handleReloadView(asViewId(2)))
     expect(send).toHaveBeenLastCalledWith({ type: 'reload-view', viewId: 2 })
   })
 
   test('derives the fullscreen flag from the current fullscreen index', () => {
     const notFull = renderCommands({ fullscreenViewIdx: null })
-    act(() => notFull.commands.handleToggleFullscreen(0))
+    act(() => notFull.commands.handleToggleFullscreen(asViewId(0)))
     expect(notFull.send).toHaveBeenLastCalledWith({
       type: 'set-view-fullscreen',
       viewId: 0,
       fullscreen: true,
     })
 
-    const full = renderCommands({ fullscreenViewIdx: 0 })
-    act(() => full.commands.handleToggleFullscreen(0))
+    const full = renderCommands({ fullscreenViewIdx: asCellIdx(0) })
+    act(() => full.commands.handleToggleFullscreen(asViewId(0)))
     expect(full.send).toHaveBeenLastCalledWith({
       type: 'set-view-fullscreen',
       viewId: 0,
@@ -237,7 +238,7 @@ describe('useGridCommands', () => {
       stateDoc,
       streams: [makeStream('a')],
     })
-    act(() => commands.handleSetView(0, 'a'))
+    act(() => commands.handleSetView(asCellIdx(0), 'a'))
     expect(cell.get('streamId')).toBe('a')
   })
 })

--- a/packages/streamwall-control-ui/src/hooks/useGridCommands.ts
+++ b/packages/streamwall-control-ui/src/hooks/useGridCommands.ts
@@ -12,6 +12,7 @@ import * as Y from 'yjs'
 import { copyTextToClipboard } from '../clipboard.ts'
 import { type CollabData } from '../collabData.ts'
 import { type Invite, parseInviteResponse } from '../invite.ts'
+import { asCellIdx, type CellIdx, type ViewId } from '../viewAddressing.ts'
 import {
   resolveEagerWriteStreamId,
   resolveTargetViewIdx,
@@ -47,14 +48,14 @@ export function useGridCommands({
   stateDoc: Y.Doc
   cols: number | null
   rows: number | null
-  fullscreenViewIdx: number | null
-  focusedInputIdx: number | undefined
+  fullscreenViewIdx: CellIdx | null
+  focusedInputIdx: CellIdx | undefined
   favoritesSet: ReadonlySet<string>
   onInvite: (invite: Invite) => void
   onError: (message: string) => void
 }) {
   const handleSetView = useCallback(
-    (idx: number, streamId: string) => {
+    (idx: CellIdx, streamId: string) => {
       const resolved = resolveEagerWriteStreamId(streams, streamId)
       if (resolved === undefined) {
         return
@@ -68,7 +69,7 @@ export function useGridCommands({
   )
 
   const handleSetListening = useCallback(
-    (viewId: number, listening: boolean) => {
+    (viewId: ViewId, listening: boolean) => {
       send({
         type: 'set-listening-view',
         viewId: listening ? viewId : null,
@@ -82,7 +83,7 @@ export function useGridCommands({
   // back to the grid. Purely runtime state -- the persisted layout is untouched
   // (issue #362).
   const handleToggleFullscreen = useCallback(
-    (viewId: number) => {
+    (viewId: ViewId) => {
       send({
         type: 'set-view-fullscreen',
         viewId,
@@ -122,7 +123,7 @@ export function useGridCommands({
   )
 
   const handleSetBackgroundListening = useCallback(
-    (viewId: number, listening: boolean) => {
+    (viewId: ViewId, listening: boolean) => {
       send({
         type: 'set-view-background-listening',
         viewId,
@@ -133,7 +134,7 @@ export function useGridCommands({
   )
 
   const handleSetBlurred = useCallback(
-    (viewId: number, blurred: boolean) => {
+    (viewId: ViewId, blurred: boolean) => {
       send({
         type: 'set-view-blurred',
         viewId,
@@ -144,7 +145,7 @@ export function useGridCommands({
   )
 
   const handleSetVolume = useCallback(
-    (viewId: number, volume: number) => {
+    (viewId: ViewId, volume: number) => {
       send({
         type: 'set-view-volume',
         viewId,
@@ -155,7 +156,7 @@ export function useGridCommands({
   )
 
   const handleReloadView = useCallback(
-    (viewId: number) => {
+    (viewId: ViewId) => {
       send({
         type: 'reload-view',
         viewId,
@@ -194,7 +195,7 @@ export function useGridCommands({
   )
 
   const handleDevTools = useCallback(
-    (viewId: number) => {
+    (viewId: ViewId) => {
       send({
         type: 'dev-tools',
         viewId,
@@ -219,7 +220,7 @@ export function useGridCommands({
       if (targetIdx === undefined) {
         return
       }
-      handleSetView(targetIdx, streamId)
+      handleSetView(asCellIdx(targetIdx), streamId)
     },
     [cols, rows, sharedState, focusedInputIdx, handleSetView],
   )

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -27,6 +27,7 @@ import { StyledDataContainer } from './StyledButton.tsx'
 import { useServerStatus } from './useServerStatus.ts'
 import { useTileDrag } from './useTileDrag.ts'
 import { useTileResize } from './useTileResize.ts'
+import { type CellIdx } from './viewAddressing.ts'
 
 // Re-exported for `streamwall-control-client` and `streamwall`'s renderer,
 // which mount it alongside `<ControlUI>` — its implementation now lives in
@@ -106,7 +107,7 @@ export function ControlUI({
     role,
   })
 
-  const [focusedInputIdx, setFocusedInputIdx] = useState<number | undefined>()
+  const [focusedInputIdx, setFocusedInputIdx] = useState<CellIdx | undefined>()
   const handleBlurInput = useCallback(() => setFocusedInputIdx(undefined), [])
 
   const {

--- a/packages/streamwall-control-ui/src/streamwallState.test.tsx
+++ b/packages/streamwall-control-ui/src/streamwallState.test.tsx
@@ -3,6 +3,7 @@ import { act } from 'preact/test-utils'
 import type { StreamwallState, ViewState } from 'streamwall-shared'
 import { afterEach, describe, expect, test } from 'vitest'
 import { useStreamwallState } from './streamwallState.tsx'
+import { asCellIdx } from './viewAddressing.ts'
 
 let container: HTMLDivElement | undefined
 
@@ -87,12 +88,47 @@ describe('useStreamwallState', () => {
     )
 
     expect(views[0]!.isPaused).toBe(true)
-    expect(stateIdxMap.get(0)!.isPaused).toBe(true)
+    expect(stateIdxMap.get(asCellIdx(0))!.isPaused).toBe(true)
   })
 
   test('leaves isPaused false while the view keeps playing', () => {
     const { views } = renderState(makeState([makeViewState('unpaused')]))
 
     expect(views[0]!.isPaused).toBe(false)
+  })
+
+  // The index used to be filled by `Object.assign`-ing each view onto a `{}`
+  // placeholder, which produced partially-typed copies. Every occupied cell
+  // must map to the very view object the `views` array holds (issue #507).
+  test('indexes every occupied cell to the view itself', () => {
+    const { views, stateIdxMap } = renderState(
+      makeState([
+        makeViewState('unpaused', {
+          pos: { x: 0, y: 0, width: 100, height: 100, spaces: [0, 1] },
+        }),
+      ]),
+    )
+
+    expect(stateIdxMap.get(asCellIdx(0))).toBe(views[0])
+    expect(stateIdxMap.get(asCellIdx(1))).toBe(views[0])
+    expect(stateIdxMap.size).toBe(2)
+  })
+
+  test('lets a later view take over a cell an earlier one also claims', () => {
+    const { views, stateIdxMap } = renderState(
+      makeState([
+        makeViewState('unpaused', {
+          id: 1,
+          pos: { x: 0, y: 0, width: 100, height: 100, spaces: [0] },
+        }),
+        makeViewState('paused', {
+          id: 2,
+          pos: { x: 0, y: 0, width: 100, height: 100, spaces: [0] },
+        }),
+      ]),
+    )
+
+    expect(stateIdxMap.get(asCellIdx(0))).toBe(views[1])
+    expect(stateIdxMap.get(asCellIdx(0))!.state.context.id).toBe(2)
   })
 })

--- a/packages/streamwall-control-ui/src/streamwallState.tsx
+++ b/packages/streamwall-control-ui/src/streamwallState.tsx
@@ -15,6 +15,7 @@ import {
 import { matchesState } from 'xstate'
 import * as Y from 'yjs'
 import { type CollabData } from './collabData.ts'
+import { asCellIdx, asCellIdxs, type CellIdx } from './viewAddressing.ts'
 
 export interface ViewInfo {
   state: ViewState
@@ -28,7 +29,8 @@ export interface ViewInfo {
    */
   isPaused: boolean
   volume: number
-  spaces: number[]
+  /** The grid cells this view occupies — never view ids (issue #507). */
+  spaces: CellIdx[]
 }
 
 /**
@@ -59,8 +61,8 @@ export interface StreamwallConnection {
    * Anchor cell index of the view currently expanded to fill the whole wall,
    * or `null` for the normal grid layout (issue #362).
    */
-  fullscreenViewIdx: number | null
-  stateIdxMap: Map<number, ViewInfo>
+  fullscreenViewIdx: CellIdx | null
+  stateIdxMap: Map<CellIdx, ViewInfo>
   delayState: StreamDelayStatus | null | undefined
   authState?: StreamwallState['auth']
   layoutPresets: LayoutPreset[]
@@ -78,7 +80,7 @@ export function useStreamwallState(state: StreamwallState | undefined) {
         customStreams: [],
         views: [],
         fullscreenViewIdx: null,
-        stateIdxMap: new Map(),
+        stateIdxMap: new Map<CellIdx, ViewInfo>(),
         delayState: undefined,
         authState: undefined,
         layoutPresets: [],
@@ -99,8 +101,8 @@ export function useStreamwallState(state: StreamwallState | undefined) {
       favorites,
       dataSourceHealth,
     } = state
-    const stateIdxMap = new Map()
-    const views = []
+    const stateIdxMap = new Map<CellIdx, ViewInfo>()
+    const views: ViewInfo[] = []
     for (const viewState of stateViews) {
       const { pos } = viewState.context
       const isListening = matchesState(
@@ -119,8 +121,8 @@ export function useStreamwallState(state: StreamwallState | undefined) {
         'displaying.running.pause.paused',
         viewState.state,
       )
-      const spaces = pos?.spaces ?? []
-      const viewInfo = {
+      const spaces = asCellIdxs(pos?.spaces ?? [])
+      const viewInfo: ViewInfo = {
         state: viewState,
         isListening,
         isBackgroundListening,
@@ -130,11 +132,11 @@ export function useStreamwallState(state: StreamwallState | undefined) {
         spaces,
       }
       views.push(viewInfo)
+      // Every occupied cell points at the view itself. Two views can only
+      // claim the same cell while the wall is mid-relayout; the later one wins,
+      // as it did when this merged onto a placeholder object (issue #507).
       for (const space of spaces) {
-        if (!stateIdxMap.has(space)) {
-          stateIdxMap.set(space, {})
-        }
-        Object.assign(stateIdxMap.get(space), viewInfo)
+        stateIdxMap.set(space, viewInfo)
       }
     }
 
@@ -146,7 +148,10 @@ export function useStreamwallState(state: StreamwallState | undefined) {
       authState: auth,
       delayState: streamdelay,
       views,
-      fullscreenViewIdx,
+      // Despite its name this is the anchor *cell* of the expanded view, not a
+      // view id (issue #362).
+      fullscreenViewIdx:
+        fullscreenViewIdx == null ? null : asCellIdx(fullscreenViewIdx),
       config,
       streams,
       customStreams,

--- a/packages/streamwall-control-ui/src/swapHotkeyRoleGating.test.tsx
+++ b/packages/streamwall-control-ui/src/swapHotkeyRoleGating.test.tsx
@@ -13,6 +13,7 @@ import {
   type StreamwallConnection,
   type ViewInfo,
 } from './index.tsx'
+import { asCellIdx, asCellIdxs, type CellIdx } from './viewAddressing.ts'
 
 // react-icons renders through preact/compat's Context.Consumer, which
 // currently crashes under this package's happy-dom test environment
@@ -95,9 +96,9 @@ function renderControlUI(role: StreamwallRole | null): HTMLDivElement {
     state: 'idle',
   }
 
-  const stateIdxMap = new Map<number, ViewInfo>([
-    [0, { spaces: [0] } as ViewInfo],
-    [1, { spaces: [1] } as ViewInfo],
+  const stateIdxMap = new Map<CellIdx, ViewInfo>([
+    [asCellIdx(0), { spaces: asCellIdxs([0]) } as ViewInfo],
+    [asCellIdx(1), { spaces: asCellIdxs([1]) } as ViewInfo],
   ])
 
   const connection: StreamwallConnection = {

--- a/packages/streamwall-control-ui/src/useTileDrag.test.tsx
+++ b/packages/streamwall-control-ui/src/useTileDrag.test.tsx
@@ -4,6 +4,7 @@ import { type StreamwallRole } from 'streamwall-shared'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import * as Y from 'yjs'
 import { useTileDrag } from './useTileDrag.ts'
+import { asCellIdx, type CellIdx } from './viewAddressing.ts'
 
 // react-hotkeys-hook resolves the real `react` package internally, which
 // crashes under this package's preact/happy-dom test environment (unrelated
@@ -80,12 +81,9 @@ function Harness({
   doc: Y.Doc
   role?: StreamwallRole | null
 }) {
-  const stateIdxMap = new Map([
-    [0, { spaces: [0] }],
-    [1, { spaces: [1] }],
-    [2, { spaces: [2] }],
-    [3, { spaces: [3] }],
-  ])
+  const stateIdxMap = new Map<CellIdx, { spaces: number[] }>(
+    [0, 1, 2, 3].map((idx) => [asCellIdx(idx), { spaces: [idx] }]),
+  )
   const {
     hoveringIdx,
     swapStartIdx,
@@ -108,7 +106,7 @@ function Harness({
       <div data-swap-start={swapStartIdx ?? ''} />
       <div data-move-start={moveStart?.idx ?? ''} />
       <div data-move-target={moveTargetIdx ?? ''} />
-      <button type="button" onClick={() => handleSwapView(0)}>
+      <button type="button" onClick={() => handleSwapView(asCellIdx(0))}>
         start-swap-from-0
       </button>
     </div>

--- a/packages/streamwall-control-ui/src/useTileDrag.ts
+++ b/packages/streamwall-control-ui/src/useTileDrag.ts
@@ -8,6 +8,7 @@ import {
   resolveMoveTarget,
 } from './gestures'
 import { computeSwap, type SwapBox } from './gridInteractions'
+import { asCellIdx, type CellIdx } from './viewAddressing.ts'
 
 interface TileInfo {
   spaces: number[]
@@ -30,12 +31,12 @@ export function useTileDrag({
   cols: number | null | undefined
   rows: number | null | undefined
   stateDoc: Y.Doc
-  stateIdxMap: Map<number, TileInfo>
+  stateIdxMap: Map<CellIdx, TileInfo>
   role: StreamwallRole | null
 }) {
-  const [swapStartIdx, setSwapStartIdx] = useState<number | undefined>()
+  const [swapStartIdx, setSwapStartIdx] = useState<CellIdx | undefined>()
   const handleSwapView = useCallback(
-    (idx: number) => {
+    (idx: CellIdx) => {
       if (!stateIdxMap.has(idx)) {
         return
       }
@@ -63,7 +64,7 @@ export function useTileDrag({
   // swap whose read boxes changed since it started). Low impact in practice
   // since concurrent operators rarely target the same cells simultaneously.
   const swapBoxes = useCallback(
-    (fromIdx: number, toIdx: number) => {
+    (fromIdx: CellIdx, toIdx: CellIdx) => {
       if (cols == null || rows == null || !roleCan(role, 'mutate-state-doc')) {
         return
       }
@@ -94,7 +95,7 @@ export function useTileDrag({
   )
 
   const handleSwap = useCallback(
-    (toIdx: number) => {
+    (toIdx: CellIdx) => {
       if (swapStartIdx === undefined) {
         return
       }
@@ -104,7 +105,7 @@ export function useTileDrag({
     [swapBoxes, swapStartIdx],
   )
 
-  const [hoveringIdx, setHoveringIdx] = useState<number>()
+  const [hoveringIdx, setHoveringIdx] = useState<CellIdx>()
   const updateHoveringIdx = useCallback(
     (ev: PointerEvent) => {
       if (
@@ -116,16 +117,15 @@ export function useTileDrag({
       }
       const { width, height, left, top } =
         ev.currentTarget.getBoundingClientRect()
-      setHoveringIdx(
-        computeHoveringIdx(
-          cols,
-          rows,
-          width,
-          height,
-          ev.clientX - left,
-          ev.clientY - top,
-        ),
+      const idx = computeHoveringIdx(
+        cols,
+        rows,
+        width,
+        height,
+        ev.clientX - left,
+        ev.clientY - top,
       )
+      setHoveringIdx(idx === undefined ? undefined : asCellIdx(idx))
     },
     [setHoveringIdx, cols, rows],
   )
@@ -136,9 +136,9 @@ export function useTileDrag({
   // dragging, so `updateHoveringIdx`'s own bounds check covers that case.
   const clearHoveringIdx = useCallback(() => setHoveringIdx(undefined), [])
   const [moveStart, setMoveStart] = useState<
-    { idx: number; x: number; y: number } | undefined
+    { idx: CellIdx; x: number; y: number } | undefined
   >()
-  const [moveTargetIdx, setMoveTargetIdx] = useState<number | undefined>()
+  const [moveTargetIdx, setMoveTargetIdx] = useState<CellIdx | undefined>()
 
   const handleGridPointerDown = useCallback(
     (ev: PointerEvent) => {
@@ -181,7 +181,7 @@ export function useTileDrag({
           ev.clientY,
         )
         if (targetIdx != null) {
-          swapBoxes(moveStart.idx, targetIdx)
+          swapBoxes(moveStart.idx, asCellIdx(targetIdx))
         }
       }
       setMoveStart(undefined)

--- a/packages/streamwall-control-ui/src/viewAddressing.test.ts
+++ b/packages/streamwall-control-ui/src/viewAddressing.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'vitest'
+import {
+  asCellIdx,
+  asCellIdxs,
+  asViewId,
+  type CellIdx,
+  type ViewId,
+} from './viewAddressing.ts'
+
+describe('viewAddressing', () => {
+  test('tagging is a compile-time-only operation', () => {
+    expect(asViewId(7)).toBe(7)
+    expect(asCellIdx(0)).toBe(0)
+    expect(asCellIdxs([0, 3])).toEqual([0, 3])
+  })
+
+  // The guards below are the actual point of this module: they fail the
+  // typecheck — not the test run — if the two axes ever become interchangeable
+  // again, which is how a cell index reached a view-id command in #470. An
+  // `@ts-expect-error` that stops erroring is itself a compile error, so an
+  // accidental widening of either brand breaks CI.
+  test('a cell index is not accepted where a view id is expected', () => {
+    function takesViewId(viewId: ViewId) {
+      return viewId
+    }
+    const cellIdx = asCellIdx(3)
+
+    // @ts-expect-error a grid cell index is not a stable view id
+    takesViewId(cellIdx)
+    // @ts-expect-error an untagged number is not a stable view id either
+    takesViewId(3)
+
+    expect(takesViewId(asViewId(3))).toBe(3)
+  })
+
+  test('a view id is not accepted where a cell index is expected', () => {
+    function takesCellIdx(idx: CellIdx) {
+      return idx
+    }
+    const viewId = asViewId(3)
+
+    // @ts-expect-error a view id does not address a grid cell
+    takesCellIdx(viewId)
+    // @ts-expect-error an untagged number does not address a grid cell either
+    takesCellIdx(3)
+
+    expect(takesCellIdx(asCellIdx(3))).toBe(3)
+  })
+
+  test('both axes stay usable as plain numbers in grid arithmetic', () => {
+    function takesNumber(value: number) {
+      return value
+    }
+
+    expect(takesNumber(asCellIdx(2))).toBe(2)
+    expect(takesNumber(asViewId(2))).toBe(2)
+  })
+})

--- a/packages/streamwall-control-ui/src/viewAddressing.ts
+++ b/packages/streamwall-control-ui/src/viewAddressing.ts
@@ -1,0 +1,46 @@
+/**
+ * The two numeric addressing axes of the wall, kept apart by the type system.
+ *
+ * A **view id** identifies a live view actor (`context.id`, i.e. the Electron
+ * `webContents.id`) and is what every `set-view-*`/`reload-view`/`dev-tools`
+ * control command addresses. A **cell index** identifies a position in the
+ * grid (`cols * y + x`) and is what the shared Yjs `views` map, drag/swap
+ * gestures, layout presets and `fullscreenViewIdx` are keyed by. The split was
+ * introduced in #397/#467.
+ *
+ * Both are plain `number`s at runtime, so the compiler used to accept one
+ * wherever the other was expected — that is exactly how #470 (a cell index
+ * passed to a view-id command) slipped through review. Branding them makes the
+ * mix-up a type error while keeping them assignable *to* `number`, so the pure
+ * grid geometry helpers (`gestures.ts`, `gridInteractions.ts`,
+ * `viewPlacement.ts`) can stay on plain numbers and only the boundaries where a
+ * raw number enters the addressed surface need an explicit conversion.
+ */
+
+declare const viewIdBrand: unique symbol
+declare const cellIdxBrand: unique symbol
+
+/** A stable view actor id (`ViewState['context']['id']`). */
+export type ViewId = number & { readonly [viewIdBrand]: true }
+
+/** A grid cell index (`cols * y + x`). */
+export type CellIdx = number & { readonly [cellIdxBrand]: true }
+
+/**
+ * Tag a raw number coming from the wire (view state, control responses) as a
+ * view id. Purely a compile-time assertion — there is no runtime validation to
+ * do, since any number the main process reports as `context.id` is one.
+ */
+export function asViewId(value: number): ViewId {
+  return value as ViewId
+}
+
+/** Tag a raw number produced by grid geometry as a cell index. */
+export function asCellIdx(value: number): CellIdx {
+  return value as CellIdx
+}
+
+/** {@link asCellIdx} for a whole list, e.g. a view's occupied `spaces`. */
+export function asCellIdxs(values: readonly number[]): CellIdx[] {
+  return values.map(asCellIdx)
+}


### PR DESCRIPTION
## Summary

`useStreamwallState` built its cell index with an untyped `new Map()` and filled it by `Object.assign`-ing each view onto a `{}` placeholder. Inside the builder every value was therefore `any`, and a cell could in principle end up holding a partially populated `ViewInfo`. The map is now constructed as `Map<CellIdx, ViewInfo>` and each occupied cell stores the view object itself.

That type hole is what let #470 through: a grid **cell index** and a stable **view id** are both `number`, so nothing stopped one being passed where the other was expected. The two axes are now branded (`CellIdx`, `ViewId` in the new `viewAddressing.ts`) and threaded through the addressing surface:

- `stateIdxMap` keys, `ViewInfo['spaces']` and `fullscreenViewIdx` (the anchor *cell* of the expanded view, despite its name)
- every `useGridCommands` handler — `viewId` for the `set-view-*`/`reload-view`/`dev-tools` commands, `CellIdx` for `handleSetView`
- the grid components and gestures: `ControlGrid`, `GridControls`, `GridInput`, `useTileDrag`, `useControlHotkeys`

Passing a cell index to a view-id command is now a compile error, and vice versa.

### Architecture decisions

- **Branding stays inside `streamwall-control-ui`.** The shared schemas keep plain `number`s on the wire; the brands are applied where the two axes actually meet in the UI, which is where #470 happened. No runtime cost — `asViewId`/`asCellIdx` are compile-time tags.
- **Pure grid geometry keeps plain `number`s.** `gestures.ts`, `gridInteractions.ts`, `viewPlacement.ts` and `useTileResize.ts` are untouched: both brands are assignable *to* `number`, so only the boundaries where a raw number enters the addressed surface (hotkey trigger index, `cols * y + x`, `computeHoveringIdx`, the wire's `fullscreenViewIdx`) convert explicitly. This keeps the index arithmetic readable instead of littering it with conversions.
- **No behavior change.** Storing the view object instead of merging onto a placeholder is equivalent for a shared cell (the later view already won every field); the new test pins that ordering.

## How was this tested?

- New `viewAddressing.test.ts`: runtime identity of the tag helpers plus `@ts-expect-error` guards that fail the **typecheck** if either axis ever becomes interchangeable again (an `@ts-expect-error` that stops erroring is itself a compile error).
- New `streamwallState.test.tsx` cases: every occupied cell maps to the view itself (multi-space views included), and a later view claiming an already-taken cell wins.
- `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm test`, `npm -w streamwall-control-client run build` and `npm run licenses:check` all pass locally.

Closes #507

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests (or this PR explains why none apply)
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments