### PR TITLE
ci: drop the dispatch shim that never satisfied the release PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-  # release-please.yml dispatches this workflow for the release PR, whose
-  # `pull_request` events GitHub never delivers (#521).
-  workflow_dispatch:
 
 # Least privilege: read-only by default. Jobs opt into more where needed.
 permissions:
@@ -21,10 +18,6 @@ concurrency:
 jobs:
   # Classify the change so docs-only edits skip the heavy jobs. Downstream
   # jobs skip based on these outputs; the ci-ok gate treats skipped as OK.
-  #
-  # A dispatched run (the release PR, see the trigger above) has no base to
-  # diff against, and a release is the last place to narrow the gate — so it
-  # skips the filter and runs everything.
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
@@ -33,22 +26,20 @@ jobs:
       contents: read
       pull-requests: read # paths-filter lists changed files via the PR API
     outputs:
-      code: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.code }}
-      dependencies: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.dependencies }}
-      docker: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.docker }}
-      workflows: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.workflows }}
+      code: ${{ steps.filter.outputs.code }}
+      dependencies: ${{ steps.filter.outputs.dependencies }}
+      docker: ${{ steps.filter.outputs.docker }}
+      workflows: ${{ steps.filter.outputs.workflows }}
       # Runner matrix for the package smoke job. macOS is the expensive leg
       # and the only one that ad-hoc re-signs the app, so it joins only when
