### PR TITLE
test(control-server): move the shared websocket setup into testHelpers

### DIFF
--- a/packages/streamwall-control-server/src/multiplexing.test.ts
+++ b/packages/streamwall-control-server/src/multiplexing.test.ts
@@ -6,89 +6,26 @@ import WebSocket from 'ws'
 import type { Delta } from 'jsondiffpatch'
 import {
   stateDiff,
-  type ClientCommandResponse,
   type ClientStateDeltaMessage,
-  type ClientStateMessage,
-  type ControlCommandMessage,
-  type ServerToClientMessage,
-  type StreamwallRole,
   type StreamwallState,
 } from 'streamwall-shared'
 import {
-  buildTestApp,
-  captureLogs,
-  connectStreamwallUplink,
-  listenTestApp,
+  bootServerWithUplink,
+  isCommandType,
+  isResponseTo,
+  isStateDelta,
+  isStateMessage,
   messageCollector,
   mintUplinkToken,
   redeemInviteAndConnectClient,
+  startTestServer,
+  TEST_BASE_URL,
   VALID_STATE,
-  WIDE_RATE_LIMITS,
 } from './testHelpers.ts'
-
-const BASE_URL = 'http://localhost:3000'
-
-/** Narrows to the server's reply to the client command with the given `id`. */
-function isResponseTo(id: number) {
-  return (m: ServerToClientMessage): m is ClientCommandResponse =>
-    'response' in m && m.response === true && m.id === id
-}
-
-/** Narrows to a forwarded control command of the given `type`. */
-function isCommandType<Type extends ControlCommandMessage['type']>(type: Type) {
-  return (
-    m: ControlCommandMessage,
-  ): m is Extract<ControlCommandMessage, { type: Type }> => m.type === type
-}
-
-const isStateMessage = (m: ServerToClientMessage): m is ClientStateMessage =>
-  'type' in m && m.type === 'state'
-
-const isStateDelta = (m: ServerToClientMessage): m is ClientStateDeltaMessage =>
-  'type' in m && m.type === 'state-delta'
 
 /** Applies a `state-delta`'s patch to a client's last-known state, as a real client would. */
 function applyDelta(state: StreamwallState, delta: Delta): StreamwallState {
   return stateDiff.patch(structuredClone(state), delta) as StreamwallState
-}
-
-/**
- * Boots a live server, connects a Streamwall uplink and seeds it with
- * `VALID_STATE`, and returns a `connectClient` helper that redeems a
- * freshly-minted invite for the given role and opens an authenticated
- * `/client/ws` socket.
- */
-async function bootServerWithUplink() {
-  const logs = captureLogs()
-  const { app, auth } = await buildTestApp({
-    baseURL: BASE_URL,
-    logs,
-    rateLimit: WIDE_RATE_LIMITS,
-  })
-  after(() => app.close())
-  const port = await listenTestApp(app)
-
-  const { ws: streamwallWs, streamwall } = await connectStreamwallUplink(
-    auth,
-    port,
-  )
-  streamwallWs.send(JSON.stringify({ type: 'state', state: VALID_STATE }))
-  // The uplink is only the state authority once the server has accepted the
-  // seeded snapshot; wait for that signal rather than a blind sleep.
-  await logs.waitForMessage('Streamwall connected')
-
-  async function connectClient(role: StreamwallRole) {
-    const { ws: clientWs, client } = await redeemInviteAndConnectClient(
-      app,
-      auth,
-      port,
-      BASE_URL,
-      role,
-    )
-    return { clientWs, client }
-  }
-
-  return { app, auth, port, streamwallWs, streamwall, connectClient, logs }
 }
 
 test('an operator cannot create-invite: it is dropped, logged, and never forwarded', async () => {
@@ -228,16 +165,9 @@ test("an admin's state broadcast includes auth while an operator's does not", as
 
 /** Boots a live server and mints a Streamwall uplink token, without connecting yet. */
 async function startUplinkServer() {
-  const logs = captureLogs()
-  const { app, auth } = await buildTestApp({
-    baseURL: BASE_URL,
-    logs,
-    rateLimit: WIDE_RATE_LIMITS,
-  })
-  after(() => app.close())
-  const port = await listenTestApp(app)
-  const { base, secret } = await mintUplinkToken(auth, port)
-  return { app, auth, port, base, secret, logs }
+  const server = await startTestServer()
+  const { base, secret } = await mintUplinkToken(server.auth, server.port)
+  return { ...server, base, secret }
 }
 
 test('rejects a second Streamwall connection while the first stays connected', async () => {
@@ -309,7 +239,7 @@ test('a state message sent immediately on connect is not dropped while auth vali
     app,
     auth,
     port,
-    BASE_URL,
+    TEST_BASE_URL,
   )
 
   const stateMsg = await client.waitFor(isStateMessage)

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -8,6 +8,10 @@ import process from 'node:process'
 import { after } from 'node:test'
 import { setTimeout as delay } from 'node:timers/promises'
 import type {
+  ClientCommandResponse,
+  ClientErrorMessage,
+  ClientStateDeltaMessage,
+  ClientStateMessage,
   ControlCommandMessage,
   ServerToClientMessage,
   StreamwallRole,
@@ -210,28 +214,35 @@ export const WIDE_RATE_LIMITS: Partial<RateLimitConfig> = {
 export const TEST_SCRYPT_PARAMS: ScryptParams = { N: 16, r: 8, p: 1 }
 
 /**
+ * The origin a test app is built for. Client sockets must present it as their
+ * `Origin` header, so specs and helpers have to agree on a single value.
+ */
+export const TEST_BASE_URL = 'http://localhost:3000'
+
+/** Everything a test may override when building an app instance. */
+export type TestAppOverrides = Partial<AppOptions> & {
+  db?: StorageDB
+  docUpdateLimits?: Partial<DocUpdateLimits>
+  logs?: LogCapture
+  logLevel?: LogLevel
+  rateLimit?: Partial<RateLimitConfig>
+  scryptParams?: ScryptParams
+  sentryEnabled?: boolean
+  sentryClient?: SentryCaptureClient
+  updateChecker?: UpdateChecker
+}
+
+/**
  * Builds a fully-wired app instance backed by in-memory storage and throwaway
  * static assets, ready for `app.inject()` or `app.listen()` in tests.
  *
  * Logging is silent unless a `logs` capture is passed, in which case every
  * entry down to `trace` is recorded (override with `logLevel`).
  */
-export function buildTestApp(
-  overrides: Partial<AppOptions> & {
-    db?: StorageDB
-    docUpdateLimits?: Partial<DocUpdateLimits>
-    logs?: LogCapture
-    logLevel?: LogLevel
-    rateLimit?: Partial<RateLimitConfig>
-    scryptParams?: ScryptParams
-    sentryEnabled?: boolean
-    sentryClient?: SentryCaptureClient
-    updateChecker?: UpdateChecker
-  } = {},
-) {
+export function buildTestApp(overrides: TestAppOverrides = {}) {
   const { logs, logLevel, ...rest } = overrides
   return initApp({
-    baseURL: 'http://localhost:3000',
+    baseURL: TEST_BASE_URL,
     clientStaticPath: makeStaticDir(),
     db: inMemoryDb(),
     logLevel: logLevel ?? (logs ? 'trace' : 'silent'),
@@ -433,3 +444,100 @@ export async function redeemInviteAndConnectClient<T = ServerToClientMessage>(
   await once(ws, 'open')
   return { ws, client }
 }
+
+/**
+ * Boots a live server on a random port with rate limits wide enough to stay out
+ * of the way, captures its structured log output, and closes it after the test.
+ *
+ * The returned `connectClient` redeems a freshly-minted invite for the given
+ * role and opens an authenticated `/client/ws` socket against this server.
+ */
+export async function startTestServer(overrides: TestAppOverrides = {}) {
+  const logs = captureLogs()
+  const { app, auth } = await buildTestApp({
+    baseURL: TEST_BASE_URL,
+    logs,
+    rateLimit: WIDE_RATE_LIMITS,
+    ...overrides,
+  })
+  after(() => app.close())
+  const port = await listenTestApp(app)
+
+  async function connectClient(role: StreamwallRole = 'admin') {
+    const { ws: clientWs, client } = await redeemInviteAndConnectClient(
+      app,
+      auth,
+      port,
+      TEST_BASE_URL,
+      role,
+    )
+    return { clientWs, client }
+  }
+
+  return { app, auth, port, logs, connectClient }
+}
+
+/**
+ * `startTestServer` plus a connected Streamwall uplink seeded with a state
+ * message (`VALID_STATE` unless overridden).
+ *
+ * Waits for the server to have finished with the seeded state instead of
+ * sleeping: it either accepts it (the uplink becomes the state authority) or
+ * rejects it with a structured warning. Both outcomes end the seeding step, and
+ * specs deliberately exercise each of them.
+ */
+export async function bootServerWithUplink({
+  stateMessage = { type: 'state', state: VALID_STATE } as Record<
+    string,
+    unknown
+  >,
+  ...overrides
+}: TestAppOverrides & {
+  stateMessage?: Record<string, unknown>
+} = {}) {
+  const server = await startTestServer(overrides)
+
+  const { ws: streamwallWs, streamwall } = await connectStreamwallUplink(
+    server.auth,
+    server.port,
+  )
+  streamwallWs.send(JSON.stringify(stateMessage))
+  await server.logs.waitFor(
+    (entry) =>
+      entry.msg === 'Streamwall connected' ||
+      (typeof entry.msg === 'string' &&
+        entry.msg.startsWith('Rejected invalid Streamwall state')),
+  )
+
+  return { ...server, streamwallWs, streamwall }
+}
+
+/** Narrows to the server's reply to the client command with the given `id`. */
+export function isResponseTo(id: number) {
+  return (m: ServerToClientMessage): m is ClientCommandResponse =>
+    'response' in m && m.response === true && m.id === id
+}
+
+/** Narrows to a forwarded control command of the given `type`. */
+export function isCommandType<Type extends ControlCommandMessage['type']>(
+  type: Type,
+) {
+  return (
+    m: ControlCommandMessage,
+  ): m is Extract<ControlCommandMessage, { type: Type }> => m.type === type
+}
+
+/** Narrows to a bare connection-level rejection (never has `response`). */
+export const isBareError = (
+  m: ServerToClientMessage,
+): m is ClientErrorMessage => !('response' in m) && 'error' in m
+
+/** Narrows to a full state broadcast. */
+export const isStateMessage = (
+  m: ServerToClientMessage,
+): m is ClientStateMessage => 'type' in m && m.type === 'state'
+
+/** Narrows to an incremental state update. */
+export const isStateDelta = (
+  m: ServerToClientMessage,
+): m is ClientStateDeltaMessage => 'type' in m && m.type === 'state-delta'

--- a/packages/streamwall-control-server/src/wsValidation.test.ts
+++ b/packages/streamwall-control-server/src/wsValidation.test.ts
@@ -1,100 +1,40 @@
 import assert from 'node:assert/strict'
 import { once } from 'node:events'
-import { after, test } from 'node:test'
+import { test } from 'node:test'
 import { setTimeout as delay } from 'node:timers/promises'
-import type {
-  ClientCommandResponse,
-  ClientErrorMessage,
-  ControlCommandMessage,
-  ServerToClientMessage,
-  StreamwallRole,
-} from 'streamwall-shared'
+import type { StreamwallRole } from 'streamwall-shared'
 import * as Y from 'yjs'
 import {
-  buildTestApp,
-  captureLogs,
-  connectStreamwallUplink,
-  listenTestApp,
-  redeemInviteAndConnectClient,
+  bootServerWithUplink,
+  isBareError,
+  isCommandType,
+  isResponseTo,
   VALID_STATE,
-  WIDE_RATE_LIMITS,
 } from './testHelpers.ts'
 
-const BASE_URL = 'http://localhost:3000'
-
-/** Narrows to the server's reply to the client command with the given `id`. */
-function isResponseTo(id: number) {
-  return (m: ServerToClientMessage): m is ClientCommandResponse =>
-    'response' in m && m.response === true && m.id === id
-}
-
-/** Narrows to a forwarded control command of the given `type`. */
-function isCommandType<Type extends ControlCommandMessage['type']>(type: Type) {
-  return (
-    m: ControlCommandMessage,
-  ): m is Extract<ControlCommandMessage, { type: Type }> => m.type === type
-}
-
-/** Narrows to a bare connection-level rejection (never has `response`). */
-const isBareError = (m: ServerToClientMessage): m is ClientErrorMessage =>
-  !('response' in m) && 'error' in m
-
 /**
- * Boots a live server, connects a Streamwall uplink and seeds a state message,
- * then redeems an invite and opens an authenticated client socket. JSON frames
- * from both sockets are recorded from the moment they open.
+ * Boots a live server with a seeded Streamwall uplink and opens an
+ * authenticated client socket on top of it.
  */
 async function connectStreamwallAndClient({
-  stateMessage = { type: 'state', state: VALID_STATE } as Record<
-    string,
-    unknown
-  >,
   role = 'admin' as StreamwallRole,
   wsUpdateMaxBytes,
+  ...overrides
 }: {
   stateMessage?: Record<string, unknown>
   role?: StreamwallRole
   wsUpdateMaxBytes?: number
 } = {}) {
-  const logs = captureLogs()
-  const { app, auth } = await buildTestApp({
-    baseURL: BASE_URL,
-    logs,
-    rateLimit: WIDE_RATE_LIMITS,
+  const booted = await bootServerWithUplink({
+    ...overrides,
     // Injected rather than set in the environment: the cap belongs to this one
     // server instance and never leaks into whichever file runs next.
     ...(wsUpdateMaxBytes !== undefined && {
       docUpdateLimits: { maxUpdateBytes: wsUpdateMaxBytes },
     }),
   })
-  after(() => app.close())
-  const port = await listenTestApp(app)
-
-  const { ws: streamwallWs, streamwall } = await connectStreamwallUplink(
-    auth,
-    port,
-  )
-  streamwallWs.send(JSON.stringify(stateMessage))
-  // Wait for the server to have finished with the seeded state instead of
-  // sleeping: it either accepts it (the uplink becomes the state authority) or
-  // rejects it with a structured warning. Both outcomes end the seeding step,
-  // and specs here deliberately exercise each of them.
-  await logs.waitFor(
-    (entry) =>
-      entry.msg === 'Streamwall connected' ||
-      (typeof entry.msg === 'string' &&
-        entry.msg.startsWith('Rejected invalid Streamwall state')),
-  )
-
-  const { ws: clientWs, client } = await redeemInviteAndConnectClient(
-    app,
-    auth,
-    port,
-    BASE_URL,
-    role,
-  )
-
-  return { app, auth, streamwallWs, clientWs, streamwall, client, logs }
+  const { clientWs, client } = await booted.connectClient(role)
+  return { ...booted, clientWs, client }
 }
 
 test('does not forward an out-of-bounds command to the Streamwall uplink', async () => {


### PR DESCRIPTION
## What

`multiplexing.test.ts` and `wsValidation.test.ts` each carried their own copy of the same live-server WebSocket setup: booting the app with wide rate limits and a log capture, listening on a random port, connecting and seeding a Streamwall uplink, redeeming an invite for a client socket, plus identical message-narrowing predicates.

This moves that setup into the package's existing `testHelpers.ts`:

- `startTestServer(overrides)` — boots a listening app with `WIDE_RATE_LIMITS` and a log capture, registers the `app.close()` cleanup, and returns a `connectClient(role)` factory that redeems a fresh invite and opens an authenticated `/client/ws` socket.
- `bootServerWithUplink({ stateMessage, ...overrides })` — `startTestServer` plus a connected Streamwall uplink seeded with a state message (`VALID_STATE` by default). It waits for the server to either accept the snapshot or log a structured rejection, so both specs' seeding semantics are covered without a sleep.
- `TEST_BASE_URL`, the extracted `TestAppOverrides` type, and the `isResponseTo` / `isCommandType` / `isBareError` / `isStateMessage` / `isStateDelta` predicates.

Both specs now consist of their test cases plus a small file-local wrapper where they need one.

## Repowise findings closed

- `packages/streamwall-control-server/src/multiplexing.test.ts` — 63% of the file duplicated; worst clone shared 26 lines with `wsValidation.test.ts` (co-changed 5x).
- `packages/streamwall-control-server/src/wsValidation.test.ts` — 40% duplicated (same clone pair).

## Notes

- No test case, assertion or test name was changed, added or removed.
- The package still runs without `--test-concurrency=1`; the `src/testConcurrency.test.ts` guard is untouched and passing.

## Verification

- `npm run test` — pass (control-server: 183 tests, 0 fail)
- `npm run lint` — pass
- `npm run typecheck` — pass