### PR TITLE
test(streamwall): pin data source I/O concurrency and error semantics

### DIFF
--- a/packages/streamwall/src/main/data.test.ts
+++ b/packages/streamwall/src/main/data.test.ts
@@ -437,6 +437,148 @@ describe('pollDataURL', () => {
       await gen.return(undefined)
     }
   })
+
+  // The serial `await fetch()` in pollDataURL's loop is deliberate: the loop
+  // is a polling interval over one endpoint, so a request must never be
+  // issued while the previous one for the same URL is still in flight.
+  test('never issues overlapping requests for a single URL', async () => {
+    let inFlight = 0
+    let maxInFlight = 0
+    let counter = 0
+    server = createServer((_req, res) => {
+      inFlight++
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      setTimeout(() => {
+        inFlight--
+        res.setHeader('content-type', 'application/json')
+        res.end(
+          JSON.stringify([
+            { link: `https://a.example/${counter++}`, kind: 'video' },
+          ]),
+        )
+      }, 20)
+    })
+    await new Promise<void>((resolve) =>
+      server!.listen(0, '127.0.0.1', resolve),
+    )
+    const { port } = server.address() as AddressInfo
+    const url = `http://127.0.0.1:${port}/`
+
+    const gen = pollDataURL(url, 0.01)
+    try {
+      for (let i = 0; i < 3; i++) {
+        await gen.next()
+      }
+      expect(maxInFlight).toBe(1)
+    } finally {
+      await gen.return(undefined)
+    }
+  })
+})
+
+describe('data source fan-out', () => {
+  let server: Server | undefined
+
+  afterEach(() => {
+    server?.close()
+    server = undefined
+  })
+
+  // Concurrency across sources lives one level up from the per-source loops:
+  // combineDataSources advances every source at once, so N URLs are polled in
+  // parallel even though each individual URL is polled serially.
+  test('polls independent URLs concurrently rather than one after another', async () => {
+    let inFlight = 0
+    let maxInFlight = 0
+    let pendingResponses: Array<() => void> = []
+
+    const flush = () => {
+      const responses = pendingResponses
+      pendingResponses = []
+      for (const respond of responses) {
+        respond()
+      }
+    }
+
+    server = createServer((req, res) => {
+      inFlight++
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      pendingResponses.push(() => {
+        inFlight--
+        res.setHeader('content-type', 'application/json')
+        res.end(
+          JSON.stringify([
+            { link: `https://example.invalid${req.url}`, kind: 'video' },
+          ]),
+        )
+      })
+      if (pendingResponses.length >= 2) {
+        flush()
+      } else {
+        // Safety valve so a serial implementation fails the assertion below
+        // instead of hanging the test forever.
+        setTimeout(flush, 500)
+      }
+    })
+    await new Promise<void>((resolve) =>
+      server!.listen(0, '127.0.0.1', resolve),
+    )
+    const { port } = server.address() as AddressInfo
+    const base = `http://127.0.0.1:${port}/`
+
+    const combined = combineDataSources(
+      [
+        markDataSource(pollDataURL(`${base}a`, 999), 'json-url'),
+        markDataSource(pollDataURL(`${base}b`, 999), 'json-url'),
+      ],
+      new StreamIDGenerator(),
+    )
+    // combineDataSources()'s .return() never resolves while its contenders
+    // stay live (Repeater.latest does not propagate return()), so - matching
+    // the existing combineDataSources tests - read values without tearing the
+    // combined generator down. The server holds every response until two
+    // requests have arrived, so a first value can only be produced once both
+    // polls are in flight at the same time.
+    const { value } = await combined.next()
+    expect(value).toBeDefined()
+    expect(maxInFlight).toBe(2)
+  })
+
+  // Error semantics of the fan-out: a source whose read fails yields an empty
+  // batch and keeps going, so it must not suppress or delay the others.
+  test('keeps delivering data from healthy sources when one source fails', async () => {
+    server = createServer((_req, res) => {
+      res.setHeader('content-type', 'application/json')
+      res.end(
+        JSON.stringify([{ link: 'https://good.example/s', kind: 'video' }]),
+      )
+    })
+    await new Promise<void>((resolve) =>
+      server!.listen(0, '127.0.0.1', resolve),
+    )
+    const { port } = server.address() as AddressInfo
+
+    const combined = combineDataSources(
+      [
+        // Nothing is listening on this port, so this source always fails.
+        markDataSource(pollDataURL('http://127.0.0.1:1/', 999), 'json-url'),
+        markDataSource(
+          pollDataURL(`http://127.0.0.1:${port}/`, 999),
+          'json-url',
+        ),
+      ],
+      new StreamIDGenerator(),
+    )
+    let seenGoodStream = false
+    // Bounded read, and no teardown: see the note in the test above.
+    for (let i = 0; i < 5 && !seenGoodStream; i++) {
+      const { value } = await combined.next()
+      seenGoodStream = Boolean(
+        value?.some((s) => s.link === 'https://good.example/s'),
+      )
+    }
+    expect(seenGoodStream).toBe(true)
+  })
 })
 
 describe('StreamIDGenerator', () => {

--- a/packages/streamwall/src/main/data.ts
+++ b/packages/streamwall/src/main/data.ts
@@ -23,6 +23,16 @@ type DataSource = AsyncIterableIterator<StreamDataContent[]>
 // only being diagnosable from a log.
 export type DataSourceHealthCallback = (ok: boolean, message?: string) => void
 
+// The `await fetch(...)` below sits inside a loop, but this is a polling
+// *interval* loop over a single endpoint, not a fan-out over independent
+// items: iteration N is one refresh cycle of the same URL and must not start
+// before iteration N-1 has finished and the interval has elapsed. Batching or
+// parallelising the iterations would turn a paced poller into an unbounded
+// request flood against the operator's endpoint. Concurrency across data
+// sources already exists one level up: `buildDataSources` creates one
+// generator per URL and `combineDataSources` advances all of them at once via
+// `Repeater.latest`, so N URLs are polled in parallel with each other while
+// each individual URL stays strictly serial (see #582).
 export async function* pollDataURL(
   url: string,
   intervalSecs: number,
@@ -57,6 +67,13 @@ export async function* pollDataURL(
   }
 }
 
+// Like `pollDataURL`, the `await fsPromises.readFile(path)` below is inside a
+// loop, but the loop is event-driven over a single file: each iteration is
+// triggered by a filesystem event for that one path, so there is nothing
+// independent to fan out over. Reading ahead would just re-read the same file.
+// Multiple watched files are already concurrent with each other, one generator
+// per path, combined by `combineDataSources` (see #582).
+//
 // Built as a Repeater rather than a plain `async function*`: once a value
 // has been yielded, this generator suspends waiting for the *next*
 // filesystem event, which may never happen. A native async generator


### PR DESCRIPTION
Audits the two N+1 I/O findings reported against `packages/streamwall/src/main/data.ts` in #582 and pins the resulting behaviour with tests.

## Verdict per site

**`pollDataURL` (~line 36) — deliberately left serial.**
The `await fetch(url)` is inside a polling *interval* loop over a single endpoint, not a fan-out over independent items. Iteration N is the next refresh cycle of the same URL and must not start before iteration N-1 has finished and the interval has elapsed. Parallelising it would turn a paced poller into an unbounded request flood against the operator's endpoint.

**`watchDataFile` (~line 85) — deliberately left serial.**
The `await fsPromises.readFile(path)` is inside an event-driven loop over a single file. Each iteration is triggered by a filesystem event for that one path, so there is nothing independent to fan out over — reading ahead would only re-read the same file.

**Concurrency across sources already exists, one level up.**
`buildDataSources` creates one generator per URL / per TOML file, and `combineDataSources` advances all of them at once via `Repeater.latest`. N URLs are therefore already polled in parallel with each other, while each individual URL stays strictly serial. There is no unbounded fan-out to cap: the number of sources is bounded by the `--data.json-url` / `--data.toml-file` / `--presets` flags, and each source is a single long-lived generator rather than a per-iteration burst of requests.

Since the reported serial awaits are correct as written, no production behaviour is changed here.

## What this PR does

- Documents both loops in `data.ts` with the reasoning above, so the static finding is not "fixed" into a regression later.
- Adds tests in `data.test.ts`:
  - `pollDataURL` never issues overlapping requests for a single URL (peak in-flight request count stays at 1 across several poll cycles).
  - Independent URLs are polled concurrently rather than one after another — the test server withholds every response until two requests have arrived, so a value can only be produced if both polls are in flight simultaneously.
  - Error semantics of the fan-out: a source whose fetch always fails does not suppress or delay data from a healthy source.

## Remaining work

The issue's second suggestion — splitting source polling, file watching and parsing into separate modules to address the change-entropy signal — is a larger structural change and is intentionally **not** part of this PR. It should be tracked separately.

## Verification

- `npm run test` — pass
- `npm run lint` — pass
- `npm run typecheck` — pass

Refs #582 (the I/O findings are addressed as false positives; the module split remains open, so the issue is not auto-closed).
