### PR TITLE
refactor(streamwall): remove dead RotationController.siteRotation field

### DIFF
--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -101,7 +101,6 @@ const pageReady = new Promise((resolve) =>
 
 export class RotationController {
   video: HTMLVideoElement
-  siteRotation = 0
   customRotation: number
 
   constructor(video: HTMLVideoElement) {


### PR DESCRIPTION
## Problem

`RotationController` in `packages/streamwall/src/preload/mediaPreload.ts` declared and initialized a `siteRotation = 0` field that was never read or written anywhere in the codebase. `_update()` only uses `customRotation`; the field was a leftover from an earlier design where the site's intrinsic rotation was meant to be combined with the user's custom rotation.

## Solution

Remove the dead field. A repo-wide search confirmed `siteRotation` had no other references, so the removal has no ripple effects. The combined-rotation behavior was never implemented and is not reinstated here.

## Testing

- `npm run format` (no changes), `npm run lint`, `npm run typecheck` — clean
- `npm run test` — full suite passes, including the existing `RotationController` tests in `mediaPreload.test.ts`

Closes #643