### PR TITLE
fix(streamwall): surface an error when a stalled view has no retry budget

### DIFF
--- a/packages/streamwall/src/main/viewStateMachine.test.ts
+++ b/packages/streamwall/src/main/viewStateMachine.test.ts
@@ -11,8 +11,11 @@ vi.mock('electron', () => ({
 }))
 
 const { createActor, fromPromise, matchesState } = await import('xstate')
-const { default: viewStateMachine, DEFAULT_RETRY_CONFIG } =
-  await import('./viewStateMachine')
+const {
+  default: viewStateMachine,
+  DEFAULT_RETRY_CONFIG,
+  STALLED_ERROR_MESSAGE,
+} = await import('./viewStateMachine')
 type RetryConfig = import('./viewStateMachine').RetryConfig
 
 const noop = () => {}
@@ -271,20 +274,45 @@ describe('viewStateMachine error handling and auto-retry', () => {
     expect(snapshot.context.retryCount).toBe(1)
   })
 
-  it('does not reload a stalled view when retry is disabled', async () => {
+  it('surfaces an error instead of reloading a stalled view when retry is disabled', async () => {
     const actor = makeActor(makeRetry({ enabled: false }))
     actor.start()
     await reachRunning(actor)
     actor.send({ type: 'VIEW_STALLED' })
 
-    vi.advanceTimersByTime(60000)
+    vi.advanceTimersByTime(2000) // stalledTimeout
 
+    const snapshot = actor.getSnapshot()
+    expect(matchesState('displaying.error', snapshot.value)).toBe(true)
+    expect(snapshot.context.error).toBe(STALLED_ERROR_MESSAGE)
+  })
+
+  it('surfaces a terminal error when a stalled view has no retry budget', async () => {
+    // maxRetries: 0 means the budget is already spent when the stall happens
+    // (reaching `running` resets the streak, so a nonzero budget always allows
+    // at least one stall-reload).
+    const actor = makeActor(makeRetry({ maxRetries: 0 }))
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'VIEW_STALLED' })
     expect(
       matchesState(
         'displaying.running.playback.stalled',
         actor.getSnapshot().value,
       ),
     ).toBe(true)
+
+    vi.advanceTimersByTime(2000) // stalledTimeout
+
+    const snapshot = actor.getSnapshot()
+    expect(matchesState('displaying.error', snapshot.value)).toBe(true)
+    expect(snapshot.context.error).toBe(STALLED_ERROR_MESSAGE)
+
+    // Terminal: with no budget left, no further auto-reload happens.
+    vi.advanceTimersByTime(60000)
+    expect(matchesState('displaying.error', actor.getSnapshot().value)).toBe(
+      true,
+    )
   })
 
   it('resets the retry budget on a manual RELOAD', () => {

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -49,6 +49,13 @@ export const DEFAULT_RETRY_CONFIG: RetryConfig = {
 }
 
 /**
+ * Reason recorded when a view stays stalled past the watchdog with no retry
+ * budget left, so the wall overlay and control UI show an error instead of a
+ * loading spinner forever.
+ */
+export const STALLED_ERROR_MESSAGE = 'Stream stalled'
+
+/**
  * Turns an arbitrary thrown value into a short, serializable reason that can be
  * shown on the wall overlay and in the control UI.
  */
@@ -652,11 +659,30 @@ const viewStateMachine = setup({
                   // (as long as it still has retry budget). A stall that clears
                   // on its own (VIEW_LOADED -> playing) simply cancels this.
                   after: {
-                    stalledTimeout: {
-                      target: '#view.displaying.loading',
-                      guard: 'canRetry',
-                      actions: 'incrementRetry',
-                    },
+                    stalledTimeout: [
+                      {
+                        target: '#view.displaying.loading',
+                        guard: 'canRetry',
+                        actions: 'incrementRetry',
+                      },
+                      // Retry budget exhausted (or retry disabled): surface a
+                      // terminal error instead of showing a loading spinner
+                      // forever, mirroring how a spent budget behaves in the
+                      // `error` state below.
+                      {
+                        target: '#view.displaying.error',
+                        actions: [
+                          {
+                            type: 'logError',
+                            params: { error: STALLED_ERROR_MESSAGE },
+                          },
+                          {
+                            type: 'setError',
+                            params: { error: STALLED_ERROR_MESSAGE },
+                          },
+                        ],
+                      },
+                    ],
                   },
                 },
               },


### PR DESCRIPTION
## Summary

The stalled watchdog (`displaying.running.playback.stalled`, `after: stalledTimeout`) only had a single transition guarded by `canRetry`. When the retry budget was spent — retry disabled or `maxRetries: 0` — the guard blocked the only exit, so the machine sat in `stalled` indefinitely, which the wall overlay maps to `isLoading` and renders as an eternal loading spinner. The operator got no signal that the tile was dead, unlike the load-failure path which lands in the terminal `error` state with a reason.

## Changes

- `viewStateMachine.ts`: the stalled watchdog now has a fallback transition — when `canRetry` is false it targets `#view.displaying.error`, logging and recording a `Stream stalled` reason (exported as `STALLED_ERROR_MESSAGE`). This mirrors the exhausted-budget behavior of the `error` state's backoff transition. No new state values are introduced (`displaying.error` already exists), so `viewStateValueSchema` in streamwall-shared is unaffected.
- `viewStateMachine.test.ts`:
  - Replaced the test that documented the old behavior ("does not reload a stalled view when retry is disabled" — staying in `stalled` forever) with one asserting the transition to `displaying.error` with the recorded reason.
  - Added a regression test for the no-budget case (`maxRetries: 0`), asserting the error state is terminal (no further auto-reload).

Note: because reaching `running` resets the retry streak (`resetRetryState` on entry), `retryCount` is always 0 while in `stalled`; `canRetry` is false there exactly when retry is disabled or `maxRetries` is 0. The tests cover both.

## Verification

- `npm run test`, `npm run lint`, `npm run typecheck`, Prettier check — all green locally.

Closes #622