### PR TITLE
docs(readme): pull the published GHCR image in the self-hosting quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,14 @@ TLS:
 ```sh
 cd deploy
 cp .env.example .env   # set your domain, then see docs/self-hosting.md
-docker compose up -d --build
+docker compose up -d
 ```
+
+This pulls the control-server image published for the latest release
+(`ghcr.io/nilsr0711/streamwall-control-server:latest`, `linux/amd64` and
+`linux/arm64`). To build the image from your checkout instead — for
+unreleased code or local modifications — run
+`docker compose up -d --build`.
 
 CI builds and boots this image (and validates the compose stack) on every
 pull request that touches it, so a deploy-breaking change cannot reach `main`


### PR DESCRIPTION
## Problem

The README self-hosting quick start told every self-hoster to run `docker compose up -d --build`, which forces a full from-source build (npm ci + client build). The canonical path documented in `docs/self-hosting.md` and in `deploy/docker-compose.yml`'s own usage comment is `docker compose up -d`, which pulls the control-server image published to GHCR for the latest release.

## What changed

- The quick start snippet now runs `docker compose up -d`.
- A short paragraph after the snippet explains that this pulls `ghcr.io/nilsr0711/streamwall-control-server:latest` (published for `linux/amd64` and `linux/arm64`, verified against `.github/workflows/release.yml` and `deploy/docker-compose.yml`) and keeps `docker compose up -d --build` documented as the from-source alternative, matching `docs/self-hosting.md`.

Docs-only change — no tests needed. Prettier check passes on the edited file.

Closes #631