### PR TITLE
test(control-ui): fix testHelpers container leak, finish icon-stub dedup

### DIFF
--- a/packages/streamwall-control-ui/src/ConnectionStatusBanner.test.tsx
+++ b/packages/streamwall-control-ui/src/ConnectionStatusBanner.test.tsx
@@ -3,9 +3,10 @@ import { act } from 'preact/test-utils'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { ConnectionStatusBanner } from './ConnectionStatusBanner.tsx'
 
-vi.mock('react-icons/fa', () => ({
-  FaExclamationTriangle: () => null,
-}))
+vi.mock(
+  'react-icons/fa',
+  async () => (await import('./testIconStubs.tsx')).faIconStubs,
+)
 
 let container: HTMLDivElement | undefined
 

--- a/packages/streamwall-control-ui/src/GridControls.test.tsx
+++ b/packages/streamwall-control-ui/src/GridControls.test.tsx
@@ -8,15 +8,10 @@ import { GridControls } from './GridControls.tsx'
 // currently crashes under this package's happy-dom test environment
 // (unrelated to the controls under test here) - stub the icons out so the
 // component can render.
-vi.mock('react-icons/fa', () => ({
-  FaExchangeAlt: () => null,
-  FaRedoAlt: () => null,
-  FaRegLifeRing: () => null,
-  FaRegWindowMaximize: () => null,
-  FaSyncAlt: () => null,
-  FaVideoSlash: () => null,
-  FaVolumeUp: () => null,
-}))
+vi.mock(
+  'react-icons/fa',
+  async () => (await import('./testIconStubs.tsx')).faIconStubs,
+)
 
 let container: HTMLDivElement | undefined
 

--- a/packages/streamwall-control-ui/src/testHelpers.test.tsx
+++ b/packages/streamwall-control-ui/src/testHelpers.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, test, vi } from 'vitest'
+import { makeConnection, renderControlUI } from './testHelpers.tsx'
+
+vi.mock(
+  'react-icons/fa',
+  async () => (await import('./testIconStubs.tsx')).faIconStubs,
+)
+vi.mock(
+  'react-icons/md',
+  async () => (await import('./testIconStubs.tsx')).mdIconStubs,
+)
+vi.mock('react-hotkeys-hook', () => ({
+  useHotkeys: () => {},
+}))
+
+// Regression test for issue #594: `renderControlUI` used to track the
+// mounted container in a single module-scope `let`, so a second call within
+// the same test silently leaked the first container (and its Preact root) -
+// the shared `afterEach` only ever unmounted the last one.
+//
+// This spans two `test`s deliberately: the leak can only be observed once
+// the shared `afterEach` between them has actually run.
+let containersFromPriorTest: HTMLDivElement[] = []
+
+describe('renderControlUI container cleanup (issue #594)', () => {
+  test('mounts two independent containers within a single test', () => {
+    const first = renderControlUI(makeConnection())
+    const second = renderControlUI(makeConnection())
+
+    expect(first).not.toBe(second)
+    expect(document.body.contains(first)).toBe(true)
+    expect(document.body.contains(second)).toBe(true)
+
+    containersFromPriorTest = [first, second]
+  })
+
+  test('the shared afterEach unmounted and detached both prior containers', () => {
+    expect(containersFromPriorTest).toHaveLength(2)
+    for (const container of containersFromPriorTest) {
+      expect(document.body.contains(container)).toBe(false)
+      expect(container.childElementCount).toBe(0)
+    }
+  })
+})

--- a/packages/streamwall-control-ui/src/testHelpers.tsx
+++ b/packages/streamwall-control-ui/src/testHelpers.tsx
@@ -124,15 +124,17 @@ export function makeConnection(
   }
 }
 
-let container: HTMLDivElement | undefined
+const containers: HTMLDivElement[] = []
 
 // Importing this module registers the teardown on the importing spec file's
 // root suite, so every mounted ControlUI is unmounted and detached again.
