### PR TITLE
fix(control-server): terminate client sockets that miss pong liveness checks

### DIFF
--- a/packages/streamwall-control-server/src/config.ts
+++ b/packages/streamwall-control-server/src/config.ts
@@ -9,6 +9,19 @@ export const SESSION_COOKIE_NAME = 's'
 export const SESSION_COOKIE_MAX_AGE_SECONDS = 365 * 24 * 60 * 60
 export const STREAMWALL_PING_TIMEOUT_MS = 5 * 1000
 
+/** Liveness probing for browser client sockets on `/client/ws`. */
+export interface ClientPingConfig {
+  /** How often the server pings each connected client. */
+  intervalMs: number
+  /** How long after a ping to wait for the pong before terminating. */
+  timeoutMs: number
+}
+
+export const DEFAULT_CLIENT_PING_CONFIG: ClientPingConfig = {
+  intervalMs: 20 * 1000,
+  timeoutMs: 5 * 1000,
+}
+
 const DEFAULT_GLOBAL_RATE_LIMIT_MAX = 100
 const DEFAULT_AUTH_RATE_LIMIT_MAX = 10
 const DEFAULT_RATE_LIMIT_WINDOW = '1 minute'

--- a/packages/streamwall-control-server/src/context.ts
+++ b/packages/streamwall-control-server/src/context.ts
@@ -3,7 +3,7 @@ import type * as Y from 'yjs'
 
 import { type AuthTokenInfo, stateDiff } from 'streamwall-shared'
 import type { Auth, StateWrapper } from './auth.ts'
-import type { WsMessageLimitConfig } from './config.ts'
+import type { ClientPingConfig, WsMessageLimitConfig } from './config.ts'
 import { identityFields, type Logger } from './logger.ts'
 import type { DocUpdateLimits } from './stateDocGuard.ts'
 import type { UpdateChecker } from './updateCheck.ts'
