### PR TITLE
fix(streamwall): revoke replaced snapshot poster object URLs

### DIFF
--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -755,6 +755,143 @@ describe('mediaPreload MutationObserver lifecycle (issue #412)', () => {
   })
 })
 
+describe('mediaPreload snapshot poster object URL lifecycle (issue #616)', () => {
+  // Must match the snapshot interval in acquireMedia (mediaPreload.ts).
+  const SNAPSHOT_INTERVAL_MS = 1000
+
+  let createdURLs: string[]
+  const createObjectURL = vi.fn(() => {
+    const url = `blob:snapshot-${createdURLs.length + 1}`
+    createdURLs.push(url)
+    return url
+  })
+  const revokeObjectURL = vi.fn()
+  const originalCreateObjectURL = Object.getOwnPropertyDescriptor(
+    URL,
+    'createObjectURL',
+  )
+  const originalRevokeObjectURL = Object.getOwnPropertyDescriptor(
+    URL,
+    'revokeObjectURL',
+  )
+
+  function restoreURLMethod(
+    name: 'createObjectURL' | 'revokeObjectURL',
+    descriptor: PropertyDescriptor | undefined,
+  ) {
+    if (descriptor) {
+      Object.defineProperty(URL, name, descriptor)
+    } else {
+      delete (URL as Record<string, unknown>)[name]
+    }
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    createdURLs = []
+    // happy-dom provides no canvas rendering or blob URL support, so stub the
+    // pieces snapshotVideo needs: a 2d context to draw into, a toBlob that
+    // synchronously delivers a blob, and the object URL registry under test.
+    // The static methods are patched in place (and restored below) rather
+    // than replacing the URL global, which must stay constructable.
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: createObjectURL,
+    })
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: revokeObjectURL,
+    })
+    Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+      configurable: true,
+      value: () => ({ drawImage: vi.fn() }),
+    })
+    Object.defineProperty(HTMLCanvasElement.prototype, 'toBlob', {
+      configurable: true,
+      value: (callback: (blob: Blob) => void) => {
+        callback(new Blob(['snapshot']))
+      },
+    })
+  })
+
+  afterEach(() => {
+    restoreURLMethod('createObjectURL', originalCreateObjectURL)
+    restoreURLMethod('revokeObjectURL', originalRevokeObjectURL)
+    delete (HTMLCanvasElement.prototype as { getContext?: unknown }).getContext
+    delete (HTMLCanvasElement.prototype as { toBlob?: unknown }).toBlob
+    createObjectURL.mockClear()
+    revokeObjectURL.mockClear()
+    vi.useRealTimers()
+    vi.resetModules()
+    invoke.mockClear()
+    send.mockClear()
+    on.mockClear()
+    exposeInMainWorld.mockClear()
+    document.body.innerHTML = ''
+  })
+
+  // Same acquisition setup as the pause/resume tests, plus a synchronous
+  // requestVideoFrameCallback so each snapshot tick runs to completion within
+  // the same timer advance that scheduled it.
+  async function loadAcquiredVideo(): Promise<HTMLVideoElement> {
+    const video = document.createElement('video')
+    ;(video as unknown as { videoWidth: number }).videoWidth = 100
+    ;(video as unknown as { videoHeight: number }).videoHeight = 100
+    ;(
+      video as unknown as {
+        requestVideoFrameCallback: (callback: () => void) => void
+      }
+    ).requestVideoFrameCallback = (callback) => callback()
+    document.body.appendChild(video)
+
+    invoke.mockResolvedValueOnce({
+      content: { kind: 'video', link: 'https://example.com/stream' },
+      options: {},
+      volume: 1,
+    })
+
+    await import('./mediaPreload')
+    document.dispatchEvent(new Event('DOMContentLoaded'))
+    process.emit('loaded' as never)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(send).toHaveBeenCalledWith('view-loaded')
+    return video
+  }
+
+  it('revokes the previous poster object URL when the next snapshot replaces it', async () => {
+    const video = await loadAcquiredVideo()
+
+    await vi.advanceTimersByTimeAsync(SNAPSHOT_INTERVAL_MS)
+    expect(createObjectURL).toHaveBeenCalledTimes(1)
+    expect(video.poster).toBe(createdURLs[0])
+    // Nothing to release yet: the first snapshot has no predecessor.
+    expect(revokeObjectURL).not.toHaveBeenCalled()
+
+    // Each subsequent tick must release the blob pinned by the previous
+    // poster, or a long-running view accumulates one PNG blob per second.
+    await vi.advanceTimersByTimeAsync(SNAPSHOT_INTERVAL_MS)
+    expect(revokeObjectURL).toHaveBeenCalledWith(createdURLs[0])
+    expect(video.poster).toBe(createdURLs[1])
+
+    await vi.advanceTimersByTimeAsync(SNAPSHOT_INTERVAL_MS)
+    expect(revokeObjectURL).toHaveBeenCalledWith(createdURLs[1])
+    expect(revokeObjectURL).not.toHaveBeenCalledWith(createdURLs[2])
+  })
+
+  it('revokes the last poster object URL when the page goes away', async () => {
+    await loadAcquiredVideo()
+
+    await vi.advanceTimersByTimeAsync(SNAPSHOT_INTERVAL_MS)
+    expect(createObjectURL).toHaveBeenCalledTimes(1)
+    expect(revokeObjectURL).not.toHaveBeenCalled()
+
+    window.dispatchEvent(new Event('pagehide'))
+
+    expect(revokeObjectURL).toHaveBeenCalledWith(createdURLs[0])
+  })
+})
+
 describe('mediaPreload pause/resume handling (issue #374)', () => {
   beforeEach(() => {
     vi.useFakeTimers()

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -130,6 +130,16 @@ class SnapshotController {
 
   constructor() {
     this.canvas = document.createElement('canvas')
+    // Object URLs pin their blobs until revoked or the document is destroyed,
+    // so release the final poster's blob when the page goes away.
+    window.addEventListener('pagehide', () => this.revokeLatest())
+  }
+
+  revokeLatest() {
+    if (this.latestSnapshotURL) {
+      URL.revokeObjectURL(this.latestSnapshotURL)
+      this.latestSnapshotURL = null
+    }
   }
 
   async snapshotVideo(videoEl: HTMLVideoElement) {
@@ -156,11 +166,14 @@ class SnapshotController {
           return
         }
 
-        if (this.latestSnapshotURL) {
-          URL.revokeObjectURL(this.latestSnapshotURL)
-        }
+        // Release the blob pinned by the previous poster before replacing
+        // it: snapshots arrive once per second, so a poster URL that is
+        // never revoked leaks one full-resolution PNG blob per tick for the
+        // rest of the document's life (issue #616).
+        this.revokeLatest()
 
         const url = URL.createObjectURL(blob)
+        this.latestSnapshotURL = url
         videoEl.poster = url
       }, 'image/png')
     })


### PR DESCRIPTION
## Problem
`SnapshotController.latestSnapshotURL` was declared and checked but never assigned, so the revoke branch in `snapshotVideo` was dead code. `acquireMedia` snapshots every video tile once per second, and each tick created a fresh full-resolution PNG blob object URL that was never released. Object URLs pin their blobs until revoked or the document is destroyed, so a long-running wall accumulated renderer memory proportional to uptime x tile count.

## Solution
- Assign `this.latestSnapshotURL` right after `URL.createObjectURL`, so each snapshot tick revokes the previous poster's URL via the (now reachable) revoke branch, extracted into a `revokeLatest()` helper.
- Register a `pagehide` listener in the controller so the final poster's blob is also released on teardown, matching the observer-teardown pattern already used in this preload.

## Testing
- New regression tests in `mediaPreload.test.ts` ("snapshot poster object URL lifecycle (issue #616)"): stubbed `URL.createObjectURL`/`revokeObjectURL` plus a synchronous `requestVideoFrameCallback`/canvas harness verify that the second snapshot revokes the first poster URL (and so on for each subsequent tick), and that `pagehide` revokes the last one. Both tests failed before the fix (zero revoke calls) and pass after.
- Full quality gate: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` all pass.

Closes #616