### PR TITLE
fix(streamwall): catch remaining fire-and-forget media load/play rejections

### DIFF
--- a/packages/streamwall/src/main/ControlWindow.test.ts
+++ b/packages/streamwall/src/main/ControlWindow.test.ts
@@ -30,7 +30,9 @@ vi.mock('electron', () => ({
   shell: { openPath },
 }))
 
-vi.mock('./loadHTML', () => ({ loadHTML: vi.fn() }))
+// Returns a resolved promise like the real loadHTML, so the caller's `.catch`
+// breadcrumb (issue #626) has something to attach to.
+vi.mock('./loadHTML', () => ({ loadHTML: vi.fn(() => Promise.resolve()) }))
 
 const createExampleConfig = vi.fn()
 vi.mock('./exampleConfig', () => ({ createExampleConfig }))

--- a/packages/streamwall/src/main/ControlWindow.ts
+++ b/packages/streamwall/src/main/ControlWindow.ts
@@ -7,6 +7,7 @@ import { type UpdateStatus } from '../updateStatus'
 import { type ControlCommandResult } from './commandDispatch'
 import { createExampleConfig } from './exampleConfig'
 import { loadHTML } from './loadHTML'
+import log from './logger'
 
 export type ControlCommandHandler = (
   command: ControlCommand,
@@ -59,7 +60,11 @@ export default class ControlWindow extends EventEmitter<ControlWindowEventMap> {
 
     this.win.on('close', (event) => this.emit('close', event))
 
-    loadHTML(this.win.webContents, 'control')
+    // A superseded load rejects with ERR_ABORTED; log it so it leaves a
+    // breadcrumb instead of an unhandled promise rejection (issue #392/#626).
+    loadHTML(this.win.webContents, 'control').catch((err) => {
+      log.warn('error loading control window', err)
+    })
 
     ipcMain.handle('control:load', (ev) => {
       if (ev.sender !== this.win.webContents) {

--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -115,7 +115,9 @@ vi.mock('electron', () => {
 // build, and would resolve renderer HTML off disk. The constructor test only
 // cares about which page each layer is told to load, so record the calls.
 vi.mock('./loadHTML', () => ({
-  loadHTML: vi.fn(),
+  // Returns a resolved promise like the real loadHTML, so the caller's `.catch`
+  // breadcrumb (issue #626) has something to attach to.
+  loadHTML: vi.fn(() => Promise.resolve()),
   devServerOrigin: () => undefined,
 }))
 

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -25,6 +25,7 @@ import {
 } from 'streamwall-shared'
 import { createActor, EventFrom, SnapshotFrom } from 'xstate'
 import { devServerOrigin, loadHTML } from './loadHTML'
+import log from './logger'
 import { secureStreamView } from './navigationSecurity'
 import { allocateViewPartition, hardenSession } from './partitions'
 import { planViewLayout, type ViewCandidate } from './viewLayoutPlan'
@@ -189,7 +190,11 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
       width,
       height,
     })
-    loadHTML(layerView.webContents, page)
+    // A superseded load rejects with ERR_ABORTED; log it so it leaves a
+    // breadcrumb instead of an unhandled promise rejection (issue #392/#626).
+    loadHTML(layerView.webContents, page).catch((err) => {
+      log.warn('error loading chrome layer', page, err)
+    })
     return layerView
   }
 

--- a/packages/streamwall/src/main/loadHTML.ts
+++ b/packages/streamwall/src/main/loadHTML.ts
@@ -20,21 +20,28 @@ export function devServerOrigin(): string | undefined {
   }
 }
 
+/**
+ * Loads one of the renderer HTML pages into `webContents`. Returns the
+ * underlying `loadURL`/`loadFile` promise so callers can attach a `.catch`
+ * breadcrumb: a superseded navigation (e.g. a reload/swap racing an in-flight
+ * load) rejects with `ERR_ABORTED`, which is otherwise invisible and surfaces
+ * as an unhandled promise rejection (issue #392/#626).
+ */
 export function loadHTML(
   webContents: WebContents,
   name: 'background' | 'overlay' | 'playHLS' | 'control',
   options?: { query?: Record<string, string> },
-) {
+): Promise<void> {
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
     const queryString = options?.query
       ? '?' + querystring.stringify(options.query)
       : ''
-    webContents.loadURL(
+    return webContents.loadURL(
       `${MAIN_WINDOW_VITE_DEV_SERVER_URL}/src/renderer/${name}.html` +
         queryString,
     )
   } else {
-    webContents.loadFile(
+    return webContents.loadFile(
       path.join(
         __dirname,
         `../renderer/${MAIN_WINDOW_VITE_NAME}/src/renderer/${name}.html`,

--- a/packages/streamwall/src/main/viewStateMachine.test.ts
+++ b/packages/streamwall/src/main/viewStateMachine.test.ts
@@ -801,6 +801,38 @@ describe('viewStateMachine loadPage navigation', () => {
 
     warnSpy.mockRestore()
   })
+
+  it('logs a warning when the HLS navigation load rejects (issue #626)', async () => {
+    // The HLS branch routes through loadHTML (which calls loadURL under the
+    // hood) and is likewise not awaited, so a superseding reload/swap that
+    // aborts the in-flight navigation would otherwise vanish with no log
+    // breadcrumb. Stub the dev-server global so loadHTML takes its loadURL
+    // path instead of the packaged loadFile path.
+    vi.stubGlobal('MAIN_WINDOW_VITE_DEV_SERVER_URL', 'http://localhost:5173')
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {})
+    const { actor, loadURL } = makeActorWithRealLoadPage(makeRetry())
+    const loadErr = new Error('net::ERR_ABORTED')
+    loadURL.mockRejectedValue(loadErr)
+    const hlsUrl = 'https://example.com/live.m3u8'
+
+    actor.start()
+    actor.send({
+      type: 'DISPLAY',
+      pos: POS,
+      content: { url: hlsUrl, kind: 'video' as const },
+    })
+
+    await vi.waitFor(() =>
+      expect(warnSpy).toHaveBeenCalledWith(
+        'error loading HLS view URL',
+        hlsUrl,
+        loadErr,
+      ),
+    )
+
+    warnSpy.mockRestore()
+    vi.unstubAllGlobals()
+  })
 })
 
 describe('viewStateMachine deferred MUTE/BLUR/BACKGROUND requests', () => {

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -392,7 +392,16 @@ const viewStateMachine = setup({
         wc.audioMuted = true
 
         if (/\.m3u8?$/.test(content.url)) {
-          loadHTML(wc, 'playHLS', { query: { src: content.url } })
+          // Do NOT await (same reason as the loadURL branch below). A reload or
+          // swap superseding this in-flight navigation rejects with
+          // ERR_ABORTED, which is invisible to the 'did-fail-load' listener;
+          // log it so it leaves a breadcrumb instead of an unhandled promise
+          // rejection (issue #392/#626).
+          loadHTML(wc, 'playHLS', { query: { src: content.url } }).catch(
+            (err) => {
+              log.warn('error loading HLS view URL', content.url, err)
+            },
+          )
         } else {
           // Do NOT await: the preload sends VIEW_INIT before loadURL resolves
           // (did-finish-load), so awaiting here would strand that event and hang

--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -244,6 +244,66 @@ describe("mediaPreload emptied handler's re-acquisition rejection", () => {
   })
 })
 
+describe('mediaPreload acquisition play() rejection (issue #626)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.resetModules()
+    vi.restoreAllMocks()
+    invoke.mockClear()
+    send.mockClear()
+    on.mockClear()
+    exposeInMainWorld.mockClear()
+    document.body.innerHTML = ''
+  })
+
+  function viewErrorCalls() {
+    return send.mock.calls.filter(([channel]) => channel === 'view-error')
+  }
+
+  it('logs and swallows the acquisition play() rejection instead of leaving it unhandled', async () => {
+    const video = document.createElement('video')
+    // happy-dom never sets videoWidth, so give it a truthy value to skip
+    // findMedia's "wait for playing" branch and let acquisition resolve as
+    // soon as the element is found.
+    ;(video as unknown as { videoWidth: number }).videoWidth = 100
+    document.body.appendChild(video)
+
+    // The acquisition's fire-and-forget play() rejects (e.g. autoplay policy
+    // or a load interrupted by a superseding acquisition).
+    const playError = new Error('play interrupted')
+    const play = vi
+      .spyOn(HTMLMediaElement.prototype, 'play')
+      .mockRejectedValue(playError)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    invoke.mockResolvedValueOnce({
+      content: { kind: 'video', link: 'https://example.com/stream' },
+      options: {},
+      volume: 1,
+    })
+
+    await import('./mediaPreload')
+    document.dispatchEvent(new Event('DOMContentLoaded'))
+    process.emit('loaded' as never)
+    await vi.advanceTimersByTimeAsync(0)
+
+    // The rejection is caught and logged as a breadcrumb, and acquisition
+    // still completes rather than being derailed or leaking an unhandled
+    // rejection.
+    expect(play).toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledWith(
+      'error starting media playback',
+      playError,
+    )
+    expect(send).toHaveBeenCalledWith('view-loaded')
+    expect(viewErrorCalls()).toEqual([])
+  })
+})
+
 describe('mediaPreload iframe video extraction (issue #413)', () => {
   // Must match INITIAL_TIMEOUT in mediaPreload.ts; the iframe scan only runs
   // after the top-level <video> wait loses its race against this timeout.

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -510,7 +510,13 @@ async function findMedia(
     document.body.appendChild(video)
   }
 
-  video.play()
+  // Fire-and-forget: playback readiness is confirmed below via videoWidth, so
+  // the play() promise is not awaited. A rejection (autoplay policy, or a load
+  // interrupted by a superseding acquisition) is otherwise invisible, so log it
+  // as a breadcrumb, symmetric with the resume path (issue #392/#626).
+  video.play().catch((err) => {
+    console.warn('error starting media playback', err)
+  })
 
   if (video instanceof HTMLVideoElement && !video.videoWidth) {
     console.log(`video isn't playing yet. waiting for it to start...`)


### PR DESCRIPTION
## Summary
The #392/#309 hardening (catch and log load rejections) covered the non-HLS navigation branch and the resume path, but three sibling fire-and-forget paths still discarded their promises. A superseded navigation (`ERR_ABORTED` from a reload/swap racing an in-flight load, or an actor torn down mid-load) or an interrupted / autoplay-policy `play()` rejection therefore surfaced as an unhandled promise rejection (log/reporting noise, potentially via Sentry) instead of a log breadcrumb.

## Changes
- `loadHTML` now returns the underlying `loadURL`/`loadFile` promise so callers can attach a breadcrumb `.catch`.
- The `viewStateMachine` HLS branch, the `StreamWindow` chrome-layer load, and the `ControlWindow` load each attach a `.catch(log.warn)`, symmetric with the existing non-HLS branch.
- The `mediaPreload` acquisition `play()` gets the same breadcrumb `.catch` as the resume path (#392).

## Tests
- `viewStateMachine.test.ts`: new regression test asserting the HLS load rejection is logged (mirrors the existing non-HLS rejection test).
- `mediaPreload.test.ts`: new regression test asserting the acquisition `play()` rejection is caught and logged, and acquisition still completes without a `view-error`.
- Updated the `loadHTML` mocks in `StreamWindow.test.ts` / `ControlWindow.test.ts` to return a resolved promise, matching the real return type.

## Impact
Low - eliminates log/reporting noise and aligns these paths with the existing #392 pattern; no user-visible behavior change.

Closes #626
