### PR TITLE
test(control-server): run the suite with the default test concurrency

### DIFF
--- a/packages/streamwall-control-server/package.json
+++ b/packages/streamwall-control-server/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "tsx ./src/index.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "test": "node --import tsx --test --test-concurrency=1 --test-force-exit --test-timeout=60000 \"src/**/*.test.ts\""
+    "test": "node --import tsx --test --test-force-exit --test-timeout=60000 \"src/**/*.test.ts\""
   },
   "repository": "github:NilsR0711/streamwall",
   "author": "Nils Reeh <info@nilsreeh.de>",

--- a/packages/streamwall-control-server/src/testConcurrency.test.ts
+++ b/packages/streamwall-control-server/src/testConcurrency.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const PACKAGE_JSON = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'package.json',
+)
+
+/**
+ * The suite used to run one file at a time because process-wide env writes made
+ * outcomes order-dependent. Those writes are gone: the rate-limit overrides now
+ * go through `buildTestApp`'s injected `rateLimit` option or `setEnvForTest`
+ * (guarded by `testEnvHygiene.test.ts`), the remaining ones live in files that
+ * `node --test` already isolates in their own process, scratch state is
+ * `mkdtemp`-scoped, and the live-server specs bind port 0.
+ *
+ * Running the files in parallel cuts the suite from ~15s to ~4s locally, so the
+ * serial flag stays off. If a genuine cross-file dependency turns up, pin the
+ * concurrency again — but replace this test with the reason, so the next
+ * attempt does not start from scratch.
+ */
+test('the package test script does not force the suite to run serially', () => {
+  const { scripts } = JSON.parse(readFileSync(PACKAGE_JSON, 'utf8')) as {
+    scripts: Record<string, string>
+  }
+
+  assert.doesNotMatch(
+    scripts.test,
+    /--test-concurrency[= ]1(?!\d)/,
+    'the control-server specs are safe to run in parallel; see the comment above before pinning them again',
+  )
+})


### PR DESCRIPTION
## Problem

The control-server package pinned `--test-concurrency=1`. The original reason —
process-wide state bleeding between files, most visibly the rate-limit env
overrides removed in #558/#566 — no longer applies, but the flag stayed and made
this the slowest suite in the repo (it dominates the `Test (windows-latest)` job).

## Solution

Drop the flag and let `node --test` use its default concurrency.

Re-checked every shared-state candidate named in #569:

- **rate-limit env vars** — gone; specs inject `rateLimit` via `buildTestApp` or
  use `setEnvForTest`, enforced by `testEnvHygiene.test.ts`.
- **`DB_PATH` / `LOG_LEVEL` / `SENTRY_*` / `STREAMWALL_WS_UPDATE_MAX_BYTES`** —
  still written process-wide, but `node --test` runs each file in its own
  process (default `--experimental-test-isolation=process`), so these never
  reach another file. Tightening them further is #568's scope and is not a
  blocker here.
- **scratch state** — every spec that touches disk goes through `mkdtemp`.
- **ports** — the live-server specs bind port 0.

`testConcurrency.test.ts` is added as the guard: it fails if the test script
pins the concurrency back to 1, and carries the reasoning above so a future
attempt does not start from scratch. If a genuine cross-file dependency ever
turns up, the instruction is to pin the flag again *and* replace that test with
the concrete reason.

## Testing

- Suite green on 3 runs at the default concurrency and 5 stress runs at
  `--test-concurrency=16` (to force contention on timing-sensitive specs such as
  `rateLimiter`, `wsRateLimit` and `updateCheck`).
- Verified the real `~/.streamwall-control-server/storage.json` stays untouched
  across parallel runs.
- Full monorepo quality gate green: format, lint, typecheck, `npm run test`.
- Wall clock for the package: ~15.3s → ~4.1s locally.

## Risks

None to production code — the change is limited to the package's test script.
CI runners have fewer cores than a dev machine, which means *less* contention
than the stress runs above.

Closes #569