### PR TITLE
docs(release): explain the inherited v2.0.0-pre tags and how to prune them

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -430,6 +430,22 @@ are skipped.
 node scripts/check-release-assets.mjs
 ```
 
+Both checks anchor on the version the manifest claims rather than on the
+highest `vX.Y.Z` tag they can find. A higher tag is not proof of a newer
+release: clones made while `origin` still pointed at the project this one
+started from picked up its `v2.0.0-pre1`…`pre3` tags, which sort above the
+whole `v0.9.x` line and never had a release here (#554). They were never
+pushed to this repository, so CI and the GitHub API never saw them — but
+`git describe` and `git tag --list` in such a clone still do. Remove them by
+name:
+
+```sh
+git tag -d v2.0.0-pre1 v2.0.0-pre2 v2.0.0-pre3
+```
+
+Not with `git fetch --prune-tags`: that deletes every local tag missing from
+the remote, including deliberately local-only ones such as rollback tags.
+
 `test/changelog.test.mjs` and `test/release-please.test.mjs` run as part of
 `npm test` and fail if `CHANGELOG.md` is missing a heading for the version
 currently in `packages/streamwall/package.json`, if a hand-maintained

--- a/packages/streamwall-shared/src/githubRelease.ts
+++ b/packages/streamwall-shared/src/githubRelease.ts
@@ -14,7 +14,7 @@ interface ParsedVersion {
 
 /**
  * Parses the `MAJOR.MINOR.PATCH[-prerelease]` subset of semver the project
- * actually publishes (`v0.9.1`, `v2.0.0-pre3`). Build metadata is ignored, and
+ * actually publishes (`v0.9.1`, `v1.0.0-pre1`). Build metadata is ignored, and
  * anything that does not match returns null so callers can degrade to "no
  * update".
  */

--- a/scripts/check-release-assets.mjs
+++ b/scripts/check-release-assets.mjs
@@ -68,9 +68,10 @@ function isBefore(version, floor) {
 }
 
 // The release to inspect is the one `main` currently claims, not simply the
-// highest tag: the repository still carries `v2.0.0-pre*` tags from the
-// project it started as, which sort above the current release line but never
-// had a GitHub Release here.
+// highest tag: a tag can sort above the release line without being the
+// release this repository stands on — a prerelease tag, or a tag inherited
+// from another project and never pruned from a clone (#554). The manifest is
+// the only statement of which version `main` is meant to have shipped.
 //
 // A version whose tag was never pushed is `check-release-tag.mjs`'s finding,
 // so it is skipped here rather than reported a second time.

--- a/test/check-release-assets.test.mjs
+++ b/test/check-release-assets.test.mjs
@@ -39,9 +39,10 @@ test('selectReleaseTag picks the tag of the version main is on', () => {
   )
 })
 
-// The repository carries tags inherited from the project it started as
-// (`v2.0.0-pre3`), which sort above the current release line but never had a
-// GitHub Release here. Anchoring on the version `main` claims skips them.
+// A tag that sorts above the release line is not automatically the release
+// this repository stands on: a prerelease tag, or a tag inherited from another
+// project and left behind in a clone (#554), has no release here. Anchoring on
+// the version `main` claims skips them.
 test('selectReleaseTag ignores tags outside the current release line', () => {
   assert.deepEqual(
     selectReleaseTag({ version: '1.0.0', tags: ['v1.0.0', 'v2.0.0-pre3'] }),


### PR DESCRIPTION
## Problem

#554 asks for the inherited `v2.0.0-pre1`…`pre3` tags to be removed, because
anything that sorts `v*` tags lands on `v2.0.0-pre3` and concludes this project
is on a 2.x release line.

Checking the actual state first changed what there is to fix:

```
$ git ls-remote --tags origin
… refs/tags/v0.9.0
… refs/tags/v0.9.1
… refs/tags/v0.9.1^{}
```

The tags were never pushed to this repository. They exist only in clones made
while `origin` still pointed at the project this one started from — `git fetch`
never deletes tags, so they have persisted there ever since. CI checks out with
`fetch-depth: 0` from this remote and has therefore never seen them, and the
GitHub API cannot report a release for a tag it does not have. The trap is real,
but it is a local-clone trap, not a repository one, and no commit can delete a
tag out of someone else's clone.

## Solution

- Removed the three tags from the local clone this was found in (`git tag -d`).
- Documented the situation and the removal command in `CONTRIBUTING.md`, next to
  the release-tag checks that the trap first surfaced in (#533 / #550), including
  the warning that `git fetch --prune-tags` is the wrong tool: it deletes every
  local tag missing from the remote, including deliberately local-only ones such
  as rollback tags.
- Restated why `scripts/check-release-assets.mjs` anchors on the manifest
  version. The issue suggested reconsidering the anchor once the tags were gone;
  it is kept, and the reasoning is now general rather than tied to these three
  tags. A higher tag is not proof of a newer release — a prerelease tag, or a tag
  pushed ahead of `main`, would mislead the check just as well, and the manifest
  is the only statement of which version `main` claims to have shipped.
- Refreshed the two other comments that cited `v2.0.0-pre3` as a tag this project
  carries or publishes (`test/check-release-assets.test.mjs`,
  `packages/streamwall-shared/src/githubRelease.ts`).

## Testing

Comment and documentation changes only — no behaviour change, so no tests were
added. `selectReleaseTag`'s existing coverage for tags outside the release line
is unchanged and still passes. Full gate green locally: `prettier --check`,
`eslint .`, `typecheck`, `npm test` (173 + 348 tests).

## Risks

None to the shipped code. The one operational note is that everyone else with an
old clone still carries the three tags until they run the documented command.

Closes #554
