### PR TITLE
fix(streamwall): deliver data from healthy sources while another hangs

### DIFF
--- a/packages/streamwall/src/main/data.test.ts
+++ b/packages/streamwall/src/main/data.test.ts
@@ -1,3 +1,4 @@
+import { Repeater } from '@repeaterjs/repeater'
 import { EventEmitter } from 'node:events'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { createServer, type Server } from 'node:http'
@@ -53,6 +54,31 @@ async function waitForListener(
     await new Promise((resolve) => setTimeout(resolve, 5))
   }
   throw new Error(`listener for "${event}" was not registered in time`)
+}
+
+// combineDataSources emits a snapshot as soon as *any* source has produced a
+// value (see #596), instead of withholding everything until every source has
+// spoken. A merge across N sources therefore converges over up to N snapshots
+// rather than arriving complete in the very first one.
+async function readUntil<T>(
+  gen: AsyncIterator<T>,
+  predicate: (value: T) => boolean,
+  maxReads = 5,
+): Promise<T> {
+  let last: T | undefined
+  for (let i = 0; i < maxReads; i++) {
+    const { value, done } = await gen.next()
+    if (done) {
+      break
+    }
+    last = value
+    if (predicate(value)) {
+      return value
+    }
+  }
+  throw new Error(
+    `no snapshot matched after ${maxReads} reads (last: ${JSON.stringify(last)})`,
+  )
 }
 
 describe('watchDataFile', () => {
@@ -533,15 +559,16 @@ describe('data source fan-out', () => {
       ],
       new StreamIDGenerator(),
     )
-    // combineDataSources()'s .return() never resolves while its contenders
-    // stay live (Repeater.latest does not propagate return()), so - matching
-    // the existing combineDataSources tests - read values without tearing the
-    // combined generator down. The server holds every response until two
-    // requests have arrived, so a first value can only be produced once both
-    // polls are in flight at the same time.
-    const { value } = await combined.next()
-    expect(value).toBeDefined()
-    expect(maxInFlight).toBe(2)
+    // The server holds every response until two requests have arrived, so a
+    // first value can only be produced once both polls are in flight at the
+    // same time.
+    try {
+      const { value } = await combined.next()
+      expect(value).toBeDefined()
+      expect(maxInFlight).toBe(2)
+    } finally {
+      await combined.return?.(undefined)
+    }
   })
 
   // Error semantics of the fan-out: a source whose read fails yields an empty
@@ -570,12 +597,15 @@ describe('data source fan-out', () => {
       new StreamIDGenerator(),
     )
     let seenGoodStream = false
-    // Bounded read, and no teardown: see the note in the test above.
-    for (let i = 0; i < 5 && !seenGoodStream; i++) {
-      const { value } = await combined.next()
-      seenGoodStream = Boolean(
-        value?.some((s) => s.link === 'https://good.example/s'),
-      )
+    try {
+      for (let i = 0; i < 5 && !seenGoodStream; i++) {
+        const { value } = await combined.next()
+        seenGoodStream = Boolean(
+          value?.some((s) => s.link === 'https://good.example/s'),
+        )
+      }
+    } finally {
+      await combined.return?.(undefined)
     }
     expect(seenGoodStream).toBe(true)
   })
