### PR TITLE
refactor(streamwall): decompose StreamWindow's brain methods

### DIFF
--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -559,6 +559,132 @@ describe('StreamWindow.setViews reusing an actor across a genuine content change
   })
 })
 
+describe('StreamWindow.setViews matcher precedence', () => {
+  const streamA: ViewContent = { url: 'https://example.com/a', kind: 'video' }
+
+  it('prefers the same-content view already sitting in the box space over an equally-matching one elsewhere', () => {
+    const sw = makeStreamWindow(makeConfig({ cols: 2, rows: 1 }))
+    sw.win = {
+      contentView: { removeChildView: vi.fn() },
+    } as unknown as InstanceType<typeof StreamWindow>['win']
+
+    const inPlace = makeReuseTestActor({
+      id: 1,
+      content: streamA,
+      spaces: [0],
+      running: true,
+    })
+    const elsewhere = makeReuseTestActor({
+      id: 2,
+      content: streamA,
+      spaces: [1],
+      running: true,
+    })
+    // `elsewhere` is registered first, so only the space-overlap tie-break in
+    // the first matcher can make `inPlace` win.
+    sw.views = new Map([
+      [2, elsewhere.actor],
+      [1, inPlace.actor],
+    ])
+    sw.createView = vi.fn()
+
+    sw.setViews(new Map([['0', streamA]]), {
+      byURL: new Map([[streamA.url, {}]]),
+    })
+
+    expect(sw.createView).not.toHaveBeenCalled()
+    expect(inPlace.send).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'DISPLAY', content: streamA }),
+    )
+    expect(sw.views.get(1)).toBe(inPlace.actor)
+    // The redundant copy is torn down rather than left dangling.
+    expect(elsewhere.stop).toHaveBeenCalled()
+    expect(sw.views.has(2)).toBe(false)
+  })
+
+  it('reuses a still-loading view that already has the requested content instead of creating a new one', () => {
+    const sw = makeStreamWindow(makeConfig({ cols: 1, rows: 1 }))
+    sw.win = {
+      contentView: { removeChildView: vi.fn() },
+    } as unknown as InstanceType<typeof StreamWindow>['win']
+
+    const loading = makeReuseTestActor({
+      id: 1,
+      content: streamA,
+      spaces: [0],
+      running: false,
+    })
+    sw.views = new Map([[1, loading.actor]])
+    sw.createView = vi.fn()
+
+    sw.setViews(new Map([['0', streamA]]), {
+      byURL: new Map([[streamA.url, {}]]),
+    })
+
+    expect(sw.createView).not.toHaveBeenCalled()
+    expect(loading.stop).not.toHaveBeenCalled()
+    expect(loading.send).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'DISPLAY', content: streamA }),
+    )
+    expect(sw.views.get(1)).toBe(loading.actor)
+  })
+
+  it('prefers a live view over an equally-matching parked one', () => {
+    const sw = makeStreamWindow(makeConfig({ cols: 1, rows: 1 }))
+    sw.win = {
+      contentView: { removeChildView: vi.fn() },
+    } as unknown as InstanceType<typeof StreamWindow>['win']
+
+    const live = makeReuseTestActor({
+      id: 1,
+      content: streamA,
+      spaces: [0],
+      running: true,
+    })
+    const parked = makeReuseTestActor({
+      id: 2,
+      content: streamA,
+      spaces: [0],
+      running: true,
+    })
+    sw.views = new Map([[1, live.actor]])
+    sw.parkedViews = new Map([[2, parked.actor]])
+    sw.createView = vi.fn()
+
+    sw.setViews(new Map([['0', streamA]]), {
+      byURL: new Map([[streamA.url, {}]]),
+    })
+
+    expect(sw.views.get(1)).toBe(live.actor)
+    expect(live.stop).not.toHaveBeenCalled()
+    expect(parked.stop).toHaveBeenCalled()
+    // The parking bookkeeping is reset by every setViews call.
+    expect(sw.parkedViews.size).toBe(0)
+  })
+
+  it('tears down a view that no box wants and that is not parked', () => {
+    const sw = makeStreamWindow(makeConfig({ cols: 1, rows: 1 }))
+    sw.win = {
+      contentView: { removeChildView: vi.fn() },
+    } as unknown as InstanceType<typeof StreamWindow>['win']
+
+    const orphan = makeReuseTestActor({
+      id: 1,
+      content: streamA,
+      spaces: [0],
+      running: true,
+    })
+    sw.views = new Map([[1, orphan.actor]])
+    sw.createView = vi.fn()
+
+    sw.setViews(new Map(), { byURL: new Map() })
+
+    expect(orphan.stop).toHaveBeenCalled()
+    expect(orphan.disposeView).toHaveBeenCalledTimes(1)
+    expect(sw.views.size).toBe(0)
+  })
+})
+
 describe('StreamWindow.setViews expanding a view to fill the wall (issue #362)', () => {
   it('reuses the running actor and spans it across every grid cell', () => {
     const sw = makeStreamWindow(makeConfig({ cols: 2, rows: 2 }))

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -8,7 +8,6 @@ import {
   WebContentsView,
 } from 'electron'
 import EventEmitter from 'events'
-import { intersection, isEqual } from 'lodash-es'
 import path from 'path'
 import {
   asViewId,
@@ -20,7 +19,6 @@ import {
   StreamList,
   StreamwallState,
   StreamWindowConfig,
-  ViewContent,
   ViewContentMap,
   ViewId,
   ViewState,
@@ -29,6 +27,7 @@ import { createActor, EventFrom, SnapshotFrom } from 'xstate'
 import { devServerOrigin, loadHTML } from './loadHTML'
 import { secureStreamView } from './navigationSecurity'
 import { allocateViewPartition, hardenSession } from './partitions'
+import { planViewLayout, type ViewCandidate } from './viewLayoutPlan'
 import viewStateMachine, {
   DEFAULT_RETRY_CONFIG,
   RetryConfig,
@@ -43,6 +42,13 @@ function getDisplayOptions(stream: StreamData): ContentDisplayOptions {
   const { rotation } = stream
   return { rotation }
 }
+
+/**
+ * One box of the requested wall layout, as produced by
+ * `boxesFromViewContentMap`: its grid geometry, the cells it covers and the
+ * content it asks for.
+ */
+type LayoutBox = ReturnType<typeof boxesFromViewContentMap>[number]
 
 export interface StreamWindowEventMap {
   load: []
@@ -91,6 +97,25 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
     this.parkedViews = new Map()
     this.viewsByWebContentsId = new Map()
 
+    // Sequenced setup: the window must exist before the layer views can be
+    // added to it, and both layers must exist before the IPC handlers that
+    // reference them are registered.
+    this.win = this.createWallWindow()
+    this.backgroundView = this.createLayerView('background', {
+      preload: path.join(__dirname, 'layerPreload.js'),
+    })
+    this.overlayView = this.createLayerView('overlay', {
+      contextIsolation: true,
+      preload: path.join(__dirname, 'layerPreload.js'),
+    })
+    this.setupIpcHandlers()
+  }
+
+  /**
+   * Creates the wall's BrowserWindow on the configured display and wires its
+   * lifecycle events (close, first show, resize) to this StreamWindow.
+   */
+  private createWallWindow(): BrowserWindow {
     const {
       width,
       height,
@@ -135,41 +160,38 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
     // the new content area.
     win.on('resize', () => this.handleResize())
 
-    this.win = win
+    return win
+  }
 
-    const backgroundView = new WebContentsView({
-      webPreferences: {
-        preload: path.join(__dirname, 'layerPreload.js'),
-      },
-    })
-    backgroundView.setBackgroundColor('#0000')
-    win.contentView.addChildView(backgroundView)
-    backgroundView.setBounds({
+  /**
+   * Creates one of the two transparent full-window chrome layers (the
+   * background and the overlay), sizes it to the configured wall dimensions
+   * and loads its HTML entry point.
+   */
+  private createLayerView(
+    page: 'background' | 'overlay',
+    webPreferences: Electron.WebPreferences,
+  ): WebContentsView {
+    const { width, height } = this.config
+    const layerView = new WebContentsView({ webPreferences })
+    layerView.setBackgroundColor('#0000')
+    this.win.contentView.addChildView(layerView)
+    layerView.setBounds({
       x: 0,
       y: 0,
       width,
       height,
     })
-    loadHTML(backgroundView.webContents, 'background')
-    this.backgroundView = backgroundView
+    loadHTML(layerView.webContents, page)
+    return layerView
+  }
 
-    const overlayView = new WebContentsView({
-      webPreferences: {
-        contextIsolation: true,
-        preload: path.join(__dirname, 'layerPreload.js'),
-      },
-    })
-    overlayView.setBackgroundColor('#0000')
-    win.contentView.addChildView(overlayView)
-    overlayView.setBounds({
-      x: 0,
-      y: 0,
-      width,
-      height,
-    })
-    loadHTML(overlayView.webContents, 'overlay')
-    this.overlayView = overlayView
-
+  /**
+   * Registers the main-process IPC handlers: the chrome layers' load
+   * notification, and the per-view messages routed back to the owning actor
+   * via `viewsByWebContentsId`.
+   */
+  private setupIpcHandlers() {
     ipcMain.handle('layer:load', (ev) => {
       if (
         ev.sender !== this.backgroundView.webContents &&
@@ -235,7 +257,7 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
       })
     })
     ipcMain.on('devtools-overlay', () => {
-      overlayView.webContents.openDevTools()
+      this.overlayView.webContents.openDevTools()
     })
   }
 
@@ -451,102 +473,52 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
     this.config.rows = rows
   }
 
-  setViews(
-    viewContentMap: ViewContentMap,
+  /**
+   * Describes every actor eligible for reuse by the next `setViews` call, in
+   * the priority order `planViewLayout` resolves ties by: live views first,
+   * then views parked by a previous `parkUnused` call -- which are reuse
+   * candidates too, so a fullscreen collapse can find and reposition them
+   * instead of creating new ones (issue #369).
+   */
+  private reuseCandidates(): Array<ViewCandidate<ViewActor>> {
+    return [...this.views.values(), ...this.parkedViews.values()].map(
+      (view) => {
+        const snapshot = view.getSnapshot()
+        return {
+          view,
+          content: snapshot.context.content,
+          spaces: snapshot.context.pos?.spaces,
+          isRunning: snapshot.matches({ displaying: 'running' }),
+        }
+      },
+    )
+  }
+
+  /**
+   * Applies the reuse/creation half of a layout plan: positions each assigned
+   * actor in its box and returns the new `views` map. Any actor whose box
+   * turns out to be unusable (no content, or a URL missing from `streams`) is
+   * added to `unusedViews` so the caller's teardown pass reclaims it --
+   * dropping the reference outright would leak the actor, its
+   * WebContentsView and its offscreen BrowserWindow permanently.
+   */
+  private displayPlannedViews(
+    viewsToDisplay: Array<{ box: LayoutBox; view: ViewActor }>,
     streams: StreamList,
-    { parkUnused = false }: { parkUnused?: boolean } = {},
-  ) {
+    previouslyParkedIds: Set<ViewId>,
+    unusedViews: Set<ViewActor>,
+  ): Map<ViewId, ViewActor> {
     const { width, height, cols, rows } = this.config
-    const { views } = this
-    const boxes = boxesFromViewContentMap(cols, rows, viewContentMap)
-    const remainingBoxes = new Set(boxes)
-    // Views parked by a previous `parkUnused` call are reuse candidates too,
-    // so a fullscreen collapse can find and reposition them via the matchers
-    // below instead of creating new ones (issue #369).
-    const unusedViews = new Set([
-      ...views.values(),
-      ...this.parkedViews.values(),
-    ])
-    // Snapshot which actor ids were parked coming into this call, so a view
-    // matched back into a box below can be told to resume playback (issue
-    // #374) -- `this.parkedViews` itself is cleared right after and
-    // repopulated with whatever is still unused once this call is done.
-    const previouslyParkedIds = new Set(this.parkedViews.keys())
-    this.parkedViews.clear()
-    const viewsToDisplay = []
-
-    // We try to find the best match for moving / reusing existing views to match the new positions.
-    const matchers: Array<
-      (
-        v: SnapshotFrom<typeof viewStateMachine>,
-        content: ViewContent | undefined,
-        spaces?: number[],
-      ) => boolean
-    > = [
-      // First try to find a loaded view of the same URL in the same space...
-      (v, content, spaces) =>
-        isEqual(v.context.content, content) &&
-        v.matches({ displaying: 'running' }) &&
-        intersection(v.context.pos?.spaces, spaces).length > 0,
-      // Then try to find a loaded view of the same URL...
-      (v, content) =>
-        isEqual(v.context.content, content) &&
-        v.matches({ displaying: 'running' }),
-      // Then try view with the same URL that is still loading...
-      (v, content) => isEqual(v.context.content, content),
-      // Finally, if no view already shows this content, reuse whichever
-      // running view already occupies the box's space regardless of its
-      // content, so a genuine content change (a playlist advance, a
-      // drag-to-place reassignment) reuses the actor already there via a
-      // DISPLAY event -- letting `running`'s own swap handling take over --
-      // instead of always tearing it down and creating a brand-new one.
-      // Scoped to `running` only: `loading`/`error` have no DISPLAY handler
-      // of their own for changed content, so the event would bubble up to
-      // `displaying`'s handler, whose `contentUnchanged` guard would then
-      // silently drop it and strand the actor on its old content.
-      (v, _content, spaces) =>
-        v.matches({ displaying: 'running' }) &&
-        intersection(v.context.pos?.spaces, spaces).length > 0,
-    ]
-
-    for (const matcher of matchers) {
-      for (const box of remainingBoxes) {
-        const { content, spaces } = box
-        let foundView
-        for (const view of unusedViews) {
-          const snapshot = view.getSnapshot()
-          if (matcher(snapshot, content, spaces)) {
-            foundView = view
-            break
-          }
-        }
-        if (foundView) {
-          viewsToDisplay.push({ box, view: foundView })
-          unusedViews.delete(foundView)
-          remainingBoxes.delete(box)
-        }
-      }
-    }
-
-    for (const box of remainingBoxes) {
-      const view = this.createView()
-      viewsToDisplay.push({ box, view })
-    }
-
-    const newViews = new Map()
+    const newViews = new Map<ViewId, ViewActor>()
     for (const { box, view } of viewsToDisplay) {
       const { content, spaces } = box
       if (!content) {
-        // Route through the teardown path below instead of dropping the
-        // reference outright, or the actor/WebContentsView/offscreen
-        // BrowserWindow behind it leaks permanently.
         unusedViews.add(view)
         continue
       }
 
       const stream = streams.byURL?.get(content.url)
       if (!stream) {
-        // Same leak risk as above, for a box whose URL isn't in `streams.byURL`.
         unusedViews.add(view)
         continue
       }
@@ -564,10 +536,17 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
       }
       newViews.set(viewId, view)
     }
+    return newViews
+  }
+
+  /**
+   * Applies the leftover half of a layout plan: every actor no box claimed is
+   * either parked (kept alive but hidden, see `hideView` and the
+   * `parkedViews` field) or stopped and fully disposed.
+   */
+  private retireUnusedViews(unusedViews: Set<ViewActor>, parkUnused: boolean) {
     for (const view of unusedViews) {
       if (parkUnused) {
-        // Keep the actor alive, just hidden -- see `hideView` and the
-        // `parkedViews` field.
         this.hideView(view)
         this.parkedViews.set(view.getSnapshot().context.id, view)
         continue
@@ -588,6 +567,39 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
         disposeView(next.view, next.offscreenWin)
       }
     }
+  }
+
+  setViews(
+    viewContentMap: ViewContentMap,
+    streams: StreamList,
+    { parkUnused = false }: { parkUnused?: boolean } = {},
+  ) {
+    const { cols, rows } = this.config
+    const boxes = boxesFromViewContentMap(cols, rows, viewContentMap)
+
+    // Snapshot which actor ids were parked coming into this call, so a view
+    // matched back into a box below can be told to resume playback (issue
+    // #374) -- `this.parkedViews` itself is cleared right after and
+    // repopulated with whatever is still unused once this call is done.
+    const previouslyParkedIds = new Set(this.parkedViews.keys())
+
+    // Decide reuse vs. teardown vs. creation up front, then just execute it.
+    const plan = planViewLayout(boxes, this.reuseCandidates())
+    this.parkedViews.clear()
+
+    const unusedViews = new Set(plan.unusedViews)
+    const viewsToDisplay = [
+      ...plan.reused,
+      ...plan.unmatchedBoxes.map((box) => ({ box, view: this.createView() })),
+    ]
+
+    const newViews = this.displayPlannedViews(
+      viewsToDisplay,
+      streams,
+      previouslyParkedIds,
+      unusedViews,
+    )
+    this.retireUnusedViews(unusedViews, parkUnused)
     this.views = newViews
     this.emitState()
   }

--- a/packages/streamwall/src/main/viewLayoutPlan.test.ts
+++ b/packages/streamwall/src/main/viewLayoutPlan.test.ts
@@ -1,0 +1,204 @@
+import { asCellIdx, type CellIdx, type ViewContent } from 'streamwall-shared'
+import { describe, expect, it } from 'vitest'
+import { planViewLayout, type ViewCandidate } from './viewLayoutPlan'
+
+const streamA: ViewContent = { url: 'https://example.com/a', kind: 'video' }
+const streamB: ViewContent = { url: 'https://example.com/b', kind: 'video' }
+const streamC: ViewContent = { url: 'https://example.com/c', kind: 'video' }
+
+function cells(...idxs: number[]): CellIdx[] {
+  return idxs.map(asCellIdx)
+}
+
+function box(content: ViewContent | undefined, ...spaces: number[]) {
+  return { content, spaces: cells(...spaces) }
+}
+
+/**
+ * A named stand-in for an existing view actor. The planner treats `view` as an
+ * opaque payload, so a plain string is enough to assert on.
+ */
+function candidate(
+  name: string,
+  opts: {
+    content?: ViewContent | null
+    spaces?: number[]
+    running?: boolean
+  } = {},
+): ViewCandidate<string> {
+  return {
+    view: name,
+    content: opts.content ?? null,
+    spaces: opts.spaces === undefined ? undefined : cells(...opts.spaces),
+    isRunning: opts.running ?? false,
+  }
+}
+
+describe('planViewLayout', () => {
+  it('leaves every box unmatched when there are no candidates', () => {
+    const boxA = box(streamA, 0)
+    const boxB = box(streamB, 1)
+
+    const plan = planViewLayout([boxA, boxB], [])
+
+    expect(plan.reused).toEqual([])
+    expect(plan.unmatchedBoxes).toEqual([boxA, boxB])
+    expect(plan.unusedViews).toEqual([])
+  })
+
+  it('returns every candidate as unused when there are no boxes', () => {
+    const plan = planViewLayout(
+      [],
+      [candidate('a', { content: streamA, spaces: [0], running: true })],
+    )
+
+    expect(plan.reused).toEqual([])
+    expect(plan.unmatchedBoxes).toEqual([])
+    expect(plan.unusedViews).toEqual(['a'])
+  })
+
+  it('matches a running view showing the same content in the same space first', () => {
+    const boxA = box(streamA, 0)
+
+    const plan = planViewLayout(
+      [boxA],
+      [
+        candidate('elsewhere', {
+          content: streamA,
+          spaces: [1],
+          running: true,
+        }),
+        candidate('inPlace', { content: streamA, spaces: [0], running: true }),
+      ],
+    )
+
+    expect(plan.reused).toEqual([{ box: boxA, view: 'inPlace' }])
+    expect(plan.unusedViews).toEqual(['elsewhere'])
+  })
+
+  it('matches a running view showing the same content in a different space when none is in place', () => {
+    const boxA = box(streamA, 0)
+
+    const plan = planViewLayout(
+      [boxA],
+      [candidate('moved', { content: streamA, spaces: [5], running: true })],
+    )
+
+    expect(plan.reused).toEqual([{ box: boxA, view: 'moved' }])
+    expect(plan.unusedViews).toEqual([])
+  })
+
+  it('matches a still-loading view with the same content when no running one exists', () => {
+    const boxA = box(streamA, 0)
+
+    const plan = planViewLayout(
+      [boxA],
+      [candidate('loading', { content: streamA, spaces: [0], running: false })],
+    )
+
+    expect(plan.reused).toEqual([{ box: boxA, view: 'loading' }])
+  })
+
+  it('falls back to the running view occupying the space across a genuine content change (issue #311)', () => {
+    const boxB = box(streamB, 0)
+
+    const plan = planViewLayout(
+      [boxB],
+      [candidate('there', { content: streamA, spaces: [0], running: true })],
+    )
+
+    expect(plan.reused).toEqual([{ box: boxB, view: 'there' }])
+    expect(plan.unmatchedBoxes).toEqual([])
+  })
+
+  it('does not apply the space fallback to a non-running view, which has no DISPLAY handler for changed content', () => {
+    const boxB = box(streamB, 0)
+
+    const plan = planViewLayout(
+      [boxB],
+      [candidate('loading', { content: streamA, spaces: [0], running: false })],
+    )
+
+    expect(plan.reused).toEqual([])
+    expect(plan.unmatchedBoxes).toEqual([boxB])
+    expect(plan.unusedViews).toEqual(['loading'])
+  })
+
+  it('resolves an exact content match before any space-only fallback, across boxes', () => {
+    // Mirrors the three-box scenario in StreamWindow.test.ts: the exact
+    // content matcher must claim `moved` for box 2 before the space fallback
+    // could steal it for box 1.
+    const boxAtZero = box(streamC, 0)
+    const boxAtOne = box(streamA, 1)
+    const boxAtTwo = box(streamB, 2)
+
+    const plan = planViewLayout(
+      [boxAtZero, boxAtOne, boxAtTwo],
+      [
+        candidate('spaceOnly', {
+          content: streamC,
+          spaces: [0],
+          running: true,
+        }),
+        candidate('moved', { content: streamB, spaces: [1], running: true }),
+      ],
+    )
+
+    expect(plan.reused).toEqual([
+      { box: boxAtZero, view: 'spaceOnly' },
+      { box: boxAtTwo, view: 'moved' },
+    ])
+    expect(plan.unmatchedBoxes).toEqual([boxAtOne])
+    expect(plan.unusedViews).toEqual([])
+  })
+
+  it('never assigns one candidate to two boxes', () => {
+    const boxOne = box(streamA, 0)
+    const boxTwo = box(streamA, 1)
+
+    const plan = planViewLayout(
+      [boxOne, boxTwo],
+      [candidate('only', { content: streamA, spaces: [0], running: true })],
+    )
+
+    expect(plan.reused).toEqual([{ box: boxOne, view: 'only' }])
+    expect(plan.unmatchedBoxes).toEqual([boxTwo])
+  })
+
+  it('breaks ties in candidate order, so live views win over parked ones', () => {
+    const boxA = box(streamA, 0)
+
+    const plan = planViewLayout(
+      [boxA],
+      [
+        candidate('live', { content: streamA, spaces: [0], running: true }),
+        candidate('parked', { content: streamA, spaces: [0], running: true }),
+      ],
+    )
+
+    expect(plan.reused).toEqual([{ box: boxA, view: 'live' }])
+    expect(plan.unusedViews).toEqual(['parked'])
+  })
+
+  it('matches a view with no placement yet by content alone', () => {
+    const boxA = box(streamA, 0)
+
+    const plan = planViewLayout(
+      [boxA],
+      [candidate('unplaced', { content: streamA, running: true })],
+    )
+
+    expect(plan.reused).toEqual([{ box: boxA, view: 'unplaced' }])
+  })
+
+  it('matches a box spanning several cells against a view overlapping any of them', () => {
+    const wide = box(streamA, 0, 1, 2, 3)
+
+    const plan = planViewLayout(
+      [wide],
+      [candidate('corner', { content: streamA, spaces: [3], running: true })],
+    )
+
+    expect(plan.reused).toEqual([{ box: wide, view: 'corner' }])
+  })
+})

--- a/packages/streamwall/src/main/viewLayoutPlan.ts
+++ b/packages/streamwall/src/main/viewLayoutPlan.ts
@@ -1,0 +1,124 @@
+import { intersection, isEqual } from 'lodash-es'
+import type { CellIdx, ViewContent } from 'streamwall-shared'
+
+/**
+ * The subset of a box produced by `boxesFromViewContentMap` that the planner
+ * needs. Kept structural so the caller can pass the full box through
+ * untouched and get the very same object back in the plan.
+ */
+export interface PlannableBox {
+  content: ViewContent | undefined
+  spaces: CellIdx[]
+}
+
+/**
+ * What the planner is allowed to know about an existing view actor: the two
+ * things the matchers read from its snapshot, plus the actor itself as an
+ * opaque payload.
+ *
+ * Note the addressing axes stay separate here (issue #397/#507): `spaces`
+ * holds *cell indexes* (positions in the current grid), never the actor's
+ * stable view id. The planner never looks at the view id at all -- reuse is
+ * decided purely from content and occupied cells, and the caller keys the
+ * resulting actors by their own `context.id` afterwards.
+ */
+export interface ViewCandidate<TView> {
+  view: TView
+  /** The content the actor is currently showing, if any. */
+  content: ViewContent | null | undefined
+  /** The grid cells the actor currently occupies, if it has a placement. */
+  spaces: CellIdx[] | undefined
+  /** Whether the actor is in `displaying.running`. */
+  isRunning: boolean
+}
+
+export interface ViewLayoutPlan<TBox, TView> {
+  /** Boxes matched to an existing actor, in the order they were matched. */
+  reused: Array<{ box: TBox; view: TView }>
+  /** Boxes no existing actor could serve; the caller must create views for these. */
+  unmatchedBoxes: TBox[]
+  /** Actors no box claimed; the caller parks or tears these down. */
+  unusedViews: TView[]
+}
+
+type Matcher<TView> = (
+  candidate: ViewCandidate<TView>,
+  content: ViewContent | undefined,
+  spaces: CellIdx[] | undefined,
+) => boolean
+
+/**
+ * We try to find the best match for moving / reusing existing views to match
+ * the new positions. Applied in order: every remaining box gets a chance at
+ * matcher *n* before matcher *n+1* is considered at all.
+ */
+const matchers: Array<Matcher<unknown>> = [
+  // First try to find a loaded view of the same URL in the same space...
+  ({ content: viewContent, spaces: viewSpaces, isRunning }, content, spaces) =>
+    isEqual(viewContent, content) &&
+    isRunning &&
+    intersection(viewSpaces, spaces).length > 0,
+  // Then try to find a loaded view of the same URL...
+  ({ content: viewContent, isRunning }, content) =>
+    isEqual(viewContent, content) && isRunning,
+  // Then try view with the same URL that is still loading...
+  ({ content: viewContent }, content) => isEqual(viewContent, content),
+  // Finally, if no view already shows this content, reuse whichever
+  // running view already occupies the box's space regardless of its
+  // content, so a genuine content change (a playlist advance, a
+  // drag-to-place reassignment) reuses the actor already there via a
+  // DISPLAY event -- letting `running`'s own swap handling take over --
+  // instead of always tearing it down and creating a brand-new one.
+  // Scoped to `running` only: `loading`/`error` have no DISPLAY handler
+  // of their own for changed content, so the event would bubble up to
+  // `displaying`'s handler, whose `contentUnchanged` guard would then
+  // silently drop it and strand the actor on its old content.
+  ({ spaces: viewSpaces, isRunning }, _content, spaces) =>
+    isRunning && intersection(viewSpaces, spaces).length > 0,
+]
+
+/**
+ * Decides, for a requested wall layout, which existing view actors get reused
+ * for which boxes, which boxes need a brand-new view, and which actors are
+ * left over.
+ *
+ * Pure: it performs no side effects and does not touch the actors it is given
+ * (they are opaque payloads). `StreamWindow.setViews` is the executor of the
+ * plan this returns.
+ *
+ * `candidates` order is significant: when several actors match a box equally
+ * well, the earliest one wins. `StreamWindow` passes its live views before its
+ * parked ones, so a live view is preferred over a parked one (issue #369).
+ */
+export function planViewLayout<TBox extends PlannableBox, TView>(
+  boxes: TBox[],
+  candidates: Array<ViewCandidate<TView>>,
+): ViewLayoutPlan<TBox, TView> {
+  const remainingBoxes = new Set(boxes)
+  const unusedViews = new Set(candidates)
+  const reused: Array<{ box: TBox; view: TView }> = []
+
+  for (const matcher of matchers as Array<Matcher<TView>>) {
+    for (const box of remainingBoxes) {
+      const { content, spaces } = box
+      let found: ViewCandidate<TView> | undefined
+      for (const candidate of unusedViews) {
+        if (matcher(candidate, content, spaces)) {
+          found = candidate
+          break
+        }
+      }
+      if (found) {
+        reused.push({ box, view: found.view })
+        unusedViews.delete(found)
+        remainingBoxes.delete(box)
+      }
+    }
+  }
+
+  return {
+    reused,
+    unmatchedBoxes: [...remainingBoxes],
+    unusedViews: [...unusedViews].map(({ view }) => view),
+  }
+}


### PR DESCRIPTION
Structural refactor of `packages/streamwall/src/main/StreamWindow.ts`, the file Repowise ranks as the highest-leverage in the repo (defect score 2.5/10, weighted deficit 2734). No behaviour change.

## What was extracted

**`planViewLayout()` (new `src/main/viewLayoutPlan.ts`)** — the view-diffing decision that used to live inline in `setViews`. Given the requested boxes and a list of reuse candidates, it returns a plan:

- `reused` — boxes matched to an existing actor,
- `unmatchedBoxes` — boxes that still need a brand-new view,
- `unusedViews` — actors no box claimed.

It is pure: actors are opaque payloads, and it only reads the three snapshot facts the matchers ever used (current content, occupied cells, whether the actor is in `displaying.running`). The four matchers moved across verbatim, comments included.

The two addressing axes stay separate (#397/#467/#507): the planner reasons about `CellIdx` only and never looks at a `ViewId` — reuse is decided from content and occupied cells, and `StreamWindow` keys the resulting actors by `context.id` afterwards, exactly as before.

**`setViews` is now a thin executor**: collect candidates (`reuseCandidates()`), plan, create views for the unmatched boxes, then apply via `displayPlannedViews()` and `retireUnusedViews()`. It went from 98 lines / CCN 19 to ~30 lines of sequencing.

**The constructor** keeps the same statement order but delegates to `createWallWindow()`, `createLayerView()` and `setupIpcHandlers()`, going from 138 lines / CCN 10 to a 10-line sequencer.

## Why it is behaviour-preserving

Unchanged: the matchers and their order; the outer-loop-per-matcher structure (every remaining box gets a chance at matcher *n* before matcher *n+1*); box and candidate iteration order; the tie-break by candidate order, so live views still win over parked ones; the leak-avoiding fallthrough that routes a box with no content or no matching stream into the teardown pass; the `parkedViews` clear/repopulate points and the `previouslyParkedIds` RESUME snapshot; and the point at which `this.views` is replaced (still after teardown).

Precomputing each candidate's snapshot facts once is equivalent to re-reading `getSnapshot()` inside the loop, because nothing mutates any actor between the start of the matching pass and its end — `createView()` is only called afterwards.

In particular, an actor is **still never reused across a genuine content change unless it is already `running`** (#311): the space-overlap fallback remains scoped to `displaying.running`, since `loading`/`error` have no DISPLAY handler of their own and the event would be swallowed by `displaying`'s `contentUnchanged` guard.

No `viewStateMachine` regions were added or touched, so `viewStateValueSchema` needs no mirroring.

## How behaviour was pinned

Characterisation tests were added to `StreamWindow.test.ts` **first** and confirmed green against the unmodified implementation, covering `setViews` paths that were previously unpinned:

- the same-content view already sitting in the box space wins over an equally-matching one elsewhere,
- a still-loading view with the requested content is reused rather than replaced,
- a live view beats an equally-matching parked one,
- a view no box wants is stopped and disposed.

`viewLayoutPlan.test.ts` then tests the extracted planner directly (14 cases: empty inputs, each matcher tier, the non-running fallback exclusion, no double-assignment, candidate-order tie-breaks, multi-cell boxes).

## Public surface

Unchanged — every new member is `private`, the only new export is the planner module used by its own tests.

## Verification

- `npm run test` — pass (844 + 338 + 26 + 183 + 363)
- `npm run lint` — clean
- `npm run typecheck` — clean
- `npx prettier --check .` — clean

Closes #581