### PR TITLE
fix(streamwall): time out pollDataURL fetches so a black-holed source reports unhealthy

### DIFF
--- a/packages/streamwall/src/main/data.test.ts
+++ b/packages/streamwall/src/main/data.test.ts
@@ -9,6 +9,7 @@ import type { StreamDataContent } from 'streamwall-shared'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import {
   combineDataSources,
+  computeFetchTimeoutMs,
   LocalStreamData,
   markDataSource,
   pollDataURL,
@@ -498,6 +499,132 @@ describe('pollDataURL', () => {
       expect(maxInFlight).toBe(1)
     } finally {
       await gen.return(undefined)
+    }
+  })
+
+  // These two tests drive the client-side fetch timeout (#603) with
+  // vi.useFakeTimers() rather than real setTimeout races: the abort timer
+  // is advanced by an exact, known amount, and the HTTP response is
+  // released only after that advance, on an explicit "the server received
+  // the request" promise rather than a real delay. That keeps the pass/fail
+  // boundary deterministic instead of depending on how fast this machine's
+  // event loop happens to be, which matters because this file's tests run
+  // in CI on three platforms.
+  test('reports unhealthy after a client-side timeout and recovers on the next successful poll', async () => {
+    // Fake only setTimeout/clearTimeout: pollDataURL's abort timer and its
+    // inter-poll `sleep()` are both built on those, but leaving
+    // setImmediate/process.nextTick real matters because Node's own
+    // http/net internals lean on them to deliver this test's real loopback
+    // response - faking those too stalls the request indefinitely.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    try {
+      let requestCount = 0
+      let firstRequestReceived: () => void
+      const firstRequestReceivedP = new Promise<void>((resolve) => {
+        firstRequestReceived = resolve
+      })
+      let secondRequestReceived: () => void
+      const secondRequestReceivedP = new Promise<void>((resolve) => {
+        secondRequestReceived = resolve
+      })
+      server = createServer((_req, res) => {
+        requestCount++
+        if (requestCount === 1) {
+          // Simulates a host that accepts the connection and never answers.
+          firstRequestReceived()
+          return
+        }
+        res.setHeader('content-type', 'application/json')
+        res.end(
+          JSON.stringify([{ link: 'https://a.example/s', kind: 'video' }]),
+        )
+        secondRequestReceived()
+      })
+      await new Promise<void>((resolve) =>
+        server!.listen(0, '127.0.0.1', resolve),
+      )
+      const { port } = server.address() as AddressInfo
+      const url = `http://127.0.0.1:${port}/`
+
+      const intervalSecs = 10
+      const timeoutMs = computeFetchTimeoutMs(intervalSecs * 1000)
+      const onHealth = vi.fn()
+      const gen = pollDataURL(url, intervalSecs, onHealth)
+      try {
+        const firstP = gen.next()
+        // Let the real request actually land at the server before
+        // fast-forwarding the fake clock, so the abort timer cannot fire
+        // before the request was ever sent.
+        await firstRequestReceivedP
+        await vi.advanceTimersByTimeAsync(timeoutMs)
+        const first = await firstP
+        expect(onHealth).toHaveBeenCalledWith(
+          false,
+          expect.stringContaining('timed out'),
+        )
+        expect(first.value).toEqual([])
+
+        const secondP = gen.next()
+        await vi.advanceTimersByTimeAsync(intervalSecs * 1000)
+        await secondRequestReceivedP
+        const second = await secondP
+        expect(second.value?.map((s: StreamDataContent) => s.link)).toEqual([
+          'https://a.example/s',
+        ])
+        expect(onHealth).toHaveBeenCalledWith(true)
+      } finally {
+        await gen.return(undefined)
+      }
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('does not report unhealthy status for a response that resolves under the timeout', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    try {
+      let pendingRes: import('node:http').ServerResponse | undefined
+      let requestReceived: () => void
+      const requestReceivedP = new Promise<void>((resolve) => {
+        requestReceived = resolve
+      })
+      server = createServer((_req, res) => {
+        pendingRes = res
+        requestReceived()
+      })
+      await new Promise<void>((resolve) =>
+        server!.listen(0, '127.0.0.1', resolve),
+      )
+      const { port } = server.address() as AddressInfo
+      const url = `http://127.0.0.1:${port}/`
+
+      const intervalSecs = 10
+      const timeoutMs = computeFetchTimeoutMs(intervalSecs * 1000)
+      const onHealth = vi.fn()
+      const gen = pollDataURL(url, intervalSecs, onHealth)
+      try {
+        const firstP = gen.next()
+        await requestReceivedP
+
+        // Advance to just under the timeout: the endpoint is slow, not dead,
+        // so no abort should fire yet.
+        await vi.advanceTimersByTimeAsync(timeoutMs - 1000)
+        pendingRes!.setHeader('content-type', 'application/json')
+        pendingRes!.end(
+          JSON.stringify([{ link: 'https://a.example/s', kind: 'video' }]),
+        )
+
+        const first = await firstP
+        expect(first.value?.map((s: StreamDataContent) => s.link)).toEqual([
+          'https://a.example/s',
+        ])
+        expect(onHealth).toHaveBeenCalledWith(true)
+        expect(onHealth).not.toHaveBeenCalledWith(false, expect.any(String))
+      } finally {
+        await gen.return(undefined)
+      }
+    } finally {
+      vi.useRealTimers()
     }
   })
 })