@@ -770,9 +800,9 @@ describe('combineDataSources', () => {
       new StreamIDGenerator(),
     )
     try {
-      const { value } = await gen.next()
+      const value = await readUntil(gen, (v) => v[0]?.label === 'From B')
       expect(value).toHaveLength(1)
-      expect(value?.[0]).toMatchObject({
+      expect(value[0]).toMatchObject({
         link: 'https://a.example/s',
         label: 'From B',
         notes: 'extra',
@@ -881,8 +911,11 @@ describe('combineDataSources', () => {
       new StreamIDGenerator(),
     )
     try {
-      const { value } = await gen.next()
-      expect(value?.byURL?.get('https://a.example/s')).toMatchObject({
+      const value = await readUntil(
+        gen,
+        (v) => v.byURL?.get('https://a.example/s')?.rotation != null,
+      )
+      expect(value.byURL?.get('https://a.example/s')).toMatchObject({
         kind: 'web',
         rotation: 90,
       })
@@ -942,6 +975,125 @@ describe('combineDataSources', () => {
 
     await expect(gen.return(undefined)).resolves.toBeDefined()
   })
+
+  test('closes its sources on teardown', async () => {
+    let markClosed!: () => void
+    const closed = new Promise<void>((resolve) => {
+      markClosed = resolve
+    })
+    const source = new Repeater<StreamDataContent[]>(async (push, stop) => {
+      try {
+        await push([{ kind: 'video', link: 'https://a.example/s' }])
+        await stop
+      } finally {
+        markClosed()
+      }
+    })
+
+    const gen = combineDataSources(
+      [markDataSource(source, 'a')],
+      new StreamIDGenerator(),
+    )
+    await gen.next()
+    await gen.return(undefined)
+
+    // Resolves only if the teardown propagated down to the source; otherwise
+    // this await never settles and the test times out.
+    await closed
+  })
+
+  // Regression tests for #596: a source that has not produced a first value
+  // yet (a hung `--data.json-url`, a file that is never readable) must not
+  // withhold the data every other source has already delivered.
+  describe('with a source that has not yielded yet', () => {
+    // A source that stays silent until `yieldBatch` is called, so the tests
+    // below drive it by explicit promise resolution rather than by timing.
+    function deferredSource(): {
+      source: AsyncIterableIterator<StreamDataContent[]>
+      yieldBatch: (batch: StreamDataContent[]) => void
+    } {
+      let yieldBatch!: (batch: StreamDataContent[]) => void
+      const first = new Promise<StreamDataContent[]>((resolve) => {
+        yieldBatch = resolve
+      })
+      const source = new Repeater<StreamDataContent[]>(async (push, stop) => {
+        await push(await first)
+        await stop
+      })
+      return { source, yieldBatch }
+    }
+
+    test('delivers a healthy source while another source stays silent', async () => {
+      const { source: silent } = deferredSource()
+      const healthy = new Repeater<StreamDataContent[]>(async (push, stop) => {
+        await push([{ kind: 'video', link: 'https://good.example/s' }])
+        await stop
+      })
+
+      const gen = combineDataSources(
+        [markDataSource(silent, 'silent'), markDataSource(healthy, 'healthy')],
+        new StreamIDGenerator(),
+      )
+
+      const { value } = await gen.next()
+      expect(value?.map((s) => s.link)).toEqual(['https://good.example/s'])
+    })
+
+    test('delivers the silent source once it finally yields, without losing or duplicating data', async () => {
+      const { source: slow, yieldBatch } = deferredSource()
+      const healthy = new Repeater<StreamDataContent[]>(async (push, stop) => {
+        await push([
+          { kind: 'video', link: 'https://good.example/s', label: 'from fast' },
+        ])
+        await stop
+      })
+
+      // The slow source sits *after* the healthy one, so once it arrives its
+      // fields must win the merge - the snapshot ordering of the underlying
+      // sources has to survive the partial-first-value handling.
+      const gen = combineDataSources(
+        [markDataSource(healthy, 'healthy'), markDataSource(slow, 'slow')],
+        new StreamIDGenerator(),
+      )
+
+      const first = await gen.next()
+      expect(first.value?.map((s) => s.link)).toEqual([
+        'https://good.example/s',
+      ])
+
+      const pending = gen.next()
+      yieldBatch([
+        { kind: 'video', link: 'https://good.example/s', label: 'from slow' },
+        { kind: 'video', link: 'https://slow.example/s' },
+      ])
+      const { value } = await pending
+
+      expect(value?.map((s) => s.link)).toEqual([
+        'https://good.example/s',
+        'https://slow.example/s',
+      ])
+      expect(value?.byURL?.get('https://good.example/s')).toMatchObject({
+        label: 'from slow',
+        _dataSource: 'slow',
+      })
+    })
+
+    test('tears down while a source has never yielded', async () => {
+      const { source: silent } = deferredSource()
+      const healthy = new Repeater<StreamDataContent[]>(async (push, stop) => {
+        await push([{ kind: 'video', link: 'https://good.example/s' }])
+        await stop
+      })
+
+      const gen = combineDataSources(
+        [markDataSource(silent, 'silent'), markDataSource(healthy, 'healthy')],
+        new StreamIDGenerator(),
+      )
+
+      await gen.next()
+      await expect(gen.return(undefined)).resolves.toBeDefined()
+    })
+  })
 })
 
 describe('presetDataSource', () => {
@@ -969,19 +1121,19 @@ describe('presetDataSource', () => {
       entries: [{ link: 'https://ard.example/s', kind: 'video', label: 'ARD' }],
     }
     const idGen = new StreamIDGenerator()
-    // combineDataSources()'s .return() never resolves (Repeater.latest does
-    // not propagate return() to its contenders), so - matching the existing
-    // combineDataSources tests above - read a single value and let the
-    // generator get garbage-collected rather than tearing it down.
     const iterator = combineDataSources(
       [markDataSource(presetDataSource(pack), 'preset:de-tv')],
       idGen,
     )
-    const { value } = await iterator.next()
-    expect(value).toHaveLength(1)
-    expect(value?.[0]).toMatchObject({
-      link: 'https://ard.example/s',
-      _dataSource: 'preset:de-tv',
-    })
+    try {
+      const { value } = await iterator.next()
+      expect(value).toHaveLength(1)
+      expect(value?.[0]).toMatchObject({
+        link: 'https://ard.example/s',
+        _dataSource: 'preset:de-tv',
+      })
+    } finally {
+      await iterator.return?.(undefined)
+    }
   })
 })

--- a/packages/streamwall/src/main/data.ts
+++ b/packages/streamwall/src/main/data.ts
@@ -31,7 +31,7 @@ export type DataSourceHealthCallback = (ok: boolean, message?: string) => void
 // request flood against the operator's endpoint. Concurrency across data
 // sources already exists one level up: `buildDataSources` creates one
 // generator per URL and `combineDataSources` advances all of them at once via
-// `Repeater.latest`, so N URLs are polled in parallel with each other while
+// `latestPerSource`, so N URLs are polled in parallel with each other while
 // each individual URL stays strictly serial (see #582).
 export async function* pollDataURL(
   url: string,
@@ -165,10 +165,10 @@ export function presetDataSource(
   })
 }
 
-// Built as a Repeater rather than a plain `async function*`: Repeater.latest()
-// (used by combineDataSources) always keeps one speculative `.next()` call
-// in flight per contender, which can be left permanently pending when a
-// source has no further data. A native async generator queues `.return()`
+// Built as a Repeater rather than a plain `async function*`: the combining
+// layer (`latestPerSource`, previously `Repeater.latest`) always keeps one
+// speculative `.next()` call in flight per source, which can be left
+// permanently pending when a source has no further data. A native async generator queues `.return()`
 // calls behind any in-flight `.next()` per the spec, so that dangling call
 // would block teardown forever; Repeater.return() instead settles pending
 // `.next()` calls immediately, which is what makes combineDataSources()'s
@@ -208,11 +208,76 @@ export function markDataSource(
 /** Name passed to `markDataSource` for the overlay (rotate-stream) source. */
 export const OVERLAY_DATA_SOURCE_NAME = 'overlay'
 
+// Combines the sources into a stream of "latest value per source" snapshots.
+//
+// This is deliberately *not* `Repeater.latest`: that combinator withholds
+// every value until each contender has produced a first one, so a single slow
+// or black-holed source (e.g. a `--data.json-url` pointing at a host that
+// accepts the connection and never answers - `fetch` has no client-side
+// timeout) keeps the entire wall empty for as long as it hangs, even though
+// every other source has already delivered (issue #596).
+//
+// Here each source is advanced independently and a snapshot is emitted as soon
+// as *any* source yields; sources that have not spoken yet contribute an empty
+// batch and are filled in when they do. No value is dropped or duplicated: a
+// snapshot is pushed per received batch, and each snapshot carries the latest
+// batch of every source at push time. Slot order matches `dataSources` order,
+// which is what gives later sources precedence in the merge below.
+function latestPerSource(
+  dataSources: DataSource[],
+): Repeater<StreamDataContent[][]> {
+  return new Repeater(async (push, stop) => {
+    const latest: StreamDataContent[][] = dataSources.map(() => [])
+    let stopped = false
+    void stop.then(() => {
+      stopped = true
+    })
+    try {
+      await Promise.all(
+        dataSources.map(async (dataSource, index) => {
+          while (!stopped) {
+            const nextP = dataSource.next()
+            // Guard the race loser against an unhandled rejection. The
+            // rejection still surfaces to the awaited race (and is logged,
+            // named, by markDataSource), so error propagation is unchanged.
+            nextP.catch(() => {})
+            const iteration = await Promise.race([nextP, stop])
+            if (stopped || iteration === undefined || iteration.done) {
+              return
+            }
+            latest[index] = iteration.value
+            // Raced against `stop` so a teardown while the consumer is not
+            // pulling settles immediately instead of waiting for a pull that
+            // will never come.
+            const pushP = push([...latest])
+            pushP.catch(() => {})
+            await Promise.race([pushP, stop])
+          }
+        }),
+      )
+    } finally {
+      // Repeater combinators do not propagate return() to their contenders, so
+      // signal the sources explicitly - otherwise pollers and file watchers
+      // keep running after the combined generator is done. Deliberately not
+      // awaited: a source that is wedged inside its own executor (exactly the
+      // hung-source case this combinator exists to survive) never settles its
+      // return(), and waiting on it would re-introduce the hang here.
+      for (const dataSource of dataSources) {
+        void Promise.resolve(dataSource.return?.(undefined)).catch(
+          (err: unknown) => {
+            log.warn('error closing data source', err)
+          },
+        )
+      }
+    }
+  })
+}
+
 export async function* combineDataSources(
   dataSources: DataSource[],
   idGen: StreamIDGenerator,
 ) {
-  for await (const streamLists of Repeater.latest(dataSources)) {
+  for await (const streamLists of latestPerSource(dataSources)) {
     const dataByURL = new Map<string, StreamData>()
     for (const list of streamLists) {
       for (const data of list) {


### PR DESCRIPTION
## The failure mode

`combineDataSources` combined its sources with `Repeater.latest`, which only emits once **every** contender has produced a first value. A single source that is slow or hung therefore withheld the data of all the others: the operator saw an empty wall with no indication why.

Today this is mostly masked because the real sources fail *fast* (connection refused, missing file → empty batch almost immediately). The exposure is a source that hangs rather than errors: a `--data.json-url` pointing at a host that accepts the connection and never answers has no client-side `fetch` timeout, so the wall can stay empty indefinitely.

## The fix

Replaced `Repeater.latest` with a local `latestPerSource` combinator (`packages/streamwall/src/main/data.ts`):

- each source is advanced independently, and a snapshot of "latest batch per source" is emitted as soon as *any* source yields;
- a source that has not spoken yet contributes an empty batch and is filled in when it does;
- slot order still matches the `dataSources` order, which is what gives later sources precedence in the merge — so the overlay/rotation patching and field-override semantics are unchanged;
- no batch is dropped or duplicated: one snapshot is pushed per received batch, each carrying every source's latest batch at push time.

Why this option rather than the alternatives listed in #596:

- **Seeding each source with an initial empty batch** would also unblock `latest`, but it fixes the symptom inside `markDataSource` (every source would have to opt in and emit a fake value) and still emits a full round of empty snapshots. Doing the same thing in the combinator is one place, with no fake values in the source layer.
- **A `fetch` timeout only** fixes the one trigger we happen to know about, not the general withholding problem — any hung source (a stalled watcher, a slow file read) would still block the wall. A request timeout is still worthwhile as defence in depth and, since it also makes a black-holed URL report itself as *unhealthy* in the UI, it is tracked separately in #603.

The teardown gotcha noted in #593 is fixed as a side effect: `combineDataSources().return()` now resolves while its sources are still live, and the combinator propagates the teardown down to the sources (fire-and-forget, deliberately not awaited — a source wedged inside its own executor never settles its `return()`, and awaiting it would re-introduce a hang). Pollers and file watchers therefore stop when the combined generator is done, instead of leaking. The tests that previously avoided teardown for that reason now tear down properly.

### Behaviour change

Consumers can now observe a partial snapshot before every source has reported, converging over at most one snapshot per source. That is the point of the change (data reaches the wall as soon as it exists), and the two existing merge tests that read exactly one value were updated to read until convergence.

## Tests

New regression tests in `data.test.ts`, all driven by explicit promise resolution rather than timers:

- a healthy source is delivered while another source stays silent;
- the silent source's data still arrives once it yields, merged in the right precedence order, with nothing lost or duplicated;
- teardown resolves while a source has never yielded;
- teardown closes the sources.

Mutation-tested: with the fix reverted to `Repeater.latest`, the three withholding/teardown tests fail (5s timeouts); with the teardown propagation removed, `closes its sources on teardown` fails. The `#593` fast-failure test ("keeps delivering data from healthy sources when one source fails") and the concurrency test stay green.

`npm run test`, `npm run lint` and `npm run typecheck` all pass; the streamwall suite was run 5× and `data.test.ts` 10× in a row with no flakes.

Closes #596
