### PR TITLE
fix(streamwall): re-apply operator-set rotation when media is re-acquired

### DIFF
--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -755,6 +755,106 @@ describe('mediaPreload MutationObserver lifecycle (issue #412)', () => {
   })
 })
 
+describe('mediaPreload rotation across re-acquisition (issue #620)', () => {
+  // Must match SCAN_THROTTLE in mediaPreload.ts: long enough for the
+  // re-acquisition's throttled scan to find the replacement element.
+  const SCAN_THROTTLE_MS = 500
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.resetModules()
+    invoke.mockClear()
+    send.mockClear()
+    on.mockClear()
+    exposeInMainWorld.mockClear()
+    document.body.innerHTML = ''
+  })
+
+  function registeredHandler(
+    channel: string,
+  ): (ev: unknown, ...args: unknown[]) => void {
+    const call = on.mock.calls.find(([ch]) => ch === channel)
+    if (!call) {
+      throw new Error(`no ipcRenderer.on('${channel}', ...) handler registered`)
+    }
+    return call[1] as (ev: unknown, ...args: unknown[]) => void
+  }
+
+  // happy-dom's HTMLVideoElement never implements videoWidth, so give it a
+  // truthy value to skip findMedia's "wait for playing" branch.
+  function playableVideo(): HTMLVideoElement {
+    const video = document.createElement('video')
+    ;(video as unknown as { videoWidth: number }).videoWidth = 100
+    return video
+  }
+
+  async function loadAcquiredVideo(
+    options: Record<string, unknown> = {},
+  ): Promise<HTMLVideoElement> {
+    const video = playableVideo()
+    document.body.appendChild(video)
+
+    invoke.mockResolvedValueOnce({
+      content: { kind: 'video', link: 'https://example.com/stream' },
+      options,
+      volume: 1,
+    })
+
+    await import('./mediaPreload')
+    document.dispatchEvent(new Event('DOMContentLoaded'))
+    process.emit('loaded' as never)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(send).toHaveBeenCalledWith('view-loaded')
+    return video
+  }
+
+  it('applies the initial rotation from view-init options once media is acquired', async () => {
+    const video = await loadAcquiredVideo({ rotation: 90 })
+
+    expect(video.className).toBe('__rot90__')
+  })
+
+  it("re-applies an operator-set rotation to the element re-acquired after an 'emptied' stall", async () => {
+    const video = await loadAcquiredVideo()
+    registeredHandler('options')(null, { rotation: 90 })
+    expect(video.className).toBe('__rot90__')
+
+    // An HLS teardown empties the element and the page brings up a fresh
+    // player; the re-acquisition finds the replacement, which starts with no
+    // rotation class of its own.
+    const newVideo = playableVideo()
+    video.remove()
+    document.body.appendChild(newVideo)
+    video.dispatchEvent(new Event('emptied'))
+    await vi.advanceTimersByTimeAsync(SCAN_THROTTLE_MS)
+
+    expect(
+      send.mock.calls.filter(([channel]) => channel === 'view-loaded'),
+    ).toHaveLength(2)
+    expect(newVideo.className).toBe('__rot90__')
+  })
+
+  it('keeps later options updates working on the re-acquired element', async () => {
+    const video = await loadAcquiredVideo()
+    registeredHandler('options')(null, { rotation: 90 })
+
+    const newVideo = playableVideo()
+    video.remove()
+    document.body.appendChild(newVideo)
+    video.dispatchEvent(new Event('emptied'))
+    await vi.advanceTimersByTimeAsync(SCAN_THROTTLE_MS)
+
+    registeredHandler('options')(null, { rotation: 180 })
+
+    expect(newVideo.className).toBe('__rot180__')
+  })
+})
+
 describe('mediaPreload pause/resume handling (issue #374)', () => {
   beforeEach(() => {
     vi.useFakeTimers()

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -573,6 +573,13 @@ async function main() {
   let rotationController: RotationController | undefined
   let volumeController: VolumeController | undefined
   let latestVolume = initialVolume ?? 1
+  // The most recently requested rotation, mirroring latestVolume: a fresh
+  // RotationController starts at 0, and neither the initial 'view-init'
+  // options (which arrive before the first acquisition finishes) nor an
+  // 'emptied' re-acquisition re-sends an 'options' IPC, so the operator-set
+  // rotation must be re-applied from here whenever a controller is (re-)
+  // created (issue #620).
+  let latestRotation = initialOptions?.rotation ?? 0
   // The most recently acquired media element (reassigned across a re-
   // acquisition, e.g. the 'emptied' handler below), so a PAUSE/RESUME
   // message received at any point can act on whichever one is current.
@@ -589,6 +596,7 @@ async function main() {
 
     if (content.kind === 'video' && media instanceof HTMLVideoElement) {
       rotationController = new RotationController(media)
+      rotationController.setCustom(latestRotation)
       snapshotInterval = window.setInterval(() => {
         snapshotController.snapshotVideo(media)
       }, 1000)
@@ -652,8 +660,9 @@ async function main() {
   }
 
   function updateOptions(options: ContentDisplayOptions) {
+    latestRotation = options.rotation ?? 0
     if (rotationController) {
-      rotationController.setCustom(options.rotation)
+      rotationController.setCustom(latestRotation)
     }
   }
   ipcRenderer.on('options', (ev, options) => updateOptions(options))


### PR DESCRIPTION
## Problem

Volume survives the `'emptied'` re-acquisition because `main()` tracks `latestVolume` and re-applies it, but rotation had no equivalent: the fresh `RotationController` starts at 0 and no `'options'` IPC is re-sent by the internal stall recovery. An operator-set rotation silently snapped back to un-rotated whenever a live stream briefly stalled. The initial rotation from the `view-init` options was affected by the same gap, since `updateOptions(initialOptions)` runs before the first acquisition finishes constructing the controller.

## Solution

Track `latestRotation` in `main()` (mirroring `latestVolume`), seeded from the initial `view-init` options and updated by every `'options'` IPC, and re-apply it via `rotationController.setCustom(latestRotation)` whenever a controller is (re-)created in `acquireMedia`.

## Testing

- New regression tests in `mediaPreload.test.ts`:
  - initial rotation from `view-init` options is applied once media is acquired
  - an operator-set rotation is re-applied to the element re-acquired after an `'emptied'` stall
  - later options updates keep working on the re-acquired element
- Full quality gate: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` all pass.

Closes #620