### PR TITLE
test(control-ui): pin which view wins a contested grid cell

### DIFF
--- a/packages/streamwall-control-ui/src/streamwallState.test.tsx
+++ b/packages/streamwall-control-ui/src/streamwallState.test.tsx
@@ -143,6 +143,18 @@ describe('useStreamwallState', () => {
     expect(stateIdxMap.get(asCellIdx(1))).toBe(views[0])
   })
 
+  test('lets the later view win a cell two views claim', () => {
+    // The builder walks `views` in order and overwrites, so the last claimant
+    // owns the cell. Pinned because it used to be an implicit consequence of
+    // `Object.assign`-ing every view onto a shared placeholder.
+    const first = makeViewState(1, [0, 1])
+    const second = makeViewState(2, [1])
+    const { stateIdxMap } = runHook(makeState([first, second]))
+
+    expect(stateIdxMap.get(asCellIdx(0))!.state).toBe(first)
+    expect(stateIdxMap.get(asCellIdx(1))!.state).toBe(second)
+  })
+
   test('leaves unoccupied cells absent', () => {
     const { stateIdxMap } = runHook(makeState([makeViewState(7, [1])]))
 


### PR DESCRIPTION
## Summary

`useStreamwallState` walks `views` in order when filling `stateIdxMap` and overwrites, so when two views claim the same cell the later one owns it. That ordering used to be an implicit consequence of `Object.assign`-ing every view onto a shared placeholder; since #560 each cell stores the view object itself, and nothing pinned the resulting precedence.

This adds the missing case — the only piece of the superseded #555 that did not land via #560 / #572.

Test-only, no production change.

## How was this tested?

`npm run lint`, `npm run format:check`, `npm run typecheck` and the control-ui suite pass locally.

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests (or this PR explains why none apply)
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments