### PR TITLE
fix(control-server): tighten testHelpers per #588 follow-ups

### DIFF
--- a/packages/streamwall-control-server/src/testHelpers.test.ts
+++ b/packages/streamwall-control-server/src/testHelpers.test.ts
@@ -6,6 +6,7 @@ import { DEFAULT_SCRYPT_PARAMS } from './auth.ts'
 import {
   captureLogs,
   setEnvForTest,
+  startTestServer,
   TEST_SCRYPT_PARAMS,
 } from './testHelpers.ts'
 
@@ -96,4 +97,38 @@ test('setEnvForTest restores the previous values after the test that set them', 
   // Guards the whole point of the helper: the override above must not have
   // leaked into this test, nor into any later file.
   assert.equal(process.env.STREAMWALL_RATE_LIMIT_MAX, RATE_LIMIT_MAX_AT_LOAD)
+})
+
+test('startTestServer merges a partial rateLimit override with the wide test defaults', async () => {
+  // Only authMax is overridden; globalMax must still come from
+  // WIDE_RATE_LIMITS rather than silently falling back to the production
+  // default merely because the caller set an unrelated field.
+  const { app } = await startTestServer({ rateLimit: { authMax: 2 } })
+
+  const globalCodes: number[] = []
+  for (let i = 0; i < 150; i++) {
+    const res = await app.inject({ method: 'GET', url: '/' })
+    globalCodes.push(res.statusCode)
+  }
+  assert.ok(
+    !globalCodes.includes(429),
+    `expected no 429s under the wide global budget (150 < 10000), got: ${globalCodes.join(',')}`,
+  )
+
+  // The override itself must still take effect.
+  const authCodes: number[] = []
+  for (let i = 0; i < 3; i++) {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/invite/x',
+      headers: { 'content-type': 'application/json' },
+      payload: { token: 'y' },
+    })
+    authCodes.push(res.statusCode)
+  }
+  assert.equal(
+    authCodes[2],
+    429,
+    `expected the overridden authMax of 2 to apply, got: ${authCodes.join(',')}`,
+  )
 })

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -454,11 +454,12 @@ export async function redeemInviteAndConnectClient<T = ServerToClientMessage>(
  */
 export async function startTestServer(overrides: TestAppOverrides = {}) {
   const logs = captureLogs()
+  const { rateLimit, ...restOverrides } = overrides
   const { app, auth } = await buildTestApp({
     baseURL: TEST_BASE_URL,
     logs,
-    rateLimit: WIDE_RATE_LIMITS,
-    ...overrides,
+    ...restOverrides,
+    rateLimit: { ...WIDE_RATE_LIMITS, ...rateLimit },
   })
   after(() => app.close())
   const port = await listenTestApp(app)
@@ -482,18 +483,22 @@ export async function startTestServer(overrides: TestAppOverrides = {}) {
  * message (`VALID_STATE` unless overridden).
  *
  * Waits for the server to have finished with the seeded state instead of
- * sleeping: it either accepts it (the uplink becomes the state authority) or
- * rejects it with a structured warning. Both outcomes end the seeding step, and
- * specs deliberately exercise each of them.
+ * sleeping. By default it waits for the seed to be accepted (`expectRejected:
+ * false`), which fails fast with one clear timeout if a spec's state was
+ * seeded wrongly. Specs that deliberately seed an invalid payload must pass
+ * `expectRejected: true` to wait for the structured rejection warning
+ * instead.
  */
 export async function bootServerWithUplink({
   stateMessage = { type: 'state', state: VALID_STATE } as Record<
     string,
     unknown
   >,
+  expectRejected = false,
   ...overrides
 }: TestAppOverrides & {
   stateMessage?: Record<string, unknown>
+  expectRejected?: boolean
 } = {}) {
   const server = await startTestServer(overrides)
 
@@ -502,11 +507,11 @@ export async function bootServerWithUplink({
     server.port,
   )
   streamwallWs.send(JSON.stringify(stateMessage))
-  await server.logs.waitFor(
-    (entry) =>
-      entry.msg === 'Streamwall connected' ||
-      (typeof entry.msg === 'string' &&
-        entry.msg.startsWith('Rejected invalid Streamwall state')),
+  await server.logs.waitFor((entry) =>
+    expectRejected
+      ? typeof entry.msg === 'string' &&
+        entry.msg.startsWith('Rejected invalid Streamwall state')
+      : entry.msg === 'Streamwall connected',
   )
 
   return { ...server, streamwallWs, streamwall }

--- a/packages/streamwall-control-server/src/wsValidation.test.ts
+++ b/packages/streamwall-control-server/src/wsValidation.test.ts
@@ -19,14 +19,19 @@ import {
 async function connectStreamwallAndClient({
   role = 'admin' as StreamwallRole,
   wsUpdateMaxBytes,
+  stateMessage,
+  expectRejected,
   ...overrides
 }: {
   stateMessage?: Record<string, unknown>
+  expectRejected?: boolean
   role?: StreamwallRole
   wsUpdateMaxBytes?: number
 } = {}) {
   const booted = await bootServerWithUplink({
     ...overrides,
+    ...(stateMessage !== undefined && { stateMessage }),
+    ...(expectRejected !== undefined && { expectRejected }),
     // Injected rather than set in the environment: the cap belongs to this one
     // server instance and never leaks into whichever file runs next.
     ...(wsUpdateMaxBytes !== undefined && {
@@ -84,6 +89,7 @@ test('rejects a state message with no payload instead of wiring a broken connect
   // the connection is never established and the client is told cleanly.
   const { client } = await connectStreamwallAndClient({
     stateMessage: { type: 'state' },
+    expectRejected: true,
   })
 
   const response = await client.waitFor(isBareError)
@@ -99,6 +105,7 @@ test('rejects an initial state payload missing a required field (issue #387)', a
 
   const { client, logs } = await connectStreamwallAndClient({
     stateMessage: { type: 'state', state: withoutStreams },
+    expectRejected: true,
   })
 
   const response = await client.waitFor(isBareError)
@@ -129,6 +136,7 @@ test('rejects an initial state payload with a malformed view state machine snaps
 
   const { client } = await connectStreamwallAndClient({
     stateMessage: { type: 'state', state: malformed },
+    expectRejected: true,
   })
 
   const response = await client.waitFor(isBareError)


### PR DESCRIPTION
Follow-ups from the review of #588, which moved shared WebSocket test setup into `packages/streamwall-control-server/src/testHelpers.ts`.

## 1. `rateLimit` is now merged, not replaced

`startTestServer` spread `...overrides` after `rateLimit: WIDE_RATE_LIMITS`, so a caller passing a partial `rateLimit` object (e.g. `{ authMax: 2 }`) silently lost the wide test defaults for every field it did not set (`globalMax` would fall back to the production default of 100). Fixed by destructuring `rateLimit` out of `overrides` and merging it explicitly:

```ts
const { rateLimit, ...restOverrides } = overrides
const { app, auth } = await buildTestApp({
  baseURL: TEST_BASE_URL,
  logs,
  ...restOverrides,
  rateLimit: { ...WIDE_RATE_LIMITS, ...rateLimit },
})
```

Added a pinning test in `testHelpers.test.ts`: `startTestServer({ rateLimit: { authMax: 2 } })` must keep `globalMax` at the wide default (150 requests to `/` never 429) while the `authMax` override itself still applies (the 3rd auth-route request 429s). Mutation-tested by temporarily reverting to the overwrite (`rateLimit: WIDE_RATE_LIMITS, ...overrides`) — the test failed as expected (429s starting at request 101, once `globalMax` reverted to the production default).

## 2. The OR-wait's rejection branch is now opt-in

`bootServerWithUplink` used to wait for either `Streamwall connected` or the `Rejected invalid Streamwall state…` warning, so a wrongly-seeded spec would proceed past the seed step and fail later as a scatter of assertion errors instead of one clear timeout. Added `expectRejected` (default `false`): by default the helper only waits for the success log; specs that deliberately seed an invalid payload pass `expectRejected: true` to wait for the rejection warning instead.

The three `wsValidation.test.ts` specs that seed invalid payloads (`rejects a state message with no payload…`, `rejects an initial state payload missing a required field…`, `rejects an initial state payload with a malformed view state machine snapshot…`) now pass `expectRejected: true`.

Verified afterwards:
- The full suite still passes (see below).
- A deliberately mis-seeded call made *without* `expectRejected: true` now fails fast: it rejects after ~2.5s with `timed out waiting for matching log entry`, instead of hanging on the runner's full timeout or surfacing as unrelated downstream assertion failures.

## 3. Dropped the dead `stateMessage` parameter

In `wsValidation.test.ts`'s `connectStreamwallAndClient` wrapper, `stateMessage` was declared in the parameter type but not destructured, reaching `bootServerWithUplink` only implicitly via `...overrides`. Destructured it explicitly (along with the new `expectRejected`) and forward both explicitly.

## 4. Per-file `after` hook — no change needed

Investigated whether `after(() => app.close())` inside `startTestServer` is file-scoped rather than per-test. Empirically, in the Node version this repo pins (v22.22.3), it is **not** file-scoped: instrumenting the hook and running `wsValidation.test.ts` shows each server is spawned and closed immediately around its own test, before the next test's subtest even starts — Node's `node:test` associates the imported `after()` with the currently-running test via its execution context, even across `await` boundaries inside the async helper. No servers accumulate at the current suite size (or any size, on this Node version), so no code change was needed here.

## Verification

- `npm run test` (control-server): 184/184 passing, run three times, no flakiness observed.
- `npm run lint` (root, `eslint .`): clean.
- `npm run typecheck` (root, all workspaces): clean.
- `src/testConcurrency.test.ts` guard (no `--test-concurrency=1`): still green.
- `npx prettier --check` on touched files: clean.

Closes #591