### PR TITLE
fix(streamwall): tear down StreamWindow ipcMain handlers on dispose

### DIFF
--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -12,13 +12,53 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
  * constructor test can assert *what* was built and *in which order* without a
  * real Electron runtime.
  */
-const electronStub = vi.hoisted(() => ({
-  windows: [] as Array<InstanceType<typeof import('electron').BrowserWindow>>,
-  webContentsViews: [] as Array<
-    InstanceType<typeof import('electron').WebContentsView>
-  >,
-  ipcMain: { handle: vi.fn(), on: vi.fn() },
-}))
+const electronStub = vi.hoisted(() => {
+  // A stand-in for Electron's process-global `ipcMain`. It tracks which
+  // channels are currently registered and throws on a duplicate `handle`,
+  // mirroring the real runtime, so tests can pin the duplicate-registration
+  // crash (issue #629) and verify `dispose()` releases the channels again.
+  const registeredHandlers = new Set<string>()
+  const registeredListeners = new Map<string, Set<(...args: never[]) => void>>()
+  const handle = vi.fn((channel: string) => {
+    if (registeredHandlers.has(channel)) {
+      throw new Error(`Attempted to register a second handler for '${channel}'`)
+    }
+    registeredHandlers.add(channel)
+  })
+  const removeHandler = vi.fn((channel: string) => {
+    registeredHandlers.delete(channel)
+  })
+  const on = vi.fn((channel: string, listener: (...args: never[]) => void) => {
+    let listeners = registeredListeners.get(channel)
+    if (!listeners) {
+      listeners = new Set()
+      registeredListeners.set(channel, listeners)
+    }
+    listeners.add(listener)
+  })
+  const removeListener = vi.fn(
+    (channel: string, listener: (...args: never[]) => void) => {
+      registeredListeners.get(channel)?.delete(listener)
+    },
+  )
+  return {
+    windows: [] as Array<InstanceType<typeof import('electron').BrowserWindow>>,
+    webContentsViews: [] as Array<
+      InstanceType<typeof import('electron').WebContentsView>
+    >,
+    registeredHandlers,
+    registeredListeners,
+    ipcMain: { handle, on, removeHandler, removeListener },
+    resetIpc() {
+      registeredHandlers.clear()
+      registeredListeners.clear()
+      handle.mockClear()
+      on.mockClear()
+      removeHandler.mockClear()
+      removeListener.mockClear()
+    },
+  }
+})
 
 // StreamWindow pulls in Electron (directly and via ./loadHTML and
 // ./viewStateMachine). Stub the module so the file can be imported without an
