### PR TITLE
fix(streamwall): revoke stale snapshot poster object URLs

### DIFF
--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -912,3 +912,76 @@ describe('mediaPreload pause/resume handling (issue #374)', () => {
     expect(() => registeredHandler('resume')()).not.toThrow()
   })
 })
+
+describe('SnapshotController poster object URLs', () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.restoreAllMocks()
+    invoke.mockClear()
+    send.mockClear()
+    on.mockClear()
+    exposeInMainWorld.mockClear()
+  })
+
+  function makeSnapshotHarness(controller: {
+    canvas: HTMLCanvasElement
+    snapshotVideo(videoEl: HTMLVideoElement): Promise<void>
+  }) {
+    controller.canvas = {
+      width: 0,
+      height: 0,
+      getContext: () => ({ drawImage: vi.fn() }),
+      toBlob: (callback: (blob: Blob) => void) => callback(new Blob(['png'])),
+    } as unknown as HTMLCanvasElement
+
+    let frameCallback: (() => void) | undefined
+    const videoEl = {
+      videoWidth: 640,
+      videoHeight: 360,
+      poster: '',
+      requestVideoFrameCallback: (callback: () => void) => {
+        frameCallback = callback
+      },
+    } as unknown as HTMLVideoElement
+
+    return {
+      videoEl,
+      async snapshotTick() {
+        await controller.snapshotVideo(videoEl)
+        frameCallback!()
+      },
+    }
+  }
+
+  it('revokes the previous poster object URL when a new snapshot replaces it (#616)', async () => {
+    const { SnapshotController } = await import('./mediaPreload')
+
+    let urlCounter = 0
+    const createObjectURL = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockImplementation(() => `blob:snapshot-${++urlCounter}`)
+    const revokeObjectURL = vi
+      .spyOn(URL, 'revokeObjectURL')
+      .mockImplementation(() => {})
+
+    const controller = new SnapshotController()
+    const { videoEl, snapshotTick } = makeSnapshotHarness(controller)
+
+    await snapshotTick()
+    expect(videoEl.poster).toBe('blob:snapshot-1')
+    expect(revokeObjectURL).not.toHaveBeenCalled()
+
+    await snapshotTick()
+    expect(videoEl.poster).toBe('blob:snapshot-2')
+    expect(revokeObjectURL).toHaveBeenCalledExactlyOnceWith('blob:snapshot-1')
+
+    await snapshotTick()
+    expect(videoEl.poster).toBe('blob:snapshot-3')
+    expect(revokeObjectURL).toHaveBeenLastCalledWith('blob:snapshot-2')
+
+    // One live object URL per tile at any time: each tick creates exactly one
+    // URL and revokes the previous one.
+    expect(createObjectURL).toHaveBeenCalledTimes(3)
+    expect(revokeObjectURL).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -123,7 +123,8 @@ class RotationController {
   }
 }
 
-class SnapshotController {
+// Exported for tests only; not part of the module's public surface.
+export class SnapshotController {
   canvas: HTMLCanvasElement
   ctx!: CanvasRenderingContext2D
   latestSnapshotURL: string | null = null
@@ -156,11 +157,15 @@ class SnapshotController {
           return
         }
 
+        // Revoke the previous poster's object URL so its blob can be
+        // collected -- without this, each 1s snapshot tick pins another
+        // full-resolution PNG in renderer memory for the page's lifetime.
         if (this.latestSnapshotURL) {
           URL.revokeObjectURL(this.latestSnapshotURL)
         }
 
         const url = URL.createObjectURL(blob)
+        this.latestSnapshotURL = url
         videoEl.poster = url
       }, 'image/png')
     })


### PR DESCRIPTION
## Summary

`SnapshotController.latestSnapshotURL` was declared and checked but never assigned, so the revoke branch in `snapshotVideo` was dead code. Since `acquireMedia` snapshots each video tile on a 1-second interval, every tick created a fresh full-resolution PNG object URL that was never released. Object URLs pin their blobs until revoked or the document unloads, so long-running walls accumulated renderer memory proportional to uptime x tile count.

## Changes

- Assign `this.latestSnapshotURL = url` right after `URL.createObjectURL(blob)`, so the next snapshot tick revokes the previous poster URL. At most one live object URL per tile at any time.
- Export `SnapshotController` (test-only) and add a regression test that drives `snapshotVideo` through three ticks with stubbed canvas/`requestVideoFrameCallback` and spied `URL.createObjectURL`/`revokeObjectURL`, asserting each new URL revokes the previous one. Verified the test fails against the unfixed code.

Closes #616