### PR TITLE
test(streamwall): make appUpdater rejection cases discriminating

### DIFF
--- a/packages/streamwall/src/main/appUpdater.test.ts
+++ b/packages/streamwall/src/main/appUpdater.test.ts
@@ -127,6 +127,15 @@ describe('AppUpdater status', () => {
 
   // One case per branch of the progress guard, so the named predicates it was
   // split into keep rejecting exactly what the original condition rejected.
+  //
+  // Each case first emits a fully-measured event to put a real (non-null)
+  // progress in place, then the payload under test. Asserting only
+  // `progress: null` after the bad payload would also pass if the listener
+  // never called extractProgress at all - download() already leaves progress
+  // at null, so a no-op guard is indistinguishable from a working one. By
+  // starting from a known non-null progress, a passing case proves the bad
+  // payload actively knocked progress *back* to null.
+  const validProgress = { percent: 10, transferred: 100, total: 1000 }
   it.each([
     ['a non-object payload', 'not-an-object'],
     ['a null payload', null],
@@ -158,10 +167,16 @@ describe('AppUpdater status', () => {
     ],
     ['a zero total', { percent: 0, transferred: 0, total: 0 }],
     ['a negative total', { percent: 0, transferred: 0, total: -1 }],
-  ])('keeps the progress indeterminate for %s', (_label, payload) => {
+  ])('knocks progress back to indeterminate for %s', (_label, payload) => {
     const { backend, updater } = createUpdater()
     backend.emit('update-available', { version: '0.9.2' })
     updater.download()
+    backend.emit('download-progress', validProgress)
+    expect(updater.getStatus()).toEqual({
+      state: 'downloading',
+      version: '0.9.2',
+      progress: validProgress,
+    })
 
     backend.emit('download-progress', payload)
 

--- a/packages/streamwall/src/main/appUpdater.ts
+++ b/packages/streamwall/src/main/appUpdater.ts
@@ -247,6 +247,14 @@ function extractProgress(info: unknown): DownloadProgress | null {
   }
 
   // A zero or negative total would make the banner's percentage meaningless.
+  //
+  // `total` is only usable as `number` here because TypeScript narrows it
+  // through `allFieldsMeasured` above: a `const` holding a direct `&&` chain
+  // is one of the aliased conditions control-flow analysis understands, so
+  // `if (!allFieldsMeasured) return` also narrows `total`. Pulling that
+  // chain into a helper function, or turning `allFieldsMeasured` into a
+  // `let`, silently drops the narrowing and forces a cast back to `number`
+  // here - keep this a `const` with the `&&` chain inline.
   const hasKnownTotal = total > 0
   if (!hasKnownTotal) {
     return null


### PR DESCRIPTION
## Summary

Follow-up from the review of #585, per #590.

- **Discriminating rejection tests**: all 15 `it.each` rejection cases in the `download-progress` guard test previously asserted only `progress: null`, which is also the state `download()` leaves in place before any `download-progress` event ever fires. Bypassing `extractProgress` entirely in the listener (hardcoding `progress: null`) left all 15 cases green. Each case now first emits a fully-measured, valid progress event, then the bad payload, and asserts progress falls *back* to `null` — so a passing case proves the bad payload actively knocked progress back down, not that nothing ever ran.
- **`'a NaN total'` case**: left as-is, with the limitation called out in a comment. It does not independently pin finiteness for `total`: `NaN > 0` is false regardless of whether the finiteness check runs, so a mutation dropping `isFiniteNumber(total)` still passes this case. Finiteness for `total` is actually pinned by the existing `'an infinite total'` case, since `Infinity > 0` is `true`. No NaN payload can ever slip past the `total > 0` guard, so this case cannot be strengthened to independently pin finiteness for `total` — it still has value for the other checks a `total` field goes through (non-object, non-numeric), so it stays.
- **Sharp edge documented in code**: added a comment at `hasKnownTotal` in `extractProgress` explaining that its `total > 0` access relies on TypeScript's aliased-condition narrowing through the `allFieldsMeasured` `const`/`&&`-chain pattern. Extracting that chain into a helper function, or switching `allFieldsMeasured` to `let`, silently loses the narrowing and forces a cast back to `number`.

## Mutation proof (task 1 acceptance criterion)

Bypassed `extractProgress` in the `download-progress` listener (hardcoded `progress: null`) and re-ran the suite:

- **Before this change**: 0 of the 15 rejection cases failed under the mutation (they all asserted `progress: null`, which the mutation also produces).
- **After this change**: all 15 of the 15 rejection cases failed under the mutation, along with the two accept-side tests that already caught it. The mutation was reverted before committing.

## Test plan

- [x] `npm run test` — all workspaces pass (streamwall: 183/183 node:test; control-ui: 363/363 vitest)
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean across all workspaces
- [x] `npx prettier --check` on the two touched files — formatted

No behavior change: `extractProgress` itself is untouched.

Closes #590