### PR TITLE
fix(streamwall): run the typecheck hook through a shell on Windows

### DIFF
--- a/packages/streamwall/forge.typecheck.test.ts
+++ b/packages/streamwall/forge.typecheck.test.ts
@@ -28,16 +28,28 @@ describe('runTypecheck', () => {
     expect(args).toEqual(['run', 'typecheck'])
   })
 
-  // npm ships as a shell script plus an `npm.cmd` shim on Windows, and
-  // `spawnSync` without a shell only finds executables - asking for `npm`
-  // there fails with ENOENT and takes the whole packaging run down (#586).
-  it('spawns the cmd shim on Windows', () => {
+  // On Windows npm is only reachable as the `npm.cmd` shim, which Node
+  // refuses to spawn without a shell since the CVE-2024-27980 fix. Without
+  // `shell` the hook dies with ENOENT (bare `npm`) or EINVAL (`npm.cmd`) and
+  // takes the whole packaging run down (#586).
+  it('spawns through a shell on Windows', () => {
     const spawn = vi.fn(() => spawnResult())
 
     runTypecheck(spawn, 'win32')
 
-    const [command] = spawn.mock.calls[0]
-    expect(command).toBe('npm.cmd')
+    const [command, args, options] = spawn.mock.calls[0]
+    expect(command).toBe('npm')
+    expect(args).toEqual(['run', 'typecheck'])
+    expect(options?.shell).toBe(true)
+  })
+
+  it('does not need a shell elsewhere', () => {
+    const spawn = vi.fn(() => spawnResult())
+
+    runTypecheck(spawn, 'linux')
+
+    const [, , options] = spawn.mock.calls[0]
+    expect(options?.shell).toBeFalsy()
   })
 
   it('runs in the package directory so it does not typecheck the caller workspace', () => {

--- a/packages/streamwall/forge.typecheck.ts
+++ b/packages/streamwall/forge.typecheck.ts
@@ -26,11 +26,14 @@ export function runTypecheck(
   spawn: SpawnSync = spawnSync,
   platform: NodeJS.Platform = process.platform,
 ): void {
-  // On Windows `npm` is a shell script next to the `npm.cmd` shim, and
-  // `spawnSync` without a shell only resolves executables - asking for `npm`
-  // fails with ENOENT and aborts packaging (#586).
-  const npm = platform === 'win32' ? 'npm.cmd' : 'npm'
-  const result = spawn(npm, ['run', 'typecheck'], {
+  // On Windows npm is only reachable as the `npm.cmd` shim: `spawnSync`
+  // without a shell resolves executables only (bare `npm` fails with ENOENT),
+  // and since the CVE-2024-27980 fix Node refuses to spawn a `.cmd` directly
+  // (EINVAL). Both abort packaging, so that platform goes through a shell
+  // (#586). The command line is a fixed literal, so nothing is interpolated
+  // into it.
+  const result = spawn('npm', ['run', 'typecheck'], {
+    shell: platform === 'win32',
     // Forge runs hooks from the directory it was invoked in, which is not
     // necessarily this package (a root-level `npm -w streamwall run make`
     // starts elsewhere), so anchor the check to this file's package.


### PR DESCRIPTION
Follow-up to #587, which was not enough: since the CVE-2024-27980 fix Node refuses to spawn a `.cmd` file without a shell, so the Windows maker leg went from `spawnSync npm ENOENT` to `spawnSync npm.cmd EINVAL` and the v0.10.0 release build still fails.

The hook now spawns `npm` with `shell: true` on win32. The command line is a fixed literal, so nothing is interpolated into the shell.

Refs #586