### PR TITLE
fix(control-ui): adopt the shared focus-visible ring for the sidebar inputs

### DIFF
--- a/packages/streamwall-control-ui/src/globalStyle.test.tsx
+++ b/packages/streamwall-control-ui/src/globalStyle.test.tsx
@@ -4,6 +4,7 @@ import { StyleSheetManager } from 'styled-components'
 import { afterEach, describe, expect, test } from 'vitest'
 import { StreamList } from './Sidebar.tsx'
 import { GlobalStyle } from './globalStyle.tsx'
+import { AppShell } from './layout.tsx'
 
 let container: HTMLDivElement | undefined
 let styleTarget: HTMLDivElement | undefined
@@ -107,7 +108,92 @@ describe('GlobalStyle', () => {
       true,
     )
   })
+
+  // The sidebar text inputs and selects used to carry their own ring
+  // (`outline: none` plus a border-colour change and a halo) keyed on `:focus`,
+  // so it fired on pointer interaction and suppressed the shared outline
+  // (see #553). They now inherit the shared affordance like every other
+  // control, so no bare `:focus` rule may survive anywhere in the sheet.
+  test('emits no bare :focus rule, so pointer interaction draws no keyboard ring', () => {
+    renderWithStyles(<GlobalStyle />)
+
+    expect(bareFocusSelectors(collectCss())).toEqual([])
+  })
+
+  test('never suppresses the shared outline', () => {
+    renderWithStyles(<GlobalStyle />)
+
+    expect(collectCss()).not.toMatch(/outline:\s*none/)
+  })
+
+  test('leaves the ring for the sidebar inputs and selects entirely to the shared rule', () => {
+    renderWithStyles(<GlobalStyle />)
+
+    const bodies = ruleBodiesMatching(
+      collectCss(),
+      /\.stream-list\s+(input|select)/,
+    )
+
+    expect(bodies.length).toBeGreaterThan(0)
+    for (const body of bodies) {
+      expect(body).not.toMatch(/outline/)
+      expect(body).not.toMatch(/box-shadow/)
+    }
+  })
+
+  // The sidebar is the scrolling region of the shell (`overflow-y: auto`, which
+  // clips horizontally too), and its filter input spans the full width. The
+  // shared ring is drawn *outside* the control, so without horizontal room in
+  // the scroll container its left and right edges would be clipped away.
+  test('reserves enough horizontal room in the scrolling sidebar for the ring', () => {
+    renderWithStyles(
+      <>
+        <GlobalStyle />
+        <AppShell />
+      </>,
+    )
+
+    const css = collectCss()
+    const rule = focusVisibleRule(css)
+    expect(rule).toBeDefined()
+
+    const sidebar = /\.stream-list\s*{([^}]*)}/.exec(css)
+    expect(sidebar, 'app shell declares no sidebar rule').not.toBeNull()
+
+    const padding = /padding-inline:\s*(\d+)px/.exec(sidebar![1])
+    expect(padding, 'sidebar reserves no inline padding').not.toBeNull()
+    expect(Number(padding![1])).toBeGreaterThanOrEqual(ringExtent(rule!.body))
+  })
 })
+
+/**
+ * How far the shared ring extends beyond the control's border box: the outline
+ * (offset plus its own width) or the soft halo, whichever reaches further.
+ */
+function ringExtent(body: string): number {
+  const outlineWidth = /outline:\s*(\d+)px/.exec(body)
+  const outlineOffset = /outline-offset:\s*(\d+)px/.exec(body)
+  const halo = /box-shadow:\s*0\s+0\s+0\s+(\d+)px/.exec(body)
+  return Math.max(
+    Number(outlineWidth?.[1] ?? 0) + Number(outlineOffset?.[1] ?? 0),
+    Number(halo?.[1] ?? 0),
+  )
+}
+
+/** Every selector in the sheet keyed on `:focus` rather than `:focus-visible`. */
+function bareFocusSelectors(css: string): string[] {
+  return Array.from(css.matchAll(/([^{}]*){[^}]*}/g))
+    .flatMap(([, selectorList]) => selectorList.split(','))
+    .map((selector) => selector.trim())
+    .filter((selector) => /:focus(?!-visible)/.test(selector))
+}
+
+/** Bodies of every rule whose selector list matches `selector`. */
+function ruleBodiesMatching(css: string, selector: RegExp): string[] {
+  return Array.from(css.matchAll(/([^{}]*){([^}]*)}/g))
+    .filter(([, selectorList]) => selector.test(selectorList))
+    .map(([, , body]) => body)
+}
 
 function collectCss(): string {
   return Array.from(document.querySelectorAll('style'))

--- a/packages/streamwall-control-ui/src/globalStyle.tsx
+++ b/packages/streamwall-control-ui/src/globalStyle.tsx
@@ -97,13 +97,16 @@ export const GlobalStyle = createGlobalStyle`
 
   * { box-sizing: border-box; }
 
-  /* Shared keyboard focus affordance. Text inputs get their accent ring from
-     the .stream-list rules below, but the custom-coloured buttons (sidebar
-     stream handle, favorite star, grid preset buttons) used to fall back to
-     the user-agent ring, which is easily lost against their own background
-     (see #508). The outline sits outside the control - so it stays visible
-     whatever the control's colours are - and the soft halo matches the ring
-     the inputs draw. */
+  /* Shared keyboard focus affordance for every focusable control: the
+     custom-coloured buttons (sidebar stream handle, favorite star, grid preset
+     buttons) used to fall back to the user-agent ring, which is easily lost
+     against their own background (see #508). The outline sits outside the
+     control - so it stays visible whatever the control's colours are - and the
+     soft halo widens it.
+
+     The sidebar text inputs and selects used to draw a bespoke ring of their
+     own on :focus, which fired on pointer interaction as well and cleared
+     this outline; they now inherit this rule like everything else (#553). */
   :focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 2px;
@@ -151,12 +154,6 @@ export const GlobalStyle = createGlobalStyle`
     padding: 7px 10px;
   }
   .stream-list input::placeholder { color: var(--text-faint); }
