### PR TITLE
perf(streamwall): resolve wall view cells via a byId stream index

### DIFF
--- a/packages/streamwall-shared/src/types.ts
+++ b/packages/streamwall-shared/src/types.ts
@@ -54,7 +54,10 @@ export interface StreamData extends StreamDataContent {
 
 export type LocalStreamData = Omit<StreamData, '_id' | '_dataSource'>
 
-export type StreamList = StreamData[] & { byURL?: Map<string, StreamData> }
+export type StreamList = StreamData[] & {
+  byURL?: Map<string, StreamData>
+  byId?: Map<string, StreamData>
+}
 
 /**
  * Mirrors `viewStateMachine.ts`'s snapshot `.value`. Derived from the schema so

--- a/packages/streamwall/src/main/data/combine.test.ts
+++ b/packages/streamwall/src/main/data/combine.test.ts
@@ -191,6 +191,36 @@ describe('combineDataSources', () => {
     }
   })
 
+  test('attaches a byId index to the yielded list for quick lookups', async () => {
+    async function* sourceA() {
+      yield [{ kind: 'video', link: 'https://a.example/s', source: 'Example' }]
+    }
+    const gen = combineDataSources([sourceA()], new StreamIDGenerator())
+    try {
+      const { value } = await gen.next()
+      const stream = value?.[0]
+      expect(stream?._id).toBeTruthy()
+      expect(value?.byId?.get(stream!._id)).toBe(stream)
+    } finally {
+      await gen.return?.(undefined)
+    }
+  })
+
+  test('omits id-less entries from the byId index instead of keying them on undefined', async () => {
+    async function* sourceA() {
+      // No source, label, or link text usable as an id base: the id generator
+      // skips this entry, leaving `_id` unset.
+      yield [{ kind: 'video', link: '' }]
+    }
+    const gen = combineDataSources([sourceA()], new StreamIDGenerator())
+    try {
+      const { value } = await gen.next()
+      expect(value?.byId?.size).toBe(0)
+    } finally {
+      await gen.return?.(undefined)
+    }
+  })
+
   test('assigns stream ids via the provided StreamIDGenerator', async () => {
     async function* sourceA() {
       yield [{ kind: 'video', link: 'https://a.example/s', source: 'Example' }]

--- a/packages/streamwall/src/main/data/combine.ts
+++ b/packages/streamwall/src/main/data/combine.ts
@@ -145,8 +145,17 @@ export async function* combineDataSources(
 
     const streams = idGen.process([...dataByURL.values()]) as StreamList
 
-    // Retain the index to speed up local lookups
+    // Retain the indexes to speed up local lookups
     streams.byURL = dataByURL
+    const dataById = new Map<string, StreamData>()
+    for (const stream of streams) {
+      // Entries the id generator skipped (no usable id base) have no `_id`;
+      // leave them out rather than keying them on undefined.
+      if (stream._id != null) {
+        dataById.set(stream._id, stream)
+      }
+    }
+    streams.byId = dataById
     yield streams
   }
 }

--- a/packages/streamwall/src/main/wallViews.test.ts
+++ b/packages/streamwall/src/main/wallViews.test.ts
@@ -78,6 +78,51 @@ describe('deriveWallViews — normal grid', () => {
   })
 })
 
+describe('deriveWallViews — byId index', () => {
+  it('resolves grid cells through the byId index when the list carries one', () => {
+    const list = streams([{ _id: 'a', link: 'http://a', kind: 'web' }])
+    // Deliberately disagree with the array so the test proves the index is
+    // the lookup actually used, not just present.
+    list.byId = new Map([
+      ['a', { _id: 'a', link: 'http://a-indexed', kind: 'video' }],
+    ]) as NonNullable<StreamList['byId']>
+
+    const result = deriveWallViews({
+      fullscreenViewIdx: null,
+      streams: list,
+      viewsState: viewsStateWith({ '0': 'a' }),
+      cols: 1,
+      rows: 1,
+    })
+
+    expect(result.contentMap.get('0')).toEqual({
+      url: 'http://a-indexed',
+      kind: 'video',
+    })
+  })
+
+  it('resolves the fullscreen stream through the byId index when the list carries one', () => {
+    const list = streams([{ _id: 'b', link: 'http://b', kind: 'web' }])
+    list.byId = new Map([
+      ['b', { _id: 'b', link: 'http://b-indexed', kind: 'video' }],
+    ]) as NonNullable<StreamList['byId']>
+
+    const result = deriveWallViews({
+      fullscreenViewIdx: 0,
+      streams: list,
+      viewsState: viewsStateWith({ '0': 'b' }),
+      cols: 1,
+      rows: 1,
+    })
+
+    expect(result.mode).toBe('fullscreen')
+    expect(result.contentMap.get('0')).toEqual({
+      url: 'http://b-indexed',
+      kind: 'video',
+    })
+  })
+})
+
 describe('deriveWallViews — fullscreen', () => {
   it('fills every cell with the expanded stream', () => {
     const result = deriveWallViews({

--- a/packages/streamwall/src/main/wallViews.ts
+++ b/packages/streamwall/src/main/wallViews.ts
@@ -54,9 +54,17 @@ export function deriveWallViews({
   cols,
   rows,
 }: DeriveWallViewsInput): WallViews {
+  // Resolve cell assignments through the id index built alongside the stream
+  // list (issue #628) instead of a per-cell linear scan; fall back to building
+  // it here (still once per call) for lists that don't carry one.
+  const streamsById =
+    streams.byId ?? new Map(streams.map((stream) => [stream._id, stream]))
+  const streamById = (streamId: string | undefined) =>
+    streamId != null ? streamsById.get(streamId) : undefined
+
   if (fullscreenViewIdx != null) {
     const streamId = viewsState.get(String(fullscreenViewIdx))?.get('streamId')
-    const stream = streams.find((s) => s._id === streamId)
+    const stream = streamById(streamId)
     if (stream) {
       return {
         mode: 'fullscreen',
@@ -70,8 +78,7 @@ export function deriveWallViews({
 
   const contentMap: ViewContentMap = new Map()
   for (const [key, viewData] of viewsState) {
-    const streamId = viewData.get('streamId')
-    const stream = streams.find((s) => s._id === streamId)
+    const stream = streamById(viewData.get('streamId'))
     if (!stream) {
       continue
     }


### PR DESCRIPTION
## Problem

`deriveWallViews` resolved each grid cell's stream with `streams.find(...)`, an O(cells × streams) scan that runs on every data-source tick, every `viewsState` observer fire (each drag/collab edit), and every resize. With aggregated JSON feeds (hundreds of streams) and a dense grid this is thousands of comparisons per tick on the hottest state path in the main process. `StreamList` already carried a `byURL` lookup index, but none for ids.

## Solution

- Add an optional `byId` map to `StreamList` alongside `byURL` (`streamwall-shared/src/types.ts`).
- Build it in `combineDataSources` right where `byURL` is built, after the id generator has assigned ids; entries the generator skipped (no usable id base) are omitted rather than keyed on `undefined`.
- `deriveWallViews` now resolves both the fullscreen override and each grid cell through that index. Lists that don't carry the index fall back to building a map once per call, so lookups stay O(1) per cell either way.

## Testing

- New tests: `combineDataSources` attaches the `byId` index and omits id-less entries; `deriveWallViews` resolves grid cells and the fullscreen stream through the index (asserting the index is the lookup actually used).
- Full quality gate: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` — all green.

Closes #628