### PR TITLE
fix(streamwall): spawn npm.cmd in the typecheck hook on Windows

### DIFF
--- a/packages/streamwall/forge.typecheck.test.ts
+++ b/packages/streamwall/forge.typecheck.test.ts
@@ -20,12 +20,24 @@ describe('runTypecheck', () => {
   it('runs the package `typecheck` script', () => {
     const spawn = vi.fn(() => spawnResult())
 
-    runTypecheck(spawn)
+    runTypecheck(spawn, 'linux')
 
     expect(spawn).toHaveBeenCalledTimes(1)
     const [command, args] = spawn.mock.calls[0]
     expect(command).toBe('npm')
     expect(args).toEqual(['run', 'typecheck'])
+  })
+
+  // npm ships as a shell script plus an `npm.cmd` shim on Windows, and
+  // `spawnSync` without a shell only finds executables - asking for `npm`
+  // there fails with ENOENT and takes the whole packaging run down (#586).
+  it('spawns the cmd shim on Windows', () => {
+    const spawn = vi.fn(() => spawnResult())
+
+    runTypecheck(spawn, 'win32')
+
+    const [command] = spawn.mock.calls[0]
+    expect(command).toBe('npm.cmd')
   })
 
   it('runs in the package directory so it does not typecheck the caller workspace', () => {

--- a/packages/streamwall/forge.typecheck.ts
+++ b/packages/streamwall/forge.typecheck.ts
@@ -22,8 +22,15 @@ export type SpawnSync = (
   options: SpawnSyncOptions,
 ) => SpawnSyncReturns<Buffer>
 
-export function runTypecheck(spawn: SpawnSync = spawnSync): void {
-  const result = spawn('npm', ['run', 'typecheck'], {
+export function runTypecheck(
+  spawn: SpawnSync = spawnSync,
+  platform: NodeJS.Platform = process.platform,
+): void {
+  // On Windows `npm` is a shell script next to the `npm.cmd` shim, and
+  // `spawnSync` without a shell only resolves executables - asking for `npm`
+  // fails with ENOENT and aborts packaging (#586).
+  const npm = platform === 'win32' ? 'npm.cmd' : 'npm'
+  const result = spawn(npm, ['run', 'typecheck'], {
     // Forge runs hooks from the directory it was invoked in, which is not
     // necessarily this package (a root-level `npm -w streamwall run make`
     // starts elsewhere), so anchor the check to this file's package.


### PR DESCRIPTION
The v0.10.0 release build failed while making the Windows installer:

```
✖ Running prePackage hook from forgeConfig [FAILED: spawnSync npm ENOENT]
    at runTypecheck (packages/streamwall/forge.typecheck.ts:26:18)
```

`spawnSync` without a shell only resolves real executables, and on Windows npm is `npm.cmd`. Every Windows packaging run has failed this way since the hook landed in #497; it surfaced now because the release gate makes the Windows installer on a Windows runner (#579).

Closes #586