### PR TITLE
feat(control-ui): revalidate /admin/status so long sessions see updates

### DIFF
--- a/packages/streamwall-control-ui/src/serverStatusGating.test.tsx
+++ b/packages/streamwall-control-ui/src/serverStatusGating.test.tsx
@@ -98,9 +98,10 @@ describe('server status gating (#436)', () => {
       json: () => Promise.resolve(ADMIN_STATUS),
     })
     const el = await renderControlUI('admin')
-    expect(fetchMock).toHaveBeenCalledWith('/admin/status', {
-      credentials: 'same-origin',
-    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/admin/status',
+      expect.objectContaining({ credentials: 'same-origin' }),
+    )
     expect(el.querySelector('.server-version-label')?.textContent).toContain(
       '0.9.1',
     )

--- a/packages/streamwall-control-ui/src/useServerStatus.test.tsx
+++ b/packages/streamwall-control-ui/src/useServerStatus.test.tsx
@@ -1,7 +1,11 @@
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { type ServerStatus, useServerStatus } from './useServerStatus.ts'
+import {
+  REFRESH_INTERVAL_MS,
+  type ServerStatus,
+  useServerStatus,
+} from './useServerStatus.ts'
 
 let container: HTMLDivElement | undefined
 let fetchMock: ReturnType<typeof vi.fn>
@@ -66,9 +70,13 @@ describe('useServerStatus', () => {
   test('fetches /admin/status with same-origin credentials when enabled', async () => {
     fetchMock.mockResolvedValue(jsonResponse(SAMPLE_STATUS))
     await renderProbe(true)
-    expect(fetchMock).toHaveBeenCalledWith('/admin/status', {
-      credentials: 'same-origin',
-    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/admin/status',
+      expect.objectContaining({
+        credentials: 'same-origin',
+        signal: expect.any(AbortSignal),
+      }),
+    )
   })
 
   test('exposes the parsed status on success', async () => {
@@ -89,5 +97,104 @@ describe('useServerStatus', () => {
     fetchMock.mockRejectedValue(new Error('network down'))
     const el = await renderProbe(true)
     expect(el.querySelector('[data-testid="probe"]')?.textContent).toBe('null')
+  })
+
+  test('rejects a malformed body (fails zod validation) as no status', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ version: 42, updateAvailable: 'yes' }),
+    )
+    const el = await renderProbe(true)
+    expect(el.querySelector('[data-testid="probe"]')?.textContent).toBe('null')
+  })
+
+  test('keeps the last known-good status when a later refresh fails', async () => {
+    vi.useFakeTimers()
+    try {
+      fetchMock.mockResolvedValueOnce(jsonResponse(SAMPLE_STATUS))
+      fetchMock.mockRejectedValueOnce(new Error('network blip'))
+
+      container = document.createElement('div')
+      document.body.appendChild(container)
+      await act(async () => {
+        render(<Probe enabled />, container!)
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0)
+      })
+      const probe = () =>
+        container!.querySelector('[data-testid="probe"]')?.textContent
+
+      expect(JSON.parse(probe()!)).toEqual(SAMPLE_STATUS)
+
+      // Second poll rejects; the good status must stay on screen.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(REFRESH_INTERVAL_MS)
+      })
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(JSON.parse(probe()!)).toEqual(SAMPLE_STATUS)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('re-fetches /admin/status on the refresh interval', async () => {
+    vi.useFakeTimers()
+    try {
+      fetchMock.mockResolvedValue(jsonResponse(SAMPLE_STATUS))
+
+      container = document.createElement('div')
+      document.body.appendChild(container)
+      await act(async () => {
+        render(<Probe enabled />, container!)
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0)
+      })
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(REFRESH_INTERVAL_MS)
+      })
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(REFRESH_INTERVAL_MS)
+      })
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('stops polling and aborts the request on unmount', async () => {
+    vi.useFakeTimers()
+    try {
+      fetchMock.mockResolvedValue(jsonResponse(SAMPLE_STATUS))
+
+      container = document.createElement('div')
+      document.body.appendChild(container)
+      await act(async () => {
+        render(<Probe enabled />, container!)
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0)
+      })
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      const signal = fetchMock.mock.calls[0][1].signal as AbortSignal
+      expect(signal.aborted).toBe(false)
+
+      // Unmount: the interval must be cleared and the inflight request aborted.
+      await act(async () => {
+        render(null, container!)
+      })
+      expect(signal.aborted).toBe(true)
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(REFRESH_INTERVAL_MS * 3)
+      })
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/packages/streamwall-control-ui/src/useServerStatus.ts
+++ b/packages/streamwall-control-ui/src/useServerStatus.ts
@@ -1,20 +1,46 @@
 import { useEffect, useState } from 'preact/hooks'
