### PR TITLE
ci: build the control-server image for arm64 on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,12 +228,24 @@ jobs:
   #
   # The image is also started once: a container that builds but exits at
   # boot is just as broken for self-hosters, and the check costs seconds.
+  #
+  # Both architectures the release publishes (#524) are built here on native
+  # runners — `ubuntu-24.04-arm` is free for public repositories, so an
+  # arm64-breaking Dockerfile change fails the pull request instead of the
+  # tag release, where a failed leg leaves the manifest unpublished (#545).
   docker:
-    name: Docker build (control server)
+    name: Docker build (control server, ${{ matrix.platform.arch }})
     needs: changes
     if: needs.changes.outputs.docker == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform.runner }}
     timeout-minutes: 20
+    strategy:
+      # One broken architecture must not hide the state of the other.
+      fail-fast: false
+      matrix:
+        platform:
+          - { arch: amd64, runner: ubuntu-latest }
+          - { arch: arm64, runner: ubuntu-24.04-arm }
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -70,9 +70,10 @@ volume, so it survives container restarts/rebuilds; back that volume up like
 you would any other persistent data.
 
 CI covers this path: every pull request that touches the server, the web
-control client, the shared packages or `deploy/` builds the image, starts a
-container and checks it serves the control client, and validates the compose
-stack (see the `Docker build (control server)` job in
+control client, the shared packages or `deploy/` builds the image on both
+published architectures (amd64 and arm64), starts a container and checks it
+serves the control client, and validates the compose stack (see the
+`Docker build (control server, …)` jobs in
 [`.github/workflows/ci.yml`](../.github/workflows/ci.yml)). A broken
 `docker compose up -d --build` therefore blocks the merge instead of reaching
 you.


### PR DESCRIPTION
## Problem

Since #524 the release publishes the control-server image for both `linux/amd64` and `linux/arm64`, but the PR gate did not follow: the `Docker build (control server)` job still ran a plain `docker build` on `ubuntu-latest`, i.e. amd64 only.

A Dockerfile change (or a dependency with prebuilt binaries) that breaks arm64 therefore passed PR CI unnoticed and surfaced for the first time during a tag release — after the whole quality gate had already run, and with the failed leg leaving the multi-arch manifest unpublished, forcing the tag to be redone.

## Solution

Matrix the existing build + boot smoke test over `ubuntu-latest` and `ubuntu-24.04-arm`:

- native runners, free for public repositories, and the same runner the release already uses — no QEMU involved
- `fail-fast: false`, so one broken architecture does not hide the state of the other
- the job stays path-filtered via `needs.changes.outputs.docker`, so the extra leg only runs for PRs touching the server, the web client, the shared packages or `deploy/`
- `CI OK` aggregates both legs unchanged (matrix jobs roll up under the same `docker` need)

`docs/self-hosting.md` referenced the job by its old name and is updated accordingly.

## Testing

No automated tests — this is workflow configuration with no testable behaviour in the codebase. Verified instead by:

- `actionlint` 1.7.12 on the whole workflow directory: clean
- Prettier: clean
- a real native arm64 build of `packages/streamwall-control-server/Dockerfile` on an arm64 host, followed by the same container boot check the job runs — the image builds and serves the control client (HTTP 200 after ~3s)

The arm64 leg itself will be exercised by this PR's own CI run, since it touches `.github/workflows/ci.yml` (part of the `docker` path filter).

## Risks

Low. Failure mode is a red PR check, not a broken release. Worst case is added PR latency on Docker-touching changes; the amd64 leg is unchanged.

Closes #545