### PR TITLE
test(control-server): cut the per-test cost of the live-server integration suites

### DIFF
--- a/packages/streamwall-control-server/src/auth.test.ts
+++ b/packages/streamwall-control-server/src/auth.test.ts
@@ -6,7 +6,9 @@ import { promisify } from 'node:util'
 import type { StreamwallRole, StreamwallState } from 'streamwall-shared'
 import {
   type AuthToken,
+  type ScryptParams,
   Auth,
+  DEFAULT_SCRYPT_PARAMS,
   rand62,
   StateWrapper,
   uniqueRand62,
@@ -23,6 +25,27 @@ const base62 = baseX(
 )
 async function legacyStoredHash(secret: string, salt: string): Promise<string> {
   return base62.encode((await scrypt(secret, salt, 24)) as Buffer)
+}
+
+/**
+ * Independent re-implementation of the *current* stored-hash format under an
+ * explicit work factor, so a spec can assert which parameters a hash was
+ * actually derived with.
+ */
+function storedHash(
+  secret: string,
+  salt: string,
+  params: ScryptParams,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    scryptCb(secret, salt, 24, params, (err, derivedKey) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(base62.encode(derivedKey))
+      }
+    })
+  })
 }
 
 test('rand62 emits only base62 characters within the expected length bound', () => {
@@ -210,6 +233,69 @@ test('validateToken accepts a legacy token hashed with the shared salt and no pe
     role: 'admin',
     name: 'legacy',
   })
+})
+
+test('hashes tokens with the production scrypt work factor by default', async () => {
+  // Guard against the work factor being lowered silently: the stored hash must
+  // still be reproducible with the exact parameters every persisted token was
+  // hashed under. Lowering these would both weaken the hash and invalidate
+  // every already-persisted session, invite and uplink token on upgrade.
+  assert.deepEqual(DEFAULT_SCRYPT_PARAMS, { N: 16384, r: 8, p: 1 })
+
+  const auth = new Auth()
+  const { tokenId, secret } = await auth.createToken({
+    kind: 'session',
+    role: 'admin',
+    name: 'default-params',
+  })
+  const stored = auth.getStoredData().tokens.find((t) => t.tokenId === tokenId)
+
+  assert.ok(stored?.salt)
+  assert.equal(
+    stored.tokenHash,
+    await storedHash(secret, stored.salt, { N: 16384, r: 8, p: 1 }),
+  )
+})
+
+test('derives token hashes with injected scrypt parameters', async () => {
+  // Tests inject a cheap work factor so a suite that boots a live server per
+  // test does not pay four production-cost derivations it never asserts on.
+  const scryptParams = { N: 16, r: 8, p: 1 }
+  const auth = new Auth(undefined, undefined, { scryptParams })
+
+  const { tokenId, secret } = await auth.createToken({
+    kind: 'session',
+    role: 'admin',
+    name: 'cheap-params',
+  })
+  const stored = auth.getStoredData().tokens.find((t) => t.tokenId === tokenId)
+
+  assert.ok(stored?.salt)
+  assert.equal(
+    stored.tokenHash,
+    await storedHash(secret, stored.salt, scryptParams),
+  )
+  // The same instance validates what it hashed: minting and verifying agree on
+  // the injected parameters.
+  assert.ok(await auth.validateToken(tokenId, secret))
+})
+
+test('validateToken rejects a token hashed under a different work factor', async () => {
+  const auth = new Auth(undefined, undefined, {
+    scryptParams: { N: 16, r: 8, p: 1 },
+  })
+  const { tokenId, secret } = await auth.createToken({
+    kind: 'session',
+    role: 'admin',
+    name: 'mismatch',
+  })
+
+  // Reloading the persisted tokens under the production work factor derives a
+  // different digest, so the secret no longer matches: the work factor is part
+  // of the stored hash and cannot be changed for existing tokens.
+  const reloaded = new Auth(auth.getStoredData())
+
+  assert.equal(await reloaded.validateToken(tokenId, secret), null)
 })
 
 test('validateToken rejects a token revoked while its hash is being computed', async () => {

--- a/packages/streamwall-control-server/src/auth.ts
+++ b/packages/streamwall-control-server/src/auth.ts
@@ -48,18 +48,28 @@ export function uniqueRand62(len: number, map: Map<string, unknown>) {
 // is what lets `validateToken` compare digests in constant time.
 const SCRYPT_KEYLEN = 24
 
+export interface ScryptParams {
+  N: number
+  r: number
+  p: number
+}
+
 // scrypt cost parameters, pinned explicitly rather than relying on Node's
 // implicit defaults. These MUST match the values used to hash every
 // already-persisted token (Node's defaults: N=16384, r=8, p=1) — raising them
 // would invalidate existing session, invite and streamwall-uplink tokens on
 // upgrade. The token secrets themselves are 24 random bytes (~143 bits), so a
 // higher work factor would add cost without meaningfully improving security.
-const SCRYPT_PARAMS = { N: 16384, r: 8, p: 1 } as const
+export const DEFAULT_SCRYPT_PARAMS: ScryptParams = { N: 16384, r: 8, p: 1 }
 
 // Raw, fixed-length scrypt digest of a secret under a given salt.
-function hashTokenRaw(secret: string, salt: string): Promise<Buffer> {
+function hashTokenRaw(
+  secret: string,
+  salt: string,
+  params: ScryptParams,
+): Promise<Buffer> {
   return new Promise((resolve, reject) => {
-    scryptCb(secret, salt, SCRYPT_KEYLEN, SCRYPT_PARAMS, (err, derivedKey) => {
+    scryptCb(secret, salt, SCRYPT_KEYLEN, params, (err, derivedKey) => {
       if (err) {
         reject(err)
       } else {
@@ -70,8 +80,12 @@ function hashTokenRaw(secret: string, salt: string): Promise<Buffer> {
 }
 
 // Persisted form of a token hash: the raw digest, base62-encoded.
-async function hashToken62(secret: string, salt: string): Promise<string> {
-  return base62.encode(await hashTokenRaw(secret, salt))
+async function hashToken62(
+  secret: string,
+  salt: string,
+  params: ScryptParams,
+): Promise<string> {
+  return base62.encode(await hashTokenRaw(secret, salt, params))
 }
 
 // Wrapper for state data to facilitate role-scoped data access.
@@ -141,13 +155,26 @@ export class Auth extends EventEmitter<AuthEvents> {
    * token lifecycle events simply go unlogged rather than to raw stdout.
    */
   private log?: Logger
+  /**
+   * The work factor every token of this instance is hashed and verified under.
+   * Injectable so test suites that boot a live server per test do not pay the
+   * production cost for derivations they never assert on; a lowered factor is
+   * deliberately not reachable from the environment, so no deployment can end
+   * up with one by accident. It is part of the stored hash: changing it for an
+   * existing store invalidates every persisted token.
+   */
+  readonly scryptParams: ScryptParams
 
   constructor(
     { salt, tokens = [] }: Partial<StoredData['auth']> = {},
     log?: Logger,
+    {
+      scryptParams = DEFAULT_SCRYPT_PARAMS,
+    }: { scryptParams?: ScryptParams } = {},
   ) {
     super()
     this.log = log
+    this.scryptParams = scryptParams
     this.salt = salt ?? rand62(24)
     this.tokensById = new Map()
     for (const token of tokens) {
@@ -197,7 +224,11 @@ export class Auth extends EventEmitter<AuthEvents> {
     // not reveal whether the id exists (a user-enumeration oracle). Tokens
     // persisted before per-token salts fall back to the shared salt.
     const salt = tokenData?.salt ?? this.salt
-    const providedTokenHash = await hashTokenRaw(secret, salt)
+    const providedTokenHash = await hashTokenRaw(
+      secret,
+      salt,
+      this.scryptParams,
+    )
 
     // Re-read the record after the (async) hash: `deleteToken` may have revoked
     // it while scrypt was running. Authenticating against the stale snapshot
@@ -243,7 +274,7 @@ export class Auth extends EventEmitter<AuthEvents> {
     const tokenId = uniqueRand62(8, this.tokensById)
     const secret = rand62(24)
     const salt = rand62(24)
-    const tokenHash = await hashToken62(secret, salt)
+    const tokenHash = await hashToken62(secret, salt, this.scryptParams)
     const tokenData: AuthToken = {
       tokenId,
       tokenHash,

--- a/packages/streamwall-control-server/src/index.test.ts
+++ b/packages/streamwall-control-server/src/index.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { after, describe, test } from 'node:test'
 
+import { DEFAULT_SCRYPT_PARAMS } from './auth.ts'
 import runServer, {
   initApp,
   resolveListenPort,
@@ -116,6 +117,19 @@ describe('session cookie security attributes', () => {
     assert.equal(response.statusCode, 403)
     assert.equal(response.headers['set-cookie'], undefined)
   })
+})
+
+test('initApp keeps the production scrypt work factor unless one is injected', async () => {
+  // `scryptParams` exists so tests can pay a cheap derivation; a real
+  // deployment must never end up with a lowered work factor by omission.
+  const { app, auth } = await initApp({
+    baseURL: 'http://localhost:3000',
+    clientStaticPath: import.meta.dirname,
+    db: inMemoryDb(),
+  })
+  after(() => app.close())
+
+  assert.deepEqual(auth.scryptParams, DEFAULT_SCRYPT_PARAMS)
 })
 
 describe('runServer', () => {

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -8,7 +8,7 @@ import path from 'node:path'
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
 
-import { Auth } from './auth.ts'
+import { Auth, type ScryptParams } from './auth.ts'
 import runServer from './bootstrap.ts'
 import {
   getDocUpdateLimits,
@@ -56,10 +56,16 @@ export async function initApp({
   logStream,
   sentryEnabled: injectedSentryEnabled,
   sentryClient,
+  scryptParams,
   trustProxy: injectedTrustProxy,
   updateChecker: injectedUpdateChecker,
 }: AppOptions & {
   db?: StorageDB
+  /**
+   * Test-only override for the token-hashing work factor. Omitted everywhere
+   * but in tests, so a deployment always gets `DEFAULT_SCRYPT_PARAMS`.
+   */
+  scryptParams?: ScryptParams
   /** Overrides the level from `LOG_LEVEL` (used by tests to silence or widen output). */
   logLevel?: LogLevel
   /** Test-only sink for log output; defaults to pino's stdout destination. */
@@ -87,7 +93,7 @@ export async function initApp({
   })
 
   const db = injectedDb ?? (await loadStorage())
-  const auth = new Auth(db.data.auth, app.log)
+  const auth = new Auth(db.data.auth, app.log, { scryptParams })
   const updateChecker =
     injectedUpdateChecker ?? createUpdateChecker({ log: app.log })
 

--- a/packages/streamwall-control-server/src/logging.test.ts
+++ b/packages/streamwall-control-server/src/logging.test.ts
@@ -1,7 +1,6 @@
 import assert from 'node:assert/strict'
 import { once } from 'node:events'
 import { after, test } from 'node:test'
-import { setTimeout as delay } from 'node:timers/promises'
 import WebSocket from 'ws'
 
 import {
@@ -39,7 +38,7 @@ async function bootWithCapturedLogs() {
   after(() => ws.terminate())
   await once(ws, 'open')
   ws.send(JSON.stringify({ type: 'state', state: VALID_STATE }))
-  await delay(150)
+  await logs.waitForMessage('Streamwall connected')
 
   return { app, auth, port, ws, logs, uplinkTokenId: tokenId }
 }
@@ -117,12 +116,10 @@ test('logs an unauthorized client command as a warning without the session name'
   clientWs.send(
     JSON.stringify({ id: 1, type: 'create-invite', role: 'admin', name: 'x' }),
   )
-  await delay(150)
-
-  const entry = logs.entries.find((e) =>
-    String(e.msg).includes('Unauthorized attempt to "create-invite"'),
+  const entry = await logs.waitForMessage(
+    'Unauthorized attempt to "create-invite"',
   )
-  assert.ok(entry, 'the rejection must be logged')
+
   assert.equal(entry.level, WARN)
   assert.equal(entry.role, 'monitor')
   assert.equal(

--- a/packages/streamwall-control-server/src/multiplexing.test.ts
+++ b/packages/streamwall-control-server/src/multiplexing.test.ts
@@ -1,7 +1,6 @@
 import assert from 'node:assert/strict'
 import { once } from 'node:events'
 import { after, test } from 'node:test'
-import { setTimeout as delay } from 'node:timers/promises'
 import WebSocket from 'ws'
 
 import type { Delta } from 'jsondiffpatch'
@@ -72,7 +71,9 @@ async function bootServerWithUplink() {
     port,
   )
   streamwallWs.send(JSON.stringify({ type: 'state', state: VALID_STATE }))
-  await delay(150)
+  // The uplink is only the state authority once the server has accepted the
+  // seeded snapshot; wait for that signal rather than a blind sleep.
+  await logs.waitForMessage('Streamwall connected')
 
   async function connectClient(role: StreamwallRole) {
     const { ws: clientWs, client } = await redeemInviteAndConnectClient(
@@ -244,9 +245,9 @@ test('rejects a second Streamwall connection while the first stays connected', a
   } = await bootServerWithUplink()
   // Registering the first uplink connection requires the server to await a
   // real `validateToken` scrypt derivation, so the client's 'open' event
-  // (and even the fixed delay in `bootServerWithUplink`) is not proof that
-  // registration has actually completed — most visible on a loaded/slower
-  // CI runner. Round-trip a client through the state broadcast the uplink
+  // alone is not proof that registration has actually completed — most
+  // visible on a loaded/slower CI runner. Round-trip a client through the
+  // state broadcast the uplink
   // just sent: that broadcast can only happen after registration finished,
   // so it deterministically proves the race window has closed rather than
   // assuming a fixed ordering.

--- a/packages/streamwall-control-server/src/sentryReporting.test.ts
+++ b/packages/streamwall-control-server/src/sentryReporting.test.ts
@@ -1,12 +1,10 @@
 import assert from 'node:assert/strict'
 import { createRequire } from 'node:module'
 import { test } from 'node:test'
-import { setTimeout as delay } from 'node:timers/promises'
 import type WebSocket from 'ws'
 import * as Y from 'yjs'
 
 import type { SentryCaptureClient } from './sentry.ts'
-import type { LogCapture } from './testHelpers.ts'
 import {
   buildTestApp,
   captureLogs,
@@ -24,11 +22,6 @@ function updateFrom(mutate: (doc: Y.Doc) => void): Uint8Array {
 }
 
 const BASE_URL = 'http://localhost:3000'
-
-/** Finds the captured log entry with exactly this message. */
-function findLogged(logs: LogCapture, msg: string) {
-  return logs.entries.find((entry) => entry.msg === msg)
-}
 
 /** Reads the message off pino's serialized `err` field of a log entry. */
 function loggedErrorMessage(entry: Record<string, unknown>) {
@@ -81,10 +74,10 @@ test('a synchronous ws.send() failure while broadcasting a state delta is report
 
   const { ws: streamwallWs } = await connectStreamwallUplink(auth, port)
   streamwallWs.send(JSON.stringify({ type: 'state', state: VALID_STATE }))
-  await delay(150)
+  await logs.waitForMessage('Streamwall connected')
 
   await redeemInviteAndConnectClient(app, auth, port, BASE_URL, 'admin')
-  await delay(50)
+  await logs.waitForMessage('Client connected')
 
   // Force the next `ws.send()` carrying a state-delta payload to throw
   // synchronously, simulating the kind of internal `ws` send failure the
@@ -116,13 +109,13 @@ test('a synchronous ws.send() failure while broadcasting a state delta is report
       state: { ...VALID_STATE, config: { ...VALID_STATE.config, cols: 4 } },
     }),
   )
-  await delay(150)
+  // The local log entry is the observable signal that the failure was caught;
+  // waiting for it doubles as the assertion that it is logged at all.
+  const logged = await logs.waitForMessage('Failed to send client state delta')
 
   assert.equal(sentryClient.calls.length, 1)
   assert.equal(sentryClient.calls[0], sendError)
 
-  const logged = findLogged(logs, 'Failed to send client state delta')
-  assert.ok(logged, 'expected the send failure to be logged locally too')
   assert.equal(
     loggedErrorMessage(logged),
     sendError.message,
@@ -147,7 +140,7 @@ test('a synchronous ws.send() failure while relaying a doc update is reported to
 
   const { ws: streamwallWs } = await connectStreamwallUplink(auth, port)
   streamwallWs.send(JSON.stringify({ type: 'state', state: VALID_STATE }))
-  await delay(150)
+  await logs.waitForMessage('Streamwall connected')
 
   const { ws: clientWs } = await redeemInviteAndConnectClient(
     app,
@@ -156,7 +149,7 @@ test('a synchronous ws.send() failure while relaying a doc update is reported to
     BASE_URL,
     'admin',
   )
-  await delay(50)
+  await logs.waitForMessage('Client connected')
 
   // Force every subsequent server-side binary (Yjs doc-update) send to throw,
   // simulating the kind of internal `ws` send failure the `Failed to send
@@ -185,22 +178,25 @@ test('a synchronous ws.send() failure while relaying a doc update is reported to
   )
 
   streamwallWs.send(updateFrom((d) => d.getMap('test').set('a', 'b')))
-  await delay(150)
+  // Both relay paths fail independently; wait for each to have been logged
+  // rather than for a fixed window that may or may not cover them.
+  const uplinkEntry = await logs.waitForMessage(
+    'Failed to send Streamwall doc update',
+  )
+  const clientEntry = await logs.waitForMessage(
+    'Failed to send client doc update',
+  )
 
   assert.equal(sentryClient.calls.length, 2)
   assert.equal(sentryClient.calls[0], sendError)
   assert.equal(sentryClient.calls[1], sendError)
 
-  const uplinkEntry = findLogged(logs, 'Failed to send Streamwall doc update')
-  assert.ok(uplinkEntry, 'expected the uplink send failure to be logged')
   assert.equal(
     loggedErrorMessage(uplinkEntry),
     sendError.message,
     'the local log should include the caught error',
   )
 
-  const clientEntry = findLogged(logs, 'Failed to send client doc update')
-  assert.ok(clientEntry, 'expected the client send failure to be logged')
   assert.equal(
     loggedErrorMessage(clientEntry),
     sendError.message,

--- a/packages/streamwall-control-server/src/testHelpers.test.ts
+++ b/packages/streamwall-control-server/src/testHelpers.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { DEFAULT_SCRYPT_PARAMS } from './auth.ts'
+import { captureLogs, TEST_SCRYPT_PARAMS } from './testHelpers.ts'
+
+/** Serializes a log entry the way pino writes it to the capture stream. */
+function line(msg: string, fields: Record<string, unknown> = {}): string {
+  return `${JSON.stringify({ level: 30, msg, ...fields })}\n`
+}
+
+test('captureLogs waitForMessage resolves with an already captured entry', async () => {
+  const logs = captureLogs()
+  logs.stream.write(line('Streamwall connected'))
+
+  const entry = await logs.waitForMessage('Streamwall connected')
+
+  assert.equal(entry.msg, 'Streamwall connected')
+})
+
+test('captureLogs waitForMessage resolves once a later entry arrives', async () => {
+  const logs = captureLogs()
+  const pending = logs.waitForMessage('Client connected')
+
+  setTimeout(() => logs.stream.write(line('Client connected')), 5)
+
+  assert.equal((await pending).msg, 'Client connected')
+})
+
+test('captureLogs waitForMessage matches a substring of the message', async () => {
+  const logs = captureLogs()
+  logs.stream.write(line('Unauthorized attempt to "create-invite"'))
+
+  const entry = await logs.waitForMessage('create-invite')
+
+  assert.equal(entry.msg, 'Unauthorized attempt to "create-invite"')
+})
+
+test('captureLogs waitFor rejects with a bounded timeout instead of hanging', async () => {
+  const logs = captureLogs()
+
+  await assert.rejects(
+    () => logs.waitFor((entry) => entry.msg === 'never logged', 20),
+    /timed out waiting for matching log entry/,
+  )
+})
+
+test('captureLogs waitFor keeps other waiters pending when one resolves', async () => {
+  const logs = captureLogs()
+  const connected = logs.waitFor((entry) => entry.msg === 'Client connected')
+  const disconnected = logs.waitFor(
+    (entry) => entry.msg === 'Client disconnected',
+    50,
+  )
+
+  logs.stream.write(line('Client connected'))
+  await connected
+
+  await assert.rejects(() => disconnected)
+})
+
+test('captureLogs waitFor exposes the matched entry fields', async () => {
+  const logs = captureLogs()
+  logs.stream.write(line('Client connected', { role: 'monitor' }))
+
+  const entry = await logs.waitFor((e) => e.msg === 'Client connected')
+
+  assert.equal(entry.role, 'monitor')
+})
+
+test('tests derive token hashes with a cheaper work factor than production', () => {
+  // The whole point of the injected parameters: a live-server suite must not
+  // pay the production cost, while production keeps it.
+  assert.ok(TEST_SCRYPT_PARAMS.N < DEFAULT_SCRYPT_PARAMS.N)
+})

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -12,6 +12,7 @@ import type {
   StreamwallRole,
 } from 'streamwall-shared'
 import WebSocket from 'ws'
+import type { ScryptParams } from './auth.ts'
 import { type AppOptions, initApp } from './index.ts'
 import type { LogLevel } from './logger.ts'
 import type { SentryCaptureClient } from './sentry.ts'
@@ -49,26 +50,83 @@ export interface LogCapture {
   stream: { write(line: string): void }
   /** True when any captured entry's message contains `substring`. */
   hasMessage(substring: string): boolean
+  /**
+   * Resolves with the first entry matching `predicate`, waiting for one to be
+   * logged if none has been yet. Already-captured entries satisfy it, so there
+   * is no race between the server logging and the test awaiting. Rejects after
+   * `timeoutMs` rather than hanging until the runner's timeout.
+   */
+  waitFor(
+    predicate: (entry: Record<string, unknown>) => boolean,
+    timeoutMs?: number,
+  ): Promise<Record<string, unknown>>
+  /** `waitFor` for the common case of matching a substring of the message. */
+  waitForMessage(
+    substring: string,
+    timeoutMs?: number,
+  ): Promise<Record<string, unknown>>
 }
 
 export function captureLogs(): LogCapture {
-  const entries: Record<string, unknown>[] = []
+  type Entry = Record<string, unknown>
+  const entries: Entry[] = []
+  const waiters: {
+    predicate: (entry: Entry) => boolean
+    resolve: (entry: Entry) => void
+  }[] = []
+
+  function waitFor(
+    predicate: (entry: Entry) => boolean,
+    timeoutMs = 2000,
+  ): Promise<Entry> {
+    const existing = entries.find(predicate)
+    if (existing !== undefined) {
+      return Promise.resolve(existing)
+    }
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error('timed out waiting for matching log entry')),
+        timeoutMs,
+      )
+      waiters.push({
+        predicate,
+        resolve: (entry) => {
+          clearTimeout(timer)
+          resolve(entry)
+        },
+      })
+    })
+  }
+
+  const messageMatches = (substring: string) => (entry: Entry) =>
+    typeof entry.msg === 'string' && entry.msg.includes(substring)
+
   return {
     entries,
     stream: {
       write(line: string) {
+        let entry: Entry
         try {
-          entries.push(JSON.parse(line))
+          entry = JSON.parse(line)
         } catch {
           // Non-JSON output cannot be asserted on; ignore it.
+          return
+        }
+        entries.push(entry)
+        for (let i = waiters.length - 1; i >= 0; i--) {
+          if (waiters[i].predicate(entry)) {
+            waiters[i].resolve(entry)
+            waiters.splice(i, 1)
+          }
         }
       },
     },
     hasMessage(substring: string) {
-      return entries.some(
-        (entry) =>
-          typeof entry.msg === 'string' && entry.msg.includes(substring),
-      )
+      return entries.some(messageMatches(substring))
+    },
+    waitFor,
+    waitForMessage(substring: string, timeoutMs?: number) {
+      return waitFor(messageMatches(substring), timeoutMs)
     },
   }
 }
@@ -103,6 +161,15 @@ export function recordingLogger() {
 }
 
 /**
+ * A deliberately cheap scrypt work factor for tests. Suites that boot a live
+ * server pay roughly four derivations per test (mint and verify an uplink
+ * token, mint and redeem an invite) that have nothing to do with what is under
+ * test; at the production factor that is ~200ms of pure overhead per test.
+ * `DEFAULT_SCRYPT_PARAMS` stays in force everywhere it is not injected.
+ */
+export const TEST_SCRYPT_PARAMS: ScryptParams = { N: 16, r: 8, p: 1 }
+
+/**
  * Builds a fully-wired app instance backed by in-memory storage and throwaway
  * static assets, ready for `app.inject()` or `app.listen()` in tests.
  *
@@ -114,6 +181,7 @@ export function buildTestApp(
     db?: StorageDB
     logs?: LogCapture
     logLevel?: LogLevel
+    scryptParams?: ScryptParams
     sentryEnabled?: boolean
     sentryClient?: SentryCaptureClient
     updateChecker?: UpdateChecker
@@ -125,6 +193,7 @@ export function buildTestApp(
     clientStaticPath: makeStaticDir(),
     db: inMemoryDb(),
     logLevel: logLevel ?? (logs ? 'trace' : 'silent'),
+    scryptParams: TEST_SCRYPT_PARAMS,
     ...(logs && { logStream: logs.stream }),
     ...rest,
   })

--- a/packages/streamwall-control-server/src/wsValidation.test.ts
+++ b/packages/streamwall-control-server/src/wsValidation.test.ts
@@ -78,7 +78,16 @@ async function connectStreamwallAndClient({
     port,
   )
   streamwallWs.send(JSON.stringify(stateMessage))
-  await delay(150)
+  // Wait for the server to have finished with the seeded state instead of
+  // sleeping: it either accepts it (the uplink becomes the state authority) or
+  // rejects it with a structured warning. Both outcomes end the seeding step,
+  // and specs here deliberately exercise each of them.
+  await logs.waitFor(
+    (entry) =>
+      entry.msg === 'Streamwall connected' ||
+      (typeof entry.msg === 'string' &&
+        entry.msg.startsWith('Rejected invalid Streamwall state')),
+  )
 
   const { ws: clientWs, client } = await redeemInviteAndConnectClient(
     app,
@@ -212,12 +221,9 @@ test('drops a malformed state update on an already-connected uplink without cras
   streamwallWs.send(
     JSON.stringify({ type: 'state', state: { ...VALID_STATE, streams: {} } }),
   )
-  await delay(150)
-
-  assert.ok(
-    logs.hasMessage('Rejected invalid Streamwall state payload'),
-    'the malformed update must be rejected with a structured warning',
-  )
+  // The rejection warning is the observable signal that the update was handled
+  // and dropped; waiting for it doubles as the assertion.
+  await logs.waitForMessage('Rejected invalid Streamwall state payload')
 
   // The session must still be alive and functional: a subsequent valid
   // command from the client is still forwarded to the (still-connected)


### PR DESCRIPTION
## Summary

The control-server integration suites boot a live server per test and paid two
avoidable costs, measured in #536: the production scrypt work factor for tokens
they never assert on (~200ms per test, four derivations), and blind `delay()`
calls that were both slow (~200ms per test) and timing-sensitive, since the
wait was not tied to any observable signal.

**Injectable work factor.** `SCRYPT_PARAMS` was a module constant; it is now
`DEFAULT_SCRYPT_PARAMS` plus a `scryptParams` option on the `Auth` factory,
passed through `initApp` alongside the other injected dependencies. It is
deliberately not reachable from the environment, so no deployment can end up
with a lowered work factor by accident, and `buildTestApp` is the only caller
that injects a cheap one. Two specs pin the production behavior: the stored
hash of a default `Auth` must be reproducible with `N=16384, r=8, p=1`, and
`initApp` must keep that default when nothing is injected. A third spec
documents that the work factor is part of the stored hash — tokens minted
under a different one no longer validate.

**Waits on observable signals.** `captureLogs` grows the `waitFor` /
`waitForMessage` pattern `recordJsonMessages` already provides: entries
captured before the wait satisfy it (no listener-attachment race) and a
bounded timeout stays the failure path. The suites now wait for the log entry
that marks the step as finished — the uplink accepting or rejecting a seeded
state, a client connecting, a send failure being caught — instead of sleeping.
Where the awaited entry *was* the assertion, the redundant `hasMessage` check
was dropped in favour of the wait itself.

The one remaining fixed delay (`wsRateLimit.test.ts`) asserts that nothing
happens within a window, which no signal can replace.

## How was this tested?

`npm run lint`, `npm run format:check`, `npm run typecheck` and `npm test`
(all workspaces) pass locally; the control-server suite is 173/173 green.

Wall-clock for `npm test --workspace streamwall-control-server`, two runs each
on the same machine:

| | Before | After |
| --- | --- | --- |
| Full control-server suite | 26.3s / 30.2s | 18.2s / 21.1s |
| `src/wsValidation.test.ts` alone | 6.0s | 2.5s |

New coverage: production-default guards for `Auth` and `initApp`, a
cross-work-factor rejection case, and `src/testHelpers.test.ts` for the new
log-capture waits (already-captured entry, later entry, substring match,
bounded timeout, independent waiters).

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests (or this PR explains why none apply)
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments

Closes #536