### PR TITLE
test(control-server): stop test files leaking rate-limit env overrides into each other

### DIFF
--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -15,6 +15,7 @@ import {
   getRateLimitConfig,
   getWsMessageLimitConfig,
   parseTrustProxy,
+  type RateLimitConfig,
 } from './config.ts'
 import {
   type AppContext,
@@ -54,6 +55,7 @@ export async function initApp({
   db: injectedDb,
   logLevel,
   logStream,
+  rateLimit: injectedRateLimit,
   sentryEnabled: injectedSentryEnabled,
   sentryClient,
   scryptParams,
@@ -70,6 +72,13 @@ export async function initApp({
   logLevel?: LogLevel
   /** Test-only sink for log output; defaults to pino's stdout destination. */
   logStream?: { write(line: string): void }
+  /**
+   * Overrides individual per-IP rate limits, so specs that are not about
+   * throttling widen them without writing the process-wide environment (which
+   * would leak into whichever file runs next). Unset fields keep the value
+   * `getRateLimitConfig()` reads from the environment.
+   */
+  rateLimit?: Partial<RateLimitConfig>
   /** Test-only override so specs can exercise Sentry-enabled paths without a real DSN. */
   sentryEnabled?: boolean
   /** Test-only override for the client `captureException(...)` reports to. */
@@ -121,7 +130,7 @@ export async function initApp({
     app.log,
   )
 
-  const rateLimitConfig = getRateLimitConfig()
+  const rateLimitConfig = { ...getRateLimitConfig(), ...injectedRateLimit }
 
   const ctx: AppContext = {
     log: app.log,

--- a/packages/streamwall-control-server/src/logging.test.ts
+++ b/packages/streamwall-control-server/src/logging.test.ts
@@ -10,6 +10,7 @@ import {
   mintUplinkToken,
   redeemInviteAndConnectClient,
   VALID_STATE,
+  WIDE_RATE_LIMITS,
 } from './testHelpers.ts'
 
 const BASE_URL = 'http://localhost:3000'
@@ -23,11 +24,12 @@ const WARN = 40
  * an authenticated Streamwall uplink and seeds it with a valid state.
  */
 async function bootWithCapturedLogs() {
-  process.env.STREAMWALL_RATE_LIMIT_MAX = '10000'
-  process.env.STREAMWALL_AUTH_RATE_LIMIT_MAX = '10000'
-
   const logs = captureLogs()
-  const { app, auth } = await buildTestApp({ baseURL: BASE_URL, logs })
+  const { app, auth } = await buildTestApp({
+    baseURL: BASE_URL,
+    logs,
+    rateLimit: WIDE_RATE_LIMITS,
+  })
   after(() => app.close())
   const port = await listenTestApp(app)
 

--- a/packages/streamwall-control-server/src/multiplexing.test.ts
+++ b/packages/streamwall-control-server/src/multiplexing.test.ts
@@ -23,6 +23,7 @@ import {
   mintUplinkToken,
   redeemInviteAndConnectClient,
   VALID_STATE,
+  WIDE_RATE_LIMITS,
 } from './testHelpers.ts'
 
 const BASE_URL = 'http://localhost:3000'
@@ -58,11 +59,12 @@ function applyDelta(state: StreamwallState, delta: Delta): StreamwallState {
  * `/client/ws` socket.
  */
 async function bootServerWithUplink() {
-  process.env.STREAMWALL_RATE_LIMIT_MAX = '10000'
-  process.env.STREAMWALL_AUTH_RATE_LIMIT_MAX = '10000'
-
   const logs = captureLogs()
-  const { app, auth } = await buildTestApp({ baseURL: BASE_URL, logs })
+  const { app, auth } = await buildTestApp({
+    baseURL: BASE_URL,
+    logs,
+    rateLimit: WIDE_RATE_LIMITS,
+  })
   after(() => app.close())
   const port = await listenTestApp(app)
 
@@ -226,9 +228,12 @@ test("an admin's state broadcast includes auth while an operator's does not", as
 
 /** Boots a live server and mints a Streamwall uplink token, without connecting yet. */
 async function startUplinkServer() {
-  process.env.STREAMWALL_RATE_LIMIT_MAX = '10000'
   const logs = captureLogs()
-  const { app, auth } = await buildTestApp({ baseURL: BASE_URL, logs })
+  const { app, auth } = await buildTestApp({
+    baseURL: BASE_URL,
+    logs,
+    rateLimit: WIDE_RATE_LIMITS,
+  })
   after(() => app.close())
   const port = await listenTestApp(app)
   const { base, secret } = await mintUplinkToken(auth, port)

--- a/packages/streamwall-control-server/src/rateLimit.test.ts
+++ b/packages/streamwall-control-server/src/rateLimit.test.ts
@@ -1,11 +1,13 @@
 import assert from 'node:assert/strict'
-import { test } from 'node:test'
+import { after, test } from 'node:test'
 import { parseTrustProxy } from './index.ts'
-import { buildTestApp } from './testHelpers.ts'
+import { buildTestApp, setEnvForTest, WIDE_RATE_LIMITS } from './testHelpers.ts'
 
 test('rate-limits the invite auth route with a strict per-route budget', async () => {
-  process.env.STREAMWALL_RATE_LIMIT_MAX = '100'
-  process.env.STREAMWALL_AUTH_RATE_LIMIT_MAX = '3'
+  setEnvForTest({
+    STREAMWALL_RATE_LIMIT_MAX: '100',
+    STREAMWALL_AUTH_RATE_LIMIT_MAX: '3',
+  })
   const { app } = await buildTestApp()
 
   const codes: number[] = []
@@ -29,8 +31,10 @@ test('rate-limits the invite auth route with a strict per-route budget', async (
 })
 
 test('applies a global rate limit to non-auth routes', async () => {
-  process.env.STREAMWALL_RATE_LIMIT_MAX = '4'
-  delete process.env.STREAMWALL_AUTH_RATE_LIMIT_MAX
+  setEnvForTest({
+    STREAMWALL_RATE_LIMIT_MAX: '4',
+    STREAMWALL_AUTH_RATE_LIMIT_MAX: undefined,
+  })
   const { app } = await buildTestApp()
 
   const codes: number[] = []
@@ -49,8 +53,10 @@ test('applies a global rate limit to non-auth routes', async () => {
 })
 
 test('the auth route budget is stricter than the global budget', async () => {
-  process.env.STREAMWALL_RATE_LIMIT_MAX = '50'
-  process.env.STREAMWALL_AUTH_RATE_LIMIT_MAX = '2'
+  setEnvForTest({
+    STREAMWALL_RATE_LIMIT_MAX: '50',
+    STREAMWALL_AUTH_RATE_LIMIT_MAX: '2',
+  })
   const { app } = await buildTestApp()
 
   const inviteCodes: number[] = []
@@ -81,9 +87,11 @@ test('parseTrustProxy is off by default and accepts boolean-ish or proxy lists',
 })
 
 test('with trustProxy, distinct X-Forwarded-For clients keep separate rate-limit budgets', async () => {
-  process.env.STREAMWALL_RATE_LIMIT_MAX = '2'
-  delete process.env.STREAMWALL_AUTH_RATE_LIMIT_MAX
-  process.env.STREAMWALL_TRUST_PROXY = 'true'
+  setEnvForTest({
+    STREAMWALL_RATE_LIMIT_MAX: '2',
+    STREAMWALL_AUTH_RATE_LIMIT_MAX: undefined,
+    STREAMWALL_TRUST_PROXY: 'true',
+  })
   const { app } = await buildTestApp()
 
   for (let i = 0; i < 2; i++) {
@@ -114,5 +122,48 @@ test('with trustProxy, distinct X-Forwarded-For clients keep separate rate-limit
   )
 
   await app.close()
-  delete process.env.STREAMWALL_TRUST_PROXY
+})
+
+test('an injected rate limit takes precedence over the environment', async () => {
+  setEnvForTest({
+    STREAMWALL_RATE_LIMIT_MAX: '1',
+    STREAMWALL_AUTH_RATE_LIMIT_MAX: '1',
+  })
+  const { app } = await buildTestApp({ rateLimit: WIDE_RATE_LIMITS })
+  after(() => app.close())
+
+  for (let i = 0; i < 5; i++) {
+    const res = await app.inject({ method: 'GET', url: '/' })
+    assert.notEqual(
+      res.statusCode,
+      429,
+      'the injected budget should replace the (much stricter) env one',
+    )
+  }
+})
+
+test('a partial injected rate limit still reads the rest from the environment', async () => {
+  setEnvForTest({
+    STREAMWALL_RATE_LIMIT_MAX: '10000',
+    STREAMWALL_AUTH_RATE_LIMIT_MAX: '2',
+  })
+  const { app } = await buildTestApp({ rateLimit: { globalMax: 10000 } })
+  after(() => app.close())
+
+  const codes: number[] = []
+  for (let i = 0; i < 3; i++) {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/invite/x',
+      headers: { 'content-type': 'application/json' },
+      payload: { token: 'y' },
+    })
+    codes.push(res.statusCode)
+  }
+
+  assert.equal(
+    codes[2],
+    429,
+    `expected the env auth budget of 2 to apply, got ${codes}`,
+  )
 })

--- a/packages/streamwall-control-server/src/sentryReporting.test.ts
+++ b/packages/streamwall-control-server/src/sentryReporting.test.ts
@@ -12,6 +12,7 @@ import {
   listenTestApp,
   redeemInviteAndConnectClient,
   VALID_STATE,
+  WIDE_RATE_LIMITS,
 } from './testHelpers.ts'
 
 /** Encodes a full-state update from a fresh doc mutated by `mutate`. */
@@ -58,9 +59,6 @@ function fakeSentryClient(): SentryCaptureClient & { calls: unknown[] } {
 }
 
 test('a synchronous ws.send() failure while broadcasting a state delta is reported to Sentry', async (t) => {
-  process.env.STREAMWALL_RATE_LIMIT_MAX = '10000'
-  process.env.STREAMWALL_AUTH_RATE_LIMIT_MAX = '10000'
-
   const sentryClient = fakeSentryClient()
   const logs = captureLogs()
   const { app, auth } = await buildTestApp({
@@ -68,6 +66,7 @@ test('a synchronous ws.send() failure while broadcasting a state delta is report
     sentryEnabled: true,
     sentryClient,
     logs,
+    rateLimit: WIDE_RATE_LIMITS,
   })
   t.after(() => app.close())
   const port = await listenTestApp(app)
@@ -124,9 +123,6 @@ test('a synchronous ws.send() failure while broadcasting a state delta is report
 })
 
 test('a synchronous ws.send() failure while relaying a doc update is reported to Sentry and logged locally for both the uplink and connected clients', async (t) => {
-  process.env.STREAMWALL_RATE_LIMIT_MAX = '10000'
-  process.env.STREAMWALL_AUTH_RATE_LIMIT_MAX = '10000'
-
   const sentryClient = fakeSentryClient()
   const logs = captureLogs()
   const { app, auth } = await buildTestApp({
@@ -134,6 +130,7 @@ test('a synchronous ws.send() failure while relaying a doc update is reported to
     sentryEnabled: true,
     sentryClient,
     logs,
+    rateLimit: WIDE_RATE_LIMITS,
   })
   t.after(() => app.close())
   const port = await listenTestApp(app)

--- a/packages/streamwall-control-server/src/testEnvHygiene.test.ts
+++ b/packages/streamwall-control-server/src/testEnvHygiene.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const SRC_DIR = path.dirname(fileURLToPath(import.meta.url))
+
+/**
+ * Bare writes to the process-wide rate-limit variables leak into every file
+ * that runs afterwards, making outcomes order-dependent and blocking a higher
+ * `--test-concurrency`. Specs widen the limits through `buildTestApp`'s
+ * injected `rateLimit` option, and the few that must exercise the environment
+ * itself go through `setEnvForTest`, which restores the previous values.
+ */
+const FORBIDDEN_ASSIGNMENT =
+  /(?:delete\s+process\.env\.STREAMWALL_(?:AUTH_)?RATE_LIMIT_(?:MAX|WINDOW)|process\.env\.STREAMWALL_(?:AUTH_)?RATE_LIMIT_(?:MAX|WINDOW)\s*=(?!=))/
+
+function testFiles(): string[] {
+  return readdirSync(SRC_DIR, { recursive: true, encoding: 'utf8' })
+    .filter((entry) => entry.endsWith('.test.ts'))
+    .map((entry) => path.join(SRC_DIR, entry))
+}
+
+test('no spec writes the rate-limit env vars without restoring them', () => {
+  const offenders = testFiles().filter((file) =>
+    readFileSync(file, 'utf8')
+      .split('\n')
+      .some((line) => FORBIDDEN_ASSIGNMENT.test(line)),
+  )
+
+  assert.deepEqual(
+    offenders.map((file) => path.relative(SRC_DIR, file)),
+    [],
+    'use buildTestApp({ rateLimit }) or setEnvForTest() instead of assigning the rate-limit env vars directly',
+  )
+})

--- a/packages/streamwall-control-server/src/testHelpers.test.ts
+++ b/packages/streamwall-control-server/src/testHelpers.test.ts
@@ -1,8 +1,16 @@
 import assert from 'node:assert/strict'
+import process from 'node:process'
 import { test } from 'node:test'
 
 import { DEFAULT_SCRYPT_PARAMS } from './auth.ts'
-import { captureLogs, TEST_SCRYPT_PARAMS } from './testHelpers.ts'
+import {
+  captureLogs,
+  setEnvForTest,
+  TEST_SCRYPT_PARAMS,
+} from './testHelpers.ts'
+
+/** Snapshot taken before any override, so the restore assertion is exact. */
+const RATE_LIMIT_MAX_AT_LOAD = process.env.STREAMWALL_RATE_LIMIT_MAX
 
 /** Serializes a log entry the way pino writes it to the capture stream. */
 function line(msg: string, fields: Record<string, unknown> = {}): string {
@@ -72,4 +80,20 @@ test('tests derive token hashes with a cheaper work factor than production', () 
   // The whole point of the injected parameters: a live-server suite must not
   // pay the production cost, while production keeps it.
   assert.ok(TEST_SCRYPT_PARAMS.N < DEFAULT_SCRYPT_PARAMS.N)
+})
+
+test('setEnvForTest applies the requested values for the running test', () => {
+  setEnvForTest({
+    STREAMWALL_RATE_LIMIT_MAX: '4242',
+    STREAMWALL_RATE_LIMIT_WINDOW: undefined,
+  })
+
+  assert.equal(process.env.STREAMWALL_RATE_LIMIT_MAX, '4242')
+  assert.equal(process.env.STREAMWALL_RATE_LIMIT_WINDOW, undefined)
+})
+
+test('setEnvForTest restores the previous values after the test that set them', () => {
+  // Guards the whole point of the helper: the override above must not have
+  // leaked into this test, nor into any later file.
+  assert.equal(process.env.STREAMWALL_RATE_LIMIT_MAX, RATE_LIMIT_MAX_AT_LOAD)
 })

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, writeFileSync } from 'node:fs'
 import type { AddressInfo } from 'node:net'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
+import process from 'node:process'
 import { after } from 'node:test'
 import { setTimeout as delay } from 'node:timers/promises'
 import type {
@@ -13,6 +14,7 @@ import type {
 } from 'streamwall-shared'
 import WebSocket from 'ws'
 import type { ScryptParams } from './auth.ts'
+import type { RateLimitConfig } from './config.ts'
 import { type AppOptions, initApp } from './index.ts'
 import type { LogLevel } from './logger.ts'
 import type { SentryCaptureClient } from './sentry.ts'
@@ -161,6 +163,43 @@ export function recordingLogger() {
 }
 
 /**
+ * Sets process-wide environment variables for the duration of the current test
+ * and restores the previous values afterwards (`undefined` unsets a variable).
+ * Reach for it only where the behaviour under test genuinely reads
+ * `process.env`; anything `initApp` accepts by injection — the rate limits
+ * included — should be passed to `buildTestApp` instead, so the variables never
+ * become test API.
+ */
+export function setEnvForTest(vars: Record<string, string | undefined>): void {
+  const previous = Object.entries(vars).map(
+    ([key]) => [key, process.env[key]] as const,
+  )
+  const apply = (
+    entries: readonly (readonly [string, string | undefined])[],
+  ) => {
+    for (const [key, value] of entries) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  }
+  apply(Object.entries(vars))
+  after(() => apply(previous))
+}
+
+/**
+ * Rate limits wide enough to stay out of the way of suites that are not about
+ * throttling: a live-server spec opens sockets and redeems invites in a tight
+ * loop and would otherwise trip the production budget.
+ */
+export const WIDE_RATE_LIMITS: Partial<RateLimitConfig> = {
+  globalMax: 10000,
+  authMax: 10000,
+}
+
+/**
  * A deliberately cheap scrypt work factor for tests. Suites that boot a live
  * server pay roughly four derivations per test (mint and verify an uplink
  * token, mint and redeem an invite) that have nothing to do with what is under
@@ -181,6 +220,7 @@ export function buildTestApp(
     db?: StorageDB
     logs?: LogCapture
     logLevel?: LogLevel
+    rateLimit?: Partial<RateLimitConfig>
     scryptParams?: ScryptParams
     sentryEnabled?: boolean
     sentryClient?: SentryCaptureClient

--- a/packages/streamwall-control-server/src/uplinkAuth.test.ts
+++ b/packages/streamwall-control-server/src/uplinkAuth.test.ts
@@ -8,6 +8,7 @@ import {
   listenTestApp,
   messageCollector,
   mintUplinkToken,
+  WIDE_RATE_LIMITS,
 } from './testHelpers.ts'
 
 /**
@@ -15,8 +16,7 @@ import {
  * the details needed to open an uplink WebSocket various ways.
  */
 async function startUplinkServer() {
-  process.env.STREAMWALL_RATE_LIMIT_MAX = '1000'
-  const { app, auth } = await buildTestApp()
+  const { app, auth } = await buildTestApp({ rateLimit: WIDE_RATE_LIMITS })
   const port = await listenTestApp(app)
   after(() => app.close())
   const { tokenId, secret, base } = await mintUplinkToken(auth, port)

--- a/packages/streamwall-control-server/src/wsRateLimit.test.ts
+++ b/packages/streamwall-control-server/src/wsRateLimit.test.ts
@@ -3,13 +3,18 @@ import { once } from 'node:events'
 import { test } from 'node:test'
 import { setTimeout as delay } from 'node:timers/promises'
 import WebSocket from 'ws'
-import { buildTestApp, listenTestApp, mintUplinkToken } from './testHelpers.ts'
+import {
+  buildTestApp,
+  listenTestApp,
+  mintUplinkToken,
+  setEnvForTest,
+  WIDE_RATE_LIMITS,
+} from './testHelpers.ts'
 
 async function startStreamwallSocket(env: Record<string, string>) {
-  process.env.STREAMWALL_RATE_LIMIT_MAX = '1000'
-  Object.assign(process.env, env)
+  setEnvForTest(env)
 
-  const { app, auth } = await buildTestApp()
+  const { app, auth } = await buildTestApp({ rateLimit: WIDE_RATE_LIMITS })
   const port = await listenTestApp(app)
   const { base, secret } = await mintUplinkToken(auth, port)
 

--- a/packages/streamwall-control-server/src/wsValidation.test.ts
+++ b/packages/streamwall-control-server/src/wsValidation.test.ts
@@ -17,6 +17,7 @@ import {
   listenTestApp,
   redeemInviteAndConnectClient,
   VALID_STATE,
+  WIDE_RATE_LIMITS,
 } from './testHelpers.ts'
 
 const BASE_URL = 'http://localhost:3000'
@@ -60,8 +61,6 @@ async function connectStreamwallAndClient({
   role?: StreamwallRole
   wsUpdateMaxBytes?: number
 } = {}) {
-  process.env.STREAMWALL_RATE_LIMIT_MAX = '10000'
-  process.env.STREAMWALL_AUTH_RATE_LIMIT_MAX = '10000'
   if (wsUpdateMaxBytes !== undefined) {
     process.env.STREAMWALL_WS_UPDATE_MAX_BYTES = String(wsUpdateMaxBytes)
   } else {
@@ -69,7 +68,11 @@ async function connectStreamwallAndClient({
   }
 
   const logs = captureLogs()
-  const { app, auth } = await buildTestApp({ baseURL: BASE_URL, logs })
+  const { app, auth } = await buildTestApp({
+    baseURL: BASE_URL,
+    logs,
+    rateLimit: WIDE_RATE_LIMITS,
+  })
   after(() => app.close())
   const port = await listenTestApp(app)
 


### PR DESCRIPTION
## Summary

Several control-server suites widened the per-IP rate limits for a whole file by
writing `STREAMWALL_RATE_LIMIT_MAX` / `STREAMWALL_AUTH_RATE_LIMIT_MAX` and never
restoring them. With `--test-concurrency=1` the leak is mostly invisible, but it
makes outcomes order-dependent (a file relying on the production limits silently
inherits a 10000-request allowance) and blocks ever raising the concurrency.

This takes the route the issue prefers: the limits become an injected option
rather than test API.

- `initApp` accepts `rateLimit?: Partial<RateLimitConfig>`, merged over what
  `getRateLimitConfig()` reads from the environment, alongside the existing
  `scryptParams` / `updateChecker` / `sentryClient` injections. Unset fields keep
  the environment value, so production behaviour is unchanged.
- `buildTestApp` passes it through and exports `WIDE_RATE_LIMITS`; `logging`,
  `multiplexing`, `sentryReporting`, `uplinkAuth`, `wsRateLimit` and
  `wsValidation` use that instead of touching `process.env`.
- `rateLimit.test.ts` still covers the environment contract, but through a new
  `setEnvForTest()` helper that snapshots and restores the previous values in an
  `after()` hook — including the `STREAMWALL_TRUST_PROXY` and
  `STREAMWALL_WS_MSG_*` overrides that leaked the same way.
- `testEnvHygiene.test.ts` fails the suite if a bare assignment (or `delete`) of
  the rate-limit variables reappears in any spec.

Closes #558

## How was this tested?

- `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm test` — all green.
- Red-first: the injection test fails (`an injected rate limit takes precedence
  over the environment`) when `initApp` ignores the override, and the hygiene
  spec fails against the pre-change test files.
- New coverage: injected override beats the environment; a partial override
  still reads the rest from the environment; `setEnvForTest` applies and then
  restores values.

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests (or this PR explains why none apply)
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments
