### PR TITLE
refactor(streamwall): extract main() startup phases into bootstrap.ts

### DIFF
--- a/packages/streamwall/src/main/bootstrap.test.ts
+++ b/packages/streamwall/src/main/bootstrap.test.ts
@@ -1,0 +1,651 @@
+import EventEmitter from 'node:events'
+import { join } from 'node:path'
+import type { StreamwallState, ViewId } from 'streamwall-shared'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import * as Y from 'yjs'
+import {
+  type LifecycleApp,
+  type LifecycleWindow,
+  type PreventableEvent,
+  configureElectronRuntime,
+  configureSentry,
+  createBrowseWindow,
+  createDataSourceHealthReporter,
+  createInitialClientState,
+  createPersistedLocalStreamData,
+  createStateDocPersister,
+  restoreStateDoc,
+  seedAndObserveViewsState,
+  setupApplicationMenu,
+  setupStreamdelayClient,
+  setupTwitchBot,
+  startPlaylistScheduler,
+  wireWindowIpc,
+  wireWindowLifecycle,
+} from './bootstrap'
+import type { StreamwallConfig } from './cliArgs'
+import log from './logger'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+function fakeStreamwallState(
+  overrides: Partial<StreamwallState> = {},
+): StreamwallState {
+  return {
+    ...createInitialClientState({
+      config: { width: 0, height: 0, x: 0, y: 0, cols: 2, rows: 2 },
+      layoutPresets: [],
+      favorites: [],
+    }),
+    ...overrides,
+  }
+}
+
+describe('setupApplicationMenu', () => {
+  it('resolves the user config path inside the userData directory', () => {
+    const installMenu = vi.fn()
+    const result = setupApplicationMenu({
+      userDataPath: '/user/data',
+      logFilePath: '/logs/main.log',
+      fileExists: () => true,
+      installMenu,
+    })
+
+    expect(result).toEqual({
+      userConfigPath: join('/user/data', 'config.toml'),
+      hasUserConfig: true,
+    })
+    expect(installMenu).toHaveBeenCalledWith(
+      join('/user/data', 'config.toml'),
+      '/logs/main.log',
+      true,
+    )
+  })
+
+  it('reports a missing user config to the menu', () => {
+    const installMenu = vi.fn()
+    const result = setupApplicationMenu({
+      userDataPath: '/user/data',
+      logFilePath: '/logs/main.log',
+      fileExists: () => false,
+      installMenu,
+    })
+
+    expect(result.hasUserConfig).toBe(false)
+    expect(installMenu).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      false,
+    )
+  })
+})
+
+describe('createPersistedLocalStreamData', () => {
+  it('seeds from stored entries and persists later updates', () => {
+    const persistEntries = vi.fn()
+    const localStreamData = createPersistedLocalStreamData({
+      initialEntries: [{ link: 'http://a.test/', kind: 'video' }],
+      persistEntries,
+    })
+
+    expect(localStreamData.dataByURL.get('http://a.test/')).toBeDefined()
+    expect(persistEntries).not.toHaveBeenCalled()
+
+    localStreamData.update('http://b.test/', { kind: 'video' })
+
+    expect(persistEntries).toHaveBeenCalledTimes(1)
+    const entries = persistEntries.mock.calls[0][0]
+    expect(entries.map((entry: { link?: string }) => entry.link)).toContain(
+      'http://b.test/',
+    )
+  })
+})
+
+describe('createInitialClientState', () => {
+  it('carries the persisted presets and favorites into a local identity', () => {
+    const state = createInitialClientState({
+      config: { width: 1, height: 2, x: 3, y: 4, cols: 3, rows: 2 },
+      layoutPresets: [],
+      favorites: [],
+    })
+
+    expect(state.identity).toEqual({ role: 'local' })
+    expect(state.config.cols).toBe(3)
+    expect(state.streams).toEqual([])
+    expect(state.fullscreenViewIdx).toBeNull()
+    expect(state.streamdelay).toBeNull()
+    expect(state.dataSourceHealth).toEqual([])
+  })
+})
+
+describe('restoreStateDoc', () => {
+  it('applies a stored snapshot', () => {
+    const source = new Y.Doc()
+    source.getMap('views').set('0', 'stored')
+    const encoded = Buffer.from(Y.encodeStateAsUpdate(source)).toString(
+      'base64',
+    )
+
+    const target = new Y.Doc()
+    restoreStateDoc(target, encoded)
+
+    expect(target.getMap('views').get('0')).toBe('stored')
+  })
+
+  it('keeps startup alive when the snapshot is corrupt', () => {
+    const warn = vi.spyOn(log, 'warn').mockImplementation(() => undefined)
+    const target = new Y.Doc()
+
+    expect(() => {
+      restoreStateDoc(target, 'bm90LWEteWpzLXVwZGF0ZQ==')
+    }).not.toThrow()
+    expect(warn).toHaveBeenCalled()
+  })
+})
+
+describe('createStateDocPersister', () => {
+  it('throttles snapshot writes and can flush a pending one', () => {
+    vi.useFakeTimers()
+    const stateDoc = new Y.Doc()
+    const saveSnapshot = vi.fn()
+    const persist = createStateDocPersister({
+      stateDoc,
+      saveSnapshot,
+      wait: 1000,
+    })
+
+    stateDoc.getMap('views').set('0', 'a')
+    stateDoc.getMap('views').set('1', 'b')
+    expect(saveSnapshot).toHaveBeenCalledTimes(1)
+
+    persist.flush()
+    expect(saveSnapshot).toHaveBeenCalledTimes(2)
+
+    const restored = new Y.Doc()
+    const lastCall = saveSnapshot.mock.calls.at(-1)
+    Y.applyUpdate(restored, Buffer.from(String(lastCall?.[0]), 'base64'))
+    expect(restored.getMap('views').get('1')).toBe('b')
+  })
+})
+
+describe('seedAndObserveViewsState', () => {
+  it('seeds every grid cell before rendering the wall once', () => {
+    const stateDoc = new Y.Doc()
+    const viewsState = stateDoc.getMap<Y.Map<string | undefined>>('views')
+    const seenCellCounts: number[] = []
+    const updateViews = vi.fn(() => {
+      seenCellCounts.push(viewsState.size)
+    })
+
+    seedAndObserveViewsState({
+      viewsState,
+      transact: (fn) => stateDoc.transact(fn),
+      cols: 2,
+      rows: 2,
+      updateViews,
+    })
+
+    // The seeding transaction must complete before the first render, and the
+    // observer must not fire during it -- exactly one render for four cells.
+    expect(updateViews).toHaveBeenCalledTimes(1)
+    expect(seenCellCounts).toEqual([4])
+  })
+
+  it('re-renders the wall on later view edits', () => {
+    const stateDoc = new Y.Doc()
+    const viewsState = stateDoc.getMap<Y.Map<string | undefined>>('views')
+    const updateViews = vi.fn()
+
+    seedAndObserveViewsState({
+      viewsState,
+      transact: (fn) => stateDoc.transact(fn),
+      cols: 1,
+      rows: 1,
+      updateViews,
+    })
+    updateViews.mockClear()
+
+    stateDoc.transact(() => {
+      viewsState.get('0')?.set('streamId', 'stream-1')
+    })
+
+    expect(updateViews).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('startPlaylistScheduler', () => {
+  it('advances a configured view onto its playlist stream', () => {
+    vi.useFakeTimers()
+    const stateDoc = new Y.Doc()
+    const viewsState = stateDoc.getMap<Y.Map<string | undefined>>('views')
+    viewsState.set('0', new Y.Map<string | undefined>())
+    const streams = [
+      { _id: 'stream-1', link: 'http://a.test/' },
+    ] as unknown as StreamwallState['streams']
+
+    const scheduler = startPlaylistScheduler({
+      playlists: [{ view: 0, interval: 1, urls: ['http://a.test/'] }],
+      getStreams: () => streams,
+      viewsState,
+      transact: (fn) => stateDoc.transact(fn),
+    })
+
+    try {
+      vi.advanceTimersByTime(1000)
+      expect(viewsState.get('0')?.get('streamId')).toBe('stream-1')
+    } finally {
+      scheduler.stop()
+    }
+  })
+})
+
+describe('createBrowseWindow', () => {
+  it('hardens the session and denies popups before handing the window over', () => {
+    const order: string[] = []
+    const win = { webContents: { session: 'session' } }
+    const result = createBrowseWindow({
+      createWindow: () => {
+        order.push('create')
+        return win
+      },
+      hardenSession: (session) => {
+        order.push(`harden:${session}`)
+      },
+      denyWindowOpen: () => {
+        order.push('deny')
+      },
+    })
+
+    expect(result).toBe(win)
+    expect(order).toEqual(['create', 'harden:session', 'deny'])
+  })
+})
+
+/** A stand-in for StreamWindow/ControlWindow's typed event emitters. */
+class FakeWindow extends EventEmitter {
+  win = { show: vi.fn(), hide: vi.fn() }
+  onState = vi.fn()
+  onYDocUpdate = vi.fn()
+  setCommandHandler = vi.fn()
+}
+
+describe('wireWindowIpc', () => {
+  function wire() {
+    const streamWindow = new FakeWindow()
+    const controlWindow = new FakeWindow()
+    const stateDoc = new Y.Doc()
+    const clientState = fakeStreamwallState()
+    const updateState = vi.fn()
+    const updateViewsFromStateDoc = vi.fn()
+    const handleCommand = vi.fn(async () => undefined)
+    const controlWindowOrigin = Symbol('control')
+
+    wireWindowIpc({
+      streamWindow,
+      controlWindow,
+      stateDoc,
+      updateState,
+      updateViewsFromStateDoc,
+      getClientState: () => clientState,
+      shouldForwardUpdate: (origin) => origin !== controlWindowOrigin,
+      controlWindowOrigin,
+      handleCommand,
+    })
+
+    return {
+      streamWindow,
+      controlWindow,
+      stateDoc,
+      clientState,
+      updateState,
+      updateViewsFromStateDoc,
+      handleCommand,
+      controlWindowOrigin,
+    }
+  }
+
+  it('broadcasts stream window view states', () => {
+    const { streamWindow, updateState } = wire()
+    streamWindow.emit('state', ['view'])
+    expect(updateState).toHaveBeenCalledWith({ views: ['view'] })
+  })
+
+  it('re-lays out and rebroadcasts on resize', () => {
+    const { streamWindow, updateState, updateViewsFromStateDoc } = wire()
+    streamWindow.emit('resize')
+    expect(updateViewsFromStateDoc).toHaveBeenCalledTimes(1)
+    expect(updateState).toHaveBeenCalledWith({})
+  })
+
+  it('sends the current state to each window as it loads', () => {
+    const { streamWindow, controlWindow, clientState } = wire()
+
+    streamWindow.emit('load')
+    expect(streamWindow.onState).toHaveBeenCalledWith(clientState)
+
+    controlWindow.emit('load')
+    expect(controlWindow.onState).toHaveBeenCalledWith(clientState)
+    expect(controlWindow.onYDocUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  it('echoes local doc updates to the control window but not its own', () => {
+    const { stateDoc, controlWindow, controlWindowOrigin } = wire()
+
+    stateDoc.getMap('views').set('0', 'local')
+    expect(controlWindow.onYDocUpdate).toHaveBeenCalledTimes(1)
+
+    controlWindow.onYDocUpdate.mockClear()
+    stateDoc.transact(() => {
+      stateDoc.getMap('views').set('1', 'echo')
+    }, controlWindowOrigin)
+    expect(controlWindow.onYDocUpdate).not.toHaveBeenCalled()
+  })
+
+  it('applies control window doc updates to the shared doc', () => {
+    const { stateDoc, controlWindow } = wire()
+    const source = new Y.Doc()
+    source.getMap('views').set('0', 'from-control')
+
+    controlWindow.emit('ydoc', Y.encodeStateAsUpdate(source))
+
+    expect(stateDoc.getMap('views').get('0')).toBe('from-control')
+  })
+
+  it('registers the control command handler', () => {
+    const { controlWindow, handleCommand } = wire()
+    expect(controlWindow.setCommandHandler).toHaveBeenCalledWith(handleCommand)
+  })
+})
+
+/** Records the app-level listeners `wireWindowLifecycle` registers. */
+class FakeApp extends EventEmitter implements LifecycleApp {
+  quit = vi.fn()
+}
+
+function preventableEvent(): PreventableEvent & { prevented: boolean } {
+  const event = {
+    prevented: false,
+    preventDefault: () => {
+      event.prevented = true
+    },
+  }
+  return event
+}
+
+describe('wireWindowLifecycle', () => {
+  function wire(
+    platform: NodeJS.Platform,
+    flushStorage = vi.fn(async () => undefined),
+  ) {
+    const app = new FakeApp()
+    const streamWindow = new FakeWindow()
+    const controlWindow = new FakeWindow()
+    wireWindowLifecycle({
+      app,
+      platform,
+      streamWindow: streamWindow as unknown as LifecycleWindow,
+      controlWindow: controlWindow as unknown as LifecycleWindow,
+      flushStorage,
+    })
+    return { app, streamWindow, controlWindow, flushStorage }
+  }
+
+  it('hides windows instead of quitting on macOS', () => {
+    const { app, streamWindow } = wire('darwin')
+    const event = preventableEvent()
+
+    streamWindow.emit('close', event)
+
+    expect(event.prevented).toBe(true)
+    expect(streamWindow.win.hide).toHaveBeenCalled()
+    expect(app.quit).not.toHaveBeenCalled()
+  })
+
+  it('quits when a window closes on other platforms', () => {
+    const { app, controlWindow } = wire('linux')
+    const event = preventableEvent()
+
+    controlWindow.emit('close', event)
+
+    expect(event.prevented).toBe(false)
+    expect(controlWindow.win.hide).not.toHaveBeenCalled()
+    expect(app.quit).toHaveBeenCalled()
+  })
+
+  it('quits on macOS once the user has asked to quit', () => {
+    const { app, streamWindow } = wire('darwin')
+
+    app.emit('before-quit', preventableEvent())
+    const event = preventableEvent()
+    streamWindow.emit('close', event)
+
+    expect(event.prevented).toBe(false)
+    expect(app.quit).toHaveBeenCalled()
+  })
+
+  it('reopens both windows on activate', () => {
+    const { app, streamWindow, controlWindow } = wire('darwin')
+    app.emit('activate')
+    expect(streamWindow.win.show).toHaveBeenCalled()
+    expect(controlWindow.win.show).toHaveBeenCalled()
+  })
+
+  it('quits when every window closed, except on macOS', () => {
+    const linux = wire('linux')
+    linux.app.emit('window-all-closed')
+    expect(linux.app.quit).toHaveBeenCalled()
+
+    const mac = wire('darwin')
+    mac.app.emit('window-all-closed')
+    expect(mac.app.quit).not.toHaveBeenCalled()
+  })
+
+  it('defers the first quit until storage is flushed, then quits once', async () => {
+    let resolveFlush: () => void = () => undefined
+    const flushStorage = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFlush = resolve
+        }),
+    )
+    const { app } = wire('linux', flushStorage)
+
+    const firstQuit = preventableEvent()
+    app.emit('before-quit', firstQuit)
+    expect(firstQuit.prevented).toBe(true)
+    expect(flushStorage).toHaveBeenCalledTimes(1)
+    expect(app.quit).not.toHaveBeenCalled()
+
+    resolveFlush()
+    await vi.waitFor(() => {
+      expect(app.quit).toHaveBeenCalledTimes(1)
+    })
+
+    // The quit triggered by the flush must pass straight through.
+    const secondQuit = preventableEvent()
+    app.emit('before-quit', secondQuit)
+    expect(secondQuit.prevented).toBe(false)
+    expect(flushStorage).toHaveBeenCalledTimes(1)
+  })
+
+  it('still quits when flushing storage fails', async () => {
+    const error = vi.spyOn(log, 'error').mockImplementation(() => undefined)
+    const { app } = wire(
+      'linux',
+      vi.fn(async () => {
+        throw new Error('disk full')
+      }),
+    )
+
+    app.emit('before-quit', preventableEvent())
+
+    await vi.waitFor(() => {
+      expect(app.quit).toHaveBeenCalledTimes(1)
+    })
+    expect(error).toHaveBeenCalled()
+  })
+})
+
+describe('setupStreamdelayClient', () => {
+  const config: StreamwallConfig['streamdelay'] = {
+    endpoint: 'http://localhost:8404',
+    key: null,
+  }
+
+  it('stays disabled without a key', () => {
+    const createClient = vi.fn()
+    expect(
+      setupStreamdelayClient({
+        config,
+        onState: vi.fn(),
+        createClient,
+      }),
+    ).toBeNull()
+    expect(createClient).not.toHaveBeenCalled()
+  })
+
+  it('connects and forwards status updates when a key is configured', () => {
+    const client = Object.assign(new EventEmitter(), { connect: vi.fn() })
+    const onState = vi.fn()
+
+    const result = setupStreamdelayClient({
+      config: { ...config, key: 'secret' },
+      onState,
+      createClient: () => client as never,
+    })
+
+    expect(result).toBe(client)
+    expect(client.connect).toHaveBeenCalledTimes(1)
+
+    client.emit('state', { isCensored: true })
+    expect(onState).toHaveBeenCalledWith({ isCensored: true })
+  })
+})
+
+describe('setupTwitchBot', () => {
+  const config = {
+    channel: null,
+    'client-id': null,
+    token: null,
+    color: '#ff0000',
+    announce: { template: '', interval: 0, delay: 0 },
+    vote: { template: '', interval: 0 },
+  } as unknown as StreamwallConfig['twitch']
+
+  it('stays disabled unless channel, client id and token are all set', () => {
+    const createBot = vi.fn()
+    expect(
+      setupTwitchBot({
+        config: { ...config, 'client-id': 'id', token: 'token' },
+        stateEmitter: new EventEmitter(),
+        getClientState: fakeStreamwallState,
+        setListeningView: vi.fn(),
+        createBot,
+      }),
+    ).toBeNull()
+    expect(createBot).not.toHaveBeenCalled()
+  })
+
+  it('connects and relays state and listening-view changes', () => {
+    const bot = Object.assign(new EventEmitter(), {
+      connect: vi.fn(),
+      onState: vi.fn(),
+    })
+    const stateEmitter = new EventEmitter()
+    const setListeningView = vi.fn()
+    const clientState = fakeStreamwallState()
+
+    const result = setupTwitchBot({
+      config: {
+        ...config,
+        channel: 'chan',
+        'client-id': 'id',
+        token: 'token',
+      },
+      stateEmitter,
+      getClientState: () => clientState,
+      setListeningView,
+      createBot: () => bot as never,
+    })
+
+    expect(result).toBe(bot)
+    expect(bot.connect).toHaveBeenCalledTimes(1)
+
+    bot.emit('setListeningView', 2 as unknown as ViewId)
+    expect(setListeningView).toHaveBeenCalledWith(2)
+
+    stateEmitter.emit('state')
+    expect(bot.onState).toHaveBeenCalledWith(clientState)
+  })
+})
+
+describe('createDataSourceHealthReporter', () => {
+  it('folds every report into the broadcast state', () => {
+    const updateState = vi.fn()
+    const track = createDataSourceHealthReporter(updateState)
+
+    track('source-a', 'json')(false, 'timed out')
+
+    expect(updateState).toHaveBeenCalledTimes(1)
+    const health = updateState.mock.calls[0][0].dataSourceHealth
+    expect(health).toEqual([
+      expect.objectContaining({
+        id: 'source-a',
+        type: 'json',
+        status: 'error',
+        message: 'timed out',
+      }),
+    ])
+  })
+})
+
+describe('configureSentry', () => {
+  function run(enabled: boolean) {
+    const initSentry = vi.fn()
+    const appendSwitch = vi.fn()
+    configureSentry({
+      enabled,
+      dsn: 'https://dsn.test/1',
+      initSentry,
+      appendSwitch,
+      switchName: 'sentry-enabled',
+      switchValue: (value) => (value ? '1' : '0'),
+    })
+    return { initSentry, appendSwitch }
+  }
+
+  it('initializes Sentry and passes the opt-in to subprocesses', () => {
+    const { initSentry, appendSwitch } = run(true)
+    expect(initSentry).toHaveBeenCalledWith({ dsn: 'https://dsn.test/1' })
+    expect(appendSwitch).toHaveBeenCalledWith('sentry-enabled', '1')
+  })
+
+  it('still passes the opt-out switch when telemetry is disabled', () => {
+    const { initSentry, appendSwitch } = run(false)
+    expect(initSentry).not.toHaveBeenCalled()
+    expect(appendSwitch).toHaveBeenCalledWith('sentry-enabled', '0')
+  })
+})
+
+describe('configureElectronRuntime', () => {
+  it('applies the display switches before enabling the sandbox', () => {
+    const order: string[] = []
+    configureElectronRuntime({
+      appendSwitch: (name, value) => {
+        order.push(`${name}=${value}`)
+      },
+      enableSandbox: () => {
+        order.push('sandbox')
+      },
+    })
+
+    expect(order).toEqual([
+      'high-dpi-support=1',
+      'force-device-scale-factor=1',
+      'sandbox',
+    ])
+  })
+})

--- a/packages/streamwall/src/main/bootstrap.ts
+++ b/packages/streamwall/src/main/bootstrap.ts
@@ -1,0 +1,536 @@
+import { throttle } from 'lodash-es'
+import { join } from 'node:path'
+import type {
+  DataSourceType,
+  StreamWindowConfig,
+  StreamwallState,
+  ViewId,
+  ViewState,
+} from 'streamwall-shared'
+import * as Y from 'yjs'
+import type { StreamwallConfig } from './cliArgs'
+import type { ControlCommandHandler } from './ControlWindow'
+import { LocalStreamData } from './data'
+import { DataSourceHealthTracker } from './dataSourceHealth'
+import log from './logger'
+import { type PlaylistConfig, PlaylistScheduler } from './playlist'
+import StreamdelayClient from './StreamdelayClient'
+import TwitchBot from './TwitchBot'
+import { initializeViewsState } from './viewsStateInit'
+import {
+  shouldHideInsteadOfQuit,
+  shouldQuitOnAllWindowsClosed,
+} from './windowCloseBehavior'
+
+/**
+ * The individually testable startup phases of the main process.
+ *
+ * `main()` (index.ts) is a thin sequencer over these functions. Electron
+ * startup is order-sensitive, so every phase takes its collaborators
+ * explicitly instead of reaching for module-level state, and the phases must
+ * be called in the same order they are declared to run in `main()`.
+ */
+
+/** The minimal shape of an event whose default action can be prevented. */
+export interface PreventableEvent {
+  preventDefault: () => void
+}
+
+/** Where the user's `config.toml` lives, and whether it exists yet. */
+export interface UserConfigLocation {
+  userConfigPath: string
+  hasUserConfig: boolean
+}
+
+export interface ApplicationMenuPhaseDeps {
+  /** Electron's `userData` directory. */
+  userDataPath: string
+  /** Path of the current log file, for the "Open Log File" menu item. */
+  logFilePath: string
+  fileExists: (path: string) => boolean
+  installMenu: (
+    configPath: string,
+    logPath: string,
+    hasUserConfig: boolean,
+  ) => void
+}
+
+/**
+ * Resolves the user config location and installs the application menu.
+ *
+ * The config path is recomputed here rather than threaded out of `parseArgs`,
+ * keeping the existence check local to the two consumers that need it: the
+ * "Open Config Folder" menu item and the control UI's first-run hint (#86).
+ */
+export function setupApplicationMenu(
+  deps: ApplicationMenuPhaseDeps,
+): UserConfigLocation {
+  const userConfigPath = join(deps.userDataPath, 'config.toml')
+  const hasUserConfig = deps.fileExists(userConfigPath)
+  deps.installMenu(userConfigPath, deps.logFilePath, hasUserConfig)
+  return { userConfigPath, hasUserConfig }
+}
+
+export interface LocalStreamDataPhaseDeps {
+  initialEntries: ConstructorParameters<typeof LocalStreamData>[0]
+  persistEntries: (
+    entries: NonNullable<ConstructorParameters<typeof LocalStreamData>[0]>,
+  ) => void
+}
+
+/**
+ * Creates the operator-editable stream data store and mirrors every change
+ * back into persistent storage.
+ */
+export function createPersistedLocalStreamData(
+  deps: LocalStreamDataPhaseDeps,
+): LocalStreamData {
+  const localStreamData = new LocalStreamData(deps.initialEntries)
+  localStreamData.on('update', (entries) => {
+    deps.persistEntries(entries)
+  })
+  return localStreamData
+}
+
+export interface InitialClientStateDeps {
+  config: StreamWindowConfig
+  layoutPresets: StreamwallState['layoutPresets']
+  favorites: StreamwallState['favorites']
+}
+
+/** Builds the initial broadcast state, seeded from persisted storage. */
+export function createInitialClientState(
+  deps: InitialClientStateDeps,
+): StreamwallState {
+  return {
+    identity: {
+      role: 'local',
+    },
+    config: deps.config,
+    streams: [],
+    customStreams: [],
+    views: [],
+    fullscreenViewIdx: null,
+    streamdelay: null,
+    layoutPresets: deps.layoutPresets,
+    favorites: deps.favorites,
+    dataSourceHealth: [],
+  }
+}
+
+/**
+ * Restores a base64-encoded Yjs snapshot into `stateDoc`.
+ *
+ * A corrupt snapshot must not take down startup: the app falls back to an
+ * empty doc, which the view-state seeding below refills.
+ */
+export function restoreStateDoc(stateDoc: Y.Doc, encoded: string): void {
+  log.info('Loading stateDoc from storage...')
+  try {
+    Y.applyUpdate(stateDoc, Buffer.from(encoded, 'base64'))
+  } catch (err) {
+    log.warn('Failed to restore stateDoc', err)
+  }
+}
+
+export interface StateDocPersisterDeps {
+  stateDoc: Y.Doc
+  /** Writes the encoded full-doc snapshot to storage. */
+  saveSnapshot: (encoded: string) => void
+  /** Throttle window in milliseconds. */
+  wait?: number
+}
+
+/**
+ * Persists the Yjs doc on every update, throttled.
+ *
+ * Returns the throttled function so a shutdown hook can `flush()` any pending
+ * write before the process exits.
+ */
+export function createStateDocPersister(deps: StateDocPersisterDeps) {
+  const persistStateDoc = throttle(() => {
+    const fullDoc = Y.encodeStateAsUpdate(deps.stateDoc)
+    deps.saveSnapshot(Buffer.from(fullDoc).toString('base64'))
+  }, deps.wait ?? 1000)
+  deps.stateDoc.on('update', persistStateDoc)
+  return persistStateDoc
+}
+
+export interface ViewsStateSeedDeps {
+  viewsState: Y.Map<Y.Map<string | undefined>>
+  transact: (fn: () => void) => void
+  cols: number
+  rows: number
+  /** Re-derives the wall layout from the current doc state. */
+  updateViews: () => void
+}
+
+/**
+ * Seeds the view-state doc for the configured grid, renders it once, and then
+ * keeps the wall in sync with later edits.
+ *
+ * Ordering matters: `observeDeep` fires synchronously at the end of a
+ * `transact`, so anything the observer reads (the grid `cols`/`rows` of the
+ * stream window config) must already be set before the seeding transaction
+ * runs. Registering the observer *after* the seeding also keeps the initial
+ * render a single explicit call rather than an observer side effect.
+ */
+export function seedAndObserveViewsState(deps: ViewsStateSeedDeps): void {
+  initializeViewsState(
+    { viewsState: deps.viewsState, transact: deps.transact },
+    deps.cols,
+    deps.rows,
+  )
+  deps.updateViews()
+  deps.viewsState.observeDeep(deps.updateViews)
+}
+
+export interface PlaylistPhaseDeps {
+  playlists: PlaylistConfig[]
+  /** The stream list the configured playlist URLs are resolved against. */
+  getStreams: () => StreamwallState['streams']
+  viewsState: Y.Map<Y.Map<string | undefined>>
+  transact: (fn: () => void) => void
+}
+
+/**
+ * Starts the playlist scheduler, which cycles any configured views through
+ * their list of stream URLs -- independent of whatever data source populated
+ * the stream list.
+ */
+export function startPlaylistScheduler(
+  deps: PlaylistPhaseDeps,
+): PlaylistScheduler {
+  const playlistScheduler = new PlaylistScheduler(deps.playlists, {
+    resolveStreamId: (url) => {
+      const streams = deps.getStreams()
+      return (streams.byURL?.get(url) ?? streams.find((s) => s.link === url))
+        ?._id
+    },
+    setViewStream: (view, streamId) => {
+      deps.transact(() => {
+        deps.viewsState.get(String(view))?.set('streamId', streamId)
+      })
+    },
+  })
+  playlistScheduler.start()
+  return playlistScheduler
+}
+
+/** The bits of a browse window the hardening steps need. */
+export interface BrowseWindowLike<TSession, TWebContents> {
+  webContents: TWebContents & { session: TSession }
+}
+
+export interface BrowseWindowFactoryDeps<
+  TSession,
+  TWebContents,
+  TWindow extends BrowseWindowLike<TSession, TWebContents>,
+> {
+  createWindow: () => TWindow
+  hardenSession: (session: TSession) => void
+  denyWindowOpen: (webContents: TWebContents) => void
+}
+
+/**
+ * Opens a window for the operator's ad-hoc browsing, isolated from the stream
+ * views: an ephemeral partition keeps it off disk, and popups are denied
+ * because the browse window is meant to show a single URL.
+ */
+export function createBrowseWindow<
+  TSession,
+  TWebContents,
+  TWindow extends BrowseWindowLike<TSession, TWebContents>,
+>(deps: BrowseWindowFactoryDeps<TSession, TWebContents, TWindow>): TWindow {
+  const win = deps.createWindow()
+  deps.hardenSession(win.webContents.session)
+  deps.denyWindowOpen(win.webContents)
+  return win
+}
+
+export interface StreamWindowIpcTarget {
+  on(event: 'state', listener: (viewStates: ViewState[]) => void): unknown
+  on(event: 'resize', listener: () => void): unknown
+  on(event: 'load', listener: () => void): unknown
+  onState(state: StreamwallState): void
+}
+
+export interface ControlWindowIpcTarget {
+  on(event: 'load', listener: () => void): unknown
+  on(event: 'ydoc', listener: (update: Uint8Array) => void): unknown
+  onState(state: StreamwallState): void
+  onYDocUpdate(update: Uint8Array): void
+  setCommandHandler(handler: ControlCommandHandler): void
+}
+
+export interface WindowIpcDeps {
+  streamWindow: StreamWindowIpcTarget
+  controlWindow: ControlWindowIpcTarget
+  stateDoc: Y.Doc
+  /** Merges a partial state and rebroadcasts it. */
+  updateState: (newState: Partial<StreamwallState>) => void
+  updateViewsFromStateDoc: () => void
+  getClientState: () => StreamwallState
+  /** Decides whether a doc update should be echoed to the control window. */
+  shouldForwardUpdate: (origin: unknown) => boolean
+  /** Transaction origin tagged onto updates coming from the control window. */
+  controlWindowOrigin: unknown
+  handleCommand: ControlCommandHandler
+}
+
+/** Wires the message flow between the two windows and the shared state doc. */
+export function wireWindowIpc(deps: WindowIpcDeps): void {
+  // StreamWindow view updates -> main
+  deps.streamWindow.on('state', (viewStates) => {
+    deps.updateState({ views: viewStates })
+  })
+
+  // StreamWindow resized -> re-layout stream views and rebroadcast state so the
+  // overlay grid matches the new window dimensions.
+  deps.streamWindow.on('resize', () => {
+    deps.updateViewsFromStateDoc()
+    deps.updateState({})
+  })
+
+  // StreamWindow <- main init state
+  deps.streamWindow.on('load', () => {
+    deps.streamWindow.onState(deps.getClientState())
+  })
+
+  // Control <- main collab updates
+  deps.stateDoc.on('update', (update: Uint8Array, origin: unknown) => {
+    if (!deps.shouldForwardUpdate(origin)) {
+      return
+    }
+    deps.controlWindow.onYDocUpdate(update)
+  })
+
+  // Control <- main init state
+  deps.controlWindow.on('load', () => {
+    deps.controlWindow.onState(deps.getClientState())
+    deps.controlWindow.onYDocUpdate(Y.encodeStateAsUpdate(deps.stateDoc))
+  })
+
+  // Control -> main
+  deps.controlWindow.on('ydoc', (update) => {
+    Y.applyUpdate(deps.stateDoc, update, deps.controlWindowOrigin)
+  })
+  deps.controlWindow.setCommandHandler(deps.handleCommand)
+}
+
+export interface LifecycleWindow {
+  win: { show: () => void; hide: () => void }
+  on(event: 'close', listener: (event: PreventableEvent) => void): unknown
+}
+
+export interface LifecycleApp {
+  on(event: 'before-quit', listener: (event: PreventableEvent) => void): unknown
+  on(event: 'activate', listener: () => void): unknown
+  on(event: 'window-all-closed', listener: () => void): unknown
+  quit(): void
+}
+
+export interface WindowLifecycleDeps {
+  app: LifecycleApp
+  platform: NodeJS.Platform
+  streamWindow: LifecycleWindow
+  controlWindow: LifecycleWindow
+  /** Forces any pending storage write to disk before the process exits. */
+  flushStorage: () => Promise<void>
+}
+
+/**
+ * Wires window close, dock re-activation and shutdown behaviour.
+ *
+ * Handler registration order is significant and matches the original inline
+ * code: the quit-intent flag is set before the storage flush hook runs, so the
+ * flush's `app.quit()` is not mistaken for a fresh close.
+ */
+export function wireWindowLifecycle(deps: WindowLifecycleDeps): void {
+  // Closing either top-level window quits the app, except on macOS where the
+  // convention is to hide the window and keep the app (and its dock icon)
+  // running until the user explicitly quits.
+  let isQuitting = false
+  let storageFlushed = false
+  deps.app.on('before-quit', () => {
+    isQuitting = true
+  })
+  deps.app.on('activate', () => {
+    deps.streamWindow.win.show()
+    deps.controlWindow.win.show()
+  })
+
+  function handleWindowClose(
+    window: LifecycleWindow,
+    event: PreventableEvent,
+  ): void {
+    if (shouldHideInsteadOfQuit(deps.platform, isQuitting)) {
+      event.preventDefault()
+      window.win.hide()
+      return
+    }
+    deps.app.quit()
+  }
+  deps.streamWindow.on('close', (event) => {
+    handleWindowClose(deps.streamWindow, event)
+  })
+  deps.controlWindow.on('close', (event) => {
+    handleWindowClose(deps.controlWindow, event)
+  })
+
+  // Standard Electron convention as a safety net: if every window somehow
+  // ends up closed without the app already quitting (e.g. a future window
+  // added without wiring into the close handling above), quit rather than
+  // linger as a windowless background process. macOS is excluded, matching
+  // the hide-instead-of-quit convention above.
+  deps.app.on('window-all-closed', () => {
+    if (shouldQuitOnAllWindowsClosed(deps.platform)) {
+      deps.app.quit()
+    }
+  })
+
+  // The throttled stateDoc persist may still have a pending write when the app
+  // quits, so flush it and wait for storage to hit disk before the process
+  // actually exits (otherwise recent grid/view changes are lost).
+  deps.app.on('before-quit', (event) => {
+    if (storageFlushed) {
+      return
+    }
+    event.preventDefault()
+    deps
+      .flushStorage()
+      .catch((err) => {
+        log.error('Failed to flush storage before quit', err)
+      })
+      .finally(() => {
+        storageFlushed = true
+        deps.app.quit()
+      })
+  })
+}
+
+export interface StreamdelayPhaseDeps {
+  config: StreamwallConfig['streamdelay']
+  onState: (state: StreamwallState['streamdelay']) => void
+  createClient?: (options: {
+    endpoint: string
+    key: string
+  }) => StreamdelayClient
+}
+
+/**
+ * Connects to Streamdelay when a key is configured. Returns `null` when the
+ * integration is disabled.
+ */
+export function setupStreamdelayClient(
+  deps: StreamdelayPhaseDeps,
+): StreamdelayClient | null {
+  const { key, endpoint } = deps.config
+  if (!key) {
+    return null
+  }
+  log.debug('Setting up Streamdelay client...')
+  const create =
+    deps.createClient ?? ((options) => new StreamdelayClient(options))
+  const streamdelayClient = create({ endpoint, key })
+  streamdelayClient.on('state', (state) => {
+    deps.onState(state)
+  })
+  streamdelayClient.connect()
+  return streamdelayClient
+}
+
+/** The bits of the state broadcaster the Twitch bot subscribes to. */
+export interface StateEmitterLike {
+  on(event: 'state', listener: (state: StreamwallState) => void): unknown
+}
+
+export interface TwitchBotPhaseDeps {
+  config: StreamwallConfig['twitch']
+  stateEmitter: StateEmitterLike
+  getClientState: () => StreamwallState
+  setListeningView: (idx: ViewId) => void
+  createBot?: (options: ConstructorParameters<typeof TwitchBot>[0]) => TwitchBot
+}
+
+/**
+ * Connects the Twitch chat bot when client id, token and channel are all
+ * configured. Returns `null` when the integration is disabled.
+ */
+export function setupTwitchBot(deps: TwitchBotPhaseDeps): TwitchBot | null {
+  const { 'client-id': clientId, token, channel } = deps.config
+  if (!clientId || !token || !channel) {
+    return null
+  }
+  log.debug('Setting up Twitch bot...')
+  const create = deps.createBot ?? ((options) => new TwitchBot(options))
+  const twitchBot = create({
+    ...deps.config,
+    'client-id': clientId,
+    token,
+    channel,
+  })
+  twitchBot.on('setListeningView', (idx) => {
+    deps.setListeningView(idx)
+  })
+  deps.stateEmitter.on('state', () => twitchBot.onState(deps.getClientState()))
+  twitchBot.connect()
+  return twitchBot
+}
+
+/**
+ * Builds the per-data-source health callback factory, folding every report
+ * into the broadcast state.
+ */
+export function createDataSourceHealthReporter(
+  updateState: (newState: Partial<StreamwallState>) => void,
+) {
+  const dataSourceHealthTracker = new DataSourceHealthTracker()
+  return function trackDataSourceHealth(id: string, type: DataSourceType) {
+    return (ok: boolean, message?: string) => {
+      updateState({
+        dataSourceHealth: dataSourceHealthTracker.report(id, type, ok, message),
+      })
+    }
+  }
+}
+
+export interface SentryPhaseDeps {
+  enabled: boolean
+  dsn: string
+  initSentry: (options: { dsn: string }) => void
+  appendSwitch: (name: string, value: string) => void
+  switchName: string
+  switchValue: (enabled: boolean) => string
+}
+
+/**
+ * Initializes Sentry in the main process and passes the opt-in down to every
+ * Chromium subprocess.
+ *
+ * Sandboxed preload scripts (control, background, overlay) have no other
+ * channel to this config, so it travels as a command-line switch every
+ * subprocess receives -- see sentryConfig.ts and sentryPreload.ts.
+ */
+export function configureSentry(deps: SentryPhaseDeps): void {
+  log.debug('Initializing Sentry...')
+  if (deps.enabled) {
+    deps.initSentry({ dsn: deps.dsn })
+  }
+  deps.appendSwitch(deps.switchName, deps.switchValue(deps.enabled))
+}
+
+export interface ElectronRuntimeDeps {
+  appendSwitch: (name: string, value: string) => void
+  enableSandbox: () => void
+}
+
+/** Applies the Chromium switches and sandbox mode the app requires. */
+export function configureElectronRuntime(deps: ElectronRuntimeDeps): void {
+  log.debug('Setting up Electron...')
+  deps.appendSwitch('high-dpi-support', '1')
+  deps.appendSwitch('force-device-scale-factor', '1')
+
+  log.debug('Enabling Electron sandbox...')
+  deps.enableSandbox()
+}

--- a/packages/streamwall/src/main/index.ts
+++ b/packages/streamwall/src/main/index.ts
@@ -1,11 +1,10 @@
 import * as Sentry from '@sentry/electron/main'
-import { BrowserWindow, Event as ElectronEvent, app, shell } from 'electron'
+import { BrowserWindow, app, shell } from 'electron'
 import fs from 'fs'
-import { throttle } from 'lodash-es'
 import EventEmitter from 'node:events'
 import { join } from 'node:path'
 import 'source-map-support/register'
-import { DataSourceType, StreamwallState } from 'streamwall-shared'
+import { StreamwallState } from 'streamwall-shared'
 import * as Y from 'yjs'
 import packageJson from '../../package.json'
 import {
@@ -15,6 +14,23 @@ import {
 } from '../sentryConfig'
 import { parseRepositorySlug } from '../updateStatus'
 import { createSessionHostResolver, ensureValidURL } from '../util'
+import {
+  configureElectronRuntime,
+  configureSentry,
+  createBrowseWindow,
+  createDataSourceHealthReporter,
+  createInitialClientState,
+  createPersistedLocalStreamData,
+  createStateDocPersister,
+  restoreStateDoc,
+  seedAndObserveViewsState,
+  setupApplicationMenu,
+  setupStreamdelayClient,
+  setupTwitchBot,
+  startPlaylistScheduler,
+  wireWindowIpc,
+  wireWindowLifecycle,
+} from './bootstrap'
 import { StreamwallConfig, parseArgs } from './cliArgs'
 import { dispatchLocalCommand } from './commandDispatch'
 import { createOnCommand } from './commandHandlers'
@@ -25,25 +41,17 @@ import {
   shouldForwardUpdateToControlWindow,
 } from './controlWindowEcho'
 import { LocalStreamData, StreamIDGenerator, combineDataSources } from './data'
-import { DataSourceHealthTracker } from './dataSourceHealth'
 import { buildDataSources } from './dataSources'
 import log, { initLogger, setLogLevel } from './logger'
 import { installApplicationMenu } from './menu'
 import { denyWindowOpen } from './navigationSecurity'
 import { BROWSE_PARTITION, hardenSession } from './partitions'
-import { PlaylistScheduler } from './playlist'
 import { flushStorage, loadStorage, safeUpdate } from './storage'
 import StreamdelayClient from './StreamdelayClient'
 import StreamWindow from './StreamWindow'
-import TwitchBot from './TwitchBot'
 import { setupAppUpdater } from './updaterSetup'
 import { connectControlUplink } from './uplinkConnection'
-import { initializeViewsState } from './viewsStateInit'
 import { deriveWallViews } from './wallViews'
-import {
-  shouldHideInsteadOfQuit,
-  shouldQuitOnAllWindowsClosed,
-} from './windowCloseBehavior'
 import { buildRetryConfig, buildStreamWindowConfig } from './windowConfig'
 
 async function main(argv: ReturnType<typeof parseArgs>) {
@@ -51,26 +59,23 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     join(app.getPath('userData'), 'streamwall-storage.json'),
   )
 
-  // Recomputes the same path parseArgs() already read from - fs.existsSync
-  // here (rather than threading a flag through the yargs config) keeps this
-  // check local to where it's needed, for the "Open Config Folder" menu item
-  // and the control UI's first-run hint (#86).
-  const userConfigPath = join(app.getPath('userData'), 'config.toml')
-  const hasUserConfig = fs.existsSync(userConfigPath)
-  installApplicationMenu(
-    userConfigPath,
-    log.transports.file.getFile().path,
-    hasUserConfig,
-  )
+  const { userConfigPath, hasUserConfig } = setupApplicationMenu({
+    userDataPath: app.getPath('userData'),
+    logFilePath: log.transports.file.getFile().path,
+    fileExists: (path) => fs.existsSync(path),
+    installMenu: installApplicationMenu,
+  })
 
   log.debug('Creating StreamWindow...')
   const idGen = new StreamIDGenerator()
 
-  const localStreamData = new LocalStreamData(db.data.localStreamData)
-  localStreamData.on('update', (entries) => {
-    safeUpdate(db, (data) => {
-      data.localStreamData = entries
-    })
+  const localStreamData = createPersistedLocalStreamData({
+    initialEntries: db.data.localStreamData,
+    persistEntries: (entries) => {
+      safeUpdate(db, (data) => {
+        data.localStreamData = entries
+      })
+    },
   })
 
   const overlayStreamData = new LocalStreamData()
@@ -99,20 +104,11 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   let streamdelayClient: StreamdelayClient | null = null
 
   log.debug('Creating initial state...')
-  let clientState: StreamwallState = {
-    identity: {
-      role: 'local',
-    },
+  let clientState: StreamwallState = createInitialClientState({
     config: streamWindowConfig,
-    streams: [],
-    customStreams: [],
-    views: [],
-    fullscreenViewIdx: null,
-    streamdelay: null,
     layoutPresets: db.data.layoutPresets,
     favorites: db.data.favorites,
-    dataSourceHealth: [],
-  }
+  })
 
   function updateViewsFromStateDoc() {
     try {
@@ -145,46 +141,32 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   const viewsState = stateDoc.getMap<Y.Map<string | undefined>>('views')
 
   if (db.data.stateDoc) {
-    log.info('Loading stateDoc from storage...')
-    try {
-      Y.applyUpdate(stateDoc, Buffer.from(db.data.stateDoc, 'base64'))
-    } catch (err) {
-      log.warn('Failed to restore stateDoc', err)
-    }
+    restoreStateDoc(stateDoc, db.data.stateDoc)
   }
 
-  const persistStateDoc = throttle(() => {
-    safeUpdate(db, (data) => {
-      const fullDoc = Y.encodeStateAsUpdate(stateDoc)
-      data.stateDoc = Buffer.from(fullDoc).toString('base64')
-    })
-  }, 1000)
-  stateDoc.on('update', persistStateDoc)
-
-  initializeViewsState(
-    { viewsState, transact: (fn) => stateDoc.transact(fn) },
-    argv.grid.cols,
-    argv.grid.rows,
-  )
-
-  updateViewsFromStateDoc()
-  viewsState.observeDeep(updateViewsFromStateDoc)
-
-  // Cycles any configured views through their playlist of stream URLs,
-  // independent of whatever data source populated `clientState.streams`.
-  const playlistScheduler = new PlaylistScheduler(argv.playlist, {
-    resolveStreamId: (url) =>
-      (
-        clientState.streams.byURL?.get(url) ??
-        clientState.streams.find((s) => s.link === url)
-      )?._id,
-    setViewStream: (view, streamId) => {
-      stateDoc.transact(() => {
-        viewsState.get(String(view))?.set('streamId', streamId)
+  const persistStateDoc = createStateDocPersister({
+    stateDoc,
+    saveSnapshot: (encoded) => {
+      safeUpdate(db, (data) => {
+        data.stateDoc = encoded
       })
     },
   })
-  playlistScheduler.start()
+
+  seedAndObserveViewsState({
+    viewsState,
+    transact: (fn) => stateDoc.transact(fn),
+    cols: argv.grid.cols,
+    rows: argv.grid.rows,
+    updateViews: updateViewsFromStateDoc,
+  })
+
+  const playlistScheduler = startPlaylistScheduler({
+    playlists: argv.playlist,
+    getStreams: () => clientState.streams,
+    viewsState,
+    transact: (fn) => stateDoc.transact(fn),
+  })
 
   const onCommand = createOnCommand({
     streamWindow,
@@ -207,22 +189,22 @@ async function main(argv: ReturnType<typeof parseArgs>) {
         data.favorites = favorites
       })
     },
-    createBrowseWindow: () => {
-      const win = new BrowserWindow({
-        webPreferences: {
-          nodeIntegration: false,
-          contextIsolation: true,
-          // Keep the operator's browsing isolated from the stream views and
-          // off disk by using a dedicated ephemeral partition.
-          partition: BROWSE_PARTITION,
-          sandbox: true,
-        },
-      })
-      hardenSession(win.webContents.session)
-      // Deny popups; the browse window is meant to show a single URL.
-      denyWindowOpen(win.webContents)
-      return win
-    },
+    createBrowseWindow: () =>
+      createBrowseWindow({
+        createWindow: () =>
+          new BrowserWindow({
+            webPreferences: {
+              nodeIntegration: false,
+              contextIsolation: true,
+              // Keep the operator's browsing isolated from the stream views and
+              // off disk by using a dedicated ephemeral partition.
+              partition: BROWSE_PARTITION,
+              sandbox: true,
+            },
+          }),
+        hardenSession,
+        denyWindowOpen,
+      }),
     validateBrowseURL: (url, browseWindow) =>
       ensureValidURL(
         url,
@@ -240,101 +222,24 @@ async function main(argv: ReturnType<typeof parseArgs>) {
   }
 
   // Wire up IPC:
-
-  // StreamWindow view updates -> main
-  streamWindow.on('state', (viewStates) => {
-    updateState({ views: viewStates })
+  wireWindowIpc({
+    streamWindow,
+    controlWindow,
+    stateDoc,
+    updateState,
+    updateViewsFromStateDoc,
+    getClientState: () => clientState,
+    shouldForwardUpdate: shouldForwardUpdateToControlWindow,
+    controlWindowOrigin: CONTROL_WINDOW_ORIGIN,
+    handleCommand: (command) => dispatchLocalCommand(onCommand, command),
   })
 
-  // StreamWindow resized -> re-layout stream views and rebroadcast state so the
-  // overlay grid matches the new window dimensions.
-  streamWindow.on('resize', () => {
-    updateViewsFromStateDoc()
-    updateState({})
-  })
-
-  // StreamWindow <- main init state
-  streamWindow.on('load', () => {
-    streamWindow.onState(clientState)
-  })
-
-  // Control <- main collab updates
-  stateDoc.on('update', (update, origin) => {
-    if (!shouldForwardUpdateToControlWindow(origin)) {
-      return
-    }
-    controlWindow.onYDocUpdate(update)
-  })
-
-  // Control <- main init state
-  controlWindow.on('load', () => {
-    controlWindow.onState(clientState)
-    controlWindow.onYDocUpdate(Y.encodeStateAsUpdate(stateDoc))
-  })
-
-  // Control -> main
-  controlWindow.on('ydoc', (update) =>
-    Y.applyUpdate(stateDoc, update, CONTROL_WINDOW_ORIGIN),
-  )
-  controlWindow.setCommandHandler((command) =>
-    dispatchLocalCommand(onCommand, command),
-  )
-
-  // Closing either top-level window quits the app, except on macOS where the
-  // convention is to hide the window and keep the app (and its dock icon)
-  // running until the user explicitly quits.
-  let isQuitting = false
-  let storageFlushed = false
-  app.on('before-quit', () => {
-    isQuitting = true
-  })
-  app.on('activate', () => {
-    streamWindow.win.show()
-    controlWindow.win.show()
-  })
-
-  function handleWindowClose(win: BrowserWindow, event: ElectronEvent) {
-    if (shouldHideInsteadOfQuit(process.platform, isQuitting)) {
-      event.preventDefault()
-      win.hide()
-      return
-    }
-    app.quit()
-  }
-  streamWindow.on('close', (event) =>
-    handleWindowClose(streamWindow.win, event),
-  )
-  controlWindow.on('close', (event) =>
-    handleWindowClose(controlWindow.win, event),
-  )
-
-  // Standard Electron convention as a safety net: if every window somehow
-  // ends up closed without the app already quitting (e.g. a future window
-  // added without wiring into the close handling above), quit rather than
-  // linger as a windowless background process. macOS is excluded, matching
-  // the hide-instead-of-quit convention above.
-  app.on('window-all-closed', () => {
-    if (shouldQuitOnAllWindowsClosed(process.platform)) {
-      app.quit()
-    }
-  })
-
-  // The throttled stateDoc persist above may still have a pending write when
-  // the app quits, so flush it and wait for storage to hit disk before the
-  // process actually exits (otherwise recent grid/view changes are lost).
-  app.on('before-quit', (event) => {
-    if (storageFlushed) {
-      return
-    }
-    event.preventDefault()
-    flushStorage(db, () => persistStateDoc.flush())
-      .catch((err) => {
-        log.error('Failed to flush storage before quit', err)
-      })
-      .finally(() => {
-        storageFlushed = true
-        app.quit()
-      })
+  wireWindowLifecycle({
+    app,
+    platform: process.platform,
+    streamWindow,
+    controlWindow,
+    flushStorage: () => flushStorage(db, () => persistStateDoc.flush()),
   })
 
   connectControlUplink({
@@ -345,46 +250,23 @@ async function main(argv: ReturnType<typeof parseArgs>) {
     onCommand,
   })
 
-  if (argv.streamdelay.key) {
-    log.debug('Setting up Streamdelay client...')
-    streamdelayClient = new StreamdelayClient({
-      endpoint: argv.streamdelay.endpoint,
-      key: argv.streamdelay.key,
-    })
-    streamdelayClient.on('state', (state) => {
+  streamdelayClient = setupStreamdelayClient({
+    config: argv.streamdelay,
+    onState: (state) => {
       updateState({ streamdelay: state })
-    })
-    streamdelayClient.connect()
-  }
+    },
+  })
 
-  const {
-    'client-id': twitchClientId,
-    token: twitchToken,
-    channel: twitchChannel,
-  } = argv.twitch
-  if (twitchClientId && twitchToken && twitchChannel) {
-    log.debug('Setting up Twitch bot...')
-    const twitchBot = new TwitchBot({
-      ...argv.twitch,
-      'client-id': twitchClientId,
-      token: twitchToken,
-      channel: twitchChannel,
-    })
-    twitchBot.on('setListeningView', (idx) => {
+  setupTwitchBot({
+    config: argv.twitch,
+    stateEmitter,
+    getClientState: () => clientState,
+    setListeningView: (idx) => {
       streamWindow.setListeningView(idx)
-    })
-    stateEmitter.on('state', () => twitchBot.onState(clientState))
-    twitchBot.connect()
-  }
+    },
+  })
 
-  const dataSourceHealthTracker = new DataSourceHealthTracker()
-  function trackDataSourceHealth(id: string, type: DataSourceType) {
-    return (ok: boolean, message?: string) => {
-      updateState({
-        dataSourceHealth: dataSourceHealthTracker.report(id, type, ok, message),
-      })
-    }
-  }
+  const trackDataSourceHealth = createDataSourceHealthReporter(updateState)
 
   const dataSources = buildDataSources({
     jsonUrls: argv.data['json-url'],
@@ -429,24 +311,23 @@ function init() {
     return
   }
 
-  log.debug('Initializing Sentry...')
-  if (argv.telemetry.sentry) {
-    Sentry.init({ dsn: SENTRY_DSN })
+  const appendSwitch = (name: string, value: string) => {
+    app.commandLine.appendSwitch(name, value)
   }
-  // Sandboxed preload scripts (control, background, overlay) have no other
-  // channel to this config, so pass it down as a command-line switch every
-  // Chromium subprocess receives -- see sentryConfig.ts and sentryPreload.ts.
-  app.commandLine.appendSwitch(
-    SENTRY_ENABLED_SWITCH,
-    sentryEnabledSwitchValue(argv.telemetry.sentry),
-  )
 
-  log.debug('Setting up Electron...')
-  app.commandLine.appendSwitch('high-dpi-support', '1')
-  app.commandLine.appendSwitch('force-device-scale-factor', '1')
+  configureSentry({
+    enabled: argv.telemetry.sentry,
+    dsn: SENTRY_DSN,
+    initSentry: (options) => Sentry.init(options),
+    appendSwitch,
+    switchName: SENTRY_ENABLED_SWITCH,
+    switchValue: sentryEnabledSwitchValue,
+  })
 
-  log.debug('Enabling Electron sandbox...')
-  app.enableSandbox()
+  configureElectronRuntime({
+    appendSwitch,
+    enableSandbox: () => app.enableSandbox(),
+  })
 
   app
     .whenReady()


### PR DESCRIPTION
`main()` in `packages/streamwall/src/main/index.ts` had grown into a 290-line
brain method (CCN 11) holding every startup concern at once — the reason
nearly every feature change had to touch the repository's highest-churn file.

The distinct startup phases now live in a sibling `bootstrap.ts` as named
functions that take their collaborators explicitly instead of reaching for
module-level state, and `main()`/`init()` are thin sequencers over them.

### Phases extracted

| Function | Phase |
| --- | --- |
| `setupApplicationMenu` | Resolve the user config location and install the application menu |
| `createPersistedLocalStreamData` | Local stream data store, mirrored back into storage on every update |
| `createInitialClientState` | Initial broadcast state, seeded from persisted storage |
| `restoreStateDoc` | Restore the base64 Yjs snapshot, tolerating a corrupt one |
| `createStateDocPersister` | Throttled state-doc persistence (returns the throttled fn so shutdown can flush it) |
| `seedAndObserveViewsState` | Seed the grid's view state, render once, then observe |
| `startPlaylistScheduler` | Playlist cycling for configured views |
| `createBrowseWindow` | Browse window creation + session hardening + popup denial |
| `wireWindowIpc` | Stream/control window and state-doc message flow |
| `wireWindowLifecycle` | Close/hide, dock activate, window-all-closed, storage flush before quit |
| `setupStreamdelayClient` | Optional Streamdelay connection |
| `setupTwitchBot` | Optional Twitch chat bot |
| `createDataSourceHealthReporter` | Per-data-source health reporting into the broadcast state |
| `configureSentry` | Sentry init plus the subprocess opt-in switch |
| `configureElectronRuntime` | Chromium display switches and sandbox mode |

### Ordering is unchanged

This is purely structural — no behaviour change. Every side effect keeps its
exact relative order, including the order-sensitive parts:

- `viewsState.observeDeep` fires synchronously at the end of a `transact`, so
  the grid config the observer reads is still set before the seeding
  transaction, and the observer is still registered *after* the seeding plus
  the single explicit initial render (`seedAndObserveViewsState`).
- `wireWindowLifecycle` registers its handlers in the original order, so the
  quit-intent `before-quit` listener still runs before the storage-flush
  `before-quit` listener; the flush's own `app.quit()` still passes straight
  through on the second pass.
- `configureSentry` still appends the Sentry switch before the display
  switches, which are still applied before `app.enableSandbox()`.

### Left inline (and why)

- `updateViewsFromStateDoc` and `updateState` — both read and reassign the
  mutable `clientState` binding that half of `main()` closes over. Extracting
  them would mean either passing a mutable state container everywhere or
  changing when `clientState` is reassigned, which is exactly the reordering
  risk this refactor avoids. They stay as local closures.
- The `createOnCommand(...)` call — already a call into an extracted module;
  what remains is argument wiring bound to those same closures.
- The `for await (const streams of combineDataSources(...))` loop — it is the
  long-lived tail of `main()`, not a startup phase.

### Tests

New `bootstrap.test.ts` covers all extracted phases (32 cases), including
regression guards for the two ordering traps above: the views-state seeding
renders exactly once with the full grid already present, and the shutdown
hook defers the first quit until storage is flushed, then quits once.
No existing test was changed or weakened.

`npm run test`, `npm run lint` and `npm run typecheck` all pass.

Closes #583
