### PR TITLE
fix(control-client): derive the WebSocket scheme from the page protocol

### DIFF
--- a/packages/streamwall-control-client/src/index.tsx
+++ b/packages/streamwall-control-client/src/index.tsx
@@ -1,12 +1,13 @@
 import { render } from 'preact'
 import { ControlUI, GlobalStyle } from 'streamwall-control-ui'
 import { useStreamwallWebsocketConnection } from './useStreamwallWebsocketConnection.ts'
+import { controlWebSocketEndpoint } from './wsEndpoint.ts'
 
 function App() {
   const { BASE_URL } = import.meta.env
 
   const connection = useStreamwallWebsocketConnection(
-    (BASE_URL === '/' ? `ws://${location.host}` : BASE_URL) + '/client/ws',
+    controlWebSocketEndpoint(BASE_URL, location),
   )
 
   return (

--- a/packages/streamwall-control-client/src/wsEndpoint.test.ts
+++ b/packages/streamwall-control-client/src/wsEndpoint.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+
+import { controlWebSocketEndpoint } from './wsEndpoint.ts'
+
+describe('controlWebSocketEndpoint', () => {
+  it('derives ws:// from an http page when BASE_URL is "/"', () => {
+    expect(
+      controlWebSocketEndpoint('/', {
+        protocol: 'http:',
+        host: '127.0.0.1:3000',
+      }),
+    ).toBe('ws://127.0.0.1:3000/client/ws')
+  })
+
+  it('derives wss:// from an https page when BASE_URL is "/"', () => {
+    // Browsers block ws:// connections from secure contexts, so a client
+    // served over TLS (e.g. the published Docker image behind Caddy) must
+    // connect via wss:// (issue #617).
+    expect(
+      controlWebSocketEndpoint('/', {
+        protocol: 'https:',
+        host: 'control.example.com',
+      }),
+    ).toBe('wss://control.example.com/client/ws')
+  })
+
+  it('maps an explicit http BASE_URL to ws:// on an http page', () => {
+    expect(
+      controlWebSocketEndpoint('http://control.example.com', {
+        protocol: 'http:',
+        host: 'control.example.com',
+      }),
+    ).toBe('ws://control.example.com/client/ws')
+  })
+
+  it('maps an explicit https BASE_URL to wss://', () => {
+    expect(
+      controlWebSocketEndpoint('https://control.example.com', {
+        protocol: 'https:',
+        host: 'control.example.com',
+      }),
+    ).toBe('wss://control.example.com/client/ws')
+  })
+
+  it('upgrades an explicit http BASE_URL to wss:// when the page is https', () => {
+    // A secure page can never open an insecure socket, whatever the build-time
+    // base claims, so the page protocol wins.
+    expect(
+      controlWebSocketEndpoint('http://control.example.com', {
+        protocol: 'https:',
+        host: 'control.example.com',
+      }),
+    ).toBe('wss://control.example.com/client/ws')
+  })
+
+  it('tolerates a trailing slash on an explicit BASE_URL', () => {
+    // Vite normalizes absolute bases to end with a slash; the endpoint path
+    // must not end up with a double slash.
+    expect(
+      controlWebSocketEndpoint('https://control.example.com/', {
+        protocol: 'https:',
+        host: 'control.example.com',
+      }),
+    ).toBe('wss://control.example.com/client/ws')
+  })
+})

--- a/packages/streamwall-control-client/src/wsEndpoint.ts
+++ b/packages/streamwall-control-client/src/wsEndpoint.ts
@@ -1,0 +1,24 @@
+/**
+ * Resolves the control WebSocket endpoint from the build-time base URL and the
+ * page location.
+ *
+ * The scheme is derived from how the page itself was loaded: browsers block
+ * ws:// connections from secure contexts, so a client served over TLS (e.g.
+ * the published Docker image behind a TLS-terminating proxy) must connect via
+ * wss:// (issue #617). An explicit http(s) base is mapped to its WebSocket
+ * counterpart, and upgraded to wss:// whenever the page is https.
+ */
+export function controlWebSocketEndpoint(
+  baseURL: string,
+  location: { protocol: string; host: string },
+): string {
+  const pageIsSecure = location.protocol === 'https:'
+  let base =
+    baseURL === '/'
+      ? `${pageIsSecure ? 'wss:' : 'ws:'}//${location.host}`
+      : baseURL.replace(/^http/, 'ws').replace(/\/$/, '')
+  if (pageIsSecure) {
+    base = base.replace(/^ws:/, 'wss:')
+  }
+  return `${base}/client/ws`
+}


### PR DESCRIPTION
## Problem
The control client derives its WebSocket endpoint as `ws://${location.host}` whenever `BASE_URL` is `/`, and the published control-server image always builds the client with `BASE_URL = '/'`. Any HTTPS deployment using the GHCR image therefore gets a mixed-content-blocked socket and a control UI that never connects.

## Solution
The endpoint is now resolved by a small pure function, `controlWebSocketEndpoint(baseURL, location)`:
- `BASE_URL === '/'`: the scheme follows the page protocol (`https:` → `wss://`, else `ws://`), so the same image works over plain HTTP and behind TLS without baking `STREAMWALL_CONTROL_URL` into the build.
- An explicit `http(s)://` base is mapped to its WebSocket counterpart (`http` → `ws`, `https` → `wss`) and upgraded to `wss://` whenever the page itself is secure, since a secure context can never open an insecure socket.
- A trailing slash on an explicit base no longer produces a double slash in the endpoint path.

## Testing
- New unit tests in `packages/streamwall-control-client/src/wsEndpoint.test.ts` cover both schemes for `BASE_URL = '/'`, explicit http/https bases, the https-page upgrade, and trailing-slash normalization.
- `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` all pass.

Closes #617