@@ -42,6 +42,7 @@ export interface AppContext {
   expectedOrigin: string
   isSecure: boolean
   wsMessageLimitConfig: WsMessageLimitConfig
+  clientPingConfig: ClientPingConfig
   docUpdateLimits: DocUpdateLimits
   clients: Map<string, Client>
   currentStreamwallWs: WebSocket | null

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -11,6 +11,8 @@ import { pathToFileURL } from 'node:url'
 import { Auth, type ScryptParams } from './auth.ts'
 import runServer from './bootstrap.ts'
 import {
+  type ClientPingConfig,
+  DEFAULT_CLIENT_PING_CONFIG,
   getDocUpdateLimits,
   getRateLimitConfig,
   getWsMessageLimitConfig,
@@ -52,6 +54,7 @@ export interface AppOptions {
 
 export async function initApp({
   baseURL,
+  clientPing: injectedClientPing,
   clientStaticPath,
   db: injectedDb,
   docUpdateLimits: injectedDocUpdateLimits,
@@ -74,6 +77,12 @@ export async function initApp({
   logLevel?: LogLevel
   /** Test-only sink for log output; defaults to pino's stdout destination. */
   logStream?: { write(line: string): void }
+  /**
+   * Overrides the client-socket liveness probing cadence, so specs exercising
+   * the ping/pong path can use short timers instead of the production 20s
+   * interval. Unset fields keep `DEFAULT_CLIENT_PING_CONFIG`.
+   */
+  clientPing?: Partial<ClientPingConfig>
   /**
    * Overrides individual per-IP rate limits, so specs that are not about
    * throttling widen them without writing the process-wide environment (which
@@ -148,6 +157,7 @@ export async function initApp({
     expectedOrigin,
     isSecure,
     wsMessageLimitConfig: getWsMessageLimitConfig(),
+    clientPingConfig: { ...DEFAULT_CLIENT_PING_CONFIG, ...injectedClientPing },
     docUpdateLimits: { ...getDocUpdateLimits(), ...injectedDocUpdateLimits },
     clients,
     currentStreamwallWs: null,

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -18,7 +18,7 @@ import type {
 } from 'streamwall-shared'
 import WebSocket from 'ws'
 import type { ScryptParams } from './auth.ts'
-import type { RateLimitConfig } from './config.ts'
+import type { ClientPingConfig, RateLimitConfig } from './config.ts'
 import { type AppOptions, initApp } from './index.ts'
 import type { LogLevel } from './logger.ts'
 import type { SentryCaptureClient } from './sentry.ts'
@@ -221,6 +221,7 @@ export const TEST_BASE_URL = 'http://localhost:3000'
 
 /** Everything a test may override when building an app instance. */
 export type TestAppOverrides = Partial<AppOptions> & {
+  clientPing?: Partial<ClientPingConfig>
   db?: StorageDB
   docUpdateLimits?: Partial<DocUpdateLimits>
   logs?: LogCapture
@@ -412,6 +413,9 @@ export async function connectStreamwallUplink<T = ControlCommandMessage>(
  *
  * `T` describes the shape of the JSON frames the caller expects to record,
  * defaulting to the real shape the server sends over this connection.
+ *
+ * `wsOptions` is merged into the socket's client options, so a spec can e.g.
+ * pass `autoPong: false` to simulate a peer that no longer answers pings.
  */
 export async function redeemInviteAndConnectClient<T = ServerToClientMessage>(
   app: TestApp['app'],
@@ -419,6 +423,7 @@ export async function redeemInviteAndConnectClient<T = ServerToClientMessage>(
   port: number,
   baseURL: string,
   role: StreamwallRole = 'admin',
+  wsOptions: WebSocket.ClientOptions = {},
 ) {
   const invite = await auth.createToken({
     kind: 'invite',
@@ -437,6 +442,7 @@ export async function redeemInviteAndConnectClient<T = ServerToClientMessage>(
   ).split(';')[0]
 
   const ws = new WebSocket(`ws://127.0.0.1:${port}/client/ws`, {
+    ...wsOptions,
     headers: { Cookie: cookie, Origin: baseURL },
   })
   const client = recordJsonMessages<T>(ws)
@@ -464,13 +470,17 @@ export async function startTestServer(overrides: TestAppOverrides = {}) {
   after(() => app.close())
   const port = await listenTestApp(app)
 
-  async function connectClient(role: StreamwallRole = 'admin') {
+  async function connectClient(
+    role: StreamwallRole = 'admin',
+    wsOptions: WebSocket.ClientOptions = {},
+  ) {
     const { ws: clientWs, client } = await redeemInviteAndConnectClient(
       app,
       auth,
       port,
       TEST_BASE_URL,
       role,
+      wsOptions,
     )
     return { clientWs, client }
   }

--- a/packages/streamwall-control-server/src/ws/client.ts
+++ b/packages/streamwall-control-server/src/ws/client.ts
@@ -96,13 +96,34 @@ export function registerClientRoutes(
         ...identityFields(identity),
       })
 
+      // Liveness check mirroring the uplink route: a peer that vanishes
+      // without a TCP FIN (laptop sleep, NAT idle timeout, network partition)
+      // never fires 'close' on its own, so its registry entry would leak and
+      // keep receiving every broadcast. A missed pong terminates the socket,
+      // which fires 'close' and cleans up (issue #618).
+      const { intervalMs: pingIntervalMs, timeoutMs: pongTimeoutMs } =
+        ctx.clientPingConfig
+      let pongTimeout: NodeJS.Timeout | undefined
       const pingInterval = setInterval(() => {
         ws.ping()
-      }, 20 * 1000)
+        clearTimeout(pongTimeout)
+        pongTimeout = setTimeout(() => {
+          if (ws.readyState === ws.OPEN) {
+            log.warn(
+              `Client timeout: no pong within ${pongTimeoutMs}ms. Closing connection.`,
+            )
+            ws.terminate()
+          }
+        }, pongTimeoutMs)
+      }, pingIntervalMs)
+      ws.on('pong', () => {
+        clearTimeout(pongTimeout)
+      })
 
       ws.on('close', () => {
         ctx.clients.delete(clientId)
         clearInterval(pingInterval)
+        clearTimeout(pongTimeout)
 
         log.info('Client disconnected')
       })

--- a/packages/streamwall-control-server/src/wsClientLiveness.test.ts
+++ b/packages/streamwall-control-server/src/wsClientLiveness.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import { once } from 'node:events'
+import { test } from 'node:test'
+import { setTimeout as delay } from 'node:timers/promises'
+import WebSocket from 'ws'
+import { bootServerWithUplink } from './testHelpers.ts'
+
+// Liveness probing for `/client/ws` (issue #618): a browser that disappears
+// without a TCP FIN never fires 'close', so without a pong deadline its
+// registry entry would leak and keep receiving every broadcast forever.
+
+test('terminates a client that stops answering pings', async () => {
+  const { logs, connectClient } = await bootServerWithUplink({
+    clientPing: { intervalMs: 100, timeoutMs: 100 },
+  })
+
+  // `autoPong: false` makes the socket ignore incoming pings — the closest a
+  // test can get to a peer that silently vanished mid-connection.
+  const { clientWs } = await connectClient('admin', { autoPong: false })
+  const closed = once(clientWs, 'close', { signal: AbortSignal.timeout(5000) })
+
+  await logs.waitForMessage('Client timeout: no pong within 100ms')
+  await closed
+  // The server-side 'close' handler removed the client from the broadcast
+  // registry — this log line is emitted right after the map deletion.
+  await logs.waitForMessage('Client disconnected')
+})
+
+test('keeps a responsive client connected across many ping cycles', async () => {
+  const { logs, connectClient } = await bootServerWithUplink({
+    clientPing: { intervalMs: 50, timeoutMs: 500 },
+  })
+
+  const { clientWs } = await connectClient()
+  // Span well over a handful of ping intervals; the ws library answers each
+  // ping with a pong automatically, so the deadline never fires.
+  await delay(400)
+
+  assert.equal(clientWs.readyState, WebSocket.OPEN)
+  assert.ok(!logs.hasMessage('Client timeout'), 'expected no liveness timeout')
+  assert.ok(!logs.hasMessage('Client disconnected'))
+})


### PR DESCRIPTION
## Summary

The `/client/ws` handler pinged every 20s but never tracked pongs or terminated unresponsive sockets. A browser that disappeared without a TCP FIN (laptop sleep, NAT idle timeout, network partition) never fired `'close'`, so its entry stayed in `ctx.clients` forever and every state broadcast kept being `ws.send()`'d to it — a slow memory/socket leak with broadcast amplification on long-lived deployments.

## Changes

- `ws/client.ts`: mirror the uplink route's liveness pattern — each ping arms a pong deadline, and a missed pong `ws.terminate()`s the socket, which fires `'close'` and removes the client from the broadcast registry. Both the interval and any pending deadline are cleared on close so no timers linger.
- `config.ts` / `context.ts` / `index.ts`: the ping cadence (`intervalMs`, `timeoutMs`) is a `ClientPingConfig` threaded through `AppContext`, injectable via `initApp({ clientPing })` so tests can use short timers. Production defaults keep the existing 20s interval and use the same 5s pong deadline as the uplink.
- `testHelpers.ts`: client-socket helpers accept `ws` client options, so a spec can pass `autoPong: false` to simulate a peer that no longer answers pings.
- `wsClientLiveness.test.ts`: regression tests — an unresponsive client is terminated and cleaned up (asserted via the structured timeout/disconnect log entries and the client-side `'close'`), and a responsive client stays connected across many ping cycles.

Closes #618

## Follow-up

- #635 — extract a shared WS heartbeat helper and fix the uplink route's timer hygiene (out-of-scope here).