### PR TITLE
fix(control-client): derive WebSocket scheme from the page protocol

### DIFF
--- a/packages/streamwall-control-client/src/index.tsx
+++ b/packages/streamwall-control-client/src/index.tsx
@@ -1,12 +1,13 @@
 import { render } from 'preact'
 import { ControlUI, GlobalStyle } from 'streamwall-control-ui'
 import { useStreamwallWebsocketConnection } from './useStreamwallWebsocketConnection.ts'
+import { getWebsocketEndpoint } from './wsEndpoint.ts'
 
 function App() {
   const { BASE_URL } = import.meta.env
 
   const connection = useStreamwallWebsocketConnection(
-    (BASE_URL === '/' ? `ws://${location.host}` : BASE_URL) + '/client/ws',
+    getWebsocketEndpoint(BASE_URL, location),
   )
 
   return (

--- a/packages/streamwall-control-client/src/wsEndpoint.test.ts
+++ b/packages/streamwall-control-client/src/wsEndpoint.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { getWebsocketEndpoint } from './wsEndpoint.ts'
+
+const httpPage = { protocol: 'http:', host: 'localhost:3000' }
+const httpsPage = { protocol: 'https:', host: 'control.example.com' }
+
+describe('getWebsocketEndpoint', () => {
+  it('uses ws:// for the default base on an http page (local dev)', () => {
+    expect(getWebsocketEndpoint('/', httpPage)).toBe(
+      'ws://localhost:3000/client/ws',
+    )
+  })
+
+  it('uses wss:// for the default base on an https page (regression #617)', () => {
+    // The published Docker image always builds the client with BASE_URL '/';
+    // behind TLS the socket must be wss:// or the browser blocks it.
+    expect(getWebsocketEndpoint('/', httpsPage)).toBe(
+      'wss://control.example.com/client/ws',
+    )
+  })
+
+  it('keeps the page host and port on an https page with a port', () => {
+    expect(
+      getWebsocketEndpoint('/', {
+        protocol: 'https:',
+        host: 'example.com:8443',
+      }),
+    ).toBe('wss://example.com:8443/client/ws')
+  })
+
+  it('maps an absolute https:// base to wss://', () => {
+    expect(getWebsocketEndpoint('https://control.example.com', httpPage)).toBe(
+      'wss://control.example.com/client/ws',
+    )
+  })
+
+  it('maps an absolute http:// base to ws://', () => {
+    expect(getWebsocketEndpoint('http://localhost:3000', httpsPage)).toBe(
+      'ws://localhost:3000/client/ws',
+    )
+  })
+
+  it('passes ws:// and wss:// bases through unchanged', () => {
+    expect(getWebsocketEndpoint('ws://localhost:3000', httpsPage)).toBe(
+      'ws://localhost:3000/client/ws',
+    )
+    expect(getWebsocketEndpoint('wss://control.example.com', httpPage)).toBe(
+      'wss://control.example.com/client/ws',
+    )
+  })
+
+  it('resolves a path base against the page and keeps the path', () => {
+    expect(getWebsocketEndpoint('/control/', httpsPage)).toBe(
+      'wss://control.example.com/control/client/ws',
+    )
+    expect(getWebsocketEndpoint('/control', httpPage)).toBe(
+      'ws://localhost:3000/control/client/ws',
+    )
+  })
+
+  it('does not double the slash for an absolute base with a trailing slash', () => {
+    expect(getWebsocketEndpoint('https://control.example.com/', httpPage)).toBe(
+      'wss://control.example.com/client/ws',
+    )
+  })
+})

--- a/packages/streamwall-control-client/src/wsEndpoint.ts
+++ b/packages/streamwall-control-client/src/wsEndpoint.ts
@@ -1,0 +1,26 @@
+/**
+ * Derives the control WebSocket endpoint from the Vite `BASE_URL` and the
+ * page location.
+ *
+ * The published Docker image always builds the client with `BASE_URL = '/'`,
+ * so the scheme must come from the page: a client served over `https:` has to
+ * open `wss://` — browsers block insecure WebSockets from secure contexts, so
+ * a hardcoded `ws://` left TLS deployments permanently disconnected (issue
+ * #617). An absolute `http(s)://` base (a `STREAMWALL_CONTROL_URL` build) is
+ * mapped to `ws(s)://` the same way; `ws://`/`wss://` bases pass through.
+ */
+export function getWebsocketEndpoint(
+  baseUrl: string,
+  location: { protocol: string; host: string },
+): string {
+  const pageWsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
+  // Resolves relative bases ('/', '/some/path/') against the page host with
+  // the page-derived scheme; absolute bases keep their own origin.
+  const url = new URL(baseUrl, `${pageWsProtocol}//${location.host}`)
+  if (url.protocol === 'http:') {
+    url.protocol = 'ws:'
+  } else if (url.protocol === 'https:') {
+    url.protocol = 'wss:'
+  }
+  return `${url.origin}${url.pathname.replace(/\/$/, '')}/client/ws`
+}


### PR DESCRIPTION
## Summary

The control client hardcoded `ws://` whenever `BASE_URL` was `/`, and the published control-server Docker image always builds the client with that default base (no `STREAMWALL_CONTROL_URL` build arg exists in the Dockerfile). Any HTTPS deployment — the documented Caddy self-hosting path — therefore opened an insecure WebSocket from a secure context, which browsers block, leaving the control UI permanently disconnected with no clear diagnostic.

## Changes

- New `getWebsocketEndpoint(baseUrl, location)` helper in `packages/streamwall-control-client/src/wsEndpoint.ts`:
  - relative bases (`/`, `/path/`) resolve against the page host with the scheme derived from the page protocol (`https:` → `wss:`, otherwise `ws:`),
  - absolute `http(s)://` bases (`STREAMWALL_CONTROL_URL` builds) are mapped to `ws(s)://` the same way,
  - `ws://` / `wss://` bases pass through unchanged.
- `src/index.tsx` uses the helper instead of the hardcoded `ws://${location.host}` fallback.
- Unit tests cover the TLS regression, local dev (plain http/ws stays `ws://`), absolute and path bases, ports, and trailing-slash handling.

This also removes any need to bake `STREAMWALL_CONTROL_URL` into the image at build time.

## Testing

- `npm run test` (all workspaces), `npm run lint`, `npm run typecheck`, Prettier — all green locally.

Closes #617