--- a/packages/streamwall/src/main/data.ts
+++ b/packages/streamwall/src/main/data.ts
@@ -5,7 +5,6 @@ import { EventEmitter, once } from 'events'
 import { promises as fsPromises } from 'fs'
 import fetch from 'node-fetch'
 import { parseStreamList } from 'streamwall-shared'
-import { promisify } from 'util'
 import {
   StreamData,
   StreamDataContent,
@@ -14,9 +13,64 @@ import {
 import log from './logger'
 import type { PresetPack } from './presets'
 
-const sleep = promisify(setTimeout)
+// Deliberately not `promisify(setTimeout)` at module scope: that binds to
+// whatever `setTimeout` function is global at import time, which is the
+// real one - a test that swaps in vi.useFakeTimers() afterwards cannot
+// intercept an already-captured reference. Resolving `setTimeout` fresh
+// inside the function body, on every call, is what lets fake timers control
+// pollDataURL's inter-poll wait (data.test.ts).
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
 
 type DataSource = AsyncIterableIterator<StreamDataContent[]>
+
+// A stalled `fetch(url)` (a host that accepts the connection and never
+// answers) must not hang pollDataURL's loop forever - see #603. The timeout
+// tracks the poll interval (half of it) so a slower configured interval
+// tolerates a proportionally slower endpoint, but is clamped to a band:
+// - a floor high enough that a merely-slow response on a short interval
+//   (including the sub-second intervals this file's own tests use) is not
+//   misreported as a dead source,
+// - a ceiling so a very long interval doesn't leave an operator waiting
+//   minutes to learn a source is unreachable.
+export const MIN_FETCH_TIMEOUT_MS = 5_000
+export const MAX_FETCH_TIMEOUT_MS = 15_000
+
+export function computeFetchTimeoutMs(refreshIntervalMs: number): number {
+  return Math.min(
+    MAX_FETCH_TIMEOUT_MS,
+    Math.max(MIN_FETCH_TIMEOUT_MS, refreshIntervalMs / 2),
+  )
+}
+
+// Deliberately built on a manual AbortController + setTimeout rather than
+// the built-in `AbortSignal.timeout()`: the latter schedules its internal
+// timer through Node's C++ timer binding, which vitest's fake-timers (used
+// by data.test.ts to drive the timeout deterministically) cannot intercept.
+// A timer created via the global `setTimeout` used elsewhere in this file
+// is reliably fake-timer-controllable.
+async function fetchWithTimeout(url: string, timeoutMs: number) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await fetch(url, { signal: controller.signal })
+  } catch (err) {
+    // node-fetch's AbortError carries a generic "The operation was aborted."
+    // message regardless of the abort reason, so a timeout looks the same
+    // as any other cancellation. Re-throw with a message that names the
+    // actual cause and duration, which is what ends up surfaced to the
+    // operator via onHealth(false, message).
+    if (controller.signal.aborted) {
+      throw new Error(`timed out after ${timeoutMs}ms waiting for ${url}`, {
+        cause: err,
+      })
+    }
+    throw err
+  } finally {
+    clearTimeout(timer)
+  }
+}
 
 // Reports whether the most recent read of a data source succeeded, so a
 // caller can surface a dead json-url/toml-file from the UI instead of it
