### PR TITLE
fix(control-ui): derive the grid focus ring from the tile colour

### DIFF
--- a/packages/streamwall-control-ui/src/GridInput.test.tsx
+++ b/packages/streamwall-control-ui/src/GridInput.test.tsx
@@ -1,10 +1,10 @@
 import { type ComponentChildren, render } from 'preact'
 import { act } from 'preact/test-utils'
-import { asCellIdx } from 'streamwall-shared'
+import { asCellIdx, Color, focusRingColors, idColor } from 'streamwall-shared'
 import { StyleSheetManager } from 'styled-components'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 
-import { GridInput } from './GridInput.tsx'
+import { cellColor, GridInput } from './GridInput.tsx'
 import { GlobalStyle } from './globalStyle.tsx'
 
 let container: HTMLDivElement | undefined
@@ -137,6 +137,11 @@ describe('GridInput', () => {
     expect(input.getAttribute('data-idx')).toBe('3')
   })
 
+  test('paints the tile lighter while it is highlighted', () => {
+    expect(cellColor(idColor('stream-1')).lightness()).toBe(75)
+    expect(cellColor(idColor('stream-1'), true).lightness()).toBe(90)
+  })
+
   // The cell used to draw its own hardcoded `outline: 1px solid black` /
   // `box-shadow: ... black inset` on `:focus`, which fired on pointer
   // interaction too and out-specified the shared `:focus-visible` ring added
@@ -150,15 +155,51 @@ describe('GridInput', () => {
       expect(collectCss()).not.toMatch(/:focus(?!-visible)/)
     })
 