@@ -51,6 +91,7 @@ vi.mock('electron', () => {
       send: vi.fn(),
       close: vi.fn(),
       openDevTools: vi.fn(),
+      isDestroyed: vi.fn(() => false),
       session: {},
     }
     setBackgroundColor = vi.fn()
@@ -1385,8 +1426,7 @@ describe('StreamWindow constructor', () => {
   beforeEach(() => {
     electronStub.windows.length = 0
     electronStub.webContentsViews.length = 0
-    electronStub.ipcMain.handle.mockClear()
-    electronStub.ipcMain.on.mockClear()
+    electronStub.resetIpc()
     vi.mocked(loadHTML).mockClear()
   })
 
@@ -1488,5 +1528,93 @@ describe('StreamWindow constructor', () => {
     layerLoad({ sender: {} })
 
     expect(loads).toBe(2)
+  })
+})
+
+describe('StreamWindow.dispose (issue #629)', () => {
+  beforeEach(() => {
+    electronStub.windows.length = 0
+    electronStub.webContentsViews.length = 0
+    electronStub.resetIpc()
+    vi.mocked(loadHTML).mockClear()
+  })
+
+  it('removes every ipcMain handler and listener it registered', () => {
+    const sw = new StreamWindow(makeConfig())
+    expect(electronStub.registeredHandlers.size).toBeGreaterThan(0)
+
+    sw.dispose()
+
+    // Each `handle` channel is removed via removeHandler, each `on` channel
+    // via removeListener -- so `ipcMain` is left with no dangling reference
+    // back into this (now discarded) window.
+    expect(
+      electronStub.ipcMain.removeHandler.mock.calls.map(([ch]) => ch),
+    ).toEqual(['layer:load', 'view-init'])
+    expect(
+      electronStub.ipcMain.removeListener.mock.calls.map(([ch]) => ch),
+    ).toEqual([
+      'view-loaded',
+      'view-stalled',
+      'view-info',
+      'view-error',
+      'devtools-overlay',
+    ])
+    expect(electronStub.registeredHandlers.size).toBe(0)
+  })
+
+  it('lets a second instance construct only after the first is disposed', () => {
+    const first = new StreamWindow(makeConfig())
+
+    // Without teardown, a second StreamWindow crashes the moment it tries to
+    // re-register the already-taken 'layer:load' invoke channel -- the exact
+    // failure a future recreate-on-config-reload path would hit.
+    expect(() => new StreamWindow(makeConfig())).toThrow(/layer:load/)
+
+    first.dispose()
+
+    // Once the channels are released, the same registration succeeds again.
+    const second = new StreamWindow(makeConfig())
+    expect(second).toBeInstanceOf(StreamWindow)
+    second.dispose()
+  })
+
+  it('constructing and disposing twice in a row does not throw', () => {
+    expect(() => {
+      const a = new StreamWindow(makeConfig())
+      a.dispose()
+      const b = new StreamWindow(makeConfig())
+      b.dispose()
+    }).not.toThrow()
+  })
+
+  it('is idempotent: a second dispose removes nothing more', () => {
+    const sw = new StreamWindow(makeConfig())
+    sw.dispose()
+    electronStub.ipcMain.removeHandler.mockClear()
+    electronStub.ipcMain.removeListener.mockClear()
+
+    sw.dispose()
+
+    expect(electronStub.ipcMain.removeHandler).not.toHaveBeenCalled()
+    expect(electronStub.ipcMain.removeListener).not.toHaveBeenCalled()
+  })
+
+  it('devtools-overlay no-ops when the overlay webContents is already destroyed', () => {
+    const sw = new StreamWindow(makeConfig())
+    const devtools = electronStub.ipcMain.on.mock.calls.find(
+      ([channel]) => channel === 'devtools-overlay',
+    )?.[1] as (ev: unknown) => void
+
+    // The handler outlives the window: firing it after the overlay's
+    // webContents is gone must not call (and throw inside) openDevTools.
+    vi.mocked(sw.overlayView.webContents.isDestroyed).mockReturnValue(true)
+    devtools({})
+    expect(sw.overlayView.webContents.openDevTools).not.toHaveBeenCalled()
+
+    // While the webContents is alive it still opens devtools as before.
+    vi.mocked(sw.overlayView.webContents.isDestroyed).mockReturnValue(false)
+    devtools({})
+    expect(sw.overlayView.webContents.openDevTools).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -83,6 +83,13 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
   // an actor's current one, that view's webContents.id generally differs
   // from the actor's original `context.id`, so routing needs its own map.
   viewsByWebContentsId: Map<number, ViewActor>
+  // Teardown thunks for every ipcMain handler/listener registered by
+  // `setupIpcHandlers`. `ipcMain` is a process-global singleton and
+  // `ipcMain.handle` throws on duplicate channel registration, so these are
+  // used by `dispose()` to release the channels when this window goes away
+  // (otherwise constructing a second StreamWindow -- e.g. a future
+  // recreate-on-config-reload path -- would crash). Filled in the constructor.
+  private ipcTeardowns: Array<() => void> = []
 
   constructor(
     config: StreamWindowConfig,
@@ -187,12 +194,38 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
   }
 
   /**
+   * Registers an `ipcMain.handle` invoke handler and records how to remove it
+   * again, so `dispose()` can release the (process-global) channel.
+   */
+  private registerIpcHandle(
+    channel: string,
+    listener: Parameters<typeof ipcMain.handle>[1],
+  ) {
+    ipcMain.handle(channel, listener)
+    this.ipcTeardowns.push(() => ipcMain.removeHandler(channel))
+  }
+
+  /**
+   * Registers an `ipcMain.on` event listener and records how to remove it
+   * again (by the exact listener reference), so `dispose()` can detach it.
+   */
+  private registerIpcOn(
+    channel: string,
+    listener: Parameters<typeof ipcMain.on>[1],
+  ) {
+    ipcMain.on(channel, listener)
+    this.ipcTeardowns.push(() => ipcMain.removeListener(channel, listener))
+  }
+
+  /**
    * Registers the main-process IPC handlers: the chrome layers' load
    * notification, and the per-view messages routed back to the owning actor
-   * via `viewsByWebContentsId`.
+   * via `viewsByWebContentsId`. Every registration is recorded so `dispose()`
+   * can tear it down -- `ipcMain` is a process-global singleton and
+   * `ipcMain.handle` throws on duplicate channel registration.
    */
   private setupIpcHandlers() {
-    ipcMain.handle('layer:load', (ev) => {
+    this.registerIpcHandle('layer:load', (ev) => {
       if (
         ev.sender !== this.backgroundView.webContents &&
         ev.sender !== this.overlayView.webContents
@@ -209,7 +242,7 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
     const isFromNextView = (actor: ViewActor, senderId: number) =>
       actor.getSnapshot().context.next?.view.webContents.id === senderId
 
-    ipcMain.handle('view-init', async (ev) => {
+    this.registerIpcHandle('view-init', async (ev) => {
       const view = this.viewsByWebContentsId.get(ev.sender.id)
       if (!view) {
         return
@@ -222,7 +255,7 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
       })
       return { content, options, volume }
     })
-    ipcMain.on('view-loaded', (ev) => {
+    this.registerIpcOn('view-loaded', (ev) => {
       const view = this.viewsByWebContentsId.get(ev.sender.id)
       if (!view) {
         return
@@ -233,18 +266,18 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
           : 'VIEW_LOADED',
       })
     })
-    ipcMain.on('view-stalled', (ev) => {
+    this.registerIpcOn('view-stalled', (ev) => {
       this.viewsByWebContentsId.get(ev.sender.id)?.send({
         type: 'VIEW_STALLED',
       })
     })
-    ipcMain.on('view-info', (ev, { info }) => {
+    this.registerIpcOn('view-info', (ev, { info }) => {
       this.viewsByWebContentsId.get(ev.sender.id)?.send({
         type: 'VIEW_INFO',
         info,
       })
     })
-    ipcMain.on('view-error', (ev, { error }) => {
+    this.registerIpcOn('view-error', (ev, { error }) => {
       const view = this.viewsByWebContentsId.get(ev.sender.id)
       if (!view) {
         return
@@ -256,9 +289,30 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
         error,
       })
     })
-    ipcMain.on('devtools-overlay', () => {
-      this.overlayView.webContents.openDevTools()
+    this.registerIpcOn('devtools-overlay', () => {
+      // The handler outlives the window, so the overlay's webContents may
+      // already be gone by the time this fires; opening devtools on a
+      // destroyed webContents throws.
+      const { webContents } = this.overlayView
+      if (webContents.isDestroyed()) {
+        return
+      }
+      webContents.openDevTools()
     })
+  }
+
+  /**
+   * Releases every process-global `ipcMain` handler/listener registered in the
+   * constructor. Must be called before this window is discarded so a later
+   * StreamWindow can register the same channels again (`ipcMain.handle` throws
+   * on a duplicate `layer:load`/`view-init` registration otherwise).
+   * Idempotent: calling it twice is a no-op.
+   */
+  dispose() {
+    for (const teardown of this.ipcTeardowns) {
+      teardown()
+    }
+    this.ipcTeardowns = []
   }
 
   handleResize() {


### PR DESCRIPTION
## Summary
`StreamWindow.setupIpcHandlers()` registered `ipcMain.handle('layer:load' | 'view-init', ...)` and several `ipcMain.on(...)` listeners in the constructor, capturing `this`, with no `removeHandler`/`removeListener` and no dispose path on the class.

Since `ipcMain` is a process-global singleton and `ipcMain.handle` throws on duplicate channel registration, constructing a second `StreamWindow` (e.g. a future recreate-on-config-reload path) would crash at `ipcMain.handle('layer:load')`. The listeners also outlived the window and dereferenced the overlay's `webContents` unconditionally in the `devtools-overlay` handler, which throws once those webContents are destroyed. This was masked today because `main()` constructs exactly one instance for the process lifetime and the unit tests stubbed `ipcMain.handle` as a no-op, hiding the duplicate-registration throw.

## Changes
- Record a teardown thunk for every `ipcMain` handler/listener registered in the constructor (via new `registerIpcHandle` / `registerIpcOn` helpers).
- Add an idempotent `dispose()` that calls `ipcMain.removeHandler` / `ipcMain.removeListener` to release the process-global channels.
- Guard the `devtools-overlay` handler against an already-destroyed overlay `webContents` (`isDestroyed()` check).
- Upgrade the test's `ipcMain` double to a realistic stub that tracks registered channels and throws on duplicate `handle` (mirroring Electron), plus `removeHandler`/`removeListener`/`isDestroyed`. This pins the duplicate-registration contract that the previous no-op stub hid.

## Tests
New `StreamWindow.dispose` suite: dispose removes every registered handler/listener; a second instance can only construct after the first is disposed (the concrete crash from the issue); constructing + disposing twice does not throw; dispose is idempotent; and `devtools-overlay` no-ops on a destroyed overlay webContents. Full streamwall package suite green (900 tests).

Closes #629