-      # the PR actually touches a packaging input (#538) — or when the run was
-      # dispatched, which cuts a release and takes the whole matrix.
-      package_os: ${{ (github.event_name == 'workflow_dispatch' || steps.filter.outputs.packaging == 'true') && '["ubuntu-latest", "macos-latest"]' || '["ubuntu-latest"]' }}
+      # the PR actually touches a packaging input (#538).
+      package_os: ${{ steps.filter.outputs.packaging == 'true' && '["ubuntu-latest", "macos-latest"]' || '["ubuntu-latest"]' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
-        if: github.event_name != 'workflow_dispatch'
         with:
           filters: |
             # Anything that can influence lint/typecheck/test/build results.

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -5,15 +5,6 @@ name: PR title
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
-  # release-please.yml dispatches this workflow for the release PR, whose
-  # `pull_request` events GitHub never delivers (#521). A dispatched run gets
-  # no pull request payload, hence the number.
-  workflow_dispatch:
-    inputs:
-      pr-number:
-        description: 'Number of the pull request whose title to check'
-        required: true
-        type: string
 
 permissions: {}
 
@@ -22,20 +13,11 @@ jobs:
     name: Conventional Commits title
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      pull-requests: read # reads the title a dispatched run has no payload for
     steps:
       - name: Check PR title
         env:
           TITLE: ${{ github.event.pull_request.title }}
-          PR_NUMBER: ${{ inputs.pr-number }}
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
         run: |
-          if [[ -z "$TITLE" ]]; then
-            TITLE="$(gh pr view "$PR_NUMBER" --json title --jq .title)"
-            echo "Checking the title of #$PR_NUMBER."
-          fi
           regex='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9./-]+\))?!?: .+'
           if [[ "$TITLE" =~ $regex ]]; then
             echo "PR title OK: $TITLE"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,16 @@ name: Release PR
 # `skip-github-release` keeps the `vX.Y.Z` tag a manual step: a tag pushed with
 # GITHUB_TOKEN does not trigger other workflows, so a release-please-created tag
 # would silently skip `release.yml` and never build the installers.
+#
+# The release PR is opened with this workflow's GITHUB_TOKEN, which raises no
+# `pull_request` events — so its required checks (`CI OK`, `Conventional
+# Commits title`) do not start on their own. Dispatching them from here was
+# tried (#547) and dropped again: a workflow_dispatch run reports on the
+# branch head, never on the pull request, so branch protection ignored it
+# while every push to `main` paid for an extra full CI matrix (#578). Closing
+# and reopening the release PR raises a real `pull_request` event and is the
+# documented release step (CONTRIBUTING.md, "Releasing"); a PAT or GitHub App
+# token would remove the workaround entirely (#549).
 on:
   push:
     branches: [main]
@@ -29,38 +39,9 @@ jobs:
     permissions:
       contents: write # commits the version bump and changelog to the release branch
       pull-requests: write # opens, updates and labels the release PR
-      actions: write # dispatches the required checks for the release PR
     steps:
-      - id: release-please
-        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           skip-github-release: true
-
-      # The PR above was opened with this workflow's GITHUB_TOKEN, and GitHub
-      # raises no `pull_request` events for it — so neither `CI OK` nor
-      # `Conventional Commits title` starts, and branch protection blocks the
-      # merge. `workflow_dispatch` is the documented exception: GitHub always
-      # creates a run for it, GITHUB_TOKEN included. Dispatching both workflows
-      # against the release branch attaches their checks to its head commit,
-      # which is what branch protection looks at (#521).
-      #
-      # This replaces closing and reopening the PR by hand, and re-runs on
-      # every push to `main`, because release-please rewrites the branch head
-      # each time it folds a new commit into the pending release.
-      - name: Run the required checks on the release PR
-        if: steps.release-please.outputs.pr
-        env:
-          GH_TOKEN: ${{ github.token }}
-          # The job never checks the repository out, so `gh` cannot infer the
-          # target from a git remote; without GH_REPO it exits with
-          # "fatal: not a git repository" and no check is ever dispatched.
-          GH_REPO: ${{ github.repository }}
-          PR: ${{ steps.release-please.outputs.pr }}
-        run: |
-          branch="$(jq -er '.headBranchName' <<< "$PR")"
-          number="$(jq -er '.number' <<< "$PR")"
-          echo "Dispatching the required checks for #$number ($branch)."
-          gh workflow run ci.yml --ref "$branch"
-          gh workflow run pr-title.yml --ref "$branch" -f pr-number="$number"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -391,17 +391,14 @@ breaking change bumps the minor version.
    for it — so the checks attach to the PR itself and `mergeStateStatus` becomes
    `CLEAN`.
 
-   `release-please.yml` also dispatches both workflows against the release
-   branch after every update, `workflow_dispatch` being the one event GitHub
-   still delivers for that token. Treat those runs as a smoke signal only: they
-   report on the branch head, **not** on the pull request, so they never enter
-   its status check rollup and cannot satisfy branch protection (#578). Because
-   a dispatched run has nothing to diff against, it always runs the full gate
-   rather than the change-scaled subset.
-
-   Both workarounds exist only because release-please runs with `GITHUB_TOKEN`.
-   Switching it to a PAT or GitHub App token (#549) would let the release PR
-   start its own required checks and make this step unnecessary.
+   This workaround exists only because release-please runs with
+   `GITHUB_TOKEN`. Switching it to a PAT or GitHub App token (#549) would let
+   the release PR start its own required checks and make this step
+   unnecessary. (An earlier shim had `release-please.yml` start both
+   workflows itself after every update; it was removed again because those
+   runs reported on the branch head, **not** on the pull request, so they
+   never satisfied branch protection while costing a full CI matrix per push
+   to `main` — #578.)
 
 3. Tag the merge commit and push the tag:
 

--- a/test/release-please.test.mjs
+++ b/test/release-please.test.mjs
@@ -149,108 +149,69 @@ test('the release-please workflow maintains the release PR on main', () => {
   assert.equal(step.with['skip-github-release'], true)
 })
 
-// A pull request opened with a workflow's GITHUB_TOKEN raises no
-// `pull_request` events, so the release PR arrives without the two checks
-// branch protection requires. `workflow_dispatch` is the one event GitHub
-// still delivers for that token, so release-please starts both checks itself
-// instead of a maintainer closing and reopening the PR by hand (#521).
-test('release-please starts the required checks on the release PR', () => {
+// The dispatch shim added in #547 was meant to start the required checks for
+// the release PR, whose `pull_request` events GitHub never delivers because
+// the PR is opened with a workflow's GITHUB_TOKEN. It never worked: a
+// workflow_dispatch run reports against the branch head, not the pull
+// request, so its checks never entered the PR's status check rollup and
+// branch protection still blocked the merge (#578) — while every push to
+// `main` paid for an extra full CI matrix, macOS packaging leg included.
+// Close/reopen is the step that works; a PAT or GitHub App token (#549)
+// would remove the workaround entirely.
+test('release-please does not dispatch the required checks (#578)', () => {
   const workflow = readWorkflow('release-please.yml')
   const job = workflow.jobs['release-please']
 
   assert.equal(
     job.permissions.actions,
-    'write',
-    'dispatching a workflow run needs the actions: write scope',
+    undefined,
+    'nothing is dispatched, so the actions scope must stay dropped',
   )
-
-  const action = job.steps.find((candidate) =>
-    candidate.uses?.startsWith('googleapis/release-please-action@'),
-  )
-  assert.ok(action.id, 'the release-please step must expose its outputs via id')
-
-  const dispatch = job.steps.find((candidate) =>
-    candidate.run?.includes('gh workflow run'),
-  )
-  assert.ok(
-    dispatch,
-    'release-please.yml must dispatch the required checks for the release PR',
-  )
-  assert.match(
-    dispatch.if ?? '',
-    new RegExp(`steps\\.${action.id}\\.outputs\\.pr`),
-    'the dispatch must be skipped on pushes that leave no release PR',
-  )
-  for (const required of ['ci.yml', 'pr-title.yml']) {
-    assert.match(
-      dispatch.run,
-      new RegExp(`gh workflow run ${required.replace('.', '\\.')}`),
-      `${required} produces a required check and must be dispatched`,
+  for (const step of job.steps) {
+    assert.doesNotMatch(
+      step.run ?? '',
+      /gh workflow run/,
+      'dispatched runs never attach to the release PR and cannot satisfy branch protection (#578)',
     )
   }
-  assert.match(
-    dispatch.run,
-    /--ref/,
-    'the checks must run against the release branch, not the default branch',
-  )
 })
 
-// Both workflows are dispatched by name from release-please.yml; without the
-// trigger the dispatch fails and the release PR stays unmergeable.
-test('the required checks can be dispatched for the release branch', () => {
+// The workflow_dispatch triggers on ci.yml and pr-title.yml existed only for
+// that shim (#547). Leaving them behind invites wiring the dispatch back up,
+// and pr-title.yml cannot even resolve a title without an event payload. A
+// genuine future need for manual runs should revisit #578 first.
+test('the required checks are event-driven only (#578)', () => {
   for (const fileName of ['ci.yml', 'pr-title.yml']) {
     assert.ok(
-      'workflow_dispatch' in readWorkflow(fileName).on,
-      `${fileName} must be dispatchable so the release PR can run it`,
+      !('workflow_dispatch' in readWorkflow(fileName).on),
+      `${fileName} must not be dispatchable — a dispatched run reports on the branch head, not the PR (#578)`,
     )
   }
-})
-
-// A dispatched run carries no pull request payload, so the check has to look
-// the title up from the number it was dispatched with.
-test('the PR title check resolves the title of a dispatched release PR', () => {
-  const workflow = readWorkflow('pr-title.yml')
-  const input = workflow.on.workflow_dispatch?.inputs?.['pr-number']
-
-  assert.ok(input, 'pr-title.yml must accept the PR number as a dispatch input')
-  assert.equal(input.required, true)
-
-  const job = workflow.jobs['conventional-title']
-  assert.equal(
-    job.permissions['pull-requests'],
-    'read',
-    'reading the title of a dispatched PR needs the pull-requests: read scope',
-  )
-
-  const step = job.steps.find((candidate) => candidate.run?.includes('regex='))
-  assert.match(
-    step.run,
-    /gh pr view/,
-    'the dispatched run must fetch the title it cannot read from the event',
-  )
-  assert.equal(step.env.PR_NUMBER, '${{ inputs.pr-number }}')
 })
 
 // This guard used to assert the opposite: that the close/reopen workaround was
 // gone, because the dispatch shim added in #547 was expected to make it
-// unnecessary. It does not. A workflow_dispatch run reports against the branch
+// unnecessary. It did not. A workflow_dispatch run reports against the branch
 // head rather than the pull request, so its checks never enter the PR's status
 // check rollup and branch protection still blocks the merge (#578). Cutting
 // v0.10.0 hit exactly that. Until release-please runs with a token that raises
 // real pull_request events (#549), close/reopen is the step that works, and the
-// documentation has to say so.
+// documentation has to say so — without describing the removed dispatch as
+// part of the release.
 test('the release documentation keeps the close/reopen step', () => {
   const contributing = readFileSync(join(rootDir, 'CONTRIBUTING.md'), 'utf8')
+  const releasing = contributing.split('#### Releasing')[1]?.split('\n### ')[0]
 
+  assert.ok(releasing, 'CONTRIBUTING.md must keep the "Releasing" walkthrough')
   assert.match(
-    contributing,
+    releasing,
     /reopen the release PR/i,
     'the release PR only gets its required checks from a real pull_request event (#578)',
   )
-  assert.match(
-    contributing,
-    /smoke signal/i,
-    'the dispatched runs must not be presented as satisfying branch protection (#578)',
+  assert.doesNotMatch(
+    releasing,
+    /dispatch/i,
+    'the removed dispatch shim must not be described as a release step (#578)',
   )
 })
 


### PR DESCRIPTION
## Problem

`release-please.yml` dispatched `ci.yml` and `pr-title.yml` against the release branch after every update (#547), on the assumption that those runs would satisfy the release PR's required checks. They never did: a `workflow_dispatch` run reports on the **branch head**, not the pull request, so its checks never enter the PR's status check rollup and branch protection still blocks the merge — cutting v0.10.0 failed with `2 of 2 required status checks are expected` and was only unblocked by closing and reopening #518 (#574). Meanwhile every push to `main` paid for an extra full CI matrix, macOS packaging leg included.

## Solution

Remove the shim entirely (the issue's first option — close/reopen is already documented as the required release step since #609):

- `release-please.yml`: drop the dispatch step and its `actions: write` scope; the header comment now records why the shim is gone.
- `ci.yml` / `pr-title.yml`: revert the `workflow_dispatch` triggers and the dispatch-only branches (`changes` output overrides, the `gh pr view` title fallback and its `pull-requests: read` scope) — both were introduced solely for the shim in #547.
- `CONTRIBUTING.md`: the "smoke signal" paragraph is gone; a short note records why the shim was removed.
- `test/release-please.test.mjs`: the guards that pinned the dispatch now pin its absence, and the docs guard asserts the Releasing walkthrough keeps close/reopen without describing any dispatch.

The real fix — running release-please with a token that raises `pull_request` events — stays tracked in #549.

## Testing

- `node --test test/release-please.test.mjs` (guards flipped red first, then green after the workflow changes)
- Full quality gate: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` — all green.
- `actionlint` on the three touched workflows: clean.

## Risks

- The release PR's CI now runs only via the close/reopen `pull_request` event; its change-scaled run still takes the heavy jobs because the version bump touches the root manifests (code/dependencies/packaging filters all match).
- Manual dispatchability of `ci.yml` is gone; it existed only for the shim, and `packaging.yml` remains the manual full-matrix entry point.

Closes #578