### PR TITLE
fix(control-ui): give each tile's resize handles a unique aria-label

### DIFF
--- a/packages/streamwall-control-ui/src/ResizeHandles.test.tsx
+++ b/packages/streamwall-control-ui/src/ResizeHandles.test.tsx
@@ -24,6 +24,7 @@ function renderHandles(
       <ResizeHandles
         anchorIdx={asCellIdx(0)}
         originalSpaces={[asCellIdx(0)]}
+        tileLabel="Downtown cam"
         role="operator"
         onResizeStart={() => {}}
         onResizeKeyDown={() => {}}
@@ -98,17 +99,61 @@ describe('ResizeHandles role gating', () => {
     expect(onResizeKeyDown).toHaveBeenCalledWith(0, 'e', [0], expect.anything())
   })
 
-  test('gives every resize handle a descriptive aria-label', () => {
-    const box = renderHandles()
+  test('folds the tile label into every resize handle aria-label', () => {
+    const box = renderHandles({ tileLabel: 'Downtown cam' })
 
     expect(
-      box.querySelector('button[aria-label="Resize right edge"]'),
+      box.querySelector(
+        'button[aria-label="Resize right edge of Downtown cam"]',
+      ),
     ).not.toBeNull()
     expect(
-      box.querySelector('button[aria-label="Resize bottom edge"]'),
+      box.querySelector(
+        'button[aria-label="Resize bottom edge of Downtown cam"]',
+      ),
     ).not.toBeNull()
     expect(
-      box.querySelector('button[aria-label="Resize bottom-right corner"]'),
+      box.querySelector(
+        'button[aria-label="Resize bottom-right corner of Downtown cam"]',
+      ),
     ).not.toBeNull()
+  })
+
+  test('gives handles on different tiles distinct aria-labels', () => {
+    const first = renderHandles({
+      anchorIdx: asCellIdx(0),
+      tileLabel: 'Downtown cam',
+    })
+    const firstLabel = first
+      .querySelector('button.handle.e')
+      ?.getAttribute('aria-label')
+    // Tear down the first render before mounting the second so their ids and
+    // labels don't coexist in the same document.
+    act(() => render(null, first))
+    first.remove()
+    container = undefined
+
+    const second = renderHandles({
+      anchorIdx: asCellIdx(3),
+      tileLabel: 'Harbor cam',
+    })
+    const secondLabel = second
+      .querySelector('button.handle.e')
+      ?.getAttribute('aria-label')
+
+    expect(firstLabel).toBe('Resize right edge of Downtown cam')
+    expect(secondLabel).toBe('Resize right edge of Harbor cam')
+    expect(firstLabel).not.toBe(secondLabel)
+  })
+
+  test('exposes the keyboard-override hint via aria-describedby', () => {
+    const box = renderHandles({ anchorIdx: asCellIdx(2) })
+
+    const handle = box.querySelector('button.handle.e') as HTMLButtonElement
+    const hintId = handle.getAttribute('aria-describedby')
+    expect(hintId).toBe('resize-keyboard-hint-2')
+
+    const hint = box.querySelector(`#${hintId}`)
+    expect(hint?.textContent).toContain('Hold Shift to overwrite')
   })
 })

--- a/packages/streamwall-control-ui/src/ResizeHandles.tsx
+++ b/packages/streamwall-control-ui/src/ResizeHandles.tsx
@@ -62,6 +62,21 @@ const StyledResizeHandles = styled.div`
   }
 `
 
+// Visually hidden but still exposed to assistive technology, so the keyboard
+// hint referenced by `aria-describedby` is announced to screen-reader users
+// without taking up any visible space (the standard sr-only clip pattern).
+const VisuallyHidden = styled.span`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+`
+
 // A keyboard resize step that would overwrite a neighbor's cells is blocked
 // (see handleResizeKeyDown); this hint surfaces the Shift-key override so
 // that block is discoverable rather than a silent no-op.
@@ -81,12 +96,19 @@ const RESIZE_HANDLES: {
 export function ResizeHandles({
   anchorIdx,
   originalSpaces,
+  tileLabel,
   role,
   onResizeStart,
   onResizeKeyDown,
 }: {
   anchorIdx: CellIdx
   originalSpaces: CellIdx[]
+  // A human-readable identifier for the tile these handles resize (the stream
+  // label or, failing that, the cell position), folded into each button's
+  // aria-label so screen-reader users can tell one tile's handles from the
+  // next instead of hearing a run of identical "Resize right edge" buttons
+  // (issue #625, WCAG 2.4.6).
+  tileLabel: string
   role: StreamwallRole | null
   onResizeStart: (
     anchorIdx: CellIdx,
@@ -106,6 +128,9 @@ export function ResizeHandles({
   // so a monitor-role client can't start a resize gesture even if a
   // pointerdown/keydown somehow still reached a disabled button.
   const disabled = !roleCan(role, 'mutate-state-doc')
+  // Unique per tile so multiple mounted ResizeHandles don't share a DOM id;
+  // all three buttons of one tile reference the same hint text.
+  const hintId = `resize-keyboard-hint-${anchorIdx}`
   return (
     <StyledResizeHandles>
       {RESIZE_HANDLES.map(({ handle, className, label }) => (
@@ -113,7 +138,8 @@ export function ResizeHandles({
           key={handle}
           type="button"
           className={className}
-          aria-label={label}
+          aria-label={`${label} of ${tileLabel}`}
+          aria-describedby={hintId}
           title={RESIZE_KEYBOARD_HINT}
           disabled={disabled}
           onPointerDown={(ev) => {
@@ -128,6 +154,7 @@ export function ResizeHandles({
           }}
         />
       ))}
+      <VisuallyHidden id={hintId}>{RESIZE_KEYBOARD_HINT}</VisuallyHidden>
     </StyledResizeHandles>
   )
 }

--- a/packages/streamwall-control-ui/src/components/ControlGrid.tsx
+++ b/packages/streamwall-control-ui/src/components/ControlGrid.tsx
@@ -160,6 +160,18 @@ export function ControlGrid({
             return null
           }
           const anchorIdx = asCellIdx(Math.min(...pos.spaces))
+          // A human-readable identifier so each tile's resize handles get a
+          // distinct aria-label (issue #625): the stream's own label/source/
+          // city when known, otherwise the (1-based) cell position, which is
+          // always present and unique per placed tile.
+          const streamId = sharedState?.views?.[anchorIdx]?.streamId
+          const streamData = streams.find((d) => d._id === streamId)
+          const tileLabel =
+            streamData?.label ||
+            streamData?.source ||
+            streamData?.city ||
+            streamId ||
+            `cell ${anchorIdx + 1}`
           return (
             <div
               key={`rh-${anchorIdx}`}
@@ -175,6 +187,7 @@ export function ControlGrid({
               <ResizeHandles
                 anchorIdx={anchorIdx}
                 originalSpaces={pos.spaces}
+                tileLabel={tileLabel}
                 role={role}
                 onResizeStart={handleResizeStart}
                 onResizeKeyDown={handleResizeKeyDown}


### PR DESCRIPTION
## Summary
`ResizeHandles` renders once per grid tile, so every placed stream exposed buttons all labeled "Resize right edge" / "Resize bottom edge" / "Resize bottom-right corner", with nothing identifying which tile a handle belongs to. A screen-reader user tabbing through the grid heard a run of indistinguishable buttons (WCAG 2.4.6 Headings and Labels / 1.3.1), and the Shift-override keyboard hint lived only in `title`, which assistive technology does not reliably announce.

## Changes
- `ResizeHandles` now takes a `tileLabel` prop and folds it into each button's aria-label, e.g. `Resize right edge of Downtown cam`.
- `ControlGrid` computes `tileLabel` per placed view: the stream's `label` → `source` → `city` → stream id, falling back to the 1-based cell position (always present and unique per placed tile).
- The keyboard-override hint (`Arrow keys resize. Hold Shift to overwrite another tile.`) is now exposed through a visually hidden element referenced via `aria-describedby`, in addition to the existing `title` tooltip for pointer users.
- Unit tests updated/added: label folding, per-tile distinctness, and the `aria-describedby` hint wiring.

No E2E selectors target these aria-labels (the operator-resize spec drives cells by `data-testid`, not the handles), so no Playwright specs needed updating.

Complements the focus-visible a11y work from #508/#531/#551/#553/#557.

Closes #625