+// Tracked as an array (not a single slot) because a test that calls
+// `renderControlUI` more than once must not leak the earlier containers and
+// their Preact roots - every mount collected here gets unmounted.
 afterEach(() => {
-  if (container) {
-    act(() => render(null, container!))
+  for (const container of containers.splice(0)) {
+    act(() => render(null, container))
     container.remove()
-    container = undefined
   }
 })
 
@@ -140,10 +142,11 @@ afterEach(() => {
 export function renderControlUI(
   connection: StreamwallConnection,
 ): HTMLDivElement {
-  container = document.createElement('div')
+  const container = document.createElement('div')
   document.body.appendChild(container)
+  containers.push(container)
   act(() => {
-    render(<ControlUI connection={connection} />, container!)
+    render(<ControlUI connection={connection} />, container)
   })
   return container
 }


### PR DESCRIPTION
Follow-ups from the review of #589.

## 1. Container leak fix (the real bug)

`renderControlUI` tracked its mounted container in a single module-scope `let`. Calling it twice within one test permanently leaked the first container and its Preact root - the shared `afterEach` only ever unmounted the last one. Fixed by tracking every mounted container in an array and unmounting all of them in `afterEach`.

Added `packages/streamwall-control-ui/src/testHelpers.test.tsx`, which calls `renderControlUI` twice in one test and then asserts, in a second test, that both containers were unmounted and detached by the intervening `afterEach`.

**Mutation-tested**: reverted `testHelpers.tsx` to the single-`let` version locally and re-ran `testHelpers.test.tsx` - the second test failed (`expected true to be false`, i.e. the first container was still attached to `document.body`), confirming the new test actually catches the leak. Re-applied the fix afterward; full suite green again.

## 2. Finishing the icon-stub dedup

Re-audited `packages/streamwall-control-ui/src/` for specs still carrying their own `react-icons` stub literal (the pattern #589 started consolidating into `testIconStubs.tsx`). Since #589 landed, most new/adjacent specs already adopted `testHelpers.tsx`/`testIconStubs.tsx` on their own as they were written, so the actual remaining count today is smaller than the "roughly 12" estimate in the issue. The full audit (`grep` for `'react-icons/fa'` / `'react-icons/md'` across every `*.test.tsx`) found exactly two specs left with an inline literal:

| File | Change |
|------|--------|
| `ConnectionStatusBanner.test.tsx` | `vi.mock('react-icons/fa', () => ({ FaExclamationTriangle: () => null }))` → `vi.mock('react-icons/fa', async () => (await import('./testIconStubs.tsx')).faIconStubs)` |
| `GridControls.test.tsx` | Same swap, replacing a 7-icon inline object with the shared `faIconStubs` |

Both specs test a sub-component (`ConnectionStatusBanner`, `GridControls`), not the full `ControlUI`, so `renderControlUI` doesn't apply to their mount/render helper - only the duplicated icon-stub *literal* is deduped here. Their own local `renderBanner`/`renderControls` container-lifecycle helpers are intentionally left as-is: introducing a generic non-ControlUI mount helper would be new surface `testHelpers.tsx` doesn't currently provide, and is out of scope for this dedup.

`preactCompatInterop.test.tsx` also references `react-icons/fa`, but deliberately imports the *real* `FaExclamationTriangle` (regression test for issue #177 - it asserts react-icons actually renders through preact/compat) - correctly left untouched.

**Per-file verification**: for both migrated files, diffed `describe`/`test` titles from `origin/main` against the working tree (line numbers shift because the mock block shrank; the title text sets are identical) and confirmed the diff touches only the `vi.mock` block - no assertion lines changed.

## 3. Naming / bundling check

`testHelpers.tsx` and `testIconStubs.tsx` sit in `src/` without a test-marker suffix and `testHelpers.tsx` imports `vitest` at module scope. Checked whether either can reach a production bundle:

- The renderer build (`packages/streamwall/vite.renderer.config.ts`) only defines four Rollup entry points (`background`, `overlay`, `playHLS`, `control`), each ultimately importing `streamwall-control-ui`'s package `main` (`./src/index.tsx`, per `packages/streamwall-control-ui/package.json`).
- `index.tsx`'s exports do not touch either file, and a repo-wide grep confirms no non-test file under `packages/streamwall-control-ui/src` imports `testHelpers.tsx` or `testIconStubs.tsx` - only `*.test.tsx` files do.
- Vite/Rollup only bundles modules reachable via the static import graph from those four entries, so neither file is reachable and neither can be pulled into a production bundle today.

**Verdict: they provably cannot reach a production bundle. No change made** (per the issue's own guidance not to fix a problem that doesn't exist).

## What was NOT done

Per the issue's explicit instruction, `testIconStubs.tsx` was not merged into `testHelpers.tsx` and no imports were added to it - it stays import-free so `vi.mock` factories that pull it in don't drag `index.tsx` (and `react-icons`) into the mock factory, which was previously verified to hang the test runner.

## Verification

- `npm run test` - all packages pass (control-ui: 49 files, 365 tests, up from 48/363 before this PR)
- `npm run lint` - clean
- `npm run typecheck` - clean
- `npx prettier --check` on all touched files - clean
- Ran the control-ui suite 4 times total (once via `npm run test`, three times via direct `vitest run`) - 49/49 files, 365/365 tests every time, no flakiness

Closes #594