### PR TITLE
fix(control-server): respond to delete-token so the client callback resolves

### DIFF
--- a/packages/streamwall-control-server/src/auth.ts
+++ b/packages/streamwall-control-server/src/auth.ts
@@ -296,12 +296,18 @@ export class Auth extends EventEmitter<AuthEvents> {
     return { tokenId, secret }
   }
 
-  deleteToken(tokenId: string) {
+  /**
+   * Removes the token with `tokenId`. Returns whether a token was actually
+   * deleted, so callers can acknowledge the outcome (see the `delete-token`
+   * command handler, which relays this to the requesting client).
+   */
+  deleteToken(tokenId: string): boolean {
     const tokenData = this.tokensById.get(tokenId)
     if (!tokenData) {
-      return
+      return false
     }
     this.tokensById.delete(tokenData.tokenId)
     this.emitState()
+    return true
   }
 }

--- a/packages/streamwall-control-server/src/ws/client.ts
+++ b/packages/streamwall-control-server/src/ws/client.ts
@@ -237,7 +237,16 @@ export function registerClientRoutes(
             respond({ name: msg.name, secret, tokenId })
           } else if (msg.type === 'delete-token') {
             log.debug('Deleting token')
-            ctx.auth.deleteToken(msg.tokenId)
+            const deleted = ctx.auth.deleteToken(msg.tokenId)
+            // Always answer so a caller that supplied a response callback does
+            // not hang until the socket closes (issue #630). Report whether a
+            // token was actually removed, matching the sibling commands that
+            // all respond via `respond(...)`.
+            if (deleted) {
+              respond({ ok: true })
+            } else {
+              respond({ error: 'unknown token' })
+            }
           } else {
             streamwallConn.ws.send(
               JSON.stringify({ ...msg, clientId: identity.tokenId }),

--- a/packages/streamwall-control-server/src/wsValidation.test.ts
+++ b/packages/streamwall-control-server/src/wsValidation.test.ts
@@ -83,6 +83,34 @@ test('answers an invalid command with an error response', async () => {
   assert.equal(response.error, 'invalid message')
 })
 
+test('answers a delete-token command so the caller callback resolves (issue #630)', async () => {
+  const { clientWs, client, auth } = await connectStreamwallAndClient()
+
+  const { tokenId } = await auth.createToken({
+    kind: 'invite',
+    role: 'operator',
+    name: 'to-delete',
+  })
+
+  clientWs.send(JSON.stringify({ id: 55, type: 'delete-token', tokenId }))
+
+  const response = await client.waitFor(isResponseTo(55))
+  assert.equal(response.ok, true)
+  assert.equal(response.error, undefined)
+})
+
+test('answers a delete-token for an unknown token with an error (issue #630)', async () => {
+  const { clientWs, client } = await connectStreamwallAndClient()
+
+  clientWs.send(
+    JSON.stringify({ id: 56, type: 'delete-token', tokenId: 'never-existed' }),
+  )
+
+  const response = await client.waitFor(isResponseTo(56))
+  assert.equal(response.error, 'unknown token')
+  assert.equal(response.ok, undefined)
+})
+
 test('rejects a state message with no payload instead of wiring a broken connection', async () => {
   // The old code built a StateWrapper around `undefined`, establishing a
   // connection that crashed clients on view(). Validation must reject it so

--- a/packages/streamwall-shared/src/types.ts
+++ b/packages/streamwall-shared/src/types.ts
@@ -193,12 +193,14 @@ export type ClientErrorMessage = {
  * The server's reply to a specific client-issued command, correlated by the
  * client-supplied `id`. `error` is present only when the command was
  * rejected; a successful `create-invite` additionally returns the minted
- * token's `name`/`secret`/`tokenId`.
+ * token's `name`/`secret`/`tokenId`, and a successful `delete-token` returns
+ * `ok: true`.
  */
 export type ClientCommandResponse = {
   response: true
   id?: number
   error?: string
+  ok?: boolean
   name?: string
   secret?: string
   tokenId?: string


### PR DESCRIPTION
## Summary
The `delete-token` command handler removed the token but never called `respond(...)`, unlike every sibling command branch. A client that supplied a response callback waited until the socket closed, at which point `handleClose` rejected the still-pending id.

## Changes
- `auth.ts`: `deleteToken` now returns a `boolean` indicating whether a token was actually removed (all existing callers ignore the value, so this is backward compatible).
- `ws/client.ts`: the `delete-token` branch now answers via `respond(...)` — `{ ok: true }` when a token was deleted, `{ error: 'unknown token' }` otherwise — matching the response pattern of the other command branches.
- `streamwall-shared/src/types.ts`: documented and added the `ok?: boolean` field on `ClientCommandResponse`.
- Regression tests in `wsValidation.test.ts` cover both the resolved (`ok: true`) and unknown-token (`error`) paths, asserting the client callback resolves.

## Verification
- `npm run typecheck`, `npm run lint`, and Prettier: green.
- Control-server suite (`wsValidation.test.ts`, `auth.test.ts`): 36/36 pass.

Closes #630