### PR TITLE
fix(release): make the Windows installer on a Windows runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,11 +80,11 @@ jobs:
   # exercises the makers too, but it is up to a week stale and does not gate
   # the tag.
   #
-  # Two legs, because MakerZIP is darwin-only and cannot be cross-built: the
-  # Linux runner covers deb/rpm natively plus the cross-built Windows NSIS
-  # installer, and a macOS runner covers the ZIP and the `latest-mac.yml`
-  # half of the update-metadata hook, which would otherwise run for the first
-  # time inside the macOS publish leg (#517).
+  # One leg per platform, mirroring the publish matrix: MakerZIP is
+  # darwin-only and the NSIS maker needs a Windows host, so each runner makes
+  # for itself. That also covers both halves of the update-metadata hook
+  # (`latest.yml` on Windows, `latest-mac.yml` on macOS), which would
+  # otherwise run for the first time inside a publish leg (#517).
   make:
     name: Installer smoke (${{ matrix.leg.name }} makers)
     runs-on: ${{ matrix.leg.os }}
@@ -96,9 +96,12 @@ jobs:
         leg:
           # `artifacts` is the whitespace-separated list of kinds only this
           # runner can produce; the verification step below asserts each one.
-          - name: linux + windows
+          - name: linux
             os: ubuntu-latest
-            artifacts: '*.deb *.rpm *-setup-*.exe latest.yml'
+            artifacts: '*.deb *.rpm'
+          - name: windows
+            os: windows-latest
+            artifacts: '*-setup-*.exe latest.yml'
           - name: macos
             os: macos-latest
             artifacts: '*.zip latest-mac.yml'
@@ -116,17 +119,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends rpm fakeroot
 
-      # Host-platform makers: deb/rpm on Linux, the darwin ZIP on macOS.
+      # Host-platform makers: deb/rpm on Linux, the NSIS installer plus the
+      # `latest.yml` half of the update-metadata hook on Windows, the darwin
+      # ZIP on macOS. Each leg makes for its own platform: cross-building the
+      # NSIS installer from Linux needs Wine, which the Ubuntu runner image no
+      # longer ships (`spawn wine ENOENT`), and the publish matrix builds
+      # Windows on a Windows runner anyway.
       - name: Make (host installers)
         run: npm -w streamwall run make
-
-      # The NSIS maker and the `latest.yml` half of the update-metadata hook
-      # only run for win32. electron-builder bundles makensis for every host
-      # OS, so the expensive Windows-only path is verified from the Linux
-      # runner rather than trusting the Windows publish leg.
-      - name: Make (windows NSIS, cross-built)
-        if: matrix.leg.os == 'ubuntu-latest'
-        run: npm -w streamwall run make -- --platform=win32
 
       # A maker that is silently skipped (unsupported-platform detection, a
       # config change that drops it) produces no output but also no error, so

--- a/test/ci-gate.test.mjs
+++ b/test/ci-gate.test.mjs
@@ -193,32 +193,38 @@ test('the release quality gate makes installers before publishing', () => {
   }
 
   // The NSIS maker and the latest.yml postMake hook only run for win32, and
-  // electron-builder bundles makensis for every host OS, so the gate
-  // cross-builds that target instead of trusting the Windows publish leg.
+  // electron-builder drives makensis through Wine when it is not on Windows —
+  // which the Ubuntu runner image no longer ships (#579). So the gate needs a
+  // Windows runner of its own rather than a cross-build.
   assert.ok(
-    makeJobs.some(([, job]) => /--platform=win32/.test(runScripts(job))),
-    'release.yml must cross-build the win32 target so the NSIS maker and ' +
-      'the update-metadata hook are exercised before publishing',
+    makeJobs.some(([, job]) =>
+      (job.strategy?.matrix?.leg ?? []).some(
+        (leg) => leg.os === 'windows-latest',
+      ),
+    ),
+    'release.yml must make the win32 target on a Windows runner so the NSIS ' +
+      'maker and the update-metadata hook are exercised before publishing',
   )
 })
 
-// MakerZIP is darwin-only and cannot be cross-built from Linux, so a
-// Linux-only gate leaves the macOS zip and the latest-mac.yml half of the
-// postMake hook to run for the first time inside the publish matrix — the
-// exact half-published release the gate exists to prevent (#517).
-test('the release quality gate makes the darwin artifacts on a macOS leg', () => {
+// MakerZIP is darwin-only and the NSIS maker needs a Windows host, so a
+// Linux-only gate leaves the macOS zip, the Windows installer and both halves
+// of the postMake hook to run for the first time inside the publish matrix —
+// the exact half-published release the gate exists to prevent (#517, #579).
+test('the release quality gate makes each platform on its own runner', () => {
   const make = readWorkflow('release.yml').jobs.make
   const legs = make.strategy?.matrix?.leg
 
   assert.ok(
     Array.isArray(legs),
-    'the make gate must fan out over a `leg` matrix so the darwin makers ' +
-      'get a macOS runner of their own',
+    'the make gate must fan out over a `leg` matrix so the darwin and win32 ' +
+      'makers get a runner of their own',
   )
 
   const legsByOs = new Map(legs.map((leg) => [leg.os, leg]))
   const expectedArtifacts = {
-    'ubuntu-latest': ['*.deb', '*.rpm', '*-setup-*.exe', 'latest.yml'],
+    'ubuntu-latest': ['*.deb', '*.rpm'],
+    'windows-latest': ['*-setup-*.exe', 'latest.yml'],
     'macos-latest': ['*.zip', 'latest-mac.yml'],
   }
 
@@ -244,18 +250,18 @@ test('the release quality gate makes the darwin artifacts on a macOS leg', () =>
     'the verification step must iterate the leg-specific pattern list',
   )
 
-  // The rpm/fakeroot install and the NSIS cross-build only make sense on the
-  // Linux leg; unguarded they would fail the macOS one.
-  for (const stepName of [
-    'Install Linux maker tooling',
-    'Make (windows NSIS, cross-built)',
-  ]) {
-    const step = make.steps.find(({ name }) => name === stepName)
-    assert.ok(step, `the make gate is missing the "${stepName}" step`)
-    assert.match(
-      step.if ?? '',
-      /ubuntu-latest/,
-      `"${stepName}" must be restricted to the Linux leg`,
-    )
-  }
+  // The rpm/fakeroot install only makes sense on the Linux leg; unguarded it
+  // would fail the Windows and macOS ones.
+  const linuxTooling = make.steps.find(
+    ({ name }) => name === 'Install Linux maker tooling',
+  )
+  assert.ok(
+    linuxTooling,
+    'the make gate is missing the "Install Linux maker tooling" step',
+  )
+  assert.match(
+    linuxTooling.if ?? '',
+    /ubuntu-latest/,
+    '"Install Linux maker tooling" must be restricted to the Linux leg',
+  )
 })


### PR DESCRIPTION
The v0.10.0 tag build failed: the installer smoke job cross-builds the NSIS installer from Ubuntu, which electron-builder does through Wine, and the Ubuntu runner image no longer ships Wine (`spawn wine ENOENT`). The gate failed and every publish job was skipped, so the tag produced no release.

The smoke matrix now has one leg per platform, mirroring the publish matrix: Linux makes deb/rpm, Windows makes the NSIS installer and `latest.yml`, macOS makes the ZIP and `latest-mac.yml`.

Closes #579