### PR TITLE
docs(contributing): document close/reopen as the release PR's check trigger

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -381,14 +381,28 @@ breaking change bumps the minor version.
    manifests, their `package-lock.json` entries and the `CHANGELOG.md` section
    for the pending release. Its description previews the release notes;
    anything merged afterwards updates the PR.
-2. Merge the release PR when you want to cut the release. A pull request opened
-   by a workflow's `GITHUB_TOKEN` raises no `pull_request` events, so neither
-   `CI OK` nor `Conventional Commits title` would start on its own. Instead,
-   `release-please.yml` dispatches both workflows against the release branch
-   after every update — `workflow_dispatch` is the one event GitHub still
-   delivers for that token. Wait for the two checks to pass before merging.
-   Because a dispatched run has nothing to diff against, it always runs the
-   full gate rather than the change-scaled subset.
+2. Close and reopen the release PR, then merge it when the checks have passed.
+
+   The close/reopen step is not optional. A pull request opened by a workflow's
+   `GITHUB_TOKEN` raises no `pull_request` events, so neither `CI OK` nor
+   `Conventional Commits title` starts on its own, and branch protection blocks
+   the merge with `2 of 2 required status checks are expected`. Reopening the PR
+   by hand raises a real `pull_request` (reopened) event — both workflows listen
+   for it — so the checks attach to the PR itself and `mergeStateStatus` becomes
+   `CLEAN`.
+
+   `release-please.yml` also dispatches both workflows against the release
+   branch after every update, `workflow_dispatch` being the one event GitHub
+   still delivers for that token. Treat those runs as a smoke signal only: they
+   report on the branch head, **not** on the pull request, so they never enter
+   its status check rollup and cannot satisfy branch protection (#578). Because
+   a dispatched run has nothing to diff against, it always runs the full gate
+   rather than the change-scaled subset.
+
+   Both workarounds exist only because release-please runs with `GITHUB_TOKEN`.
+   Switching it to a PAT or GitHub App token (#549) would let the release PR
+   start its own required checks and make this step unnecessary.
+
 3. Tag the merge commit and push the tag:
 
    ```sh

--- a/test/release-please.test.mjs
+++ b/test/release-please.test.mjs
@@ -231,13 +231,26 @@ test('the PR title check resolves the title of a dispatched release PR', () => {
   assert.equal(step.env.PR_NUMBER, '${{ inputs.pr-number }}')
 })
 
-test('the release documentation drops the close/reopen workaround', () => {
+// This guard used to assert the opposite: that the close/reopen workaround was
+// gone, because the dispatch shim added in #547 was expected to make it
+// unnecessary. It does not. A workflow_dispatch run reports against the branch
+// head rather than the pull request, so its checks never enter the PR's status
+// check rollup and branch protection still blocks the merge (#578). Cutting
+// v0.10.0 hit exactly that. Until release-please runs with a token that raises
+// real pull_request events (#549), close/reopen is the step that works, and the
+// documentation has to say so.
+test('the release documentation keeps the close/reopen step', () => {
   const contributing = readFileSync(join(rootDir, 'CONTRIBUTING.md'), 'utf8')
 
-  assert.doesNotMatch(
+  assert.match(
     contributing,
     /reopen the release PR/i,
-    'release-please.yml starts the checks itself now (#521)',
+    'the release PR only gets its required checks from a real pull_request event (#578)',
+  )
+  assert.match(
+    contributing,
+    /smoke signal/i,
+    'the dispatched runs must not be presented as satisfying branch protection (#578)',
   )
 })
 


### PR DESCRIPTION
Addresses the documentation half of #578. No workflow changes — the dispatch shim and `GITHUB_TOKEN` setup stay as they are.

## The problem

"Cutting a release", step 2 told the reader that `release-please.yml` dispatches `ci.yml` and `pr-title.yml` against the release branch, and to "wait for the two checks to pass before merging". That implies the dispatched runs satisfy branch protection. They do not.

A `workflow_dispatch` run is not associated with the pull request, so its check runs report against the branch head and never enter the PR's status check rollup. For #518 the rollup contained only `CodeQL`, and the merge failed with:

```
Repository rule violations found
2 of 2 required status checks are expected.
```

The v0.10.0 release was unblocked by closing and reopening the release PR, which raises a real `pull_request` (reopened) event. Both workflows listen for it — `ci.yml` via a bare `pull_request:` trigger (whose default types include `reopened`) and `pr-title.yml` by listing `reopened` explicitly — so the checks attached to the PR, `mergeStateStatus` became `CLEAN`, and the merge went through.

Anyone following the current instructions waits for green checks, tries to merge, and hits the same wall. The documented workaround does not work, and the one that does was undocumented.

## The change

Step 2 now:

- states close/reopen as the actual, non-optional step, with the reason
- demotes the dispatched runs to a smoke signal and says explicitly that they cannot satisfy branch protection
- keeps the existing note that a dispatched run has nothing to diff against and therefore always runs the full gate
- points at #549 (PAT / GitHub App token) as the change that would make both workarounds unnecessary

## Scope

`CONTRIBUTING.md` only. #578 stays open for the workflow-side decision, which needs a token other than `GITHUB_TOKEN` and is therefore blocked on repository configuration.