### PR TITLE
fix(streamwall): ignore invalid rotation instead of clobbering the current one

### DIFF
--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -985,3 +985,49 @@ describe('SnapshotController poster object URLs', () => {
     expect(revokeObjectURL).toHaveBeenCalledTimes(2)
   })
 })
+
+describe('RotationController', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  async function makeController() {
+    const { RotationController } = await import('./mediaPreload')
+    const video = document.createElement('video')
+    return { controller: new RotationController(video), video }
+  }
+
+  it('applies each supported rotation as its matching class', async () => {
+    const { controller, video } = await makeController()
+    for (const rotation of [0, 90, 180, 270]) {
+      controller.setCustom(rotation)
+      expect(video.className).toBe(`__rot${rotation}__`)
+    }
+  })
+
+  it('normalizes negative rotations into [0, 360) instead of emitting an inert class', async () => {
+    const { controller, video } = await makeController()
+    controller.setCustom(-90)
+    expect(video.className).toBe('__rot270__')
+  })
+
+  it('normalizes rotations >= 360 into [0, 360)', async () => {
+    const { controller, video } = await makeController()
+    controller.setCustom(450)
+    expect(video.className).toBe('__rot90__')
+  })
+
+  it('ignores an invalid rotation and keeps the current rotation class', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { controller, video } = await makeController()
+
+    controller.setCustom(90)
+    expect(video.className).toBe('__rot90__')
+
+    // A bad value (not a multiple of 90) must not clobber the valid 90° class.
+    controller.setCustom(45)
+    expect(video.className).toBe('__rot90__')
+    expect(warn).toHaveBeenCalledWith('ignoring invalid rotation', 45)
+  })
+})

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -99,7 +99,7 @@ const pageReady = new Promise((resolve) =>
   document.addEventListener('DOMContentLoaded', resolve, { once: true }),
 )
 
-class RotationController {
+export class RotationController {
   video: HTMLVideoElement
   siteRotation = 0
   customRotation: number
@@ -110,9 +110,14 @@ class RotationController {
   }
 
   _update() {
-    const rotation = this.customRotation % 360
+    // JS `%` keeps the operand's sign, so normalize negatives into [0, 360)
+    // before validating (e.g. -90 -> 270).
+    const rotation = ((this.customRotation % 360) + 360) % 360
     if (![0, 90, 180, 270].includes(rotation)) {
-      console.warn('ignoring invalid rotation', rotation)
+      // Only 0/90/180/270 have CSS rules. Ignore anything else and keep the
+      // current rotation class rather than replacing it with an inert one.
+      console.warn('ignoring invalid rotation', this.customRotation)
+      return
     }
     this.video.className = `__rot${rotation}__`
   }


### PR DESCRIPTION
## Summary

`RotationController._update()` in `packages/streamwall/src/preload/mediaPreload.ts` logged that an invalid rotation was being "ignored" but then unconditionally overwrote the video's `className`, replacing a previously valid rotation class (e.g. `__rot90__`) with an inert one — so a stream that received a bad rotation value lost its rotation and rendered unrotated, contradicting its own warning.

Two related problems:
- JS `%` keeps the operand's sign, so `-90 % 360 === -90`, producing `__rot-90__`, for which no CSS rule exists.
- Even for a genuinely unsupported value, the class was applied instead of skipped.

## Fix

- Normalize into `[0, 360)` with `(((r % 360) + 360) % 360)` so negatives map correctly (`-90` -> `270`).
- Early-return when the normalized rotation is not one of `0/90/180/270`, keeping the current rotation class intact.

## Tests

Added a `RotationController` describe block to `mediaPreload.test.ts` covering:
- each supported rotation maps to its class,
- negative and `>= 360` values normalize correctly,
- an invalid value keeps the current class and warns.

Verified the two regression tests fail against the old code and pass with the fix. Full streamwall suite green (899 tests). Lint, typecheck, and Prettier all pass.

Closes #627
