### PR TITLE
fix(scripts): spawn npm through a shell on Windows in release/check tooling

### DIFF
--- a/scripts/check-deprecated-deps.mjs
+++ b/scripts/check-deprecated-deps.mjs
@@ -142,13 +142,22 @@ export async function fetchDeprecations(
   return deprecations
 }
 
+// On Windows npm is only reachable as the `npm.cmd` shim, and since the
+// CVE-2024-27980 fix Node refuses to spawn a `.cmd` file without a shell
+// (bare `npm` fails with ENOENT, `npm.cmd` fails with EINVAL) - so a
+// maintainer running this check locally on Windows needs the shell branch
+// (#586). CI only runs this on Linux, where the extra option is a no-op.
+export function buildNpmExecOptions(platform = process.platform) {
+  return { cwd: rootDir, shell: platform === 'win32' }
+}
+
 // `npm view <name>@<exact-version> deprecated --json` prints the deprecation
 // message, or nothing at all when the version is current.
 async function lookUpDeprecation({ name, version }) {
   const { stdout } = await execFileAsync(
     'npm',
     ['view', `${name}@${version}`, 'deprecated', '--json'],
-    { cwd: rootDir },
+    buildNpmExecOptions(),
   )
   const trimmed = stdout.trim()
   return trimmed === '' ? null : JSON.parse(trimmed)

--- a/scripts/check-licenses.mjs
+++ b/scripts/check-licenses.mjs
@@ -188,6 +188,19 @@ export function formatViolations(violations) {
     .join('\n')
 }
 
+// On Windows npm is only reachable as the `npm.cmd` shim, and since the
+// CVE-2024-27980 fix Node refuses to spawn a `.cmd` file without a shell
+// (bare `npm` fails with ENOENT, `npm.cmd` fails with EINVAL) - so a
+// maintainer running this check locally on Windows needs the shell branch
+// (#586). CI only runs this on Linux, where the extra option is a no-op.
+export function buildNpmExecOptions(platform = process.platform) {
+  return {
+    encoding: 'utf8',
+    maxBuffer: 256 * 1024 * 1024,
+    shell: platform === 'win32',
+  }
+}
+
 function readProductionTree() {
   // `npm ls` exits non-zero whenever the tree has any problem (an unmet
   // optional dependency is enough), so the exit code is not a useful signal
@@ -195,7 +208,7 @@ function readProductionTree() {
   const output = execFileSync(
     'npm',
     ['ls', '--omit=dev', '--all', '--long', '--json'],
-    { encoding: 'utf8', maxBuffer: 256 * 1024 * 1024 },
+    buildNpmExecOptions(),
   )
   return JSON.parse(output)
 }

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -57,6 +57,15 @@ export function buildReleasePleaseManifest(version) {
   return `${JSON.stringify({ '.': version }, null, 2)}\n`
 }
 
+// On Windows npm is only reachable as the `npm.cmd` shim, and since the
+// CVE-2024-27980 fix Node refuses to spawn a `.cmd` file without a shell
+// (bare `npm` fails with ENOENT, `npm.cmd` fails with EINVAL) - so a
+// release engineer bumping the version on a Windows machine needs the
+// shell branch (#586).
+export function buildNpmSpawnOptions(platform = process.platform) {
+  return { stdio: 'inherit', shell: platform === 'win32' }
+}
+
 function main() {
   let version
   try {
@@ -69,7 +78,7 @@ function main() {
     buildRootVersionArgs(version),
     buildNpmVersionArgs(version),
   ]) {
-    const result = spawnSync('npm', args, { stdio: 'inherit' })
+    const result = spawnSync('npm', args, buildNpmSpawnOptions())
     if (result.status !== 0) {
       process.exit(result.status ?? 1)
     }

--- a/test/check-deprecated-deps.test.mjs
+++ b/test/check-deprecated-deps.test.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url'
 
 import {
   ALLOWLIST_PATH,
+  buildNpmExecOptions,
   collectDirectDependencies,
   evaluateDeprecations,
   fetchDeprecations,
@@ -316,6 +317,18 @@ test('fetchDeprecations omits dependencies whose lookup failed', async () => {
   })
 
   assert.deepEqual([...deprecations.keys()], ['abandoned@1.0.0'])
+})
+
+// On Windows npm is only reachable as the `npm.cmd` shim, which Node refuses
+// to spawn without a shell since the CVE-2024-27980 fix (#586).
+test('buildNpmExecOptions spawns through a shell on Windows', () => {
+  const options = buildNpmExecOptions('win32')
+  assert.equal(options.shell, true)
+})
+
+test('buildNpmExecOptions does not need a shell elsewhere', () => {
+  assert.equal(buildNpmExecOptions('linux').shell, false)
+  assert.equal(buildNpmExecOptions('darwin').shell, false)
 })
 
 test('the committed allowlist is valid', () => {

--- a/test/licenses.test.mjs
+++ b/test/licenses.test.mjs
@@ -6,6 +6,7 @@ import { test } from 'node:test'
 import { fileURLToPath } from 'node:url'
 import {
   ALLOWED_LICENSES,
+  buildNpmExecOptions,
   collectProductionPackages,
   findLicenseViolations,
   formatViolations,
@@ -198,6 +199,18 @@ test('violations name every offending package and its license', () => {
   assert.match(report, /GPL-3\.0-only/)
   assert.match(report, /nameless@0\.1\.0/)
   assert.match(report, /no license field/)
+})
+
+// On Windows npm is only reachable as the `npm.cmd` shim, which Node refuses
+// to spawn without a shell since the CVE-2024-27980 fix (#586).
+test('buildNpmExecOptions spawns through a shell on Windows', () => {
+  const options = buildNpmExecOptions('win32')
+  assert.equal(options.shell, true)
+})
+
+test('buildNpmExecOptions does not need a shell elsewhere', () => {
+  assert.equal(buildNpmExecOptions('linux').shell, false)
+  assert.equal(buildNpmExecOptions('darwin').shell, false)
 })
 
 // The check only gates merges while it hangs off the aggregate `CI OK` job,

--- a/test/release-version.test.mjs
+++ b/test/release-version.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import { test } from 'node:test'
 
 import {
+  buildNpmSpawnOptions,
   buildNpmVersionArgs,
   buildReleasePleaseManifest,
   buildRootVersionArgs,
@@ -76,4 +77,24 @@ test('buildNpmVersionArgs bumps every release-tracked workspace without tagging'
     '0.9.2',
     '--no-git-tag-version',
   ])
+})
+
+// On Windows npm is only reachable as the `npm.cmd` shim, which Node refuses
+// to spawn without a shell since the CVE-2024-27980 fix (#586).
+test('buildNpmSpawnOptions spawns through a shell on Windows', () => {
+  assert.deepEqual(buildNpmSpawnOptions('win32'), {
+    stdio: 'inherit',
+    shell: true,
+  })
+})
+
+test('buildNpmSpawnOptions does not need a shell elsewhere', () => {
+  assert.deepEqual(buildNpmSpawnOptions('linux'), {
+    stdio: 'inherit',
+    shell: false,
+  })
+  assert.deepEqual(buildNpmSpawnOptions('darwin'), {
+    stdio: 'inherit',
+    shell: false,
+  })
 })


### PR DESCRIPTION
## Background

`packages/streamwall/forge.typecheck.ts` spawned `npm` via `spawnSync` without a shell. On Windows, npm is only reachable through the `npm.cmd` shim: `spawnSync` without a shell resolves only real executables, so bare `npm` fails with `ENOENT`. This aborted the `electron-forge package`/`make`/`publish` `prePackage` hook on every Windows packaging run since the hook landed in #497.

That specific bug is **already fixed and merged on `main`** (PR #587 spawned `npm.cmd`, then PR #592 followed up: since the CVE-2024-27980 fix, Node also refuses to spawn a `.cmd` file without a shell, so `npm.cmd` alone fails with `EINVAL` — the hook now runs through `shell: true` on `win32` with a regression test covering both branches). Issue #586 was left open because that follow-up used `Refs #586` rather than `Closes #586`.

## What this PR does

Per the issue's request to check for the same bug elsewhere, I grepped the repo for other `spawnSync`/`spawn`/`execFile(Sync)` calls that invoke `npm` without a shell option and found three more in build/release tooling, all with the exact same failure mode on Windows:

- `scripts/release-version.mjs` — `spawnSync('npm', args, { stdio: 'inherit' })`. This is a release engineer's local script (`npm run release:version`) and can genuinely be run on a Windows machine.
- `scripts/check-deprecated-deps.mjs` — `execFileAsync('npm', [...], { cwd: rootDir })`.
- `scripts/check-licenses.mjs` — `execFileSync('npm', [...], { encoding: 'utf8', maxBuffer: ... })`.

The two `check-*` scripts currently only run in CI on `ubuntu-latest`, so they are not blocking a release today, but they are build tooling a maintainer could run locally on Windows, so I fixed them for consistency with the same pattern.

Each file now builds its spawn/exec options through a small, platform-aware, independently exported helper (`buildNpmSpawnOptions` / `buildNpmExecOptions`), mirroring the pattern already established in `forge.typecheck.ts`'s `runTypecheck`. The command line stays a fixed literal in every case, so `shell: true` does not reintroduce any interpolation/injection concern.

## Testing

- Added a unit test per helper pinning the Windows branch (`shell: true`) and a non-Windows branch (`shell: false`).
- Mutation-tested: reverted the three source fixes (keeping the new tests) and confirmed all three new/affected test files failed (missing export) before re-applying the fix.
- `npm run test` — all workspaces pass (183/183 root `node --test`, 363/363 control-ui vitest).
- `npm run lint` — clean.
- `npm run typecheck` — clean across all workspaces.
- `npm run format -- --check` — clean.

Closes #586