### PR TITLE
refactor(main): split the extractProgress guard into named predicates

### DIFF
--- a/packages/streamwall/src/main/appUpdater.test.ts
+++ b/packages/streamwall/src/main/appUpdater.test.ts
@@ -125,6 +125,85 @@ describe('AppUpdater status', () => {
     })
   })
 
+  // One case per branch of the progress guard, so the named predicates it was
+  // split into keep rejecting exactly what the original condition rejected.
+  it.each([
+    ['a non-object payload', 'not-an-object'],
+    ['a null payload', null],
+    ['an undefined payload', undefined],
+    ['no fields at all', {}],
+    ['a non-numeric percent', { percent: '40', transferred: 400, total: 1000 }],
+    [
+      'a non-numeric transferred',
+      { percent: 40, transferred: '400', total: 1000 },
+    ],
+    ['a non-numeric total', { percent: 40, transferred: 400, total: '1000' }],
+    ['a NaN percent', { percent: Number.NaN, transferred: 400, total: 1000 }],
+    [
+      'a NaN transferred',
+      { percent: 40, transferred: Number.NaN, total: 1000 },
+    ],
+    ['a NaN total', { percent: 40, transferred: 400, total: Number.NaN }],
+    [
+      'an infinite percent',
+      { percent: Number.POSITIVE_INFINITY, transferred: 400, total: 1000 },
+    ],
+    [
+      'an infinite transferred',
+      { percent: 40, transferred: Number.POSITIVE_INFINITY, total: 1000 },
+    ],
+    [
+      'an infinite total',
+      { percent: 40, transferred: 400, total: Number.POSITIVE_INFINITY },
+    ],
+    ['a zero total', { percent: 0, transferred: 0, total: 0 }],
+    ['a negative total', { percent: 0, transferred: 0, total: -1 }],
+  ])('keeps the progress indeterminate for %s', (_label, payload) => {
+    const { backend, updater } = createUpdater()
+    backend.emit('update-available', { version: '0.9.2' })
+    updater.download()
+
+    backend.emit('download-progress', payload)
+
+    expect(updater.getStatus()).toEqual({
+      state: 'downloading',
+      version: '0.9.2',
+      progress: null,
+    })
+  })
+
+  it('accepts a fully measured payload down to a single-byte total', () => {
+    const { backend, updater } = createUpdater()
+    backend.emit('update-available', { version: '0.9.2' })
+    updater.download()
+
+    backend.emit('download-progress', { percent: 0, transferred: 0, total: 1 })
+
+    expect(updater.getStatus()).toEqual({
+      state: 'downloading',
+      version: '0.9.2',
+      progress: { percent: 0, transferred: 0, total: 1 },
+    })
+  })
+
+  it('ignores progress events outside the downloading state', () => {
+    const { backend, updater } = createUpdater()
+    backend.emit('update-available', { version: '0.9.2' })
+
+    backend.emit('download-progress', {
+      percent: 40,
+      transferred: 400,
+      total: 1000,
+    })
+
+    expect(updater.getStatus()).toEqual({
+      state: 'available',
+      version: '0.9.2',
+      releaseUrl,
+      canDownload: true,
+    })
+  })
+
   it('reports the downloaded version and a release notes link once install is possible', () => {
     const { backend, updater } = createUpdater()
     backend.emit('update-available', { version: '0.9.2' })

--- a/packages/streamwall/src/main/appUpdater.ts
+++ b/packages/streamwall/src/main/appUpdater.ts
@@ -235,16 +235,27 @@ function extractProgress(info: unknown): DownloadProgress | null {
     return null
   }
   const { percent, transferred, total } = info as Record<string, unknown>
-  if (
-    typeof percent !== 'number' ||
-    typeof transferred !== 'number' ||
-    typeof total !== 'number' ||
-    !Number.isFinite(percent) ||
-    !Number.isFinite(transferred) ||
-    !Number.isFinite(total) ||
-    total <= 0
-  ) {
+
+  // A NaN/Infinity (or entirely absent) field means the backend cannot measure
+  // this download - e.g. a server that omits Content-Length.
+  const allFieldsMeasured =
+    isFiniteNumber(percent) &&
+    isFiniteNumber(transferred) &&
+    isFiniteNumber(total)
+  if (!allFieldsMeasured) {
     return null
   }
+
+  // A zero or negative total would make the banner's percentage meaningless.
+  const hasKnownTotal = total > 0
+  if (!hasKnownTotal) {
+    return null
+  }
+
   return { percent, transferred, total }
+}
+
+/** Guards against both non-numeric fields and the NaN/Infinity a stalled or unmeasurable download reports. */
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
 }


### PR DESCRIPTION
Closes the Repowise `complex_conditional` finding at `packages/streamwall/src/main/appUpdater.ts` in `extractProgress` — the repo's highest single health impact (2.17). The guard combined six boolean operators in one `if`, mixing three unrelated concerns: field types, finiteness, and whether the total is usable as a denominator.

### Before

```ts
const { percent, transferred, total } = info as Record<string, unknown>
if (
  typeof percent !== 'number' ||
  typeof transferred !== 'number' ||
  typeof total !== 'number' ||
  !Number.isFinite(percent) ||
  !Number.isFinite(transferred) ||
  !Number.isFinite(total) ||
  total <= 0
) {
  return null
}
return { percent, transferred, total }
```

### After

```ts
const { percent, transferred, total } = info as Record<string, unknown>

// A NaN/Infinity (or entirely absent) field means the backend cannot measure
// this download - e.g. a server that omits Content-Length.
const allFieldsMeasured =
  isFiniteNumber(percent) &&
  isFiniteNumber(transferred) &&
  isFiniteNumber(total)
if (!allFieldsMeasured) {
  return null
}

// A zero or negative total would make the banner's percentage meaningless.
const hasKnownTotal = total > 0
if (!hasKnownTotal) {
  return null
}

return { percent, transferred, total }
```

with

```ts
function isFiniteNumber(value: unknown): value is number {
  return typeof value === 'number' && Number.isFinite(value)
}
```

`isFiniteNumber` is a type guard, so the `typeof` and `Number.isFinite` pair collapses into one predicate per field and the returned object still narrows to `number` without a cast.

### Behaviour-preserving

Identical semantics: the type check still short-circuits before `Number.isFinite`, and `total > 0` is still only evaluated once all three fields are known-finite numbers. No public surface changed — `extractProgress` remains module-private and `AppUpdater`'s API is untouched.

### Tests

Added characterisation tests driving the guard through the `download-progress` event, one case per branch of the original condition:

- non-object payloads (string, `null`, `undefined`), and an object with no fields at all
- a non-numeric `percent` / `transferred` / `total`
- a `NaN` `percent` / `transferred` / `total`
- an infinite `percent` / `transferred` / `total`
- a zero total and a negative total
- the smallest accepted payload (`total: 1`), plus progress events arriving outside the `downloading` state

`appUpdater.test.ts` goes from 26 to 41 tests.

### Verification

- `npm run test` — pass (all workspaces)
- `npm run lint` — pass
- `npm run typecheck` — pass