### PR TITLE
fix(control-server): surface storage write failures from db.update()

### DIFF
--- a/packages/streamwall-control-server/src/authStatePersistence.test.ts
+++ b/packages/streamwall-control-server/src/authStatePersistence.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict'
+import { after, describe, test } from 'node:test'
+
+import type { SentryCaptureClient } from './sentry.ts'
+import { buildTestApp, captureLogs, failingWriteDb } from './testHelpers.ts'
+
+/** Pino's numeric level for `error` entries. */
+const ERROR = 50
+
+/** Reads the message off pino's serialized `err` field of a log entry. */
+function loggedErrorMessage(entry: Record<string, unknown>) {
+  return (entry.err as { message?: string } | undefined)?.message
+}
+
+/** Records every error passed to `captureException`. */
+function fakeSentryClient(): SentryCaptureClient & { calls: unknown[] } {
+  const calls: unknown[] = []
+  return {
+    calls,
+    captureException(err: unknown) {
+      calls.push(err)
+      return 'fake-event-id'
+    },
+  }
+}
+
+// The auth 'state' listener persists every auth change to storage as a
+// fire-and-forget write. Its rejection used to be dropped entirely, so a
+// failed persist (disk full, read-only volume) was invisible while the
+// in-memory auth state silently diverged from storage.json (issue #619).
+describe('auth state persistence failures', () => {
+  test('a failed auth state write is logged as an error', async () => {
+    const logs = captureLogs()
+    const { app, auth } = await buildTestApp({
+      db: failingWriteDb(new Error('read-only volume')),
+      logs,
+    })
+    after(() => app.close())
+
+    await auth.createToken({ kind: 'invite', role: 'admin', name: 'invite' })
+
+    const entry = await logs.waitForMessage(
+      'Failed to persist auth state to storage',
+    )
+    assert.equal(entry.level, ERROR)
+    assert.equal(loggedErrorMessage(entry), 'read-only volume')
+  })
+
+  test('a failed auth state write is reported to Sentry when enabled', async () => {
+    const logs = captureLogs()
+    const sentryClient = fakeSentryClient()
+    const { app, auth } = await buildTestApp({
+      db: failingWriteDb(new Error('disk full')),
+      logs,
+      sentryEnabled: true,
+      sentryClient,
+    })
+    after(() => app.close())
+
+    await auth.createToken({ kind: 'invite', role: 'admin', name: 'invite' })
+
+    await logs.waitForMessage('Failed to persist auth state to storage')
+    assert.equal(sentryClient.calls.length, 1)
+    assert.equal((sentryClient.calls[0] as Error).message, 'disk full')
+  })
+})

--- a/packages/streamwall-control-server/src/bootstrap.test.ts
+++ b/packages/streamwall-control-server/src/bootstrap.test.ts
@@ -3,7 +3,12 @@ import { after, describe, test } from 'node:test'
 
 import { initApp, initialInviteCodes } from './index.ts'
 import type { StorageDB } from './storage.ts'
-import { inMemoryDb, makeStaticDir } from './testHelpers.ts'
+import {
+  failingWriteDb,
+  inMemoryDb,
+  makeStaticDir,
+  TEST_SCRYPT_PARAMS,
+} from './testHelpers.ts'
 
 const BASE_URL = 'https://wall.example.com'
 
@@ -142,6 +147,56 @@ describe('initialInviteCodes uplink token', () => {
       streamwallTokens.length,
       1,
       'the superseded uplink token is removed so the old secret stops working',
+    )
+  })
+
+  test('rejects when persisting a freshly minted uplink token id fails', async () => {
+    // A dropped rejection here would strand a token id that exists only in
+    // memory, silently rotating the uplink token on every restart (issue #619).
+    const db = failingWriteDb(new Error('disk full'))
+    const { app, auth } = await initApp({
+      baseURL: BASE_URL,
+      clientStaticPath: makeStaticDir(),
+      db,
+      logLevel: 'silent',
+      scryptParams: TEST_SCRYPT_PARAMS,
+    })
+    after(() => app.close())
+
+    await assert.rejects(
+      initialInviteCodes({ db, auth, baseURL: BASE_URL }),
+      /disk full/,
+    )
+  })
+
+  test('rejects when scrubbing a legacy plaintext secret fails to persist', async () => {
+    // If this write silently fails, the plaintext secret stays on disk while
+    // the server carries on as if it had been scrubbed (issue #619).
+    const db = failingWriteDb(new Error('read-only volume'))
+    const { app, auth } = await initApp({
+      baseURL: BASE_URL,
+      clientStaticPath: makeStaticDir(),
+      db,
+      logLevel: 'silent',
+      scryptParams: TEST_SCRYPT_PARAMS,
+    })
+    after(() => app.close())
+
+    // Recreate the pre-fix on-disk shape: a valid hashed uplink token whose
+    // storage record still carries the plaintext secret it used to hold.
+    const minted = await auth.createToken({
+      kind: 'streamwall',
+      role: 'admin',
+      name: 'Streamwall',
+    })
+    db.data.streamwallToken = {
+      tokenId: minted.tokenId,
+      secret: 'legacy-plaintext-secret',
+    } as StorageDB['data']['streamwallToken']
+
+    await assert.rejects(
+      initialInviteCodes({ db, auth, baseURL: BASE_URL }),
+      /read-only volume/,
     )
   })
 

--- a/packages/streamwall-control-server/src/bootstrap.ts
+++ b/packages/streamwall-control-server/src/bootstrap.ts
@@ -47,7 +47,9 @@ export async function initialInviteCodes({
     // Scrub any plaintext secret a pre-fix server version may have persisted
     // alongside the id, so it stops leaking through storage.json.
     if ((record as { secret?: string }).secret !== undefined) {
-      db.update((data) => {
+      // Awaited so a failed scrub write surfaces at startup instead of being
+      // silently dropped, leaving the plaintext secret on disk (issue #619).
+      await db.update((data) => {
         data.streamwallToken = { tokenId: uplinkTokenId }
       })
     }
@@ -67,7 +69,10 @@ export async function initialInviteCodes({
     })
     uplinkSecret = minted.secret
     uplinkTokenId = minted.tokenId
-    db.update((data) => {
+    // Awaited so an unwritable storage fails the boot loudly: dropping this
+    // rejection would strand a token id that only exists in memory, forcing a
+    // silent uplink-token rotation on every restart (issue #619).
+    await db.update((data) => {
       data.streamwallToken = { tokenId: minted.tokenId }
     })
   }

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -204,8 +204,15 @@ export async function initApp({
   registerClientRoutes(app, ctx, { clientStaticPath })
 
   auth.on('state', (state) => {
+    // The write is fire-and-forget by design (the listener is synchronous),
+    // but its rejection must not be dropped: a failed persist means the
+    // in-memory auth state — including token revocations — silently diverges
+    // from storage.json and would be undone by the next restart (issue #619).
     db.update((data) => {
       data.auth = auth.getStoredData()
+    }).catch((err: unknown) => {
+      app.log.error({ err }, 'Failed to persist auth state to storage')
+      reportCaughtError(err)
     })
 
     const tokenIds = new Set(state.sessions.map((t) => t.tokenId))

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -48,6 +48,22 @@ export function inMemoryDb(): Low<StoredData> {
 }
 
 /**
+ * An in-memory storage backend whose every write rejects with `error`, for
+ * specs that exercise how storage persistence failures are surfaced
+ * (issue #619). Reads behave like a fresh, empty store.
+ */
+export function failingWriteDb(
+  error: Error = new Error('simulated storage write failure'),
+): Low<StoredData> {
+  const adapter = new Memory<StoredData>()
+  adapter.write = () => Promise.reject(error)
+  return new Low<StoredData>(adapter, {
+    auth: { salt: null, tokens: [] },
+    streamwallToken: null,
+  })
+}
+
+/**
  * Collects the server's structured log output as parsed JSON entries, so specs
  * can assert on what was logged (and on what was deliberately *not* logged)
  * instead of spying on `console`.


### PR DESCRIPTION
## Summary

All three `db.update()` call sites dropped the returned promise. `Low.update()` writes `storage.json` asynchronously, so a failed write (disk full, permissions, read-only volume) surfaced as an unhandled rejection — invisible at best, process-terminating at worst — while the in-memory auth state silently diverged from disk. Concretely, a token revocation that never reached disk resurrected the token as valid after the next restart.

## Changes

- **`index.ts` auth `state` listener**: the write stays fire-and-forget (the listener is synchronous), but its rejection is now caught, logged as an error through `app.log`, and reported via `reportCaughtError` (Sentry, when enabled).
- **`bootstrap.ts` `initialInviteCodes`**: both writes are now awaited — the legacy plaintext-secret scrub and the minted uplink token id persist — so an unwritable storage fails the boot loudly instead of stranding state that only exists in memory (which would silently rotate the uplink token on every restart, or leave a plaintext secret on disk).
- **`testHelpers.ts`**: new shared `failingWriteDb()` helper (in-memory backend whose writes always reject).

## Tests

- `authStatePersistence.test.ts` (new): a failed auth-state write is logged at error level with the serialized cause, and reported to Sentry when enabled.
- `bootstrap.test.ts`: `initialInviteCodes` rejects when persisting the minted uplink token id fails, and when the legacy-secret scrub write fails.

All 188 control-server tests pass; lint, typecheck, and format are clean.

Closes #619