### PR TITLE
fix(streamwall): guard onState layer sends against destroyed webContents

### DIFF
--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -337,6 +337,73 @@ describe('StreamWindow.emitState', () => {
   })
 })
 
+describe('StreamWindow.onState', () => {
+  /**
+   * A stand-in for a layer WebContentsView whose `send` throws once the
+   * webContents is marked destroyed, mirroring Electron's "Object has been
+   * destroyed" behavior (issue #651).
+   */
+  function makeFakeLayerView(destroyed = false) {
+    const send = vi.fn(() => {
+      if (destroyed) {
+        throw new Error('Object has been destroyed')
+      }
+    })
+    return {
+      view: {
+        webContents: { send, isDestroyed: () => destroyed },
+      } as unknown as InstanceType<typeof StreamWindow>['overlayView'],
+      send,
+    }
+  }
+
+  const state = { streams: {} } as Parameters<
+    typeof StreamWindow.prototype.onState
+  >[0]
+
+  it('sends the state to both layer webContents', () => {
+    const sw = makeStreamWindow(makeConfig())
+    const overlay = makeFakeLayerView()
+    const background = makeFakeLayerView()
+    sw.overlayView = overlay.view
+    sw.backgroundView = background.view
+    sw.views = new Map()
+
+    sw.onState(state)
+
+    expect(overlay.send).toHaveBeenCalledWith('state', state)
+    expect(background.send).toHaveBeenCalledWith('state', state)
+  })
+
+  it('skips a destroyed layer webContents instead of throwing (issue #651)', () => {
+    const sw = makeStreamWindow(makeConfig())
+    const overlay = makeFakeLayerView(true)
+    const background = makeFakeLayerView()
+    sw.overlayView = overlay.view
+    sw.backgroundView = background.view
+    sw.views = new Map()
+
+    expect(() => sw.onState(state)).not.toThrow()
+
+    expect(overlay.send).not.toHaveBeenCalled()
+    expect(background.send).toHaveBeenCalledWith('state', state)
+  })
+
+  it('does not throw when both layer webContents are destroyed', () => {
+    const sw = makeStreamWindow(makeConfig())
+    const overlay = makeFakeLayerView(true)
+    const background = makeFakeLayerView(true)
+    sw.overlayView = overlay.view
+    sw.backgroundView = background.view
+    sw.views = new Map()
+
+    expect(() => sw.onState(state)).not.toThrow()
+
+    expect(overlay.send).not.toHaveBeenCalled()
+    expect(background.send).not.toHaveBeenCalled()
+  })
+})
+
 function makeFakeViewActorWithSnapshot(snapshot: {
   value: unknown
   context: Record<string, unknown>

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -728,8 +728,15 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
   }
 
   onState(state: StreamwallState) {
-    this.overlayView.webContents.send('state', state)
-    this.backgroundView.webContents.send('state', state)
+    // A layer's webContents may already be gone during window teardown (or a
+    // future recreate flow); sending to a destroyed webContents throws. Same
+    // guard as the `devtools-overlay` handler (issue #651).
+    for (const layerView of [this.overlayView, this.backgroundView]) {
+      const { webContents } = layerView
+      if (!webContents.isDestroyed()) {
+        webContents.send('state', state)
+      }
+    }
 
     for (const view of this.views.values()) {
       const { content } = view.getSnapshot().context


### PR DESCRIPTION
## Problem

`StreamWindow.onState()` called `this.overlayView.webContents.send('state', state)` and `this.backgroundView.webContents.send('state', state)` unconditionally. If either layer's webContents has already been destroyed (window teardown / shutdown, or a future recreate flow), `webContents.send` throws `Object has been destroyed`. This is the sibling of the `devtools-overlay` guard added in #648 (issue #629), which deliberately left the `onState` send paths out of scope.

## Solution

Guard both layer sends with `webContents.isDestroyed()` before calling `send`, iterating over the two layer views so both get the same guard. Mirrors the existing guard in the `devtools-overlay` handler. The per-view OPTIONS loop below is untouched (view actors have their own lifecycle).

## Testing

Added a `StreamWindow.onState` describe block to `StreamWindow.test.ts` following the existing `makeStreamWindow` prototype-instance pattern, with a layer-view double whose `send` throws `Object has been destroyed` when marked destroyed (mirroring Electron):
- sends the state to both layer webContents in the normal case
- skips a destroyed layer without throwing while still sending to the live one
- does not throw when both layers are destroyed

Written TDD: the destroyed-layer tests failed against the unguarded code and pass with the guard.

- `npm run format` (no changes), `npm run lint`, `npm run typecheck` — clean
- `npm run test` — full suite passes

Closes #651