### PR TITLE
docs: pull published GHCR image in README self-hosting quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,14 @@ TLS:
 ```sh
 cd deploy
 cp .env.example .env   # set your domain, then see docs/self-hosting.md
-docker compose up -d --build
+docker compose up -d   # pulls the published GHCR image
 ```
+
+This pulls the released control-server image
+(`ghcr.io/nilsr0711/streamwall-control-server:latest`, published for both
+`linux/amd64` and `linux/arm64`). To build the image from this checkout
+instead — for unreleased code or a local modification — run
+`docker compose up -d --build`.
 
 CI builds and boots this image (and validates the compose stack) on every
 pull request that touches it, so a deploy-breaking change cannot reach `main`


### PR DESCRIPTION
## Summary

The README self-hosting quick start ran `docker compose up -d --build`, forcing every self-hoster into a full from-source build (npm ci + client build), while `docs/self-hosting.md` and `deploy/docker-compose.yml` document `docker compose up -d` (which pulls the released GHCR image) as the normal path and `--build` as the from-source alternative.

## Change

- README snippet now runs `docker compose up -d` (pulls the published GHCR image `ghcr.io/nilsr0711/streamwall-control-server:latest`, multi-arch amd64+arm64).
- `--build` is mentioned only as the from-source alternative, matching the canonical doc and the compose file's own comment.

Closes #631