### PR TITLE
fix(streamwall): keep rotation and paused state across media re-acquisition

### DIFF
--- a/packages/streamwall/src/main/viewStateMachine.test.ts
+++ b/packages/streamwall/src/main/viewStateMachine.test.ts
@@ -1387,3 +1387,101 @@ describe('viewStateMachine pause/resume IPC (issue #374)', () => {
     expect(sendViewResume).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('viewStateMachine resyncSwappedView pause re-send (issue #621)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // Unlike makeActorWithSwapSpies above, this keeps the REAL resyncSwappedView
+  // action and instead fakes the webContents of the preloaded next view, so
+  // tests can assert exactly which IPC messages the swapped-in view receives.
+  function makeActorWithRealResync(retry: RetryConfig) {
+    const nextSend = vi.fn()
+    const nextView = { webContents: { send: nextSend, audioMuted: false } }
+    const machine = viewStateMachine.provide({
+      actions: {
+        offscreenView: noop,
+        positionView: noop,
+        offscreenNextView: noop,
+        performSwap: noop,
+        muteAudio: noop,
+        unmuteAudio: noop,
+        openDevTools: noop,
+        sendViewOptions: noop,
+        sendViewVolume: noop,
+        sendViewPause: noop,
+        sendViewResume: noop,
+        logError: noop,
+      },
+      actors: {
+        loadPage: fromPromise(async () => {}),
+      },
+    })
+    const actor = createActor(machine, {
+      input: {
+        id: 1,
+        view: {} as never,
+        win: {} as never,
+        offscreenWin: {} as never,
+        retry,
+        createNextView: () => ({
+          view: nextView as never,
+          offscreenWin: {} as never,
+        }),
+        disposeView: noopDisposeView,
+      },
+    })
+    return { actor, nextSend }
+  }
+
+  async function swapToOtherContent(
+    actor: ReturnType<typeof makeActorWithRealResync>['actor'],
+  ) {
+    actor.send({ type: 'DISPLAY', pos: POS, content: OTHER_CONTENT })
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'NEXT_VIEW_INIT' })
+    actor.send({ type: 'NEXT_VIEW_LOADED' })
+  }
+
+  it('re-sends pause to the swapped-in view when the cell is parked-paused', async () => {
+    const { actor, nextSend } = makeActorWithRealResync(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'PAUSE' })
+
+    await swapToOtherContent(actor)
+
+    // The fresh view starts playing on load; without a pause re-send the
+    // parked cell silently resumes decoding (and potentially audio).
+    expect(nextSend).toHaveBeenCalledWith('pause')
+  })
+
+  it('does not send pause to the swapped-in view when the cell is not paused', async () => {
+    const { actor, nextSend } = makeActorWithRealResync(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+
+    await swapToOtherContent(actor)
+
+    // Sanity check that the real resync ran at all for this swap.
+    expect(nextSend).toHaveBeenCalledWith('volume', 1)
+    expect(nextSend).not.toHaveBeenCalledWith('pause')
+  })
+
+  it('does not send pause to the swapped-in view when the cell was resumed before the swap', async () => {
+    const { actor, nextSend } = makeActorWithRealResync(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'PAUSE' })
+    actor.send({ type: 'RESUME' })
+
+    await swapToOtherContent(actor)
+
+    expect(nextSend).toHaveBeenCalledWith('volume', 1)
+    expect(nextSend).not.toHaveBeenCalledWith('pause')
+  })
+})

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -319,12 +319,18 @@ const viewStateMachine = setup({
     // options/volume/mute state that the retired view already had, since
     // none of `running`'s own entry actions re-fire for an in-place swap.
     resyncSwappedView: ({ context }) => {
-      const { view, options, volume, desiredAudio } = context
+      const { view, options, volume, desiredAudio, desiredPaused } = context
       view.webContents.audioMuted = desiredAudio === 'muted'
       if (options) {
         view.webContents.send('options', options)
       }
       view.webContents.send('volume', volume)
+      // The pause region's `paused` entry action does not re-fire for an
+      // in-place swap, so a parked (paused) cell must re-send the pause to
+      // the fresh view or it comes up playing (issue #621).
+      if (desiredPaused) {
+        view.webContents.send('pause')
+      }
     },
   },
 

--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -760,7 +760,14 @@ describe('mediaPreload pause/resume handling (issue #374)', () => {
     vi.useFakeTimers()
   })
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Some tests here never dispatch DOMContentLoaded, leaving their module
+    // instance's media search pending on the page-ready gate. Run out the
+    // acquisition timeout while this test's fake timers are still in charge
+    // so the abandoned search aborts for good -- otherwise a later describe's
+    // DOMContentLoaded would revive it against that test's document and the
+    // stale instance would acquire (and start mutating) the new test's video.
+    await vi.advanceTimersByTimeAsync(10 * 1000)
     vi.useRealTimers()
     vi.resetModules()
     invoke.mockClear()
@@ -1029,5 +1036,144 @@ describe('RotationController', () => {
     controller.setCustom(45)
     expect(video.className).toBe('__rot90__')
     expect(warn).toHaveBeenCalledWith('ignoring invalid rotation', 45)
+  })
+})
+
+describe('mediaPreload re-acquisition keeps operator-set state (issues #620/#621)', () => {
+  // Must match SCAN_THROTTLE in mediaPreload.ts: long enough for the
+  // re-acquisition's throttled scan to find the replacement element.
+  const SCAN_THROTTLE_MS = 500
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.resetModules()
+    invoke.mockClear()
+    send.mockClear()
+    on.mockClear()
+    exposeInMainWorld.mockClear()
+    document.body.innerHTML = ''
+  })
+
+  function registeredHandler(
+    channel: string,
+  ): (ev: unknown, ...args: unknown[]) => void {
+    const call = on.mock.calls.find(([ch]) => ch === channel)
+    if (!call) {
+      throw new Error(`no ipcRenderer.on('${channel}', ...) handler registered`)
+    }
+    return call[1] as (ev: unknown, ...args: unknown[]) => void
+  }
+
+  function viewLoadedCalls() {
+    return send.mock.calls.filter(([channel]) => channel === 'view-loaded')
+  }
+
+  // happy-dom's HTMLVideoElement never implements videoWidth, so give it a
+  // truthy value to skip findMedia's "wait for playing" branch.
+  function playableVideo(): HTMLVideoElement {
+    const video = document.createElement('video')
+    ;(video as unknown as { videoWidth: number }).videoWidth = 100
+    return video
+  }
+
+  async function loadAcquiredVideo(
+    options: Record<string, unknown> = {},
+  ): Promise<HTMLVideoElement> {
+    const video = playableVideo()
+    document.body.appendChild(video)
+
+    invoke.mockResolvedValueOnce({
+      content: { kind: 'video', link: 'https://example.com/stream' },
+      options,
+      volume: 1,
+    })
+
+    await import('./mediaPreload')
+    document.dispatchEvent(new Event('DOMContentLoaded'))
+    process.emit('loaded' as never)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(viewLoadedCalls()).toHaveLength(1)
+    return video
+  }
+
+  // Simulates an HLS teardown that discards the old element entirely: the
+  // page swaps in a brand-new <video>, and the 'emptied' handler's
+  // re-acquisition finds that one instead of the original.
+  async function reacquireOnNewElement(
+    oldVideo: HTMLVideoElement,
+  ): Promise<HTMLVideoElement> {
+    oldVideo.remove()
+    const next = playableVideo()
+    document.body.appendChild(next)
+    oldVideo.dispatchEvent(new Event('emptied'))
+    await vi.advanceTimersByTimeAsync(SCAN_THROTTLE_MS)
+    expect(viewLoadedCalls()).toHaveLength(2)
+    return next
+  }
+
+  it('applies the initial rotation from view-init options once media is acquired', async () => {
+    const video = await loadAcquiredVideo({ rotation: 180 })
+
+    expect(video.className).toBe('__rot180__')
+  })
+
+  it('keeps an operator-set rotation across an emptied re-acquisition (issue #620)', async () => {
+    const video = await loadAcquiredVideo()
+    registeredHandler('options')(undefined, { rotation: 90 })
+    expect(video.className).toBe('__rot90__')
+
+    const next = await reacquireOnNewElement(video)
+
+    expect(next.className).toBe('__rot90__')
+  })
+
+  it('keeps a parked view paused across an emptied re-acquisition (issue #621)', async () => {
+    const video = await loadAcquiredVideo()
+    registeredHandler('pause')()
+    expect(video.paused).toBe(true)
+
+    const next = await reacquireOnNewElement(video)
+
+    expect(next.paused).toBe(true)
+  })
+
+  it('keeps a parked view paused when re-acquisition finds the same element again', async () => {
+    const video = await loadAcquiredVideo()
+    registeredHandler('pause')()
+    expect(video.paused).toBe(true)
+
+    video.dispatchEvent(new Event('emptied'))
+    await vi.advanceTimersByTimeAsync(SCAN_THROTTLE_MS)
+    expect(viewLoadedCalls()).toHaveLength(2)
+
+    expect(video.paused).toBe(true)
+  })
+
+  it('resumes the re-acquired element on a later resume message', async () => {
+    const video = await loadAcquiredVideo()
+    registeredHandler('pause')()
+    const next = await reacquireOnNewElement(video)
+    expect(next.paused).toBe(true)
+
+    registeredHandler('resume')()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(next.paused).toBe(false)
+  })
+
+  it('does not pause a re-acquired element for a view that was resumed before the stall', async () => {
+    const video = await loadAcquiredVideo()
+    registeredHandler('pause')()
+    registeredHandler('resume')()
+    await vi.advanceTimersByTimeAsync(0)
+
+    const next = await reacquireOnNewElement(video)
+
+    expect(next.paused).toBe(false)
   })
 })

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -583,6 +583,16 @@ async function main() {
   let rotationController: RotationController | undefined
   let volumeController: VolumeController | undefined
   let latestVolume = initialVolume ?? 1
+  // The most recent operator-set rotation, mirroring `latestVolume`: a
+  // re-acquisition constructs a fresh RotationController (which starts at
+  // 0°), and no 'options' message is re-sent for the internal stall
+  // recovery, so the tracked value is re-applied below (issue #620).
+  let latestRotation: number | undefined = initialOptions?.rotation
+  // Whether the operator asked this view's playback to stay paused (a parked
+  // view, issue #374). Tracked so a re-acquisition -- whose findMedia()
+  // unconditionally starts playback -- can re-assert the pause instead of
+  // silently resuming a hidden view (issue #621).
+  let desiredPaused = false
   // The most recently acquired media element (reassigned across a re-
   // acquisition, e.g. the 'emptied' handler below), so a PAUSE/RESUME
   // message received at any point can act on whichever one is current.
@@ -595,10 +605,17 @@ async function main() {
 
     currentMedia = media
     volumeController = new VolumeController(media, latestVolume)
+    if (desiredPaused) {
+      // Same caveat as the 'pause' handler below: lockdownMediaTags()
+      // permanently shadows the element's own `pause` with a no-op, so the
+      // native implementation must be called directly.
+      HTMLMediaElement.prototype.pause.call(media)
+    }
     ipcRenderer.send('view-loaded')
 
     if (content.kind === 'video' && media instanceof HTMLVideoElement) {
       rotationController = new RotationController(media)
+      rotationController.setCustom(latestRotation)
       snapshotInterval = window.setInterval(() => {
         snapshotController.snapshotVideo(media)
       }, 1000)
@@ -662,6 +679,7 @@ async function main() {
   }
 
   function updateOptions(options: ContentDisplayOptions) {
+    latestRotation = options.rotation
     if (rotationController) {
       rotationController.setCustom(options.rotation)
     }
@@ -685,6 +703,7 @@ async function main() {
     // cannot reach, and it should stop fetching segments whether or not a
     // <video> has been acquired here yet (issue #384).
     document.dispatchEvent(new CustomEvent(MEDIA_PAUSE_EVENT))
+    desiredPaused = true
     if (!currentMedia) {
       return
     }
@@ -696,6 +715,7 @@ async function main() {
   })
   ipcRenderer.on('resume', () => {
     document.dispatchEvent(new CustomEvent(MEDIA_RESUME_EVENT))
+    desiredPaused = false
     // Live streams are typically not seekable on-demand video, so resuming
     // after a pause may briefly re-buffer or land slightly behind the live
     // edge -- both cheaper than a full reload and expected to self-correct


### PR DESCRIPTION
## Summary

Two closely related bugs where per-view operator state was lost when media is re-acquired:

- #620: an operator-set rotation snapped back to 0° after a stream stall, because the `'emptied'` re-acquisition constructed a fresh `RotationController` (starting at 0°) and the internal stall recovery never re-sends `'options'`.
- #621: a parked (paused, `--park.pause`) view started playing again after re-acquisition or an in-place content swap, because `findMedia()` unconditionally calls `video.play()`, the preload kept no paused flag, and `resyncSwappedView` re-applied mute/options/volume but not pause.

## Changes

**Preload (`mediaPreload.ts`)**
- Track `latestRotation`, mirroring the existing `latestVolume`, and re-apply it when the `RotationController` is constructed in `acquireMedia`. This also fixes the initial rotation from `view-init` options, which could previously arrive before the controller existed and be dropped.
- Track `desiredPaused` (set/cleared by the `pause`/`resume` IPC handlers) and re-assert the pause after every acquisition via `HTMLMediaElement.prototype.pause.call(media)` — the element's own `pause()` is permanently shadowed as a no-op by `lockdownMediaTags()`.

**Main (`viewStateMachine.ts`)**
- `resyncSwappedView` now re-sends `'pause'` to the swapped-in view when `context.desiredPaused` is set, matching the existing re-sync of mute/options/volume. Previously the invariant only held because unparking happened to send `RESUME`. No new state region, so `viewStateValueSchema` is unaffected.

**Tests**
- Regression tests for both bugs, written first and verified to fail before the fix: rotation and paused state across an `'emptied'` re-acquisition (both same-element and new-element flows), resume acting on the re-acquired element, and pause re-send (positive and negative) in `resyncSwappedView`.
- Fixed a latent test-isolation leak in the pause/resume describe: tests that never dispatch `DOMContentLoaded` left their module instance's media search pending, and a later describe's `DOMContentLoaded` revived it against that test's document. The searches are now drained in `afterEach` while the test's fake timers are still active.

Closes #620
Closes #621