### PR TITLE
ci: clear the release PR label that blocks the next release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -414,6 +414,51 @@ jobs:
             fi
           done
 
+  # release-please stops building release PRs while a merged one still carries
+  # `autorelease: pending` — it logs "There are untagged, merged release PRs
+  # outstanding - aborting" and exits successfully, so its workflow stays green
+  # (an 11s run) while every commit on `main` piles up unreleased. That label is
+  # normally cleared by release-please's own GitHub-release step, which this
+  # repository skips (`skip-github-release`, see release-please.yml) because the
+  # tag has to be pushed by hand. Cutting the tag is therefore the moment the
+  # label has to move, and this job is that moment (#611).
+  #
+  # The label `autorelease: tagged` must exist in the repository; `gh pr edit`
+  # fails on an unknown label, which is the intended outcome — a loud failure in
+  # the release run beats the silent blockage this job exists to prevent.
+  release-pr-label:
+    name: Mark the release PR as tagged
+    needs: [publish]
+    # A workflow_dispatch run carries no version to look a release PR up by.
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write # relabelling the merged release PR
+    steps:
+      - name: Move the release PR from pending to tagged
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The job never checks the repository out, so `gh` cannot infer the
+          # target from a git remote.
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          version="${TAG#v}"
+          number=$(gh pr list --state merged --label 'autorelease: pending' \
+            --search "\"release $version\" in:title" \
+            --json number --jq '.[0].number // empty')
+          if [ -z "$number" ]; then
+            # A release cut by hand (`npm run release:version`) has no release
+            # PR to relabel, and neither has a re-run of an already handled tag.
+            echo "::notice::No merged release PR labelled 'autorelease: pending' for $version — nothing to relabel."
+            exit 0
+          fi
+          gh pr edit "$number" \
+            --add-label 'autorelease: tagged' \
+            --remove-label 'autorelease: pending'
+          echo "::notice::Marked release PR #$number as tagged; release-please can build the next release PR."
+
   # electron-forge's GitHub publisher creates the release for the tag but leaves
   # its body empty. The changelog section for that version — generated from the
   # Conventional Commit subjects by release-please.yml — is exactly the release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -419,6 +419,15 @@ breaking change bumps the minor version.
    electron-forge, and then copies the `CHANGELOG.md` section for that version
    into the GitHub Release body (`scripts/changelog-section.mjs`).
 
+   Its `release-pr-label` job also moves the merged release PR from
+   `autorelease: pending` to `autorelease: tagged`. release-please normally
+   clears that label when it creates the GitHub release, which it does not do
+   here (`skip-github-release`), and while the label is still `pending` it
+   refuses to build the next release PR at all — logging "There are untagged,
+   merged release PRs outstanding - aborting" and finishing green, so nothing
+   reports the blockage. That is how thirteen commits sat on `main` without a
+   release PR after v0.10.0 (#611).
+
 Because that tag is the one manual step,
 [`.github/workflows/release-tag.yml`](.github/workflows/release-tag.yml) checks
 every morning that the version on `main` has a matching `vX.Y.Z` tag and fails

--- a/test/release-please.test.mjs
+++ b/test/release-please.test.mjs
@@ -269,3 +269,40 @@ test('release.yml turns the changelog section into the release notes', () => {
     /scripts\/changelog-section\.mjs/,
   )
 })
+
+// release-please refuses to build the next release PR while a merged one still
+// carries `autorelease: pending`: it reports "There are untagged, merged
+// release PRs outstanding - aborting" and exits successfully, so the workflow
+// stays green while every commit on `main` piles up unreleased. The label is
+// normally cleared by the GitHub-release step, which this repository skips
+// because the tag is pushed by hand — so the tag run has to clear it instead
+// (#611).
+test('release.yml clears the release PR label that blocks the next release', () => {
+  const release = readWorkflow('release.yml')
+  const job = release.jobs['release-pr-label']
+
+  assert.ok(job, 'release.yml is missing a release-pr-label job')
+  assert.equal(
+    job.permissions['pull-requests'],
+    'write',
+    'relabelling the release PR needs the pull-requests: write scope',
+  )
+  assert.match(
+    job.if ?? '',
+    /refs\/tags\/v/,
+    'only a tag run knows which release version to relabel',
+  )
+  assert.ok(
+    job.needs.includes('publish'),
+    'the label must only move once the tag actually produced a release',
+  )
+
+  const run = job.steps.map((step) => step.run ?? '').join('\n')
+  assert.match(run, /--add-label\s+'autorelease: tagged'/)
+  assert.match(run, /--remove-label\s+'autorelease: pending'/)
+  assert.match(
+    run,
+    /autorelease: pending/,
+    'the merged release PR is found by the label release-please left on it',
+  )
+})


### PR DESCRIPTION
## Problem

After a release, `release-please.yml` stops opening release PRs. The run stays green (~11s) and only the log says why:

```
⚠ There are untagged, merged release PRs outstanding - aborting
```

release-please treats a merged release PR labelled `autorelease: pending` as an unreleased release and refuses to build the next one. That label is cleared by its GitHub-release step — which this repository skips (`skip-github-release`), because a tag pushed with `GITHUB_TOKEN` would never start `release.yml`. So the label never moves, and the blockage is invisible: thirteen commits piled up on `main` between v0.10.0 and v0.10.1 with no release PR.

## Change

`release.yml` gains a `release-pr-label` job that runs after the publish matrix on a `vX.Y.Z` tag, finds the merged release PR for that version by its `autorelease: pending` label and title, and moves it to `autorelease: tagged`. Cutting the tag is the moment the label should move, and the tag run is the only actor that knows it happened.

- No release PR to match (a hand-cut release, a re-run of a handled tag) is a `::notice::` and a green job, not a failure.
- An unknown `autorelease: tagged` label fails the job loudly — better than the silent blockage this exists to prevent.
- CONTRIBUTING's release checklist documents the job and why it is needed.

Guarded by a new test in `test/release-please.test.mjs`.

Closes #611