-    test('does not hardcode a focus colour, leaving the shared accent ring to apply', () => {
-      renderInput()
+    // The ring is drawn outside the cell, so it lands on the neighbouring
+    // tiles - whose colour is whatever their stream id hashes to. The accent
+    // token is a red, leaving it at roughly 2:1 against a red-ish neighbour
+    // (#557), so the grid derives a contrast-safe pair from the tile while
+    // keeping the shared rule's shape (2px ring plus 4px halo).
+    test('recolours the shared ring from the tile instead of using the accent', () => {
+      renderInput({ spaceValue: 'stream-1' })
 
       const rule = ownFocusVisibleRule(collectCss())
+      const { ring, halo } = focusRingColors(cellColor(idColor('stream-1')))
 
       expect(rule).toBeDefined()
-      expect(rule!.body).not.toMatch(/black/)
+      expect(rule!.body).not.toMatch(/var\(--accent/)
+      // Only the colour is overridden; the width/style stay with the shared
+      // rule, so an unwanted `outline` shorthand would drop its 2px ring.
       expect(rule!.body).not.toMatch(/outline:/)
-      expect(rule!.body).not.toMatch(/box-shadow:/)
+      expect(rule!.body.toLowerCase()).toMatch(
+        new RegExp(`outline-color:\\s*${ring.toLowerCase()}`),
+      )
+      expect(rule!.body.toLowerCase()).toMatch(
+        new RegExp(`box-shadow:\\s*0 0 0 4px\\s*${halo.toLowerCase()}`),
+      )
+    })
+
+    test('keeps the derived ring above 3:1 against every tile the id space can paint', () => {
+      const ids = [
+        '',
+        'stream-1',
+        'streamwall',
+        'https://twitch.tv/somechannel',
+        ...Array.from({ length: 64 }, (_, i) => `id-${i}`),
+      ]
+      const tiles = ids.flatMap((id) => [
+        cellColor(idColor(id)),
+        cellColor(idColor(id), true),
+      ])
+
+      for (const tile of tiles) {
+        const { ring } = focusRingColors(tile)
+        // The ring sits on the neighbours, so it has to clear 3:1 against
+        // every colour the grid can paint - not just against its own cell.
+        for (const neighbour of tiles) {
+          expect(neighbour.contrast(Color(ring))).toBeGreaterThanOrEqual(3)
+        }
+      }
     })
 
     test('confines the idle cell border to :not(:focus-visible) so it cannot beat the shared ring', () => {
@@ -184,7 +225,7 @@ describe('GridInput', () => {
       expect(rule!.body).toMatch(/z-index:\s*100/)
     })
 
-    test('is covered by the shared accent ring from GlobalStyle', () => {
+    test('is covered by the shared ring from GlobalStyle, whose shape it keeps', () => {
       renderWithStyles(
         <>
           <GlobalStyle />

--- a/packages/streamwall-control-ui/src/GridInput.tsx
+++ b/packages/streamwall-control-ui/src/GridInput.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'preact/hooks'
 import {
   type CellIdx,
   Color,
+  focusRingColors,
   idColor,
   roleCan,
   type StreamwallRole,
@@ -16,6 +17,15 @@ const StyledGridInputContainer = styled.div`
   touch-action: none;
 `
 
+/**
+ * The colour a cell is actually painted with: the id-derived hue lightened to
+ * the grid's tile lightness. Shared by the background and the focus ring, so
+ * the ring is derived from what the eye sees rather than the raw id colour.
+ */
+export function cellColor(color: ColorInstance, isHighlighted?: boolean) {
+  return Color(color).lightness(isHighlighted ? 90 : 75)
+}
+
 const StyledGridInput = styled(LazyChangeInput)<{
   $color: ColorInstance
   $isHighlighted?: boolean
@@ -25,9 +35,7 @@ const StyledGridInput = styled(LazyChangeInput)<{
   border: none;
   padding: 0;
   background: ${({ $color, $isHighlighted }) =>
-    $isHighlighted
-      ? Color($color).lightness(90).hsl().string()
-      : Color($color).lightness(75).hsl().string()};
+    cellColor($color, $isHighlighted).hsl().string()};
   font-size: 20px;
   text-align: center;
 
@@ -42,10 +50,21 @@ const StyledGridInput = styled(LazyChangeInput)<{
   /* The shared ring is drawn outside the cell (outline-offset plus a halo), so
      the focused cell has to rise above its neighbours or the ring gets clipped
      by them. z-index only applies to positioned elements, hence the
-     position. */
+     position.
+
+     Being drawn outside also means the ring lands on the neighbouring tiles,
+     whose colour is whatever their stream id hashes to - so the accent token
+     can drop to ~2:1 against a red-ish neighbour. Only the colours are
+     overridden here; width, offset and halo size stay with the shared rule in
+     globalStyle.tsx so the grid keeps the same affordance (see #557). */
   &:focus-visible {
     position: relative;
     z-index: 100;
+    outline-color: ${({ $color, $isHighlighted }) =>
+      focusRingColors(cellColor($color, $isHighlighted)).ring};
+    box-shadow: 0 0 0 4px
+      ${({ $color, $isHighlighted }) =>
+        focusRingColors(cellColor($color, $isHighlighted)).halo};
   }
 `
 

--- a/packages/streamwall-shared/src/colors.test.ts
+++ b/packages/streamwall-shared/src/colors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { Color, hashText, idColor } from './colors.ts'
+import { Color, focusRingColors, hashText, idColor } from './colors.ts'
 
 describe('hashText', () => {
   it('returns a fixed hash for a fixed input', () => {
@@ -90,5 +90,48 @@ describe('idColor', () => {
   // fast path fails, throwing "Unable to parse color from object".
   it('returns an instance recognized by the re-exported Color constructor', () => {
     expect(idColor('streamwall')).toBeInstanceOf(Color)
+  })
+})
+
+// The grid draws the shared `:focus-visible` ring with `outline-offset`, so
+// the ring lands on the *neighbouring* tiles rather than on a neutral surface.
+// A tile's colour comes from its stream id, so the accent token cannot
+// guarantee the 3:1 WCAG 2.4.11 asks for — a red-ish tile leaves the red
+// accent at roughly 2:1 (#557).
+describe('focusRingColors', () => {
+  it('picks the black/white pair with the better contrast against the tile', () => {
+    expect(focusRingColors(Color('white'))).toEqual({
+      ring: '#000000',
+      halo: '#FFFFFF',
+    })
+    expect(focusRingColors(Color('black'))).toEqual({
+      ring: '#FFFFFF',
+      halo: '#000000',
+    })
+  })
+
+  it('keeps the ring and halo contrasting against each other', () => {
+    const { ring, halo } = focusRingColors(idColor('streamwall'))
+    expect(Color(ring).contrast(Color(halo))).toBe(21)
+  })
+
+  it('clears 3:1 against the tile for every colour the id space can produce', () => {
+    const ids = [
+      '',
+      'a',
+      'stream-1',
+      'streamwall',
+      'dQw4w9WgXcQ',
+      'https://twitch.tv/somechannel',
+      ...Array.from({ length: 64 }, (_, i) => `id-${i}`),
+    ]
+    for (const id of ids) {
+      // The grid paints tiles at lightness 75, or 90 while highlighted.
+      for (const lightness of [75, 90]) {
+        const tile = idColor(id).lightness(lightness)
+        const { ring } = focusRingColors(tile)
+        expect(tile.contrast(Color(ring))).toBeGreaterThanOrEqual(3)
+      }
+    }
   })
 })

--- a/packages/streamwall-shared/src/colors.ts
+++ b/packages/streamwall-shared/src/colors.ts
@@ -39,3 +39,27 @@ export function idColor(id: string) {
   const sPart = hashText(id, 40)
   return Color({ h, s: 20 + sPart, l: 50 })
 }
+
+/**
+ * Contrast-safe focus ring colours for a surface painted with an id-derived
+ * colour (see idColor above).
+ *
+ * The shared `:focus-visible` affordance uses the accent token, which works
+ * everywhere it sits on a neutral surface. In the grid the ring is drawn with
+ * `outline-offset` onto the *neighbouring* cells, whose colour is whatever the
+ * stream id hashes to — so a red-ish tile can leave the red accent at roughly
+ * 2:1, below the 3:1 WCAG 2.4.11 (Focus Appearance) asks for (#557).
+ *
+ * Picking the better of black/white clears 3:1 against every colour the id
+ * space can paint, and the pair contrasts against itself, so both edges of the
+ * indicator stay legible.
+ */
+export function focusRingColors(tile: ReturnType<typeof Color>) {
+  const black = Color('black')
+  const white = Color('white')
+  const ringIsBlack = tile.contrast(black) >= tile.contrast(white)
+  return {
+    ring: (ringIsBlack ? black : white).hex(),
+    halo: (ringIsBlack ? white : black).hex(),
+  }
+}


### PR DESCRIPTION
## Summary

The shared `:focus-visible` affordance from `globalStyle.tsx` draws a 2px accent
ring with `outline-offset: 2px` — outside the focused element. Grid cells are
laid out edge to edge (`ControlGrid.tsx`, no gaps), so that ring lands on the
*neighbouring* tiles, whose colour is derived from the stream id (`idColor` →
`hsl(h, 20-60%, 50%)`, painted at lightness 75, or 90 while highlighted).

The accent is a red, so against a red-ish neighbour (e.g. `hsl(0, 60%, 75%)`)
the ring sits at roughly 2:1 — below the 3:1 WCAG 2.4.11 (Focus Appearance)
asks for. The `--accent-soft` halo is a near-white tint in the light theme and
washes out on a light tile rather than rescuing it. Every other surface the
shared rule covers sits on the neutral `--surface` / `--cell-bg` tokens, where
the accent has ample contrast; the grid is the one place where the neighbour's
colour is arbitrary.

## Technical solution

- `focusRingColors(tile)` in `streamwall-shared/src/colors.ts` picks whichever
  of black/white contrasts better with the tile and uses the other one as the
  halo. That pair clears 3:1 against every colour the id space can paint (tiles
  are always lightness 75/90, so it resolves to black today, but the derivation
  keeps it correct if that ever changes), and the two colours contrast against
  each other so both edges of the indicator stay legible.
- The grid cell overrides only `outline-color` and the halo colour in its
  `:focus-visible` rule. Width, offset and halo size stay with the shared rule,
  so the grid keeps the same affordance shape as the rest of the UI — this is
  deliberately *not* a revert of #544, only a recolour of the one surface where
  the measured contrast is not guaranteed.
- The tile lightness moved into an exported `cellColor()` helper so the
  background and the focus ring derive from the same painted colour instead of
  duplicating the 75/90 constants.

Closes #557

## How was this tested?

- `packages/streamwall-shared/src/colors.test.ts`: `focusRingColors` picks the
  better black/white pair, keeps ring and halo at 21:1 against each other, and
  clears 3:1 against 70 ids × both tile lightnesses.
- `packages/streamwall-control-ui/src/GridInput.test.tsx`: the emitted
  `:focus-visible` rule no longer references `var(--accent…)`, carries no
  `outline` shorthand (which would drop the shared 2px ring), and sets
  `outline-color` / `box-shadow` to the derived pair. A second test sweeps the
  id space and asserts the derived ring clears 3:1 against *every* tile colour,
  not just its own cell — the ring sits on the neighbours. The existing test
  that the shared GlobalStyle rule still matches the cell is kept.
- `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm test` green
  locally.

## Risks / breaking changes

None. Visual-only change confined to the grid cells' keyboard focus ring; the
pointer-focus behaviour and the idle cell divider are untouched.

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments