### PR TITLE
test(control-ui): extract the shared render setup out of the duplicated specs

### DIFF
--- a/packages/streamwall-control-ui/src/GridViewIdentity.test.tsx
+++ b/packages/streamwall-control-ui/src/GridViewIdentity.test.tsx
@@ -1,150 +1,51 @@
-import { render } from 'preact'
-import { act } from 'preact/test-utils'
+import { asCellIdx, type CellIdx } from 'streamwall-shared'
+import { describe, expect, test, vi } from 'vitest'
+import type { StreamwallConnection, ViewInfo } from './index.tsx'
 import {
-  asCellIdx,
-  asViewId,
-  type CellIdx,
-  type StreamData,
-  type StreamDelayStatus,
-  type StreamWindowConfig,
-} from 'streamwall-shared'
-import { afterEach, describe, expect, test, vi } from 'vitest'
-import * as Y from 'yjs'
-import {
-  ControlUI,
-  type StreamwallConnection,
-  type ViewInfo,
-} from './index.tsx'
+  makeConnection,
+  makeStream,
+  makeStreamWindowConfig,
+  makeView,
+  renderControlUI,
+  rerenderControlUI,
+} from './testHelpers.tsx'
 
-vi.mock('react-icons/fa', () => ({
-  FaExchangeAlt: () => null,
-  FaExclamationTriangle: () => null,
-  FaRedoAlt: () => null,
-  FaRegLifeRing: () => null,
-  FaRegWindowMaximize: () => null,
-  FaSyncAlt: () => null,
-  FaVideoSlash: () => null,
-  FaVolumeUp: () => null,
-}))
-vi.mock('react-icons/md', () => ({
-  MdOutlineStayCurrentLandscape: () => null,
-  MdOutlineStayCurrentPortrait: () => null,
-}))
+vi.mock(
+  'react-icons/fa',
+  async () => (await import('./testIconStubs.tsx')).faIconStubs,
+)
+vi.mock(
+  'react-icons/md',
+  async () => (await import('./testIconStubs.tsx')).mdIconStubs,
+)
 vi.mock('react-hotkeys-hook', () => ({
   useHotkeys: () => {},
 }))
 
-let container: HTMLDivElement | undefined
-
-afterEach(() => {
-  if (container) {
-    act(() => render(null, container!))
-    container.remove()
-    container = undefined
-  }
-})
-
-function makeStream(id: string): StreamData {
-  return {
-    _id: id,
-    _dataSource: 'test',
-    kind: 'video',
-    link: `https://example.com/${id}`,
-  }
-}
-
-function makeView(streamIdx: number, cells: number[]): ViewInfo {
-  const spaces = cells.map(asCellIdx)
-  return {
-    state: {
-      state: {
-        displaying: {
-          running: {
-            playback: 'playing',
-            video: 'normal',
-            audio: 'muted',
-            pause: 'unpaused',
-            swap: 'idle',
-          },
-        },
-      },
-      context: {
-        id: asViewId(streamIdx),
-        content: { url: `https://example.com/s${streamIdx}`, kind: 'video' },
-        info: null,
-        pos: { x: spaces[0] * 100, y: 0, width: 100, height: 100, spaces },
-        error: null,
-        volume: 1,
-      },
-    },
-    isListening: false,
-    isBackgroundListening: false,
-    isBlurred: false,
-    isPaused: false,
-    volume: 1,
-    spaces,
-  }
-}
-
-function makeConnection(viewCount: number): StreamwallConnection {
-  const delayState: StreamDelayStatus = {
-    isConnected: true,
-    delaySeconds: 0,
-    restartSeconds: 0,
-    isCensored: false,
-    isStreamRunning: true,
-    startTime: 0,
-    state: 'idle',
-  }
-  const config: StreamWindowConfig = {
-    cols: viewCount,
-    rows: 1,
-    width: 100 * viewCount,
-    height: 100,
-    frameless: false,
-    fullscreen: false,
-    activeColor: '#0f0',
-    backgroundColor: '#000',
-  }
-
+function makeGridConnection(viewCount: number): StreamwallConnection {
   const streams = Array.from({ length: viewCount }, (_, i) =>
     makeStream(`s${i}`),
   )
-  const views = Array.from({ length: viewCount }, (_, i) => makeView(i, [i]))
+  const views = Array.from({ length: viewCount }, (_, i) =>
+    makeView({ id: i, contentUrl: `https://example.com/s${i}`, cells: [i] }),
+  )
   const stateIdxMap = new Map<CellIdx, ViewInfo>()
   views.forEach((v, i) => stateIdxMap.set(asCellIdx(i), v))
 
-  return {
-    isConnected: true,
-    role: 'operator',
-    send: () => {},
+  return makeConnection({
     sharedState: {
       views: Object.fromEntries(
         streams.map((s, i) => [i, { streamId: s._id }]),
       ),
     },
-    stateDoc: new Y.Doc(),
-    config,
+    config: makeStreamWindowConfig({
+      cols: viewCount,
+      width: 100 * viewCount,
+    }),
     streams,
-    customStreams: [],
     views,
-    fullscreenViewIdx: null,
     stateIdxMap,
-    delayState,
-    authState: undefined,
-    layoutPresets: [],
-    favorites: [],
-    dataSourceHealth: [],
-  }
-}
-
-function renderControlUI(viewCount: number): HTMLDivElement {
-  container = document.createElement('div')
-  document.body.appendChild(container)
-  act(() => {
-    render(<ControlUI connection={makeConnection(viewCount)} />, container!)
   })
-  return container
 }
 
 function findPreviewBox(
@@ -165,21 +66,19 @@ function findPreviewBox(
 // each box by its view's stable grid position fixes this.
 describe('grid view identity across a shrinking view list', () => {
   test('a surviving preview box keeps its own DOM node after an earlier view disappears', () => {
-    const root = renderControlUI(2)
+    const root = renderControlUI(makeGridConnection(2))
     const boxBefore = findPreviewBox(root, 's1')
     expect(
       boxBefore,
       'expected to find a preview box for stream s1',
     ).not.toBeUndefined()
 
-    act(() => {
-      const connection = makeConnection(2)
-      // Simulate the first cell's view disappearing (e.g. it's stream
-      // stopped): only the second view remains, now at array position 0.
-      connection.views = [connection.views[1]]
-      connection.stateIdxMap = new Map([[asCellIdx(1), connection.views[0]]])
-      render(<ControlUI connection={connection} />, root)
-    })
+    const connection = makeGridConnection(2)
+    // Simulate the first cell's view disappearing (e.g. it's stream
+    // stopped): only the second view remains, now at array position 0.
+    connection.views = [connection.views[1]]
+    connection.stateIdxMap = new Map([[asCellIdx(1), connection.views[0]]])
+    rerenderControlUI(root, connection)
 
     const boxAfter = findPreviewBox(root, 's1')
     expect(

--- a/packages/streamwall-control-ui/src/gridFullscreen.test.tsx
+++ b/packages/streamwall-control-ui/src/gridFullscreen.test.tsx
@@ -1,143 +1,51 @@
-import { render } from 'preact'
 import { act } from 'preact/test-utils'
+import { asCellIdx, type ControlCommand } from 'streamwall-shared'
+import { describe, expect, test, vi } from 'vitest'
+import type { StreamwallConnection, ViewInfo } from './index.tsx'
 import {
-  asCellIdx,
-  asViewId,
-  type ControlCommand,
-  type StreamData,
-  type StreamWindowConfig,
-} from 'streamwall-shared'
-import { afterEach, describe, expect, test, vi } from 'vitest'
-import * as Y from 'yjs'
-import {
-  ControlUI,
-  type StreamwallConnection,
-  type ViewInfo,
-} from './index.tsx'
+  makeConnection,
+  makeStream,
+  makeStreamWindowConfig,
+  makeView,
+  renderControlUI,
+} from './testHelpers.tsx'
 
-vi.mock('react-icons/fa', () => ({
-  FaExchangeAlt: () => null,
-  FaExclamationTriangle: () => null,
-  FaRedoAlt: () => null,
-  FaRegLifeRing: () => null,
-  FaRegWindowMaximize: () => null,
-  FaSyncAlt: () => null,
-  FaVideoSlash: () => null,
-  FaVolumeUp: () => null,
-}))
-vi.mock('react-icons/md', () => ({
-  MdOutlineStayCurrentLandscape: () => null,
-  MdOutlineStayCurrentPortrait: () => null,
-}))
+vi.mock(
+  'react-icons/fa',
+  async () => (await import('./testIconStubs.tsx')).faIconStubs,
+)
+vi.mock(
+  'react-icons/md',
+  async () => (await import('./testIconStubs.tsx')).mdIconStubs,
+)
 vi.mock('react-hotkeys-hook', () => ({
   useHotkeys: () => {},
 }))
 
-let container: HTMLDivElement | undefined
-
-afterEach(() => {
-  if (container) {
-    act(() => render(null, container!))
-    container.remove()
-    container = undefined
-  }
-})
-
-function makeStream(id: string): StreamData {
-  return {
-    _id: id,
-    _dataSource: 'test',
-    kind: 'video',
-    link: `https://example.com/${id}`,
-  }
-}
-
-function makeView(streamId: string, cells: number[]): ViewInfo {
-  const spaces = cells.map(asCellIdx)
-  return {
-    state: {
-      state: {
-        displaying: {
-          running: {
-            playback: 'playing',
-            video: 'normal',
-            audio: 'muted',
-            pause: 'unpaused',
-            swap: 'idle',
-          },
-        },
-      },
-      context: {
-        // Deliberately distinct from the grid cell index so tests that assert
-        // on dispatched commands prove they carry the stable view id, not the
-        // cell index (issue #397).
-        id: asViewId(1000 + spaces[0]),
-        content: { url: `https://example.com/${streamId}`, kind: 'video' },
-        info: null,
-        pos: {
-          x: spaces[0] * 100,
-          y: 0,
-          width: 100 * spaces.length,
-          height: 100,
-          spaces,
-        },
-        error: null,
-        volume: 1,
-      },
-    },
-    isListening: false,
-    isBackgroundListening: false,
-    isBlurred: false,
-    isPaused: false,
-    volume: 1,
-    spaces,
-  }
+// Deliberately distinct from the grid cell index so tests that assert on
+// dispatched commands prove they carry the stable view id, not the cell index
+// (issue #397).
+function makeFullscreenView(streamId: string, cells: number[]): ViewInfo {
+  return makeView({
+    id: 1000 + cells[0],
+    contentUrl: `https://example.com/${streamId}`,
+    cells,
+  })
 }
 
 function baseConnection(
   overrides: Partial<StreamwallConnection> = {},
 ): StreamwallConnection {
-  const config: StreamWindowConfig = {
-    cols: 2,
-    rows: 1,
-    width: 200,
-    height: 100,
-    frameless: false,
-    fullscreen: false,
-    activeColor: '#0f0',
-    backgroundColor: '#000',
-  }
-  const streams = [makeStream('s0'), makeStream('s1')]
-  return {
-    isConnected: true,
-    role: 'operator',
-    send: () => {},
+  return makeConnection({
     sharedState: {
       views: { 0: { streamId: 's0' }, 1: { streamId: 's1' } },
     },
-    stateDoc: new Y.Doc(),
-    config,
-    streams,
-    customStreams: [],
-    views: [makeView('s0', [0]), makeView('s1', [1])],
-    fullscreenViewIdx: null,
-    stateIdxMap: new Map(),
+    config: makeStreamWindowConfig(),
+    streams: [makeStream('s0'), makeStream('s1')],
+    views: [makeFullscreenView('s0', [0]), makeFullscreenView('s1', [1])],
     delayState: undefined,
-    authState: undefined,
-    layoutPresets: [],
-    favorites: [],
-    dataSourceHealth: [],
     ...overrides,
-  }
-}
-
-function renderControlUI(connection: StreamwallConnection): HTMLDivElement {
-  container = document.createElement('div')
-  document.body.appendChild(container)
-  act(() => {
-    render(<ControlUI connection={connection} />, container!)
   })
-  return container
 }
 
 // The GridControls container (the interactive layer that owns the double-click
@@ -177,7 +85,7 @@ describe('ControlUI double-click fullscreen', () => {
     const root = renderControlUI(
       baseConnection({
         send: (msg) => sent.push(msg),
-        views: [makeView('s1', [0, 1])],
+        views: [makeFullscreenView('s1', [0, 1])],
         fullscreenViewIdx: asCellIdx(1),
       }),
     )
@@ -201,7 +109,7 @@ describe('ControlUI double-click fullscreen', () => {
     // the preview must resolve via fullscreenViewIdx rather than spaces[0].
     const root = renderControlUI(
       baseConnection({
-        views: [makeView('s1', [0, 1])],
+        views: [makeFullscreenView('s1', [0, 1])],
         fullscreenViewIdx: asCellIdx(1),
       }),
     )

--- a/packages/streamwall-control-ui/src/hotkeysOptions.test.tsx
+++ b/packages/streamwall-control-ui/src/hotkeysOptions.test.tsx
@@ -1,88 +1,31 @@
-import { render } from 'preact'
-import { act } from 'preact/test-utils'
-import type { StreamDelayStatus } from 'streamwall-shared'
 import { afterEach, describe, expect, test, vi } from 'vitest'
-import * as Y from 'yjs'
-import type { StreamwallConnection } from './index.tsx'
-import { ControlUI } from './index.tsx'
+import { makeConnection, renderControlUI } from './testHelpers.tsx'
 
-// react-icons renders through preact/compat's Context.Consumer, which
-// currently crashes under this package's happy-dom test environment
-// (unrelated to the hotkey wiring under test here) - stub the icons out so
-// the component can render far enough to register its hotkeys.
-vi.mock('react-icons/fa', () => ({
-  FaExchangeAlt: () => null,
-  FaExclamationTriangle: () => null,
-  FaRedoAlt: () => null,
-  FaRegLifeRing: () => null,
-  FaRegWindowMaximize: () => null,
-  FaSyncAlt: () => null,
-  FaVideoSlash: () => null,
-  FaVolumeUp: () => null,
-}))
-vi.mock('react-icons/md', () => ({
-  MdOutlineStayCurrentLandscape: () => null,
-  MdOutlineStayCurrentPortrait: () => null,
-}))
+vi.mock(
+  'react-icons/fa',
+  async () => (await import('./testIconStubs.tsx')).faIconStubs,
+)
+vi.mock(
+  'react-icons/md',
+  async () => (await import('./testIconStubs.tsx')).mdIconStubs,
+)
 
 const useHotkeysMock = vi.hoisted(() => vi.fn())
 vi.mock('react-hotkeys-hook', () => ({
   useHotkeys: useHotkeysMock,
 }))
 
-let container: HTMLDivElement | undefined
-
 afterEach(() => {
-  if (container) {
-    act(() => render(null, container!))
-    container.remove()
-    container = undefined
-  }
   useHotkeysMock.mockClear()
 })
 
-function renderControlUI(): HTMLDivElement {
-  container = document.createElement('div')
-  document.body.appendChild(container)
-
-  const delayState: StreamDelayStatus = {
-    isConnected: true,
-    delaySeconds: 0,
-    restartSeconds: 0,
-    isCensored: false,
-    isStreamRunning: true,
-    startTime: 0,
-    state: 'idle',
-  }
-
-  const connection: StreamwallConnection = {
-    isConnected: true,
-    role: 'operator',
-    send: () => {},
-    sharedState: { views: {} },
-    stateDoc: new Y.Doc(),
-    config: undefined,
-    streams: [],
-    customStreams: [],
-    views: [],
-    fullscreenViewIdx: null,
-    stateIdxMap: new Map(),
-    delayState,
-    authState: undefined,
-    layoutPresets: [],
-    favorites: [],
-    dataSourceHealth: [],
-  }
-
-  act(() => {
-    render(<ControlUI connection={connection} />, container!)
-  })
-  return container
+function renderWithHotkeys(): HTMLDivElement {
+  return renderControlUI(makeConnection())
 }
 
 describe('alt+<n> listen-toggle hotkey', () => {
   test('enables the hotkey while a grid input is focused via the v5 enableOnFormTags option', () => {
-    renderControlUI()
+    renderWithHotkeys()
 
     const listenToggleCall = useHotkeysMock.mock.calls.find(
       ([keys]) =>
@@ -105,7 +48,7 @@ describe('alt+<n> listen-toggle hotkey', () => {
 
 describe('alt+ctrl+<n> second-layer listen-toggle hotkey (#240)', () => {
   test('registers an alt+ctrl chord layer covering the same 20 trigger keys', () => {
-    renderControlUI()
+    renderWithHotkeys()
 
     const secondLayerCall = useHotkeysMock.mock.calls.find(
       ([keys]) =>
@@ -124,7 +67,7 @@ describe('alt+ctrl+<n> second-layer listen-toggle hotkey (#240)', () => {
 
 describe('alt+shift+<n> blur-toggle hotkey', () => {
   test('registers a base alt+shift chord layer covering 20 trigger keys', () => {
-    renderControlUI()
+    renderWithHotkeys()
 
     const baseLayerCall = useHotkeysMock.mock.calls.find(
       ([keys]) =>
@@ -142,7 +85,7 @@ describe('alt+shift+<n> blur-toggle hotkey', () => {
 
 describe('alt+ctrl+shift+<n> second-layer blur-toggle hotkey (#294)', () => {
   test('registers an alt+ctrl+shift chord layer covering the same 20 trigger keys', () => {
-    renderControlUI()
+    renderWithHotkeys()
 
     const secondLayerCall = useHotkeysMock.mock.calls.find(
       ([keys]) =>

--- a/packages/streamwall-control-ui/src/testHelpers.tsx
+++ b/packages/streamwall-control-ui/src/testHelpers.tsx
@@ -1,0 +1,159 @@
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import {
+  asCellIdx,
+  asViewId,
+  type StreamData,
+  type StreamDelayStatus,
+  type StreamWindowConfig,
+} from 'streamwall-shared'
+import { afterEach } from 'vitest'
+import * as Y from 'yjs'
+import {
+  ControlUI,
+  type StreamwallConnection,
+  type ViewInfo,
+} from './index.tsx'
+
+export function makeDelayState(): StreamDelayStatus {
+  return {
+    isConnected: true,
+    delaySeconds: 0,
+    restartSeconds: 0,
+    isCensored: false,
+    isStreamRunning: true,
+    startTime: 0,
+    state: 'idle',
+  }
+}
+
+export function makeStream(id: string): StreamData {
+  return {
+    _id: id,
+    _dataSource: 'test',
+    kind: 'video',
+    link: `https://example.com/${id}`,
+  }
+}
+
+export function makeStreamWindowConfig(
+  overrides: Partial<StreamWindowConfig> = {},
+): StreamWindowConfig {
+  return {
+    cols: 2,
+    rows: 1,
+    width: 200,
+    height: 100,
+    frameless: false,
+    fullscreen: false,
+    activeColor: '#0f0',
+    backgroundColor: '#000',
+    ...overrides,
+  }
+}
+
+export interface MakeViewOptions {
+  /** The stable view id carried on `context.id` (issue #397). */
+  id: number
+  /** The URL rendered as the view's content. */
+  contentUrl: string
+  /** The grid cells the view occupies. */
+  cells: number[]
+}
+
+export function makeView({ id, contentUrl, cells }: MakeViewOptions): ViewInfo {
+  const spaces = cells.map(asCellIdx)
+  return {
+    state: {
+      state: {
+        displaying: {
+          running: {
+            playback: 'playing',
+            video: 'normal',
+            audio: 'muted',
+            pause: 'unpaused',
+            swap: 'idle',
+          },
+        },
+      },
+      context: {
+        id: asViewId(id),
+        content: { url: contentUrl, kind: 'video' },
+        info: null,
+        pos: {
+          x: spaces[0] * 100,
+          y: 0,
+          width: 100 * spaces.length,
+          height: 100,
+          spaces,
+        },
+        error: null,
+        volume: 1,
+      },
+    },
+    isListening: false,
+    isBackgroundListening: false,
+    isBlurred: false,
+    isPaused: false,
+    volume: 1,
+    spaces,
+  }
+}
+
+export function makeConnection(
+  overrides: Partial<StreamwallConnection> = {},
+): StreamwallConnection {
+  return {
+    isConnected: true,
+    role: 'operator',
+    send: () => {},
+    sharedState: { views: {} },
+    stateDoc: new Y.Doc(),
+    config: undefined,
+    streams: [],
+    customStreams: [],
+    views: [],
+    fullscreenViewIdx: null,
+    stateIdxMap: new Map(),
+    delayState: makeDelayState(),
+    authState: undefined,
+    layoutPresets: [],
+    favorites: [],
+    dataSourceHealth: [],
+    ...overrides,
+  }
+}
+
+let container: HTMLDivElement | undefined
+
+// Importing this module registers the teardown on the importing spec file's
+// root suite, so every mounted ControlUI is unmounted and detached again.
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container!))
+    container.remove()
+    container = undefined
+  }
+})
+
+/** Mounts a fresh ControlUI into a detachable container and returns its root. */
+export function renderControlUI(
+  connection: StreamwallConnection,
+): HTMLDivElement {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    render(<ControlUI connection={connection} />, container!)
+  })
+  return container
+}
+
+/** Re-renders ControlUI into an already mounted root, keeping the same tree. */
+export function rerenderControlUI(
+  root: HTMLDivElement,
+  connection: StreamwallConnection,
+): void {
+  act(() => {
+    render(<ControlUI connection={connection} />, root)
+  })
+}

--- a/packages/streamwall-control-ui/src/testIconStubs.tsx
+++ b/packages/streamwall-control-ui/src/testIconStubs.tsx
@@ -1,0 +1,25 @@
+// react-icons renders through preact/compat's Context.Consumer, which currently
+// crashes under this package's happy-dom test environment (unrelated to
+// anything the ControlUI specs assert on). Every spec that mounts the full
+// ControlUI stubs the icon modules out with these, so the component can render
+// far enough to be exercised in isolation.
+//
+// This module deliberately has no imports: the specs pull it in from inside
+// their `vi.mock('react-icons/...')` factories, so it must not drag the
+// component tree - and with it react-icons itself - into the factory.
+
+export const faIconStubs = {
+  FaExchangeAlt: () => null,
+  FaExclamationTriangle: () => null,
+  FaRedoAlt: () => null,
+  FaRegLifeRing: () => null,
+  FaRegWindowMaximize: () => null,
+  FaSyncAlt: () => null,
+  FaVideoSlash: () => null,
+  FaVolumeUp: () => null,
+}
+
+export const mdIconStubs = {
+  MdOutlineStayCurrentLandscape: () => null,
+  MdOutlineStayCurrentPortrait: () => null,
+}

--- a/packages/streamwall-control-ui/src/transientProps.test.tsx
+++ b/packages/streamwall-control-ui/src/transientProps.test.tsx
@@ -1,29 +1,14 @@
-import { render } from 'preact'
-import { act } from 'preact/test-utils'
-import type { StreamDelayStatus } from 'streamwall-shared'
-import { afterEach, describe, expect, test, vi } from 'vitest'
-import * as Y from 'yjs'
-import type { StreamwallConnection } from './index.tsx'
-import { ControlUI } from './index.tsx'
+import { describe, expect, test, vi } from 'vitest'
+import { makeConnection, renderControlUI } from './testHelpers.tsx'
 
-// react-icons renders through preact/compat's Context.Consumer, which
-// currently crashes under this package's happy-dom test environment
-// (unrelated to the markup under test here) - stub the icons out so the
-// component's own rendering logic can be exercised in isolation.
-vi.mock('react-icons/fa', () => ({
-  FaExchangeAlt: () => null,
-  FaExclamationTriangle: () => null,
-  FaRedoAlt: () => null,
-  FaRegLifeRing: () => null,
-  FaRegWindowMaximize: () => null,
-  FaSyncAlt: () => null,
-  FaVideoSlash: () => null,
-  FaVolumeUp: () => null,
-}))
-vi.mock('react-icons/md', () => ({
-  MdOutlineStayCurrentLandscape: () => null,
-  MdOutlineStayCurrentPortrait: () => null,
-}))
+vi.mock(
+  'react-icons/fa',
+  async () => (await import('./testIconStubs.tsx')).faIconStubs,
+)
+vi.mock(
+  'react-icons/md',
+  async () => (await import('./testIconStubs.tsx')).mdIconStubs,
+)
 // react-hotkeys-hook resolves its own copy of `react` (bypassing this
 // package's `react` -> `preact/compat` test alias), which crashes under
 // happy-dom with an "Invalid hook call" error unrelated to the markup under
@@ -32,16 +17,6 @@ vi.mock('react-icons/md', () => ({
 vi.mock('react-hotkeys-hook', () => ({
   useHotkeys: () => {},
 }))
-
-let container: HTMLDivElement | undefined
-
-afterEach(() => {
-  if (container) {
-    act(() => render(null, container!))
-    container.remove()
-    container = undefined
-  }
-})
 
 // styled-components v6 forwards any non-`$`-prefixed custom prop that isn't a
 // recognized HTML attribute straight onto the DOM node. Each of these is a
@@ -58,48 +33,9 @@ const leakedPropNames = [
   'activecolor',
 ]
 
-function renderControlUI(): HTMLDivElement {
-  container = document.createElement('div')
-  document.body.appendChild(container)
-
-  const delayState: StreamDelayStatus = {
-    isConnected: true,
-    delaySeconds: 0,
-    restartSeconds: 0,
-    isCensored: false,
-    isStreamRunning: true,
-    startTime: 0,
-    state: 'idle',
-  }
-
-  const connection: StreamwallConnection = {
-    isConnected: true,
-    role: 'operator',
-    send: () => {},
-    sharedState: { views: {} },
-    stateDoc: new Y.Doc(),
-    config: undefined,
-    streams: [],
-    customStreams: [],
-    views: [],
-    fullscreenViewIdx: null,
-    stateIdxMap: new Map(),
-    delayState,
-    authState: undefined,
-    layoutPresets: [],
-    favorites: [],
-    dataSourceHealth: [],
-  }
-
-  act(() => {
-    render(<ControlUI connection={connection} />, container!)
-  })
-  return container
-}
-
 describe('styled-component custom props (transient props)', () => {
   test('never leak onto rendered DOM elements as literal attributes', () => {
-    const root = renderControlUI()
+    const root = renderControlUI(makeConnection())
 
     for (const el of root.querySelectorAll('*')) {
       for (const propName of leakedPropNames) {


### PR DESCRIPTION
Closes the Repowise DRY findings in the control-UI test suite.

## Findings addressed

| File | Finding |
|------|---------|
| `packages/streamwall-control-ui/src/hotkeysOptions.test.tsx` | 100% duplicated, worst clone 41 lines shared with `transientProps.test.tsx` |
| `packages/streamwall-control-ui/src/transientProps.test.tsx` | 89% duplicated (same clone pair) |
| `packages/streamwall-control-ui/src/gridFullscreen.test.tsx` ↔ `packages/streamwall-control-ui/src/GridViewIdentity.test.tsx` | worst clone 70 shared lines |

## What changed

- New `src/testHelpers.tsx` holds the setup every ControlUI spec had its own copy of:
  - the container mount/unmount lifecycle (`renderControlUI`, `rerenderControlUI`, plus the `afterEach` teardown that unmounts and detaches the container),
  - the fake data builders `makeConnection`, `makeDelayState`, `makeStream`, `makeStreamWindowConfig` and `makeView`.
- New `src/testIconStubs.tsx` holds the `react-icons` stubs. It is deliberately import-free, because the specs pull it in from inside their `vi.mock('react-icons/...')` factories — importing the shared helper there would drag the component tree (and with it `react-icons`) into the factory.
- The four specs above now build on those helpers. Specs keep thin local wrappers where their fixtures differ in intent (e.g. `gridFullscreen` deliberately uses view ids offset from the cell index, per #397).

No test case was removed, renamed or weakened; all assertions are byte-for-byte the same as before.

## Known remaining item

`packages/streamwall-control-ui/src/GridPreviewBox.test.tsx` is reported as 85% duplicated, with its worst clone (24 lines) shared with `packages/streamwall/src/renderer/OverlayViewTile.test.tsx`. That clone crosses a package boundary, so deduping it would mean introducing a cross-package test-helper package. That is out of scope here and left as a follow-up.

## Verification

- `npm run test` — all packages pass (control-ui: 48 files, 363 tests)
- `npm run lint` — clean
- `npm run typecheck` — clean