-
-export interface ServerStatus {
-  version: string
-  latestVersion: string | null
-  updateAvailable: boolean
-  releaseUrl: string | null
-  lastCheckedAt: string | null
-  checkEnabled: boolean
-}
+import { z } from 'zod'
 
 /**
- * Fetches `GET /admin/status` (#430) while `enabled`. The endpoint is
- * admin-only and returns a bare 403 for every other role/anonymous request;
- * that's treated the same as any other failure (no status), since callers
- * are expected to only set `enabled` once they already know the role can
- * see it (#436) - a 403 here just means that check raced a role change.
+ * Shape of `GET /admin/status` (mirrors the server's `UpdateStatus` in
+ * `streamwall-control-server/src/updateCheck.ts`). Validated at runtime because
+ * this is a cross-boundary payload; a malformed body yields no status rather
+ * than a mistyped object leaking into the UI.
+ */
+export const serverStatusSchema = z.object({
+  version: z.string(),
+  latestVersion: z.string().nullable(),
+  updateAvailable: z.boolean(),
+  releaseUrl: z.string().nullable(),
+  lastCheckedAt: z.string().nullable(),
+  checkEnabled: z.boolean(),
+})
+
+export type ServerStatus = z.infer<typeof serverStatusSchema>
+
+/**
+ * How often to revalidate `/admin/status` while enabled. The server refreshes
+ * its update check daily, so an hourly poll is more than frequent enough to
+ * surface a new "update available" notice to an operator whose control UI has
+ * been open for days, without meaningfully adding load (#624).
+ */
+export const REFRESH_INTERVAL_MS = 60 * 60 * 1000
+
+/**
+ * Abort a single `/admin/status` request after this long so a hung fetch can
+ * never leave `status` stuck for the whole session; the next interval simply
+ * tries again.
+ */
+export const FETCH_TIMEOUT_MS = 10 * 1000
+
+/**
+ * Fetches `GET /admin/status` (#430) while `enabled`, then revalidates on an
+ * interval so long-lived sessions still pick up a newly published update
+ * (#624). The endpoint is admin-only and returns a bare 403 for every other
+ * role/anonymous request; that's treated the same as any other failure (no
+ * status), since callers are expected to only set `enabled` once they already
+ * know the role can see it (#436) - a 403 here just means that check raced a
+ * role change.
  */
 export function useServerStatus(enabled: boolean): ServerStatus | null {
   const [status, setStatus] = useState<ServerStatus | null>(null)
@@ -26,21 +52,44 @@ export function useServerStatus(enabled: boolean): ServerStatus | null {
     }
 
     let cancelled = false
-    fetch('/admin/status', { credentials: 'same-origin' })
-      .then((res) => (res.ok ? (res.json() as Promise<ServerStatus>) : null))
-      .then((data) => {
-        if (!cancelled) {
-          setStatus(data)
-        }
+    let activeController: AbortController | null = null
+
+    const load = () => {
+      // Supersede any still-inflight request so overlapping polls can't race.
+      activeController?.abort()
+      const controller = new AbortController()
+      activeController = controller
+      const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+
+      fetch('/admin/status', {
+        credentials: 'same-origin',
+        signal: controller.signal,
       })
-      .catch(() => {
-        if (!cancelled) {
-          setStatus(null)
-        }
-      })
+        .then((res) => (res.ok ? res.json() : null))
+        .then((data) => {
+          if (cancelled || controller !== activeController) {
+            return
+          }
+          const parsed = serverStatusSchema.safeParse(data)
+          setStatus(parsed.success ? parsed.data : null)
+        })
+        .catch(() => {
+          // Network error, timeout, or unmount abort: keep the last known-good
+          // status (if any) so a single transient failure doesn't blank the
+          // version label / update banner; the next interval retries.
+        })
+        .finally(() => {
+          clearTimeout(timeout)
+        })
+    }
+
+    load()
+    const interval = setInterval(load, REFRESH_INTERVAL_MS)
 
     return () => {
       cancelled = true
+      activeController?.abort()
+      clearInterval(interval)
     }
   }, [enabled])
 


### PR DESCRIPTION
## Summary
`useServerStatus` fetched `GET /admin/status` exactly once on mount (its only dependency, `enabled`, is stable for a session), so:

- an operator who keeps the control UI open for days (walls run for days) never saw a newly published "update available" notice until a manual reload;
- a hung fetch left `status` permanently `null` for the session, so the version label and `ServerUpdateBanner` silently never rendered;
- the response body was cast unchecked (`res.json() as Promise<ServerStatus>`), the one cross-boundary payload in the repo without runtime validation.

## Changes
- **Interval revalidation** — poll `/admin/status` on an hourly interval while `enabled`, cleaning up the interval on unmount so no polling leaks after the component is gone. Hourly is ample since the server refreshes its update check daily.
- **Abort timeout** — each request runs under an `AbortController` with a 10s timeout, so a hung fetch can no longer stick for the session; the next interval retries. Overlapping polls supersede any still-inflight request.
- **Runtime validation** — the body is parsed with a small zod schema (`serverStatusSchema`, mirroring the server's `UpdateStatus`); a malformed payload yields no status rather than a mistyped object leaking into the UI. `ServerStatus` is now inferred from the schema.
- **Last-known-good on transient failure** — a single network blip or timeout no longer blanks a working version label / banner; the previous status stays until the next successful poll.

## Tests
Added vitest fake-timer coverage in `useServerStatus.test.tsx`: interval re-fetch, interval + abort cleanup on unmount (asserts the inflight `AbortSignal` is aborted and no further polls fire), zod rejection of a malformed body, and last-known-good retention across a failed refresh. Existing `fetch` call-site assertions updated for the new `signal` argument.

Closes #624