@@ -39,11 +93,12 @@ export async function* pollDataURL(
   onHealth?: DataSourceHealthCallback,
 ) {
   const refreshInterval = intervalSecs * 1000
+  const fetchTimeout = computeFetchTimeoutMs(refreshInterval)
   let lastData: StreamDataContent[] = []
   while (true) {
     let data: StreamDataContent[] = []
     try {
-      const resp = await fetch(url)
+      const resp = await fetchWithTimeout(url, fetchTimeout)
       const { streams, errors } = parseStreamList(await resp.json())
       if (errors.length) {
         log.warn(`ignoring ${errors.length} invalid stream(s) from ${url}`)


### PR DESCRIPTION
## Problem

`pollDataURL` (`packages/streamwall/src/main/data.ts`) called `fetch(url)` with no client-side timeout. A `--data.json-url` pointing at a host that accepts the TCP connection and never answers hung that source forever:

- no batch was ever yielded for that URL,
- `onHealth` was never called with `false`, so the operator saw the source as neither ok nor failed - no indication the endpoint was dead.

This is the remaining half of #596 (fixed by PR #605, which made `combineDataSources` emit partial snapshots so a hung source no longer withholds the other sources' data). What was left: the hung source itself never reported unhealthy.

## Fix

`fetchWithTimeout` races the request against an `AbortController` timeout, sized by `computeFetchTimeoutMs`:

```
timeout = clamp(refreshInterval / 2, 5_000ms, 15_000ms)
```

Rationale for the sizing:
- **Half the interval** keeps the timeout meaningfully shorter than the poll cadence, so a hung request degrades and retries well before the next scheduled poll would have fired anyway.
- **5s floor** stops a merely-slow (not dead) endpoint on a short poll interval from being misreported as unreachable - including the sub-second intervals this file's own tests already use for unrelated scenarios.
- **15s ceiling** stops a very long configured interval (default is 30s, but operators can set it higher) from leaving an operator waiting minutes to find out a source is dead.

On timeout, the request aborts and the *existing* unhealthy-source path runs unchanged: log a warning, call `onHealth(false, message)`, keep any cached data, and loop back into `sleep(refreshInterval)` to retry on the next tick - the generator is never terminated.

Two related but incidental changes needed to make this properly testable:
- `fetchWithTimeout` builds its own `AbortController` + `setTimeout` rather than the built-in `AbortSignal.timeout()`, because the latter's internal timer isn't interceptable by vitest's fake timers.
- `sleep()` (previously `promisify(setTimeout)` bound once at module load) now resolves `setTimeout` fresh on every call, so `vi.useFakeTimers()` installed inside a test can actually control pollDataURL's inter-poll wait. The pre-existing binding silently ignored fake timers because it had already captured the real `setTimeout` reference before any test ran.

## Tests

Added to `pollDataURL`'s test suite in `data.test.ts`, both driven with `vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })` and explicit promise gating (never a real-time race):

- a never-answering endpoint reports `onHealth(false, ...)` within the timeout, then recovers and reports `onHealth(true)` on a later successful poll, without the generator terminating;
- a slow-but-answering endpoint that resolves under the timeout is never reported unhealthy.

`setImmediate`/`process.nextTick` are deliberately left un-faked - Node's http/net internals lean on them to actually deliver the real loopback request/response used by these tests, so faking them stalls the request indefinitely.

**Mutation check**: temporarily reverted the `fetchWithTimeout` call back to plain `fetch(url)` and reran the new tests - the "reports unhealthy after a client-side timeout" test failed red (test timeout, request hangs forever) as expected. Reverted back before committing.

## Verification

- `npm run test` - all workspaces pass (streamwall: 893 tests; control-server: 184; control-ui: 365), run 3x with no flakiness on `data.test.ts` specifically (5x) and the full streamwall suite (3x).
- `npm run lint` - clean.
- `npm run typecheck` - clean across all workspaces.
- `npm run format:check` - clean.
- Confirmed the #605 behaviour is unaffected: partial-snapshot and "failing source doesn't suppress a healthy one" tests in `data.test.ts` still pass.

Closes #603