### PR TITLE
fix(release): dispatch the release PR checks without a checkout

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -53,6 +53,10 @@ jobs:
         if: steps.release-please.outputs.pr
         env:
           GH_TOKEN: ${{ github.token }}
+          # The job never checks the repository out, so `gh` cannot infer the
+          # target from a git remote; without GH_REPO it exits with
+          # "fatal: not a git repository" and no check is ever dispatched.
+          GH_REPO: ${{ github.repository }}
           PR: ${{ steps.release-please.outputs.pr }}
         run: |
           branch="$(jq -er '.headBranchName' <<< "$PR")"


### PR DESCRIPTION
The `Run the required checks on the release PR` step never dispatched anything: the job has no checkout, so `gh workflow run` could not resolve the repository and exited with `fatal: not a git repository`. The release PR therefore ends up with zero status checks and stays blocked by branch protection.

Setting `GH_REPO` lets `gh` target the repository without a working tree.

Closes #574