-  .stream-list input:focus,
-  .stream-list select:focus {
-    outline: none;
-    border-color: var(--accent);
-    box-shadow: 0 0 0 3px var(--accent-soft);
-  }
   .stream-list .filter-input {
     width: 100%;
     margin-bottom: 4px;

--- a/packages/streamwall-control-ui/src/layout.tsx
+++ b/packages/streamwall-control-ui/src/layout.tsx
@@ -43,6 +43,12 @@ export const AppShell = styled.div`
 
   > .stream-list {
     flex: 0 0 340px;
+    /* The sidebar is the scrolling region (overflow-y: auto), and overflow
+       clipping applies on both axes. Its filter input spans the full width and
+       the shared :focus-visible ring is drawn outside the control, so without
+       this much horizontal room the ring's left and right edges would be
+       clipped away (see #553). */
+    padding-inline: 6px;
   }
 
   @media (max-width: ${NARROW_BREAKPOINT}px) {


### PR DESCRIPTION
## Problem

`globalStyle.tsx` still gave the sidebar text inputs and selects a bespoke focus ring:

```css
.stream-list input:focus,
.stream-list select:focus {
  outline: none;
  border-color: var(--accent);
  box-shadow: 0 0 0 3px var(--accent-soft);
}
```

Two issues (#553):

- It matched `:focus`, not `:focus-visible`, so the keyboard ring also appeared on plain pointer interaction — the same inconsistency #508 / PR #528 fixed for buttons and #531 / PR #544 fixed for grid cells.
- `outline: none` actively suppressed the shared `:focus-visible` outline. What the inputs got instead was a border-*colour* change plus a halo: the border already exists in the idle state, so only its hue changed — a weaker affordance than a real outline for WCAG 2.4.11 (Focus Appearance).

The sidebar was the last place in the control UI with a divergent keyboard affordance.

## Solution

The bespoke rule is gone; the inputs and selects inherit the shared `:focus-visible` ring like every other control. One detail makes that work:

- **The scrolling sidebar reserves 6px of inline padding.** `.stream-list` is the shell's scroll region (`overflow-y: auto`, and overflow clipping applies on both axes), and its filter input spans the full width. The shared ring is drawn *outside* the control (`outline-offset: 2px` plus a 4px halo), so without that room the ring's left and right edges would be clipped away. `box-sizing: border-box` plus the existing `flex: 0 0 340px` basis keeps the sidebar's outer width unchanged.

## Architecture decisions

- **Adopt rather than keep a text-field variant.** The issue offered the alternative of keeping the inset halo for text fields and merely switching the selector to `:focus-visible`. That would preserve a second, divergent affordance for no benefit — the shared ring already contains a halo, and a single source of truth in `globalStyle.tsx` is the point of #508.
- **The padding lives on `AppShell > .stream-list`** (layout.tsx), next to the flex basis that already shapes the region, rather than in the global sheet where it would compete with the styled-component class by injection order.

## Testing

New `globalStyle` tests, in the style of the existing focus-affordance ones:

- the sheet emits no bare `:focus` selector anywhere, so pointer interaction draws no keyboard ring
- no rule anywhere clears the outline (`outline: none`)
- every `.stream-list input` / `select` rule is free of `outline` / `box-shadow`, leaving the ring entirely to the shared rule
- the sidebar reserves inline padding at least as wide as the ring extent, derived from the shared rule's own outline width/offset and halo spread rather than hardcoded

Quality gate green locally: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (all workspaces; 352 control-ui tests). The repo has no root `build` script — CI covers the per-package builds.

## Risks / breaking changes

None functionally. Visual change only: focused sidebar inputs now show the accent outline instead of a recoloured border, and no longer show a ring on click. The sidebar's usable content width shrinks by 12px at an unchanged outer width. No test or E2E selector depends on the removed rule.

Closes #553
