### PR TITLE
test(control-server): route the remaining env overrides through setEnvForTest

### DIFF
--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -29,6 +29,7 @@ import {
   initSentry,
   type SentryCaptureClient,
 } from './sentry.ts'
+import type { DocUpdateLimits } from './stateDocGuard.ts'
 import { loadStorage, type StorageDB } from './storage.ts'
 import { createUpdateChecker, type UpdateChecker } from './updateCheck.ts'
 import { registerClientRoutes } from './ws/client.ts'
@@ -53,6 +54,7 @@ export async function initApp({
   baseURL,
   clientStaticPath,
   db: injectedDb,
+  docUpdateLimits: injectedDocUpdateLimits,
   logLevel,
   logStream,
   rateLimit: injectedRateLimit,
@@ -79,6 +81,13 @@ export async function initApp({
    * `getRateLimitConfig()` reads from the environment.
    */
   rateLimit?: Partial<RateLimitConfig>
+  /**
+   * Overrides individual inbound Yjs update size limits, for the same reason
+   * `rateLimit` exists: a spec that needs a tiny cap injects it instead of
+   * writing `STREAMWALL_WS_UPDATE_MAX_BYTES` process-wide. Unset fields keep
+   * the value `getDocUpdateLimits()` reads from the environment.
+   */
+  docUpdateLimits?: Partial<DocUpdateLimits>
   /** Test-only override so specs can exercise Sentry-enabled paths without a real DSN. */
   sentryEnabled?: boolean
   /** Test-only override for the client `captureException(...)` reports to. */
@@ -139,7 +148,7 @@ export async function initApp({
     expectedOrigin,
     isSecure,
     wsMessageLimitConfig: getWsMessageLimitConfig(),
-    docUpdateLimits: getDocUpdateLimits(),
+    docUpdateLimits: { ...getDocUpdateLimits(), ...injectedDocUpdateLimits },
     clients,
     currentStreamwallWs: null,
     currentStreamwallConn: null,

--- a/packages/streamwall-control-server/src/logger.test.ts
+++ b/packages/streamwall-control-server/src/logger.test.ts
@@ -1,6 +1,5 @@
 import assert from 'node:assert/strict'
-import process from 'node:process'
-import { after, test } from 'node:test'
+import { test } from 'node:test'
 
 import {
   getLoggerOptions,
@@ -8,10 +7,7 @@ import {
   resolveLogLevel,
   tokenIdPrefix,
 } from './logger.ts'
-
-after(() => {
-  delete process.env.LOG_LEVEL
-})
+import { setEnvForTest } from './testHelpers.ts'
 
 test('resolveLogLevel defaults to info when unset or blank', () => {
   assert.equal(resolveLogLevel(undefined), 'info')
@@ -40,9 +36,14 @@ test('resolveLogLevel falls back to info for an unknown level', () => {
 })
 
 test('getLoggerOptions reads LOG_LEVEL from the environment', () => {
-  process.env.LOG_LEVEL = 'debug'
+  setEnvForTest({ LOG_LEVEL: 'debug' })
+
   assert.equal(getLoggerOptions().level, 'debug')
-  delete process.env.LOG_LEVEL
+})
+
+test('getLoggerOptions falls back to info when LOG_LEVEL is unset', () => {
+  setEnvForTest({ LOG_LEVEL: undefined })
+
   assert.equal(getLoggerOptions().level, 'info')
 })
 

--- a/packages/streamwall-control-server/src/sentry.test.ts
+++ b/packages/streamwall-control-server/src/sentry.test.ts
@@ -8,45 +8,35 @@ import {
   getSentryConfig,
   initSentry,
 } from './sentry.ts'
-import { recordingLogger } from './testHelpers.ts'
+import { recordingLogger, setEnvForTest } from './testHelpers.ts'
 
 describe('getSentryConfig', () => {
-  const originalEnabled = process.env[SENTRY_ENABLED_ENV]
-  const originalDsn = process.env[SENTRY_DSN_ENV]
-
-  afterEach(() => {
-    if (originalEnabled === undefined) {
-      delete process.env[SENTRY_ENABLED_ENV]
-    } else {
-      process.env[SENTRY_ENABLED_ENV] = originalEnabled
-    }
-    if (originalDsn === undefined) {
-      delete process.env[SENTRY_DSN_ENV]
-    } else {
-      process.env[SENTRY_DSN_ENV] = originalDsn
-    }
-  })
-
   test('defaults to disabled with no DSN when unset', () => {
-    delete process.env[SENTRY_ENABLED_ENV]
-    delete process.env[SENTRY_DSN_ENV]
+    setEnvForTest({
+      [SENTRY_ENABLED_ENV]: undefined,
+      [SENTRY_DSN_ENV]: undefined,
+    })
 
     assert.deepEqual(getSentryConfig(), { enabled: false, dsn: undefined })
   })
 
-  test('enables only on the exact string "true"', () => {
-    process.env[SENTRY_ENABLED_ENV] = 'true'
-    assert.equal(getSentryConfig().enabled, true)
+  // Anything but the exact string stays off, so a half-set variable never
+  // silently starts shipping events.
+  for (const [value, enabled] of [
+    ['true', true],
+    ['1', false],
+    ['TRUE', false],
+  ] as const) {
+    test(`is ${enabled ? 'enabled' : 'disabled'} for ${SENTRY_ENABLED_ENV}=${value}`, () => {
+      setEnvForTest({ [SENTRY_ENABLED_ENV]: value })
 
-    process.env[SENTRY_ENABLED_ENV] = '1'
-    assert.equal(getSentryConfig().enabled, false)
-
-    process.env[SENTRY_ENABLED_ENV] = 'TRUE'
-    assert.equal(getSentryConfig().enabled, false)
-  })
+      assert.equal(getSentryConfig().enabled, enabled)
+    })
+  }
 
   test('reads the DSN from the environment', () => {
-    process.env[SENTRY_DSN_ENV] = 'https://example@o0.ingest.sentry.io/1'
+    setEnvForTest({ [SENTRY_DSN_ENV]: 'https://example@o0.ingest.sentry.io/1' })
+
     assert.equal(getSentryConfig().dsn, 'https://example@o0.ingest.sentry.io/1')
   })
 })

--- a/packages/streamwall-control-server/src/storage.test.ts
+++ b/packages/streamwall-control-server/src/storage.test.ts
@@ -7,22 +7,17 @@ import process from 'node:process'
 import { after, afterEach, describe, test } from 'node:test'
 
 import { loadStorage, resolveDbPath } from './storage.ts'
+import { setEnvForTest } from './testHelpers.ts'
 
 describe('resolveDbPath', () => {
-  const originalDbPath = process.env.DB_PATH
   const originalCwd = process.cwd()
 
   afterEach(() => {
-    if (originalDbPath === undefined) {
-      delete process.env.DB_PATH
-    } else {
-      process.env.DB_PATH = originalDbPath
-    }
     process.chdir(originalCwd)
   })
 
   test('defaults to a path under the home directory, not the working directory', () => {
-    delete process.env.DB_PATH
+    setEnvForTest({ DB_PATH: undefined })
 
     const resolved = resolveDbPath()
 
@@ -38,7 +33,7 @@ describe('resolveDbPath', () => {
   })
 
   test('the default path is stable regardless of the process working directory', () => {
-    delete process.env.DB_PATH
+    setEnvForTest({ DB_PATH: undefined })
     const fromOriginalCwd = resolveDbPath()
 
     const scratchCwd = mkdtempSync(path.join(tmpdir(), 'sw-cwd-'))
@@ -53,23 +48,14 @@ describe('resolveDbPath', () => {
   })
 
   test('an explicit DB_PATH override always wins', () => {
-    process.env.DB_PATH = '/custom/path/storage.json'
+    setEnvForTest({ DB_PATH: '/custom/path/storage.json' })
 
     assert.equal(resolveDbPath(), '/custom/path/storage.json')
   })
 })
 
 describe('loadStorage', () => {
-  const originalDbPath = process.env.DB_PATH
   let scratchDir: string
-
-  afterEach(() => {
-    if (originalDbPath === undefined) {
-      delete process.env.DB_PATH
-    } else {
-      process.env.DB_PATH = originalDbPath
-    }
-  })
 
   after(() => {
     if (scratchDir) {
@@ -80,7 +66,7 @@ describe('loadStorage', () => {
   test('creates missing parent directories so a first write succeeds', async () => {
     scratchDir = mkdtempSync(path.join(tmpdir(), 'sw-storage-'))
     const dbPath = path.join(scratchDir, 'nested', 'deeper', 'storage.json')
-    process.env.DB_PATH = dbPath
+    setEnvForTest({ DB_PATH: dbPath })
 
     const db = await loadStorage()
     assert.deepEqual(db.data.auth, { salt: null, tokens: [] })
@@ -95,7 +81,7 @@ describe('loadStorage', () => {
   test('persists writes to the resolved path', async () => {
     scratchDir = mkdtempSync(path.join(tmpdir(), 'sw-storage-'))
     const dbPath = path.join(scratchDir, 'storage.json')
-    process.env.DB_PATH = dbPath
+    setEnvForTest({ DB_PATH: dbPath })
 
     const db = await loadStorage()
     db.data.auth.salt = 'test-salt'

--- a/packages/streamwall-control-server/src/testEnvHygiene.test.ts
+++ b/packages/streamwall-control-server/src/testEnvHygiene.test.ts
@@ -6,32 +6,78 @@ import { fileURLToPath } from 'node:url'
 
 const SRC_DIR = path.dirname(fileURLToPath(import.meta.url))
 
+/** This file — it names the guarded variables and must not flag itself. */
+const SELF = path.basename(fileURLToPath(import.meta.url))
+
 /**
- * Bare writes to the process-wide rate-limit variables leak into every file
- * that runs afterwards, making outcomes order-dependent and blocking a higher
- * `--test-concurrency`. Specs widen the limits through `buildTestApp`'s
- * injected `rateLimit` option, and the few that must exercise the environment
- * itself go through `setEnvForTest`, which restores the previous values.
+ * The process-wide variables the server reads at boot. A bare write to any of
+ * them leaks into every file that runs afterwards, making outcomes
+ * order-dependent and blocking a higher `--test-concurrency`. Specs pass the
+ * value through `buildTestApp` where `initApp` accepts one by injection
+ * (`rateLimit`, `docUpdateLimits`), and the ones that must exercise the
+ * environment itself go through `setEnvForTest`, which restores the previous
+ * value rather than merely unsetting the variable.
  */
-const FORBIDDEN_ASSIGNMENT =
-  /(?:delete\s+process\.env\.STREAMWALL_(?:AUTH_)?RATE_LIMIT_(?:MAX|WINDOW)|process\.env\.STREAMWALL_(?:AUTH_)?RATE_LIMIT_(?:MAX|WINDOW)\s*=(?!=))/
+const GUARDED_ENV_VARS = [
+  'STREAMWALL_RATE_LIMIT_MAX',
+  'STREAMWALL_AUTH_RATE_LIMIT_MAX',
+  'STREAMWALL_RATE_LIMIT_WINDOW',
+  'STREAMWALL_WS_MSG_BURST',
+  'STREAMWALL_WS_MSG_RATE',
+  'STREAMWALL_WS_UPDATE_MAX_BYTES',
+  'STREAMWALL_WS_DOC_GROWTH_MAX_BYTES',
+  'STREAMWALL_TRUST_PROXY',
+  'STREAMWALL_SENTRY_ENABLED',
+  'STREAMWALL_SENTRY_DSN',
+  'LOG_LEVEL',
+  'DB_PATH',
+]
+
+const guardedNames = GUARDED_ENV_VARS.join('|')
+
+/** `process.env.FOO = ...` or `delete process.env.FOO` for a guarded name. */
+const FORBIDDEN_DOT_ACCESS = new RegExp(
+  `(?:delete\\s+process\\.env\\.(?:${guardedNames})\\b|process\\.env\\.(?:${guardedNames})\\s*=(?!=))`,
+)
+
+/**
+ * The same writes spelled with a computed key (`process.env[SENTRY_DSN_ENV]`).
+ * Guarded names cannot be recognized through the indirection, so any bracketed
+ * write is rejected: no spec needs one that `setEnvForTest` cannot express.
+ */
+const FORBIDDEN_BRACKET_ACCESS =
+  /(?:delete\s+process\.env\[|process\.env\[[^\]]*\]\s*=(?!=))/
 
 function testFiles(): string[] {
   return readdirSync(SRC_DIR, { recursive: true, encoding: 'utf8' })
-    .filter((entry) => entry.endsWith('.test.ts'))
+    .filter(
+      (entry) => entry.endsWith('.test.ts') && path.basename(entry) !== SELF,
+    )
     .map((entry) => path.join(SRC_DIR, entry))
 }
 
-test('no spec writes the rate-limit env vars without restoring them', () => {
-  const offenders = testFiles().filter((file) =>
-    readFileSync(file, 'utf8')
-      .split('\n')
-      .some((line) => FORBIDDEN_ASSIGNMENT.test(line)),
-  )
+function offendersMatching(pattern: RegExp): string[] {
+  return testFiles()
+    .filter((file) =>
+      readFileSync(file, 'utf8')
+        .split('\n')
+        .some((line) => pattern.test(line)),
+    )
+    .map((file) => path.relative(SRC_DIR, file))
+}
 
+test('no spec writes a guarded env var without restoring it', () => {
   assert.deepEqual(
-    offenders.map((file) => path.relative(SRC_DIR, file)),
+    offendersMatching(FORBIDDEN_DOT_ACCESS),
     [],
-    'use buildTestApp({ rateLimit }) or setEnvForTest() instead of assigning the rate-limit env vars directly',
+    'use an injected buildTestApp option or setEnvForTest() instead of assigning these env vars directly',
+  )
+})
+
+test('no spec writes process.env through a computed key', () => {
+  assert.deepEqual(
+    offendersMatching(FORBIDDEN_BRACKET_ACCESS),
+    [],
+    'setEnvForTest() takes a variable name as a key, so a bracketed write is never needed',
   )
 })

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -18,6 +18,7 @@ import type { RateLimitConfig } from './config.ts'
 import { type AppOptions, initApp } from './index.ts'
 import type { LogLevel } from './logger.ts'
 import type { SentryCaptureClient } from './sentry.ts'
+import type { DocUpdateLimits } from './stateDocGuard.ts'
 import type { StorageDB, StoredData } from './storage.ts'
 import type { UpdateChecker } from './updateCheck.ts'
 
@@ -218,6 +219,7 @@ export const TEST_SCRYPT_PARAMS: ScryptParams = { N: 16, r: 8, p: 1 }
 export function buildTestApp(
   overrides: Partial<AppOptions> & {
     db?: StorageDB
+    docUpdateLimits?: Partial<DocUpdateLimits>
     logs?: LogCapture
     logLevel?: LogLevel
     rateLimit?: Partial<RateLimitConfig>

--- a/packages/streamwall-control-server/src/wsValidation.test.ts
+++ b/packages/streamwall-control-server/src/wsValidation.test.ts
@@ -39,11 +39,6 @@ function isCommandType<Type extends ControlCommandMessage['type']>(type: Type) {
 const isBareError = (m: ServerToClientMessage): m is ClientErrorMessage =>
   !('response' in m) && 'error' in m
 
-// A per-test override of the update cap must not leak into other test files.
-after(() => {
-  delete process.env.STREAMWALL_WS_UPDATE_MAX_BYTES
-})
-
 /**
  * Boots a live server, connects a Streamwall uplink and seeds a state message,
  * then redeems an invite and opens an authenticated client socket. JSON frames
@@ -61,17 +56,16 @@ async function connectStreamwallAndClient({
   role?: StreamwallRole
   wsUpdateMaxBytes?: number
 } = {}) {
-  if (wsUpdateMaxBytes !== undefined) {
-    process.env.STREAMWALL_WS_UPDATE_MAX_BYTES = String(wsUpdateMaxBytes)
-  } else {
-    delete process.env.STREAMWALL_WS_UPDATE_MAX_BYTES
-  }
-
   const logs = captureLogs()
   const { app, auth } = await buildTestApp({
     baseURL: BASE_URL,
     logs,
     rateLimit: WIDE_RATE_LIMITS,
+    // Injected rather than set in the environment: the cap belongs to this one
+    // server instance and never leaks into whichever file runs next.
+    ...(wsUpdateMaxBytes !== undefined && {
+      docUpdateLimits: { maxUpdateBytes: wsUpdateMaxBytes },
+    }),
   })
   after(() => app.close())
   const port = await listenTestApp(app)


### PR DESCRIPTION
## Problem

#566 introduced `setEnvForTest()` for the rate-limit variables, but four specs
still hand-rolled their own save/restore:

- `wsValidation.test.ts` set `STREAMWALL_WS_UPDATE_MAX_BYTES` per boot and
  cleared it in a file-level `after()`, far from the assignment.
- `logger.test.ts` (`LOG_LEVEL`), `storage.test.ts` (`DB_PATH`) and
  `sentry.test.ts` (`SENTRY_*`) each repeated their own dance.

Every variant restored "unset" rather than the value the environment actually
had — the same class of order-dependence #566 addressed.

## Solution

- `initApp` now accepts `docUpdateLimits` by injection, mirroring `rateLimit`:
  unset fields keep what `getDocUpdateLimits()` reads from the environment.
  `buildTestApp` exposes it, and `wsValidation.test.ts` injects its tiny cap
  instead of writing the process-wide variable.
- `logger`, `storage` and `sentry` route their overrides through
  `setEnvForTest()`; their bespoke `afterEach`/`after` restore blocks are gone.
  Two multi-state tests (`LOG_LEVEL` set vs. unset, and the three
  `STREAMWALL_SENTRY_ENABLED` values) split into one test per state, since
  `setEnvForTest()` restores per test.
- `testEnvHygiene.test.ts` now guards every process-wide variable the server
  reads at boot, not just the rate limits, and rejects the computed-key
  spelling (`process.env[SENTRY_DSN_ENV]`) the sentry spec used.

## Testing

Guard extended first and confirmed red (it listed `logger.test.ts`,
`storage.test.ts`, `wsValidation.test.ts` and `sentry.test.ts`), then green
after the refactor. Full gate locally: `npm run format`, `npm run lint`,
`npm run typecheck`, `npm run test` (control-server 182 tests, all suites
green).

## Risks

None for production behaviour: the only non-test change is a new optional
`initApp` option that defaults to the previous environment-derived value.

Closes #568