### PR TITLE
refactor(shared): extend the CellIdx brand to the cell-geometry helpers

### DIFF
--- a/packages/streamwall-control-ui/src/ResizeHandles.test.tsx
+++ b/packages/streamwall-control-ui/src/ResizeHandles.test.tsx
@@ -1,5 +1,6 @@
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
+import { asCellIdx } from 'streamwall-shared'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { ResizeHandles } from './ResizeHandles.tsx'
 
@@ -21,8 +22,8 @@ function renderHandles(
   act(() => {
     render(
       <ResizeHandles
-        anchorIdx={0}
-        originalSpaces={[0]}
+        anchorIdx={asCellIdx(0)}
+        originalSpaces={[asCellIdx(0)]}
         role="operator"
         onResizeStart={() => {}}
         onResizeKeyDown={() => {}}

--- a/packages/streamwall-control-ui/src/ResizeHandles.tsx
+++ b/packages/streamwall-control-ui/src/ResizeHandles.tsx
@@ -1,4 +1,4 @@
-import { roleCan, type StreamwallRole } from 'streamwall-shared'
+import { type CellIdx, roleCan, type StreamwallRole } from 'streamwall-shared'
 import { styled } from 'styled-components'
 import { type ResizeHandle } from './gridInteractions'
 
@@ -85,19 +85,19 @@ export function ResizeHandles({
   onResizeStart,
   onResizeKeyDown,
 }: {
-  anchorIdx: number
-  originalSpaces: number[]
+  anchorIdx: CellIdx
+  originalSpaces: CellIdx[]
   role: StreamwallRole | null
   onResizeStart: (
-    anchorIdx: number,
+    anchorIdx: CellIdx,
     handle: ResizeHandle,
-    originalSpaces: number[],
+    originalSpaces: CellIdx[],
     ev: PointerEvent,
   ) => void
   onResizeKeyDown: (
-    anchorIdx: number,
+    anchorIdx: CellIdx,
     handle: ResizeHandle,
-    originalSpaces: number[],
+    originalSpaces: CellIdx[],
     ev: KeyboardEvent,
   ) => void
 }) {

--- a/packages/streamwall-control-ui/src/components/ControlGrid.tsx
+++ b/packages/streamwall-control-ui/src/components/ControlGrid.tsx
@@ -159,7 +159,7 @@ export function ControlGrid({
           if (pos == null) {
             return null
           }
-          const anchorIdx = Math.min(...pos.spaces)
+          const anchorIdx = asCellIdx(Math.min(...pos.spaces))
           return (
             <div
               key={`rh-${anchorIdx}`}

--- a/packages/streamwall-control-ui/src/gridInteractions.test.ts
+++ b/packages/streamwall-control-ui/src/gridInteractions.test.ts
@@ -1,3 +1,4 @@
+import { asCellIdx, asViewId, type CellIdx } from 'streamwall-shared'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -9,14 +10,24 @@ import {
   type SwapBox,
 } from './gridInteractions'
 
+/** Tags a list of raw cell indices for the branded helper signatures. */
+const cells = (...idxs: number[]): CellIdx[] => idxs.map(asCellIdx)
+
+/** Builds the cell-index-keyed assignment map the resize helpers take. */
+function cellAssignments(
+  entries: [number, string | undefined][],
+): Map<CellIdx, string | undefined> {
+  return new Map(entries.map(([idx, streamId]) => [asCellIdx(idx), streamId]))
+}
+
 describe('computeSwap', () => {
   it('swaps two equal-sized (single-space) boxes', () => {
-    const boxes = new Map<number, SwapBox>([
-      [0, { spaces: [0], streamId: 'stream-a' }],
-      [1, { spaces: [1], streamId: 'stream-b' }],
+    const boxes = new Map<CellIdx, SwapBox>([
+      [asCellIdx(0), { spaces: cells(0), streamId: 'stream-a' }],
+      [asCellIdx(1), { spaces: cells(1), streamId: 'stream-b' }],
     ])
 
-    expect(computeSwap(boxes, 0, 1, 3, 3)).toEqual(
+    expect(computeSwap(boxes, asCellIdx(0), asCellIdx(1), 3, 3)).toEqual(
       new Map([
         [0, 'stream-b'],
         [1, 'stream-a'],
@@ -26,12 +37,12 @@ describe('computeSwap', () => {
 
   it('swaps boxes of unequal size, reassigning every space of both boxes', () => {
     // A 1x1 box at idx 0 and a 2x1 box spanning idx 1 and idx 2 (e.g. after a resize).
-    const boxes = new Map<number, SwapBox>([
-      [0, { spaces: [0], streamId: 'stream-a' }],
-      [1, { spaces: [1, 2], streamId: 'stream-b' }],
+    const boxes = new Map<CellIdx, SwapBox>([
+      [asCellIdx(0), { spaces: cells(0), streamId: 'stream-a' }],
+      [asCellIdx(1), { spaces: cells(1, 2), streamId: 'stream-b' }],
     ])
 
-    expect(computeSwap(boxes, 0, 1, 3, 3)).toEqual(
+    expect(computeSwap(boxes, asCellIdx(0), asCellIdx(1), 3, 3)).toEqual(
       new Map([
         [0, 'stream-b'],
         [1, 'stream-a'],
@@ -41,19 +52,21 @@ describe('computeSwap', () => {
   })
 
   it('is a no-op when dropped on its own box', () => {
-    const boxes = new Map<number, SwapBox>([
-      [0, { spaces: [0], streamId: 'stream-a' }],
+    const boxes = new Map<CellIdx, SwapBox>([
+      [asCellIdx(0), { spaces: cells(0), streamId: 'stream-a' }],
     ])
 
-    expect(computeSwap(boxes, 0, 0, 3, 3)).toEqual(new Map())
+    expect(computeSwap(boxes, asCellIdx(0), asCellIdx(0), 3, 3)).toEqual(
+      new Map(),
+    )
   })
 
   it('treats a box missing from the map as a single space at its own index', () => {
-    const boxes = new Map<number, SwapBox>([
-      [1, { spaces: [1], streamId: 'stream-b' }],
+    const boxes = new Map<CellIdx, SwapBox>([
+      [asCellIdx(1), { spaces: cells(1), streamId: 'stream-b' }],
     ])
 
-    expect(computeSwap(boxes, 0, 1, 3, 3)).toEqual(
+    expect(computeSwap(boxes, asCellIdx(0), asCellIdx(1), 3, 3)).toEqual(
       new Map([
         [0, 'stream-b'],
         [1, undefined],
@@ -62,12 +75,12 @@ describe('computeSwap', () => {
   })
 
   it('swaps an empty box with an occupied one, clearing the target spaces', () => {
-    const boxes = new Map<number, SwapBox>([
-      [0, { spaces: [0], streamId: undefined }],
-      [1, { spaces: [1], streamId: 'stream-b' }],
+    const boxes = new Map<CellIdx, SwapBox>([
+      [asCellIdx(0), { spaces: cells(0), streamId: undefined }],
+      [asCellIdx(1), { spaces: cells(1), streamId: 'stream-b' }],
     ])
 
-    expect(computeSwap(boxes, 0, 1, 3, 3)).toEqual(
+    expect(computeSwap(boxes, asCellIdx(0), asCellIdx(1), 3, 3)).toEqual(
       new Map([
         [0, 'stream-b'],
         [1, undefined],
@@ -80,11 +93,11 @@ describe('computeSwap', () => {
     // it (from its anchor) onto empty idx 10 (x2,y2) must move the whole
     // footprint there — { 10,11, 14,15 } — not just fill idx 10 alone while
     // clearing the other three source cells for nothing.
-    const boxes = new Map<number, SwapBox>([
-      [0, { spaces: [0, 1, 4, 5], streamId: 'stream-a' }],
+    const boxes = new Map<CellIdx, SwapBox>([
+      [asCellIdx(0), { spaces: cells(0, 1, 4, 5), streamId: 'stream-a' }],
     ])
 
-    expect(computeSwap(boxes, 0, 10, 4, 4)).toEqual(
+    expect(computeSwap(boxes, asCellIdx(0), asCellIdx(10), 4, 4)).toEqual(
       new Map([
         [0, undefined],
         [1, undefined],
@@ -103,11 +116,11 @@ describe('computeSwap', () => {
     // anchor there by the raw (dx,dy) would push the box half off the
     // 4x4 grid. The whole box must shift together and clamp so it still
     // lands fully on-grid as an intact 2x2 shape.
-    const boxes = new Map<number, SwapBox>([
-      [0, { spaces: [0, 1, 4, 5], streamId: 'stream-a' }],
+    const boxes = new Map<CellIdx, SwapBox>([
+      [asCellIdx(0), { spaces: cells(0, 1, 4, 5), streamId: 'stream-a' }],
     ])
 
-    expect(computeSwap(boxes, 0, 15, 4, 4)).toEqual(
+    expect(computeSwap(boxes, asCellIdx(0), asCellIdx(15), 4, 4)).toEqual(
       new Map([
         [0, undefined],
         [1, undefined],
@@ -126,11 +139,11 @@ describe('computeSwap', () => {
     // anchor. Dragging from idx 5 (the box's bottom-right cell, x1y1) onto
     // empty idx 9 (x1y2) must move the whole box down by one row — landing
     // at { 4,5, 8,9 } — keeping the dragged cell under the drop target.
-    const boxes = new Map<number, SwapBox>([
-      [5, { spaces: [0, 1, 4, 5], streamId: 'stream-a' }],
+    const boxes = new Map<CellIdx, SwapBox>([
+      [asCellIdx(5), { spaces: cells(0, 1, 4, 5), streamId: 'stream-a' }],
     ])
 
-    expect(computeSwap(boxes, 5, 9, 4, 4)).toEqual(
+    expect(computeSwap(boxes, asCellIdx(5), asCellIdx(9), 4, 4)).toEqual(
       new Map([
         [0, undefined],
         [1, undefined],
@@ -145,16 +158,32 @@ describe('computeSwap', () => {
 
 describe('computeResizeAssignments', () => {
   it('assigns a single cell when the anchor and hover are the same', () => {
-    expect(computeResizeAssignments(3, 4, 4, 'stream-a', 'se', [4])).toEqual(
-      new Map([[4, 'stream-a']]),
-    )
+    expect(
+      computeResizeAssignments(
+        3,
+        asCellIdx(4),
+        asCellIdx(4),
+        'stream-a',
+        'se',
+        cells(4),
+      ),
+    ).toEqual(new Map([[4, 'stream-a']]))
   })
 
   it('assigns every cell in the box spanned by the anchor and hover, overwriting other streams', () => {
     // 3-col grid; anchor at idx 0 (x0,y0), hover at idx 4 (x1,y1) spans the
     // 2x2 box { 0, 1, 3, 4 }. Cells 1 and 3 belong to other, unrelated boxes
     // before the resize — they must be overwritten by the anchor's stream.
-    expect(computeResizeAssignments(3, 0, 4, 'stream-a', 'se', [0])).toEqual(
+    expect(
+      computeResizeAssignments(
+        3,
+        asCellIdx(0),
+        asCellIdx(4),
+        'stream-a',
+        'se',
+        cells(0),
+      ),
+    ).toEqual(
       new Map([
         [0, 'stream-a'],
         [1, 'stream-a'],
@@ -165,18 +194,32 @@ describe('computeResizeAssignments', () => {
   })
 
   it('does not include cells outside the spanned box', () => {
-    const assignments = computeResizeAssignments(3, 0, 4, 'stream-a', 'se', [0])
-    expect(assignments.has(2)).toBe(false)
-    expect(assignments.has(5)).toBe(false)
+    const assignments = computeResizeAssignments(
+      3,
+      asCellIdx(0),
+      asCellIdx(4),
+      'stream-a',
+      'se',
+      cells(0),
+    )
+    expect(assignments.has(asCellIdx(2))).toBe(false)
+    expect(assignments.has(asCellIdx(5))).toBe(false)
   })
 
   it('clamps to the anchor when the hover is dragged past it, instead of spanning backward', () => {
     // The anchor (top-left corner of the box) never moves. Dragging the 'se'
     // handle up and to the left of the anchor must not grow the box in that
     // direction — it must clamp to the anchor cell itself.
-    expect(computeResizeAssignments(3, 4, 0, 'stream-a', 'se', [4])).toEqual(
-      new Map([[4, 'stream-a']]),
-    )
+    expect(
+      computeResizeAssignments(
+        3,
+        asCellIdx(4),
+        asCellIdx(0),
+        'stream-a',
+        'se',
+        cells(4),
+      ),
+    ).toEqual(new Map([[4, 'stream-a']]))
   })
 
   it('clears vacated cells when shrinking a box', () => {
@@ -184,11 +227,11 @@ describe('computeResizeAssignments', () => {
     // Shrinking via the 'se' handle to hover at idx 5 (x1,y1) leaves a 2x2 box
     // { 0,1, 4,5 } — the other five original cells must be explicitly cleared,
     // not left with the stale streamId.
-    const originalSpaces = [0, 1, 2, 4, 5, 6, 8, 9, 10]
+    const originalSpaces = cells(0, 1, 2, 4, 5, 6, 8, 9, 10)
     const assignments = computeResizeAssignments(
       4,
-      0,
-      5,
+      asCellIdx(0),
+      asCellIdx(5),
       'stream-a',
       'se',
       originalSpaces,
@@ -212,9 +255,16 @@ describe('computeResizeAssignments', () => {
     // 4-col grid; a 1x2 box anchored at idx 0 occupies { 0, 4 } (height 2).
     // Dragging the east handle to idx 6 (x2,y1) must only grow the width —
     // the height stays locked at the original 2 rows regardless of hover y.
-    const originalSpaces = [0, 4]
+    const originalSpaces = cells(0, 4)
     expect(
-      computeResizeAssignments(4, 0, 6, 'stream-a', 'e', originalSpaces),
+      computeResizeAssignments(
+        4,
+        asCellIdx(0),
+        asCellIdx(6),
+        'stream-a',
+        'e',
+        originalSpaces,
+      ),
     ).toEqual(
       new Map([
         [0, 'stream-a'],
@@ -231,9 +281,16 @@ describe('computeResizeAssignments', () => {
     // 4-col grid; a 2x1 box anchored at idx 0 occupies { 0, 1 } (width 2).
     // Dragging the south handle to idx 9 (x1,y2) must only grow the height —
     // the width stays locked at the original 2 columns regardless of hover x.
-    const originalSpaces = [0, 1]
+    const originalSpaces = cells(0, 1)
     expect(
-      computeResizeAssignments(4, 0, 9, 'stream-a', 's', originalSpaces),
+      computeResizeAssignments(
+        4,
+        asCellIdx(0),
+        asCellIdx(9),
+        'stream-a',
+        's',
+        originalSpaces,
+      ),
     ).toEqual(
       new Map([
         [0, 'stream-a'],
@@ -254,56 +311,133 @@ describe('computeKeyboardResizeHoverIdx', () => {
 
   it('grows the east handle one cell to the right on ArrowRight', () => {
     expect(
-      computeKeyboardResizeHoverIdx(cols, rows, 0, 'e', [0], 'ArrowRight'),
+      computeKeyboardResizeHoverIdx(
+        cols,
+        rows,
+        asCellIdx(0),
+        'e',
+        cells(0),
+        'ArrowRight',
+      ),
     ).toBe(1)
   })
 
   it('grows the south handle one cell down on ArrowDown', () => {
     expect(
-      computeKeyboardResizeHoverIdx(cols, rows, 0, 's', [0], 'ArrowDown'),
+      computeKeyboardResizeHoverIdx(
+        cols,
+        rows,
+        asCellIdx(0),
+        's',
+        cells(0),
+        'ArrowDown',
+      ),
     ).toBe(4)
   })
 
   it('shrinks a wider east box by one column on ArrowLeft', () => {
     // Box anchored at idx 0 currently spans { 0, 1, 2 } (width 3).
     expect(
-      computeKeyboardResizeHoverIdx(cols, rows, 0, 'e', [0, 1, 2], 'ArrowLeft'),
+      computeKeyboardResizeHoverIdx(
+        cols,
+        rows,
+        asCellIdx(0),
+        'e',
+        cells(0, 1, 2),
+        'ArrowLeft',
+      ),
     ).toBe(1)
   })
 
   it('ignores the cross-axis key for an east handle', () => {
     expect(
-      computeKeyboardResizeHoverIdx(cols, rows, 0, 'e', [0], 'ArrowDown'),
+      computeKeyboardResizeHoverIdx(
+        cols,
+        rows,
+        asCellIdx(0),
+        'e',
+        cells(0),
+        'ArrowDown',
+      ),
     ).toBeUndefined()
     expect(
-      computeKeyboardResizeHoverIdx(cols, rows, 0, 'e', [0], 'ArrowUp'),
+      computeKeyboardResizeHoverIdx(
+        cols,
+        rows,
+        asCellIdx(0),
+        'e',
+        cells(0),
+        'ArrowUp',
+      ),
     ).toBeUndefined()
   })
 
   it('ignores the cross-axis key for a south handle', () => {
     expect(
-      computeKeyboardResizeHoverIdx(cols, rows, 0, 's', [0], 'ArrowRight'),
+      computeKeyboardResizeHoverIdx(
+        cols,
+        rows,
+        asCellIdx(0),
+        's',
+        cells(0),
+        'ArrowRight',
+      ),
     ).toBeUndefined()
     expect(
-      computeKeyboardResizeHoverIdx(cols, rows, 0, 's', [0], 'ArrowLeft'),
+      computeKeyboardResizeHoverIdx(
+        cols,
+        rows,
+        asCellIdx(0),
+        's',
+        cells(0),
+        'ArrowLeft',
+      ),
     ).toBeUndefined()
   })
 
   it('moves either axis, one cell at a time, for a se (corner) handle', () => {
     expect(
-      computeKeyboardResizeHoverIdx(cols, rows, 0, 'se', [0], 'ArrowRight'),
+      computeKeyboardResizeHoverIdx(
+        cols,
+        rows,
+        asCellIdx(0),
+        'se',
+        cells(0),
+        'ArrowRight',
+      ),
     ).toBe(1)
     expect(
-      computeKeyboardResizeHoverIdx(cols, rows, 0, 'se', [0], 'ArrowDown'),
+      computeKeyboardResizeHoverIdx(
+        cols,
+        rows,
+        asCellIdx(0),
+        'se',
+        cells(0),
+        'ArrowDown',
+      ),
     ).toBe(4)
   })
 
   it('clamps to the anchor and refuses to shrink past a 1-cell box', () => {
     expect(
-      computeKeyboardResizeHoverIdx(cols, rows, 0, 'e', [0], 'ArrowLeft'),
+      computeKeyboardResizeHoverIdx(
+        cols,
+        rows,
+        asCellIdx(0),
+        'e',
+        cells(0),
+        'ArrowLeft',
+      ),
     ).toBeUndefined()
     expect(
-      computeKeyboardResizeHoverIdx(cols, rows, 0, 's', [0], 'ArrowUp'),
+      computeKeyboardResizeHoverIdx(
+        cols,
+        rows,
+        asCellIdx(0),
+        's',
+        cells(0),
+        'ArrowUp',
+      ),
     ).toBeUndefined()
   })
 
@@ -313,9 +447,9 @@ describe('computeKeyboardResizeHoverIdx', () => {
       computeKeyboardResizeHoverIdx(
         cols,
         rows,
-        0,
+        asCellIdx(0),
         'e',
-        [0, 1, 2, 3],
+        cells(0, 1, 2, 3),
         'ArrowRight',
       ),
     ).toBeUndefined()
@@ -324,9 +458,9 @@ describe('computeKeyboardResizeHoverIdx', () => {
       computeKeyboardResizeHoverIdx(
         cols,
         rows,
-        0,
+        asCellIdx(0),
         's',
-        [0, 4, 8, 12],
+        cells(0, 4, 8, 12),
         'ArrowDown',
       ),
     ).toBeUndefined()
@@ -334,7 +468,14 @@ describe('computeKeyboardResizeHoverIdx', () => {
 
   it('returns undefined for a non-arrow key', () => {
     expect(
-      computeKeyboardResizeHoverIdx(cols, rows, 0, 'se', [0], 'Enter'),
+      computeKeyboardResizeHoverIdx(
+        cols,
+        rows,
+        asCellIdx(0),
+        'se',
+        cells(0),
+        'Enter',
+      ),
     ).toBeUndefined()
   })
 })
@@ -343,7 +484,7 @@ describe('resizeWouldOverwriteOtherStream', () => {
   it('reports true when the box spanned by the resize covers a cell held by a different stream', () => {
     // 3-col grid; anchor at idx 0 (x0,y0), hover at idx 4 (x1,y1) spans the
     // 2x2 box { 0, 1, 3, 4 }. Cell 4 already belongs to a different stream.
-    const currentAssignments = new Map([
+    const currentAssignments = cellAssignments([
       [0, 'stream-a'],
       [1, undefined],
       [3, undefined],
@@ -352,18 +493,18 @@ describe('resizeWouldOverwriteOtherStream', () => {
     expect(
       resizeWouldOverwriteOtherStream(
         3,
-        0,
-        4,
+        asCellIdx(0),
+        asCellIdx(4),
         'stream-a',
         'se',
-        [0],
+        cells(0),
         currentAssignments,
       ),
     ).toBe(true)
   })
 
   it('reports false when every spanned cell is already empty or already this stream', () => {
-    const currentAssignments = new Map([
+    const currentAssignments = cellAssignments([
       [0, 'stream-a'],
       [1, undefined],
       [3, undefined],
@@ -372,29 +513,29 @@ describe('resizeWouldOverwriteOtherStream', () => {
     expect(
       resizeWouldOverwriteOtherStream(
         3,
-        0,
-        4,
+        asCellIdx(0),
+        asCellIdx(4),
         'stream-a',
         'se',
-        [0],
+        cells(0),
         currentAssignments,
       ),
     ).toBe(false)
   })
 
   it('treats an empty-string streamId the same as undefined', () => {
-    const currentAssignments = new Map([
+    const currentAssignments = cellAssignments([
       [0, 'stream-a'],
       [1, ''],
     ])
     expect(
       resizeWouldOverwriteOtherStream(
         3,
-        0,
-        1,
+        asCellIdx(0),
+        asCellIdx(1),
         'stream-a',
         'e',
-        [0],
+        cells(0),
         currentAssignments,
       ),
     ).toBe(false)
@@ -403,7 +544,7 @@ describe('resizeWouldOverwriteOtherStream', () => {
   it('ignores cells outside the spanned box even if they belong to another stream', () => {
     // Same grid as above but hover only reaches idx 1 (width 2, height 1) —
     // cell 4's occupant is irrelevant since it falls outside the box.
-    const currentAssignments = new Map([
+    const currentAssignments = cellAssignments([
       [0, 'stream-a'],
       [1, undefined],
       [4, 'stream-b'],
@@ -411,28 +552,26 @@ describe('resizeWouldOverwriteOtherStream', () => {
     expect(
       resizeWouldOverwriteOtherStream(
         3,
-        0,
-        1,
+        asCellIdx(0),
+        asCellIdx(1),
         'stream-a',
         'e',
-        [0],
+        cells(0),
         currentAssignments,
       ),
     ).toBe(false)
   })
 
   it('does not flag a cell that is not present in the current assignments map', () => {
-    const currentAssignments = new Map<number, string | undefined>([
-      [0, 'stream-a'],
-    ])
+    const currentAssignments = cellAssignments([[0, 'stream-a']])
     expect(
       resizeWouldOverwriteOtherStream(
         3,
-        0,
-        1,
+        asCellIdx(0),
+        asCellIdx(1),
         'stream-a',
         'e',
-        [0],
+        cells(0),
         currentAssignments,
       ),
     ).toBe(false)
@@ -441,16 +580,74 @@ describe('resizeWouldOverwriteOtherStream', () => {
 
 describe('isIdxInResizeBox', () => {
   it('matches the box computeResizeAssignments would commit, including axis locking and clamping', () => {
-    const originalSpaces = [0, 4]
+    const originalSpaces = cells(0, 4)
     // Growing the 'e' handle to idx 6: width grows to x<=2, height stays
     // locked to the original y<=1 — idx 10 (x2,y2) falls outside the height
     // lock even though it shares the grown column.
-    expect(isIdxInResizeBox(4, 0, 6, 'e', originalSpaces, 2)).toBe(true)
-    expect(isIdxInResizeBox(4, 0, 6, 'e', originalSpaces, 10)).toBe(false)
+    expect(
+      isIdxInResizeBox(
+        4,
+        asCellIdx(0),
+        asCellIdx(6),
+        'e',
+        originalSpaces,
+        asCellIdx(2),
+      ),
+    ).toBe(true)
+    expect(
+      isIdxInResizeBox(
+        4,
+        asCellIdx(0),
+        asCellIdx(6),
+        'e',
+        originalSpaces,
+        asCellIdx(10),
+      ),
+    ).toBe(false)
   })
 
   it('reports only the anchor cell when the hover is dragged past the anchor', () => {
-    expect(isIdxInResizeBox(3, 4, 0, 'se', [4], 4)).toBe(true)
-    expect(isIdxInResizeBox(3, 4, 0, 'se', [4], 0)).toBe(false)
+    expect(
+      isIdxInResizeBox(
+        3,
+        asCellIdx(4),
+        asCellIdx(0),
+        'se',
+        cells(4),
+        asCellIdx(4),
+      ),
+    ).toBe(true)
+    expect(
+      isIdxInResizeBox(
+        3,
+        asCellIdx(4),
+        asCellIdx(0),
+        'se',
+        cells(4),
+        asCellIdx(0),
+      ),
+    ).toBe(false)
+  })
+})
+
+// Compile-time guards. Every index these helpers take is a *grid cell index*,
+// never a stable view id — branding the signatures keeps the #470 defect class
+// out of the pure geometry layer too (issue #567).
+describe('cell-index typing', () => {
+  it('rejects a bare number and a view id where a cell index is expected', () => {
+    const boxes = new Map<CellIdx, SwapBox>([
+      [asCellIdx(0), { spaces: [asCellIdx(0)], streamId: 'stream-a' }],
+    ])
+
+    // @ts-expect-error - a bare number is not a cell index
+    computeSwap(boxes, 0, 1, 3, 3)
+    // @ts-expect-error - a stable view id is not a cell index
+    computeSwap(boxes, asViewId(0), asCellIdx(1), 3, 3)
+    // @ts-expect-error - `spaces` is a list of cell indices, not of numbers
+    isIdxInResizeBox(3, asCellIdx(0), asCellIdx(1), 'e', [0], asCellIdx(1))
+
+    expect(
+      computeSwap(boxes, asCellIdx(0), asCellIdx(1), 3, 3).get(asCellIdx(0)),
+    ).toBeUndefined()
   })
 })

--- a/packages/streamwall-control-ui/src/gridInteractions.ts
+++ b/packages/streamwall-control-ui/src/gridInteractions.ts
@@ -6,11 +6,11 @@
  * wiring in the `ControlUI` component, so the assignment math can be
  * unit-tested in isolation.
  */
-import { idxToCoords } from 'streamwall-shared'
+import { asCellIdx, type CellIdx, idxToCoords } from 'streamwall-shared'
 
 export interface SwapBox {
   /** Grid cell indexes occupied by this box. */
-  spaces: number[]
+  spaces: CellIdx[]
   streamId: string | undefined
 }
 
@@ -24,10 +24,10 @@ export interface SwapBox {
 function translateFootprint(
   cols: number,
   rows: number,
-  spaces: number[],
-  fromIdx: number,
-  toIdx: number,
-): number[] {
+  spaces: CellIdx[],
+  fromIdx: CellIdx,
+  toIdx: CellIdx,
+): CellIdx[] {
   const coords = spaces.map((idx) => idxToCoords(cols, idx))
   const { x: fromX, y: fromY } = idxToCoords(cols, fromIdx)
   const { x: toX, y: toY } = idxToCoords(cols, toIdx)
@@ -50,7 +50,7 @@ function translateFootprint(
     dy = rows - 1 - maxY
   }
 
-  return coords.map(({ x, y }) => cols * (y + dy) + (x + dx))
+  return coords.map(({ x, y }) => asCellIdx(cols * (y + dy) + (x + dx)))
 }
 
 /**
@@ -67,18 +67,18 @@ function translateFootprint(
  * so a merged tile keeps its size and shape.
  */
 export function computeSwap(
-  boxes: Map<number, SwapBox>,
-  fromIdx: number,
-  toIdx: number,
+  boxes: Map<CellIdx, SwapBox>,
+  fromIdx: CellIdx,
+  toIdx: CellIdx,
   cols: number,
   rows: number,
-): Map<number, string | undefined> {
+): Map<CellIdx, string | undefined> {
   if (fromIdx === toIdx) {
     return new Map()
   }
   const fromBox = boxes.get(fromIdx)
   const toBox = boxes.get(toIdx)
-  const assignments = new Map<number, string | undefined>()
+  const assignments = new Map<CellIdx, string | undefined>()
 
   if (fromBox !== undefined && toBox === undefined) {
     const targetSpaces = translateFootprint(
@@ -119,10 +119,10 @@ export type ResizeHandle = 'e' | 's' | 'se'
  */
 function computeResizeBox(
   cols: number,
-  anchorIdx: number,
-  hoverIdx: number,
+  anchorIdx: CellIdx,
+  hoverIdx: CellIdx,
   handle: ResizeHandle,
-  originalSpaces: number[],
+  originalSpaces: CellIdx[],
 ) {
   const { x: anchorX, y: anchorY } = idxToCoords(cols, anchorIdx)
   const { x: hoverX, y: hoverY } = idxToCoords(cols, hoverIdx)
@@ -140,11 +140,11 @@ function computeResizeBox(
 /** Whether `idx` falls inside the box an in-progress resize gesture spans — used to preview which cells a commit would overwrite. */
 export function isIdxInResizeBox(
   cols: number,
-  anchorIdx: number,
-  hoverIdx: number,
+  anchorIdx: CellIdx,
+  hoverIdx: CellIdx,
   handle: ResizeHandle,
-  originalSpaces: number[],
-  idx: number,
+  originalSpaces: CellIdx[],
+  idx: CellIdx,
 ): boolean {
   const { minX, maxX, minY, maxY } = computeResizeBox(
     cols,
@@ -180,11 +180,11 @@ export function isIdxInResizeBox(
 export function computeKeyboardResizeHoverIdx(
   cols: number,
   rows: number,
-  anchorIdx: number,
+  anchorIdx: CellIdx,
   handle: ResizeHandle,
-  originalSpaces: number[],
+  originalSpaces: CellIdx[],
   key: string,
-): number | undefined {
+): CellIdx | undefined {
   const dx = key === 'ArrowRight' ? 1 : key === 'ArrowLeft' ? -1 : 0
   const dy = key === 'ArrowDown' ? 1 : key === 'ArrowUp' ? -1 : 0
   if (dx === 0 && dy === 0) {
@@ -207,7 +207,7 @@ export function computeKeyboardResizeHoverIdx(
   if (newMaxX === maxX && newMaxY === maxY) {
     return undefined
   }
-  return cols * newMaxY + newMaxX
+  return asCellIdx(cols * newMaxY + newMaxX)
 }
 
 /**
@@ -220,12 +220,12 @@ export function computeKeyboardResizeHoverIdx(
  */
 export function resizeWouldOverwriteOtherStream(
   cols: number,
-  anchorIdx: number,
-  hoverIdx: number,
+  anchorIdx: CellIdx,
+  hoverIdx: CellIdx,
   streamId: string,
   handle: ResizeHandle,
-  originalSpaces: number[],
-  currentAssignments: Map<number, string | undefined>,
+  originalSpaces: CellIdx[],
+  currentAssignments: Map<CellIdx, string | undefined>,
 ): boolean {
   const { minX, maxX, minY, maxY } = computeResizeBox(
     cols,
@@ -236,7 +236,7 @@ export function resizeWouldOverwriteOtherStream(
   )
   for (let y = minY; y <= maxY; y++) {
     for (let x = minX; x <= maxX; x++) {
-      const existing = currentAssignments.get(cols * y + x)
+      const existing = currentAssignments.get(asCellIdx(cols * y + x))
       if (existing !== undefined && existing !== '' && existing !== streamId) {
         return true
       }
@@ -247,12 +247,12 @@ export function resizeWouldOverwriteOtherStream(
 
 export function computeResizeAssignments(
   cols: number,
-  anchorIdx: number,
-  hoverIdx: number,
+  anchorIdx: CellIdx,
+  hoverIdx: CellIdx,
   streamId: string,
   handle: ResizeHandle,
-  originalSpaces: number[],
-): Map<number, string | undefined> {
+  originalSpaces: CellIdx[],
+): Map<CellIdx, string | undefined> {
   const { minX, maxX, minY, maxY } = computeResizeBox(
     cols,
     anchorIdx,
@@ -260,10 +260,10 @@ export function computeResizeAssignments(
     handle,
     originalSpaces,
   )
-  const assignments = new Map<number, string | undefined>()
+  const assignments = new Map<CellIdx, string | undefined>()
   for (let y = minY; y <= maxY; y++) {
     for (let x = minX; x <= maxX; x++) {
-      assignments.set(cols * y + x, streamId)
+      assignments.set(asCellIdx(cols * y + x), streamId)
     }
   }
   for (const idx of originalSpaces) {

--- a/packages/streamwall-control-ui/src/hooks/useGridCommands.ts
+++ b/packages/streamwall-control-ui/src/hooks/useGridCommands.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'preact/hooks'
 import {
+  asCellIdx,
   type CellIdx,
   clampGridDimension,
   type ControlCommand,
@@ -101,9 +102,9 @@ export function useGridCommands({
       // Shrinking the grid permanently drops any placement whose (x, y) no
       // longer fits. Warn before that happens so it is never silent.
       if (cols != null && sharedState) {
-        const assignments = new Map<number, string | undefined>()
+        const assignments = new Map<CellIdx, string | undefined>()
         for (const [idx, view] of Object.entries(sharedState.views)) {
-          assignments.set(Number(idx), view.streamId)
+          assignments.set(asCellIdx(Number(idx)), view.streamId)
         }
         if (
           gridWouldDropAssignments(cols, targetCols, targetRows, assignments) &&
@@ -313,9 +314,9 @@ export function useGridCommands({
       // fall outside the new bounds. So warn whenever the current layout has
       // any live assignment, mirroring handleSetGridSize's confirm above.
       if (sharedState) {
-        const assignments = new Map<number, string | undefined>()
+        const assignments = new Map<CellIdx, string | undefined>()
         for (const [idx, view] of Object.entries(sharedState.views)) {
-          assignments.set(Number(idx), view.streamId)
+          assignments.set(asCellIdx(Number(idx)), view.streamId)
         }
         if (
           hasGridAssignments(assignments) &&

--- a/packages/streamwall-control-ui/src/useTileResize.test.tsx
+++ b/packages/streamwall-control-ui/src/useTileResize.test.tsx
@@ -1,7 +1,7 @@
 import { render } from 'preact'
 import { useState } from 'preact/hooks'
 import { act } from 'preact/test-utils'
-import { type StreamwallRole } from 'streamwall-shared'
+import { asCellIdx, type CellIdx, type StreamwallRole } from 'streamwall-shared'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import * as Y from 'yjs'
 import { useTileResize } from './useTileResize.ts'
@@ -92,7 +92,7 @@ function Harness({
   sharedState: { views: { [idx: string]: { streamId: string | undefined } } }
   role?: StreamwallRole | null
 }) {
-  const [hoveringIdx, setHoveringIdx] = useState<number | undefined>()
+  const [hoveringIdx, setHoveringIdx] = useState<CellIdx | undefined>()
   const { resize, handleResizeStart, handleResizeKeyDown } = useTileResize({
     cols: 2,
     rows: 2,
@@ -107,17 +107,29 @@ function Harness({
       <div data-resizing={resize?.anchorIdx ?? ''} />
       <button
         type="button"
-        onClick={() => handleResizeStart(0, 'e', [0], fakePointerDown())}
+        onClick={() =>
+          handleResizeStart(
+            asCellIdx(0),
+            'e',
+            [asCellIdx(0)],
+            fakePointerDown(),
+          )
+        }
       >
         start-resize-anchor-0-e
       </button>
-      <button type="button" onClick={() => setHoveringIdx(1)}>
+      <button type="button" onClick={() => setHoveringIdx(asCellIdx(1))}>
         hover-1
       </button>
       <button
         type="button"
         onClick={() =>
-          handleResizeKeyDown(0, 'e', [0], fakeKeyDown('ArrowRight'))
+          handleResizeKeyDown(
+            asCellIdx(0),
+            'e',
+            [asCellIdx(0)],
+            fakeKeyDown('ArrowRight'),
+          )
         }
       >
         keyboard-resize-anchor-0-e-right
@@ -125,7 +137,12 @@ function Harness({
       <button
         type="button"
         onClick={() =>
-          handleResizeKeyDown(0, 'e', [0], fakeKeyDown('ArrowDown'))
+          handleResizeKeyDown(
+            asCellIdx(0),
+            'e',
+            [asCellIdx(0)],
+            fakeKeyDown('ArrowDown'),
+          )
         }
       >
         keyboard-resize-anchor-0-e-down
@@ -134,9 +151,9 @@ function Harness({
         type="button"
         onClick={() =>
           handleResizeKeyDown(
-            0,
+            asCellIdx(0),
             'e',
-            [0],
+            [asCellIdx(0)],
             fakeKeyDown('ArrowRight', { shiftKey: true }),
           )
         }

--- a/packages/streamwall-control-ui/src/useTileResize.ts
+++ b/packages/streamwall-control-ui/src/useTileResize.ts
@@ -1,6 +1,11 @@
 import { useCallback, useLayoutEffect, useState } from 'preact/hooks'
 import { useHotkeys } from 'react-hotkeys-hook'
-import { roleCan, type StreamwallRole } from 'streamwall-shared'
+import {
+  asCellIdx,
+  roleCan,
+  type CellIdx,
+  type StreamwallRole,
+} from 'streamwall-shared'
 import * as Y from 'yjs'
 import { type CollabData } from './collabData.ts'
 import { isPrimaryButton } from './gestures'
@@ -14,10 +19,10 @@ import {
 /** Snapshots a `CollabData.views` map into the `Map<idx, streamId>` shape `resizeWouldOverwriteOtherStream` expects. */
 function collectCurrentAssignments(
   views: CollabData['views'] | undefined,
-): Map<number, string | undefined> {
-  const currentAssignments = new Map<number, string | undefined>()
+): Map<CellIdx, string | undefined> {
+  const currentAssignments = new Map<CellIdx, string | undefined>()
   for (const [idx, view] of Object.entries(views ?? {})) {
-    currentAssignments.set(Number(idx), view.streamId)
+    currentAssignments.set(asCellIdx(Number(idx)), view.streamId)
   }
   return currentAssignments
 }
@@ -39,26 +44,26 @@ export function useTileResize({
 }: {
   cols: number | null | undefined
   rows: number | null | undefined
-  hoveringIdx: number | undefined
+  hoveringIdx: CellIdx | undefined
   stateDoc: Y.Doc
   sharedState: CollabData | undefined
   role: StreamwallRole | null
 }) {
   const [resize, setResize] = useState<
     | {
-        anchorIdx: number
+        anchorIdx: CellIdx
         streamId: string
         handle: ResizeHandle
-        originalSpaces: number[]
+        originalSpaces: CellIdx[]
       }
     | undefined
   >()
 
   const handleResizeStart = useCallback(
     (
-      anchorIdx: number,
+      anchorIdx: CellIdx,
       handle: ResizeHandle,
-      originalSpaces: number[],
+      originalSpaces: CellIdx[],
       ev: PointerEvent,
     ) => {
       if (!isPrimaryButton(ev.button) || !roleCan(role, 'mutate-state-doc')) {
@@ -84,9 +89,9 @@ export function useTileResize({
   // Shift explicitly overrides the block and commits the step anyway.
   const handleResizeKeyDown = useCallback(
     (
-      anchorIdx: number,
+      anchorIdx: CellIdx,
       handle: ResizeHandle,
-      originalSpaces: number[],
+      originalSpaces: CellIdx[],
       ev: KeyboardEvent,
     ) => {
       if (cols == null || rows == null || !roleCan(role, 'mutate-state-doc')) {

--- a/packages/streamwall-control-ui/src/yUndo.test.ts
+++ b/packages/streamwall-control-ui/src/yUndo.test.ts
@@ -1,11 +1,15 @@
-import { remapGridAssignments } from 'streamwall-shared'
+import {
+  asCellIdx,
+  type CellIdx,
+  remapGridAssignments,
+} from 'streamwall-shared'
 import { describe, expect, it } from 'vitest'
 import * as Y from 'yjs'
 import { createSharedUndoManager } from './yUndo.ts'
 
 function seedViews(
   doc: Y.Doc,
-  assignments: Map<number, string | undefined>,
+  assignments: Map<CellIdx, string | undefined>,
 ): void {
   const views = doc.getMap<Y.Map<string | undefined>>('views')
   doc.transact(() => {
@@ -29,7 +33,7 @@ function readViews(doc: Y.Doc): Map<number, string | undefined> {
 describe('createSharedUndoManager', () => {
   it('undoes and redoes a local edit (e.g. a drag-move)', () => {
     const doc = new Y.Doc()
-    seedViews(doc, new Map([[0, undefined]]))
+    seedViews(doc, new Map([[asCellIdx(0), undefined]]))
     const undoManager = createSharedUndoManager(doc, ['views'])
 
     doc
@@ -47,7 +51,7 @@ describe('createSharedUndoManager', () => {
 
   it('does not track transactions whose origin is not local or the configured remote origin', () => {
     const doc = new Y.Doc()
-    seedViews(doc, new Map([[0, undefined]]))
+    seedViews(doc, new Map([[asCellIdx(0), undefined]]))
     const undoManager = createSharedUndoManager(doc, ['views'], 'server')
 
     doc.transact(() => {
@@ -69,9 +73,9 @@ describe('createSharedUndoManager', () => {
     // which applies it with a remote origin (`applyUpdate(clientDoc, update,
     // 'server')`, see streamwall-control-client's `receiveUpdate`).
     const oldCols = 2
-    const oldAssignments = new Map<number, string | undefined>([
-      [0, 'keep-me'],
-      [1, 'drop-me'], // (x=1, y=0) falls outside a 1x1 grid.
+    const oldAssignments = new Map<CellIdx, string | undefined>([
+      [asCellIdx(0), 'keep-me'],
+      [asCellIdx(1), 'drop-me'], // (x=1, y=0) falls outside a 1x1 grid.
     ])
 
     // The authoritative doc lives in the main process; the client doc mirrors

--- a/packages/streamwall-shared/src/geometry.test.ts
+++ b/packages/streamwall-shared/src/geometry.test.ts
@@ -13,10 +13,18 @@ import {
   parseGridDimensionInput,
   remapGridAssignments,
 } from './geometry.ts'
+import { asCellIdx, asViewId, type CellIdx } from './viewAddressing.ts'
+
+/** Builds the cell-index-keyed assignment map the grid helpers take. */
+function cellAssignments(
+  entries: [number, string | undefined][],
+): Map<CellIdx, string | undefined> {
+  return new Map(entries.map(([idx, streamId]) => [asCellIdx(idx), streamId]))
+}
 
 describe('idxToCoords', () => {
   it('maps an index to grid coordinates', () => {
-    expect(idxToCoords(3, 4)).toEqual({ x: 1, y: 1 })
+    expect(idxToCoords(3, asCellIdx(4))).toEqual({ x: 1, y: 1 })
   })
 })
 
@@ -201,7 +209,7 @@ describe('clampGridDimension', () => {
 describe('remapGridAssignments', () => {
   it('keeps assignments at the same (x,y) when adding columns', () => {
     // 2x2: idx0='a' at (0,0), idx3='b' at (1,1)
-    const old = new Map<number, string | undefined>([
+    const old = cellAssignments([
       [0, 'a'],
       [1, undefined],
       [2, undefined],
@@ -209,38 +217,38 @@ describe('remapGridAssignments', () => {
     ])
     const result = remapGridAssignments(2, 3, 2, old)
     // 3 cols: (0,0)->0, (1,1)->4
-    expect(result.get(0)).toBe('a')
-    expect(result.get(4)).toBe('b')
+    expect(result.get(asCellIdx(0))).toBe('a')
+    expect(result.get(asCellIdx(4))).toBe('b')
   })
 
   it('drops assignments outside a shrunk grid', () => {
     // 3x3: 'a' at (2,2)=idx8, 'b' at (0,0)=idx0
-    const old = new Map<number, string | undefined>([
+    const old = cellAssignments([
       [8, 'a'],
       [0, 'b'],
     ])
     const result = remapGridAssignments(3, 2, 2, old)
     expect([...result.values()].filter((v) => v === 'a')).toHaveLength(0)
-    expect(result.get(0)).toBe('b')
+    expect(result.get(asCellIdx(0))).toBe('b')
   })
 
   it('returns a full new grid with empty new cells', () => {
-    const old = new Map<number, string | undefined>([[0, 'a']])
+    const old = cellAssignments([[0, 'a']])
     const result = remapGridAssignments(1, 2, 2, old)
     expect(result.size).toBe(4)
-    expect(result.get(0)).toBe('a')
-    expect(result.get(1)).toBeUndefined()
-    expect(result.get(3)).toBeUndefined()
+    expect(result.get(asCellIdx(0))).toBe('a')
+    expect(result.get(asCellIdx(1))).toBeUndefined()
+    expect(result.get(asCellIdx(3))).toBeUndefined()
   })
 
   it('treats empty-string assignments as empty', () => {
-    const old = new Map<number, string | undefined>([
+    const old = cellAssignments([
       [0, ''],
       [1, 'a'],
     ])
     const result = remapGridAssignments(2, 2, 1, old)
-    expect(result.get(0)).toBeUndefined()
-    expect(result.get(1)).toBe('a')
+    expect(result.get(asCellIdx(0))).toBeUndefined()
+    expect(result.get(asCellIdx(1))).toBe('a')
   })
 
   it('ignores a stale entry beyond the true old grid when oldRows is given (issue #17)', () => {
@@ -248,26 +256,26 @@ describe('remapGridAssignments', () => {
     // some previous, larger grid config that was never pruned. Naively reading
     // it via oldCols=3 alone gives (x=17%3=2, y=floor(17/3)=5), which lands
     // inside a large-enough new grid and would revive as a ghost stream.
-    const old = new Map<number, string | undefined>([
+    const old = cellAssignments([
       [0, 'a'],
       [17, 'ghost'],
     ])
     const result = remapGridAssignments(3, 6, 6, old, 1)
     expect([...result.values()]).not.toContain('ghost')
-    expect(result.get(0)).toBe('a')
+    expect(result.get(asCellIdx(0))).toBe('a')
   })
 
   it('keeps an entry within the true old grid when oldRows is given', () => {
     // 3x2 grid: idx3 = (x=0, y=1).
-    const old = new Map<number, string | undefined>([[3, 'b']])
+    const old = cellAssignments([[3, 'b']])
     const result = remapGridAssignments(3, 4, 4, old, 2)
-    expect(result.get(4)).toBe('b') // (0,1) -> 4*1 + 0 = 4
+    expect(result.get(asCellIdx(4))).toBe('b') // (0,1) -> 4*1 + 0 = 4
   })
 
   it('applies no extra filtering when oldRows is omitted (back-compat)', () => {
-    const old = new Map<number, string | undefined>([[17, 'ghost']])
+    const old = cellAssignments([[17, 'ghost']])
     const result = remapGridAssignments(3, 6, 6, old)
-    expect(result.get(32)).toBe('ghost') // (x=2, y=5) -> 6*5 + 2 = 32
+    expect(result.get(asCellIdx(32))).toBe('ghost') // (x=2, y=5) -> 6*5 + 2 = 32
   })
 })
 
@@ -301,23 +309,23 @@ describe('parseGridDimensionInput', () => {
 describe('gridWouldDropAssignments', () => {
   it('returns true when a non-empty cell falls outside the shrunk grid', () => {
     // 4x4: 'a' at (3,3)=idx15 is dropped when shrinking to 2x2
-    const assignments = new Map<number, string | undefined>([[15, 'a']])
+    const assignments = cellAssignments([[15, 'a']])
     expect(gridWouldDropAssignments(4, 2, 2, assignments)).toBe(true)
   })
   it('returns false when every non-empty cell survives', () => {
     // 4x4: 'a' at (0,0)=idx0 survives a shrink to 2x2
-    const assignments = new Map<number, string | undefined>([[0, 'a']])
+    const assignments = cellAssignments([[0, 'a']])
     expect(gridWouldDropAssignments(4, 2, 2, assignments)).toBe(false)
   })
   it('ignores empty and empty-string cells that would be dropped', () => {
-    const assignments = new Map<number, string | undefined>([
+    const assignments = cellAssignments([
       [15, ''],
       [14, undefined],
     ])
     expect(gridWouldDropAssignments(4, 2, 2, assignments)).toBe(false)
   })
   it('returns false when the grid grows', () => {
-    const assignments = new Map<number, string | undefined>([[3, 'a']])
+    const assignments = cellAssignments([[3, 'a']])
     expect(gridWouldDropAssignments(2, 4, 4, assignments)).toBe(false)
   })
 })
@@ -327,14 +335,14 @@ describe('hasGridAssignments', () => {
     expect(hasGridAssignments(new Map())).toBe(false)
   })
   it('returns false when every cell is empty or empty-string', () => {
-    const assignments = new Map<number, string | undefined>([
+    const assignments = cellAssignments([
       [0, undefined],
       [1, ''],
     ])
     expect(hasGridAssignments(assignments)).toBe(false)
   })
   it('returns true when at least one cell holds a streamId', () => {
-    const assignments = new Map<number, string | undefined>([
+    const assignments = cellAssignments([
       [0, undefined],
       [1, 'a'],
     ])
@@ -369,5 +377,26 @@ describe('fullscreenViewContentMap', () => {
     )
     expect(boxes).toHaveLength(1)
     expect(boxes[0].spaces).toEqual([0])
+  })
+})
+
+// Compile-time guards. The assignment maps are keyed by *grid cell index*,
+// never by a stable view id (issue #567).
+describe('cell-index typing', () => {
+  it('rejects assignment maps keyed by a bare number or a view id', () => {
+    const assignments = new Map<CellIdx, string | undefined>([
+      [asCellIdx(0), 'stream-a'],
+    ])
+
+    // @ts-expect-error - the map is keyed by cell index, not by a bare number
+    hasGridAssignments(new Map<number, string | undefined>())
+    // @ts-expect-error - the map is keyed by cell index, not by a view id
+    gridWouldDropAssignments(2, 1, 1, new Map([[asViewId(0), 'stream-a']]))
+    // @ts-expect-error - a bare number is not a cell index
+    idxToCoords(3, 4)
+
+    expect(remapGridAssignments(2, 1, 1, assignments).get(asCellIdx(0))).toBe(
+      'stream-a',
+    )
   })
 })

--- a/packages/streamwall-shared/src/geometry.ts
+++ b/packages/streamwall-shared/src/geometry.ts
@@ -151,7 +151,7 @@ export function computeBoxRect(
   }
 }
 
-export function idxToCoords(cols: number, idx: number) {
+export function idxToCoords(cols: number, idx: CellIdx) {
   const x = idx % cols
   const y = Math.floor(idx / cols)
   return { x, y }
@@ -206,7 +206,7 @@ export function gridWouldDropAssignments(
   oldCols: number,
   newCols: number,
   newRows: number,
-  assignments: Map<number, string | undefined>,
+  assignments: Map<CellIdx, string | undefined>,
 ): boolean {
   for (const [oldIdx, streamId] of assignments) {
     if (streamId === undefined || streamId === '') {
@@ -230,7 +230,7 @@ export function gridWouldDropAssignments(
  * @param assignments Map of cell index -> streamId (undefined/'' = empty).
  */
 export function hasGridAssignments(
-  assignments: Map<number, string | undefined>,
+  assignments: Map<CellIdx, string | undefined>,
 ): boolean {
   for (const streamId of assignments.values()) {
     if (streamId !== undefined && streamId !== '') {
@@ -262,12 +262,12 @@ export function remapGridAssignments(
   oldCols: number,
   newCols: number,
   newRows: number,
-  oldAssignments: Map<number, string | undefined>,
+  oldAssignments: Map<CellIdx, string | undefined>,
   oldRows?: number,
-): Map<number, string | undefined> {
-  const result = new Map<number, string | undefined>()
+): Map<CellIdx, string | undefined> {
+  const result = new Map<CellIdx, string | undefined>()
   for (let idx = 0; idx < newCols * newRows; idx++) {
-    result.set(idx, undefined)
+    result.set(asCellIdx(idx), undefined)
   }
   const oldCellCount = oldRows === undefined ? undefined : oldCols * oldRows
   for (const [oldIdx, streamId] of oldAssignments) {
@@ -280,7 +280,7 @@ export function remapGridAssignments(
     const x = oldIdx % oldCols
     const y = Math.floor(oldIdx / oldCols)
     if (x < newCols && y < newRows) {
-      result.set(newCols * y + x, streamId)
+      result.set(asCellIdx(newCols * y + x), streamId)
     }
   }
   return result

--- a/packages/streamwall/src/main/gridResize.ts
+++ b/packages/streamwall/src/main/gridResize.ts
@@ -1,4 +1,9 @@
-import { clampGridDimension, remapGridAssignments } from 'streamwall-shared'
+import {
+  asCellIdx,
+  type CellIdx,
+  clampGridDimension,
+  remapGridAssignments,
+} from 'streamwall-shared'
 import * as Y from 'yjs'
 
 /**
@@ -51,9 +56,9 @@ export function applyGridResize(
   const oldRows = ctx.getRows()
 
   // Read current assignments keyed by old cell index.
-  const oldAssignments = new Map<number, string | undefined>()
+  const oldAssignments = new Map<CellIdx, string | undefined>()
   for (const [key, viewData] of ctx.viewsState) {
-    oldAssignments.set(Number(key), viewData.get('streamId'))
+    oldAssignments.set(asCellIdx(Number(key)), viewData.get('streamId'))
   }
 
   // Remap by (x, y) into the new grid, then rebuild the views map.


### PR DESCRIPTION
## Problem

[#560](https://github.com/NilsR0711/streamwall/pull/560) branded the two numeric addressing axes (`ViewId` / `CellIdx`) and threaded them through the layers where the axes meet, but deliberately left the pure cell-geometry helpers on plain `number`. The gap is one of consistency: a reader cannot tell from a signature alone whether a `number` in these modules is a cell index, every caller that wants a `CellIdx` back has to re-tag with `asCellIdx`, and a future helper that grows a `viewId` parameter would silently re-open the [#470](https://github.com/NilsR0711/streamwall/issues/470) defect class in these files.

## Solution

Swept the modules named in the issue onto `CellIdx`:

- `streamwall-shared/src/geometry.ts` — `idxToCoords`, and the assignment maps of `remapGridAssignments` / `gridWouldDropAssignments` / `hasGridAssignments` (`Map<CellIdx, string | undefined>`, in and out).
- `streamwall-control-ui/src/gridInteractions.ts` — `SwapBox.spaces`, `computeSwap`, `translateFootprint`, `computeResizeBox`, `isIdxInResizeBox`, `computeKeyboardResizeHoverIdx`, `resizeWouldOverwriteOtherStream`, `computeResizeAssignments`.
- `streamwall-control-ui/src/useTileResize.ts` and `ResizeHandles.tsx` — `anchorIdx`, `hoveringIdx`, `originalSpaces`, and the collected assignment map.

Tagging happens at the arithmetic origins (`cols * y + x`, `newCols * y + x`) with `asCellIdx`, exactly as `boxesFromViewContentMap` already did. The three call sites that build an assignment map out of the Yjs `views` keys (`useGridCommands`, `useTileResize`, `main/gridResize.ts`) tag once at the `Number(key)` boundary; `ControlGrid` tags the `Math.min(...pos.spaces)` anchor.

### Deliberately unbranded

- `computeBoxRect` — its `GridBox` carries (x, y, w, h) grid *coordinates* and a pixel `Rectangle`, neither of which is a cell index. Nothing in that signature is on the `CellIdx` axis.
- `StreamWindow.viewsByWebContentsId` stays `Map<number, ViewActor>`, as the issue notes: it is keyed by the *live* `webContents.id`, not by an actor's creation-time `ViewId`.

## Testing

Runtime behavior is unchanged — the brand is erased at runtime — so the new coverage is compile-time: `geometry.test.ts` and `gridInteractions.test.ts` each gained a `cell-index typing` guard block using `@ts-expect-error`, mirroring the ones added for the same defect class in `streamwallState.test.tsx`. These fail typecheck (as unused directives) if the branding is ever loosened back to `number`. Existing fixtures were re-tagged via local `cells(...)` / `cellAssignments([...])` helpers.

Quality gate green locally: `format:check`, `lint`, `typecheck`, `npm test` (810 + 335 + 26 + 360 tests), and the workspace builds.

## Risks

None expected: purely type-level, no runtime diff.

Closes #567