### PR TITLE
docs(contributing): note how to retire a stale code scanning configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,6 +200,12 @@ a PR (which only runs the `ci.yml` one) would be blocked waiting for the other
 forever. `codeql.yml` pins one explicit category for all callers instead;
 `test/ci-gate.test.mjs` guards that.
 
+If the category ever has to change, the old configuration keeps being expected
+on every pull request until it has gone unused for two weeks. Deleting its
+analyses (`DELETE /repos/{owner}/{repo}/code-scanning/analyses/{id}`, newest
+first) retires it immediately; the next run on `main` re-establishes the
+baseline under the new category.
+
 CodeQL does produce false positives here — see the `HTMLMediaElement.src` sink
 overmatch in [#301](https://github.com/NilsR0711/streamwall/issues/301). Resolve
 them per alert rather than by weakening the queries repo-wide: dismiss the alert


### PR DESCRIPTION
## Problem

Changing the CodeQL analysis category leaves the previous code scanning
configuration behind, and every pull request keeps being blocked waiting for a
result from it until it has been unused for two weeks. That happened while
landing #526 and cost an afternoon of guessing.

## Solution

Document the escape hatch next to the merge-gate description: delete the stale
configuration's analyses (newest first) and let the next run on `main`
re-establish the baseline.

## Testing

Docs-only, so no tests. `npm run format:check` and `test/ci-gate.test.mjs`
pass. The PR doubles as the first end-to-end check that the `code_scanning`
merge rule now resolves instead of hanging.

Follow-up to #476.