### PR TITLE
perf(streamwall): resolve wall-view cells via a byId index

### DIFF
--- a/packages/streamwall-shared/src/types.ts
+++ b/packages/streamwall-shared/src/types.ts
@@ -54,7 +54,10 @@ export interface StreamData extends StreamDataContent {
 
 export type LocalStreamData = Omit<StreamData, '_id' | '_dataSource'>
 
-export type StreamList = StreamData[] & { byURL?: Map<string, StreamData> }
+export type StreamList = StreamData[] & {
+  byURL?: Map<string, StreamData>
+  byId?: Map<string, StreamData>
+}
 
 /**
  * Mirrors `viewStateMachine.ts`'s snapshot `.value`. Derived from the schema so

--- a/packages/streamwall/src/main/data/combine.test.ts
+++ b/packages/streamwall/src/main/data/combine.test.ts
@@ -191,6 +191,22 @@ describe('combineDataSources', () => {
     }
   })
 
+  test('attaches a byId index keyed by the assigned stream id', async () => {
+    async function* sourceA() {
+      yield [{ kind: 'video', link: 'https://a.example/s', source: 'Example' }]
+    }
+    const gen = combineDataSources([sourceA()], new StreamIDGenerator())
+    try {
+      const { value } = await gen.next()
+      expect(value?.byId?.get('exa')).toMatchObject({
+        _id: 'exa',
+        link: 'https://a.example/s',
+      })
+    } finally {
+      await gen.return?.(undefined)
+    }
+  })
+
   test('assigns stream ids via the provided StreamIDGenerator', async () => {
     async function* sourceA() {
       yield [{ kind: 'video', link: 'https://a.example/s', source: 'Example' }]

--- a/packages/streamwall/src/main/data/combine.ts
+++ b/packages/streamwall/src/main/data/combine.ts
@@ -145,8 +145,17 @@ export async function* combineDataSources(
 
     const streams = idGen.process([...dataByURL.values()]) as StreamList
 
-    // Retain the index to speed up local lookups
+    // Retain indexes to speed up local lookups. `byId` is keyed by the `_id`
+    // that `idGen.process` just assigned; on a duplicate id the first entry
+    // wins, matching the `streams.find(...)` scan it replaces.
+    const dataById = new Map<string, StreamData>()
+    for (const stream of streams) {
+      if (stream._id != null && !dataById.has(stream._id)) {
+        dataById.set(stream._id, stream)
+      }
+    }
     streams.byURL = dataByURL
+    streams.byId = dataById
     yield streams
   }
 }

--- a/packages/streamwall/src/main/wallViews.test.ts
+++ b/packages/streamwall/src/main/wallViews.test.ts
@@ -76,6 +76,43 @@ describe('deriveWallViews — normal grid', () => {
     expect(result.contentMap.has('0')).toBe(true)
     expect(result.contentMap.has('1')).toBe(false)
   })
+
+  it('resolves cells through a caller-attached byId index', () => {
+    // Only the attached index carries the stream; the array is empty, proving
+    // the lookup does not fall back to scanning the list.
+    const list = streams([])
+    list.byId = new Map([
+      ['a', { _id: 'a', link: 'http://a', kind: 'web' }],
+    ]) as unknown as NonNullable<StreamList['byId']>
+
+    const result = deriveWallViews({
+      fullscreenViewIdx: null,
+      streams: list,
+      viewsState: viewsStateWith({ '0': 'a' }),
+      cols: 1,
+      rows: 1,
+    })
+
+    expect(result.contentMap.get('0')).toEqual({ url: 'http://a', kind: 'web' })
+  })
+
+  it('keeps the first stream when two share an id', () => {
+    const result = deriveWallViews({
+      fullscreenViewIdx: null,
+      streams: streams([
+        { _id: 'dup', link: 'http://first', kind: 'video' },
+        { _id: 'dup', link: 'http://second', kind: 'web' },
+      ]),
+      viewsState: viewsStateWith({ '0': 'dup' }),
+      cols: 1,
+      rows: 1,
+    })
+
+    expect(result.contentMap.get('0')).toEqual({
+      url: 'http://first',
+      kind: 'video',
+    })
+  })
 })
 
 describe('deriveWallViews — fullscreen', () => {

--- a/packages/streamwall/src/main/wallViews.ts
+++ b/packages/streamwall/src/main/wallViews.ts
@@ -1,9 +1,25 @@
 import {
+  type StreamData,
   type StreamList,
   type ViewContentMap,
   fullscreenViewContentMap,
 } from 'streamwall-shared'
 import * as Y from 'yjs'
+
+/**
+ * Indexes a stream list by `_id` for O(1) cell resolution. First entry wins on
+ * a duplicate id, preserving the first-match behaviour of the `streams.find`
+ * scan this replaces.
+ */
+function buildStreamById(streams: StreamList): Map<string, StreamData> {
+  const byId = new Map<string, StreamData>()
+  for (const stream of streams) {
+    if (stream._id != null && !byId.has(stream._id)) {
+      byId.set(stream._id, stream)
+    }
+  }
+  return byId
+}
 
 export interface DeriveWallViewsInput {
   /** The view currently expanded to fill the wall, or null for the normal grid. */
@@ -54,9 +70,16 @@ export function deriveWallViews({
   cols,
   rows,
 }: DeriveWallViewsInput): WallViews {
+  // Resolve cell assignments through an id -> stream index built once per
+  // invocation, rather than scanning the whole stream list per cell. Prefer the
+  // index the data pipeline already attached (see combine.ts); fall back to
+  // building one here so callers that pass a bare list still work. First entry
+  // wins on a duplicate id, matching the previous `streams.find(...)` scan.
+  const byId = streams.byId ?? buildStreamById(streams)
+
   if (fullscreenViewIdx != null) {
     const streamId = viewsState.get(String(fullscreenViewIdx))?.get('streamId')
-    const stream = streams.find((s) => s._id === streamId)
+    const stream = streamId != null ? byId.get(streamId) : undefined
     if (stream) {
       return {
         mode: 'fullscreen',
@@ -71,7 +94,7 @@ export function deriveWallViews({
   const contentMap: ViewContentMap = new Map()
   for (const [key, viewData] of viewsState) {
     const streamId = viewData.get('streamId')
-    const stream = streams.find((s) => s._id === streamId)
+    const stream = streamId != null ? byId.get(streamId) : undefined
     if (!stream) {
       continue
     }


### PR DESCRIPTION
## Summary

`deriveWallViews` resolved each grid cell's stream (and the fullscreen view) with `streams.find(...)`, an O(cells × streams) linear scan that runs on the hottest state path in the main process: every data-source tick, every `viewsState` observer fire (each drag / collab edit), and every resize. With aggregated JSON feeds (hundreds of streams) on a dense grid, that is thousands of comparisons per tick for what should be an O(1) lookup.

## Changes

- Add an optional `byId` index to `StreamList` in `streamwall-shared`, alongside the existing `byURL`.
- Build `byId` once in `combineDataSources` (`data/combine.ts`), right after `StreamIDGenerator` assigns the ids, keyed by `_id`.
- Use the index in `deriveWallViews` for O(1) per-cell resolution. When a caller passes a bare list without the index attached, it falls back to building one locally once per invocation (still O(streams + cells) instead of O(cells × streams)).
- On a duplicate id the first entry wins, preserving the previous `streams.find(...)` first-match semantics.

Behavior-preserving; the existing `deriveWallViews` tests still pass. Added coverage for the caller-attached-index path, the duplicate-id first-match rule, and the `byId` attachment in `combineDataSources`.

## Verification

- `npm run test` (streamwall package): 898 passed
- `npm run typecheck`, `npm run lint`, `npm run format`: clean

Closes #628