### PR TITLE
refactor(shared): share the /admin/status shape via a single zod schema

### DIFF
--- a/packages/streamwall-control-server/src/updateCheck.ts
+++ b/packages/streamwall-control-server/src/updateCheck.ts
@@ -6,6 +6,7 @@ import {
   isNewerVersion,
   type GithubReleaseFetchImpl,
   type LatestRelease,
+  type ServerStatus,
 } from 'streamwall-shared'
 
 import type { Logger } from './logger.ts'
@@ -61,17 +62,12 @@ export function isUpdateCheckEnabled(raw: string | undefined): boolean {
   return !(v === '0' || v === 'false' || v === 'no' || v === 'off')
 }
 
-export interface UpdateStatus {
-  /** Version of the running server. */
-  version: string
-  /** Latest release seen by the most recent successful check, if any. */
-  latestVersion: string | null
-  updateAvailable: boolean
-  releaseUrl: string | null
-  /** ISO timestamp of the last *successful* check. */
-  lastCheckedAt: string | null
-  checkEnabled: boolean
-}
+/**
+ * The `GET /admin/status` payload. Derived from the shared
+ * `serverStatusSchema` (issue #649), which the control UI uses to validate
+ * the fetched body — so this producer and that consumer cannot drift.
+ */
+export type UpdateStatus = ServerStatus
 
 export interface UpdateChecker {
   getStatus(): UpdateStatus

--- a/packages/streamwall-control-ui/src/ServerUpdateBanner.test.tsx
+++ b/packages/streamwall-control-ui/src/ServerUpdateBanner.test.tsx
@@ -1,8 +1,8 @@
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
+import { type ServerStatus } from 'streamwall-shared'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { ServerUpdateBanner } from './ServerUpdateBanner.tsx'
-import { type ServerStatus } from './useServerStatus.ts'
 
 let container: HTMLDivElement | undefined
 

--- a/packages/streamwall-control-ui/src/ServerUpdateBanner.tsx
+++ b/packages/streamwall-control-ui/src/ServerUpdateBanner.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'preact/hooks'
+import { type ServerStatus } from 'streamwall-shared'
 import { styled } from 'styled-components'
-import { type ServerStatus } from './useServerStatus.ts'
 
 const StyledServerUpdateBanner = styled.div`
   display: flex;

--- a/packages/streamwall-control-ui/src/components/ControlBanners.tsx
+++ b/packages/streamwall-control-ui/src/components/ControlBanners.tsx
@@ -1,9 +1,12 @@
-import { type DataSourceHealth, type DisconnectReason } from 'streamwall-shared'
+import {
+  type DataSourceHealth,
+  type DisconnectReason,
+  type ServerStatus,
+} from 'streamwall-shared'
 import { CommandErrorBanner } from '../CommandErrorBanner.tsx'
 import { ConnectionStatusBanner } from '../ConnectionStatusBanner.tsx'
 import { DataSourceHealthBanner } from '../DataSourceHealthBanner.tsx'
 import { ServerUpdateBanner } from '../ServerUpdateBanner.tsx'
-import { type ServerStatus } from '../useServerStatus.ts'
 
 /**
  * The stack of transient status banners shown above the wall: connection

--- a/packages/streamwall-control-ui/src/serverStatusGating.test.tsx
+++ b/packages/streamwall-control-ui/src/serverStatusGating.test.tsx
@@ -1,11 +1,10 @@
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
-import type { StreamwallRole } from 'streamwall-shared'
+import type { ServerStatus, StreamwallRole } from 'streamwall-shared'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import * as Y from 'yjs'
 import type { StreamwallConnection } from './index.tsx'
 import { ControlUI } from './index.tsx'
-import { type ServerStatus } from './useServerStatus.ts'
 
 // react-icons renders through preact/compat's Context.Consumer, which
 // currently crashes under this package's happy-dom test environment

--- a/packages/streamwall-control-ui/src/useServerStatus.test.tsx
+++ b/packages/streamwall-control-ui/src/useServerStatus.test.tsx
@@ -1,11 +1,8 @@
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
+import { type ServerStatus } from 'streamwall-shared'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import {
-  REFRESH_INTERVAL_MS,
-  type ServerStatus,
-  useServerStatus,
-} from './useServerStatus.ts'
+import { REFRESH_INTERVAL_MS, useServerStatus } from './useServerStatus.ts'
 
 let container: HTMLDivElement | undefined
 let fetchMock: ReturnType<typeof vi.fn>

--- a/packages/streamwall-control-ui/src/useServerStatus.ts
+++ b/packages/streamwall-control-ui/src/useServerStatus.ts
@@ -1,22 +1,5 @@
 import { useEffect, useState } from 'preact/hooks'
-import { z } from 'zod'
-
-/**
- * Shape of `GET /admin/status` (mirrors the server's `UpdateStatus` in
- * `streamwall-control-server/src/updateCheck.ts`). Validated at runtime because
- * this is a cross-boundary payload; a malformed body yields no status rather
- * than a mistyped object leaking into the UI.
- */
-export const serverStatusSchema = z.object({
-  version: z.string(),
-  latestVersion: z.string().nullable(),
-  updateAvailable: z.boolean(),
-  releaseUrl: z.string().nullable(),
-  lastCheckedAt: z.string().nullable(),
-  checkEnabled: z.boolean(),
-})
-
-export type ServerStatus = z.infer<typeof serverStatusSchema>
+import { serverStatusSchema, type ServerStatus } from 'streamwall-shared'
 
 /**
  * How often to revalidate `/admin/status` while enabled. The server refreshes

--- a/packages/streamwall-shared/src/schemas.test.ts
+++ b/packages/streamwall-shared/src/schemas.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, test } from 'vitest'
 import {
   type ControlCommand,
   MAX_VIEW_IDX,
+  type ServerStatus,
   controlCommandMessageSchema,
   controlStateMessageSchema,
   localStreamDataSchema,
   parseStreamList,
+  serverStatusSchema,
   streamDataInputSchema,
   streamwallStateSchema,
 } from './schemas.ts'
@@ -752,6 +754,58 @@ describe('streamwallStateSchema', () => {
       // Compile-time guard against schema/type drift.
       const state: StreamwallState = result.data
       expect(state.identity.role).toBe('admin')
+    }
+  })
+})
+
+describe('serverStatusSchema', () => {
+  /** A payload exactly as the control server's `GET /admin/status` sends it. */
+  const VALID_STATUS: ServerStatus = {
+    version: '0.10.1',
+    latestVersion: '0.11.0',
+    updateAvailable: true,
+    releaseUrl: 'https://example.com/releases/v0.11.0',
+    lastCheckedAt: '2026-07-23T00:00:00.000Z',
+    checkEnabled: true,
+  }
+
+  test('accepts a fully populated status', () => {
+    expect(serverStatusSchema.safeParse(VALID_STATUS).success).toBe(true)
+  })
+
+  test('accepts the before-first-check shape with null fields', () => {
+    expect(
+      serverStatusSchema.safeParse({
+        version: '0.10.1',
+        latestVersion: null,
+        updateAvailable: false,
+        releaseUrl: null,
+        lastCheckedAt: null,
+        checkEnabled: false,
+      }).success,
+    ).toBe(true)
+  })
+
+  test('rejects a payload with a missing field', () => {
+    const { checkEnabled: _checkEnabled, ...missingField } = VALID_STATUS
+    expect(serverStatusSchema.safeParse(missingField).success).toBe(false)
+  })
+
+  test('rejects a payload with a mistyped field', () => {
+    expect(
+      serverStatusSchema.safeParse({ ...VALID_STATUS, updateAvailable: 'yes' })
+        .success,
+    ).toBe(false)
+  })
+
+  test('strips unknown keys from a newer server', () => {
+    const result = serverStatusSchema.safeParse({
+      ...VALID_STATUS,
+      futureField: 'ignored',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toEqual(VALID_STATUS)
     }
   })
 })

--- a/packages/streamwall-shared/src/schemas.ts
+++ b/packages/streamwall-shared/src/schemas.ts
@@ -433,3 +433,25 @@ export const streamwallStateSchema = z.object({
   favorites: z.array(z.string()),
   dataSourceHealth: z.array(dataSourceHealthSchema),
 })
+
+/**
+ * Response body of the control server's admin-only `GET /admin/status`
+ * endpoint (issue #430): the running server version plus whether a newer
+ * release exists. The single source of truth for this cross-boundary payload
+ * (issue #649): the server derives its `UpdateStatus` response type from it,
+ * and the control UI validates the fetched body with it, so producer and
+ * consumer cannot drift.
+ */
+export const serverStatusSchema = z.object({
+  /** Version of the running server. */
+  version: z.string(),
+  /** Latest release seen by the most recent successful check, if any. */
+  latestVersion: z.string().nullable(),
+  updateAvailable: z.boolean(),
+  releaseUrl: z.string().nullable(),
+  /** ISO timestamp of the last *successful* check. */
+  lastCheckedAt: z.string().nullable(),
+  checkEnabled: z.boolean(),
+})
+
+export type ServerStatus = z.infer<typeof serverStatusSchema>


### PR DESCRIPTION
## Summary

Resolves #649.

The `GET /admin/status` payload shape was declared in two independent places since PR #646: the `UpdateStatus` interface in `streamwall-control-server/src/updateCheck.ts` (producer) and a local `serverStatusSchema` in `streamwall-control-ui/src/useServerStatus.ts` (consumer). This PR makes `streamwall-shared` the single source of truth, following the repo convention that cross-boundary payloads live as zod schemas in `streamwall-shared/src/schemas.ts`.

## Changes

- **streamwall-shared**: add `serverStatusSchema` and the inferred `ServerStatus` type to `src/schemas.ts` (exported via the existing barrel), carrying over the field documentation from the server interface.
- **streamwall-control-server**: `UpdateStatus` is now a type alias derived from the shared schema, so the compiler pins the `/admin/status` response (`getStatus(): UpdateStatus`) to the exact shared shape. No runtime change.
- **streamwall-control-ui**: `useServerStatus` imports the shared schema instead of its local copy and keeps validating the fetched body with it; all `ServerStatus` consumers now import the type from `streamwall-shared`.
- **Tests**: new `serverStatusSchema` suite in `streamwall-shared/src/schemas.test.ts` (valid payloads, missing/mistyped fields rejected, unknown keys stripped). Existing server/UI tests are unchanged in behavior and still pass.

No behavior change; refactor only.

## Verification

- `npm run format` / `npm run lint` / `npm run typecheck`: clean
- `npm run test`: all packages green (shared 72 files, control-server 198 tests, control-ui 371 tests, streamwall 137 tests)
