### PR TITLE
refactor(control-server): extract a shared WS heartbeat helper

### DIFF
--- a/packages/streamwall-control-server/src/config.ts
+++ b/packages/streamwall-control-server/src/config.ts
@@ -7,18 +7,23 @@ export const SESSION_COOKIE_NAME = 's'
 // which is measured in SECONDS (not milliseconds). Keep this value in seconds —
 // one year — so sessions stay long-lived while remaining bounded.
 export const SESSION_COOKIE_MAX_AGE_SECONDS = 365 * 24 * 60 * 60
-export const STREAMWALL_PING_TIMEOUT_MS = 5 * 1000
-
-/** Liveness probing for browser client sockets on `/client/ws`. */
-export interface ClientPingConfig {
-  /** How often the server pings each connected client. */
+/** Cadence of a WebSocket ping/pong liveness probe (see `startHeartbeat`). */
+export interface HeartbeatConfig {
+  /** How often the server pings the peer. */
   intervalMs: number
   /** How long after a ping to wait for the pong before terminating. */
   timeoutMs: number
 }
 
-export const DEFAULT_CLIENT_PING_CONFIG: ClientPingConfig = {
+/** Liveness probing for browser client sockets on `/client/ws`. */
+export const DEFAULT_CLIENT_PING_CONFIG: HeartbeatConfig = {
   intervalMs: 20 * 1000,
+  timeoutMs: 5 * 1000,
+}
+
+/** Liveness probing for the desktop uplink socket on `/streamwall/:id/ws`. */
+export const DEFAULT_UPLINK_PING_CONFIG: HeartbeatConfig = {
+  intervalMs: 5 * 1000,
   timeoutMs: 5 * 1000,
 }
 

--- a/packages/streamwall-control-server/src/context.ts
+++ b/packages/streamwall-control-server/src/context.ts
@@ -3,7 +3,7 @@ import type * as Y from 'yjs'
 
 import { type AuthTokenInfo, stateDiff } from 'streamwall-shared'
 import type { Auth, StateWrapper } from './auth.ts'
-import type { ClientPingConfig, WsMessageLimitConfig } from './config.ts'
+import type { HeartbeatConfig, WsMessageLimitConfig } from './config.ts'
 import { identityFields, type Logger } from './logger.ts'
 import type { DocUpdateLimits } from './stateDocGuard.ts'
 import type { UpdateChecker } from './updateCheck.ts'
@@ -42,7 +42,8 @@ export interface AppContext {
   expectedOrigin: string
   isSecure: boolean
   wsMessageLimitConfig: WsMessageLimitConfig
-  clientPingConfig: ClientPingConfig
+  clientPingConfig: HeartbeatConfig
+  uplinkPingConfig: HeartbeatConfig
   docUpdateLimits: DocUpdateLimits
   clients: Map<string, Client>
   currentStreamwallWs: WebSocket | null

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -11,12 +11,13 @@ import { pathToFileURL } from 'node:url'
 import { Auth, type ScryptParams } from './auth.ts'
 import runServer from './bootstrap.ts'
 import {
-  type ClientPingConfig,
   DEFAULT_CLIENT_PING_CONFIG,
+  DEFAULT_UPLINK_PING_CONFIG,
   getDocUpdateLimits,
   getRateLimitConfig,
   getWsMaxPayloadBytes,
   getWsMessageLimitConfig,
+  type HeartbeatConfig,
   parseTrustProxy,
   type RateLimitConfig,
 } from './config.ts'
@@ -71,6 +72,7 @@ export async function initApp({
   scryptParams,
   trustProxy: injectedTrustProxy,
   updateChecker: injectedUpdateChecker,
+  uplinkPing: injectedUplinkPing,
 }: AppOptions & {
   db?: StorageDB
   /**
@@ -87,7 +89,12 @@ export async function initApp({
    * the ping/pong path can use short timers instead of the production 20s
    * interval. Unset fields keep `DEFAULT_CLIENT_PING_CONFIG`.
    */
-  clientPing?: Partial<ClientPingConfig>
+  clientPing?: Partial<HeartbeatConfig>
+  /**
+   * Overrides the uplink-socket liveness probing cadence, for the same reason
+   * `clientPing` exists. Unset fields keep `DEFAULT_UPLINK_PING_CONFIG`.
+   */
+  uplinkPing?: Partial<HeartbeatConfig>
   /**
    * Overrides individual per-IP rate limits, so specs that are not about
    * throttling widen them without writing the process-wide environment (which
@@ -163,6 +170,7 @@ export async function initApp({
     isSecure,
     wsMessageLimitConfig: getWsMessageLimitConfig(),
     clientPingConfig: { ...DEFAULT_CLIENT_PING_CONFIG, ...injectedClientPing },
+    uplinkPingConfig: { ...DEFAULT_UPLINK_PING_CONFIG, ...injectedUplinkPing },
     docUpdateLimits: { ...getDocUpdateLimits(), ...injectedDocUpdateLimits },
     clients,
     currentStreamwallWs: null,

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -18,7 +18,7 @@ import type {
 } from 'streamwall-shared'
 import WebSocket from 'ws'
 import type { ScryptParams } from './auth.ts'
-import type { ClientPingConfig, RateLimitConfig } from './config.ts'
+import type { HeartbeatConfig, RateLimitConfig } from './config.ts'
 import { type AppOptions, initApp } from './index.ts'
 import type { LogLevel } from './logger.ts'
 import type { SentryCaptureClient } from './sentry.ts'
@@ -237,7 +237,8 @@ export const TEST_BASE_URL = 'http://localhost:3000'
 
 /** Everything a test may override when building an app instance. */
 export type TestAppOverrides = Partial<AppOptions> & {
-  clientPing?: Partial<ClientPingConfig>
+  clientPing?: Partial<HeartbeatConfig>
+  uplinkPing?: Partial<HeartbeatConfig>
   db?: StorageDB
   docUpdateLimits?: Partial<DocUpdateLimits>
   logs?: LogCapture
@@ -408,13 +409,18 @@ export async function mintUplinkToken(auth: TestApp['auth'], port: number) {
  *
  * `T` describes the shape of the JSON frames the caller expects to record,
  * defaulting to the real shape the server forwards over this connection.
+ *
+ * `wsOptions` is merged into the socket's client options, so a spec can e.g.
+ * pass `autoPong: false` to simulate a peer that no longer answers pings.
  */
 export async function connectStreamwallUplink<T = ControlCommandMessage>(
   auth: TestApp['auth'],
   port: number,
+  wsOptions: WebSocket.ClientOptions = {},
 ) {
   const { base, secret } = await mintUplinkToken(auth, port)
   const ws = new WebSocket(base, {
+    ...wsOptions,
     headers: { authorization: `Bearer ${secret}` },
   })
   const streamwall = recordJsonMessages<T>(ws)

--- a/packages/streamwall-control-server/src/ws/client.ts
+++ b/packages/streamwall-control-server/src/ws/client.ts
@@ -13,7 +13,11 @@ import { SESSION_COOKIE_NAME } from '../config.ts'
 import { type AppContext, type Client } from '../context.ts'
 import { identityDebugFields, identityFields } from '../logger.ts'
 import { applyValidatedDocUpdate } from '../stateDocGuard.ts'
-import { createWsMessageGuard, queueWebSocketMessages } from '../wsSupport.ts'
+import {
+  createWsMessageGuard,
+  queueWebSocketMessages,
+  startHeartbeat,
+} from '../wsSupport.ts'
 
 export interface ClientRouteOptions {
   /** Filesystem root of the built control client served at `/`. */
@@ -96,34 +100,19 @@ export function registerClientRoutes(
         ...identityFields(identity),
       })
 
-      // Liveness check mirroring the uplink route: a peer that vanishes
-      // without a TCP FIN (laptop sleep, NAT idle timeout, network partition)
-      // never fires 'close' on its own, so its registry entry would leak and
-      // keep receiving every broadcast. A missed pong terminates the socket,
-      // which fires 'close' and cleans up (issue #618).
-      const { intervalMs: pingIntervalMs, timeoutMs: pongTimeoutMs } =
-        ctx.clientPingConfig
-      let pongTimeout: NodeJS.Timeout | undefined
-      const pingInterval = setInterval(() => {
-        ws.ping()
-        clearTimeout(pongTimeout)
-        pongTimeout = setTimeout(() => {
-          if (ws.readyState === ws.OPEN) {
-            log.warn(
-              `Client timeout: no pong within ${pongTimeoutMs}ms. Closing connection.`,
-            )
-            ws.terminate()
-          }
-        }, pongTimeoutMs)
-      }, pingIntervalMs)
-      ws.on('pong', () => {
-        clearTimeout(pongTimeout)
-      })
+      // Liveness check: without it, a browser that disappears mid-connection
+      // would leak its registry entry and keep receiving every broadcast
+      // forever (issue #618).
+      const stopHeartbeat = startHeartbeat(
+        ws,
+        ctx.clientPingConfig,
+        'Client',
+        log,
+      )
 
       ws.on('close', () => {
         ctx.clients.delete(clientId)
-        clearInterval(pingInterval)
-        clearTimeout(pongTimeout)
+        stopHeartbeat()
 
         log.info('Client disconnected')
       })

--- a/packages/streamwall-control-server/src/ws/uplink.ts
+++ b/packages/streamwall-control-server/src/ws/uplink.ts
@@ -6,13 +6,13 @@ import {
   streamwallStateSchema,
 } from 'streamwall-shared'
 import { StateWrapper } from '../auth.ts'
-import { STREAMWALL_PING_TIMEOUT_MS } from '../config.ts'
 import type { AppContext } from '../context.ts'
 import { identityDebugFields, identityFields } from '../logger.ts'
 import {
   bearerToken,
   createWsMessageGuard,
   queueWebSocketMessages,
+  startHeartbeat,
 } from '../wsSupport.ts'
 
 /**
@@ -59,26 +59,20 @@ export function registerUplinkRoute(
 
       ctx.currentStreamwallWs = ws
 
-      const pingInterval = setInterval(() => {
-        ws.ping()
-        const pongTimeout = setTimeout(() => {
-          if (ws.readyState === ws.OPEN) {
-            log.warn(
-              `Streamwall timeout: no pong within ${STREAMWALL_PING_TIMEOUT_MS}ms. Closing connection.`,
-            )
-            ws.terminate()
-          }
-        }, STREAMWALL_PING_TIMEOUT_MS)
-        ws.once('pong', () => {
-          clearTimeout(pongTimeout)
-        })
-      }, STREAMWALL_PING_TIMEOUT_MS)
+      // Liveness check: without it, a desktop that disappears mid-connection
+      // would keep the single uplink slot occupied and block any reconnect.
+      const stopHeartbeat = startHeartbeat(
+        ws,
+        ctx.uplinkPingConfig,
+        'Streamwall',
+        log,
+      )
 
       ws.on('close', () => {
         log.info('Streamwall disconnected')
         ctx.currentStreamwallWs = null
         ctx.currentStreamwallConn = null
-        clearInterval(pingInterval)
+        stopHeartbeat()
 
         for (const client of ctx.clients.values()) {
           client.ws.close()

--- a/packages/streamwall-control-server/src/wsSupport.ts
+++ b/packages/streamwall-control-server/src/wsSupport.ts
@@ -1,6 +1,6 @@
 import WebSocket from 'ws'
 
-import type { WsMessageLimitConfig } from './config.ts'
+import type { HeartbeatConfig, WsMessageLimitConfig } from './config.ts'
 import type { Logger } from './logger.ts'
 import { TokenBucket } from './rateLimiter.ts'
 
@@ -106,6 +106,46 @@ export function queueWebSocketMessages(ws: WebSocket, log: Logger) {
   })
 
   return setMessageHandler
+}
+
+/**
+ * Starts a ping/pong liveness probe on a socket: a peer that vanishes without
+ * a TCP FIN (laptop sleep, NAT idle timeout, network partition) never fires
+ * 'close' on its own, so a missed pong terminates the socket, which fires
+ * 'close' and lets the route's cleanup run (issues #618/#635).
+ *
+ * `label` names the peer in the timeout warning (e.g. `Client`, `Streamwall`).
+ * Returns a stop function that clears every timer and listener the heartbeat
+ * registered; call it from the route's 'close' handler.
+ */
+export function startHeartbeat(
+  ws: WebSocket,
+  { intervalMs, timeoutMs }: HeartbeatConfig,
+  label: string,
+  log: Logger,
+): () => void {
+  let pongTimeout: NodeJS.Timeout | undefined
+  const onPong = () => {
+    clearTimeout(pongTimeout)
+  }
+  const pingInterval = setInterval(() => {
+    ws.ping()
+    clearTimeout(pongTimeout)
+    pongTimeout = setTimeout(() => {
+      if (ws.readyState === ws.OPEN) {
+        log.warn(
+          `${label} timeout: no pong within ${timeoutMs}ms. Closing connection.`,
+        )
+        ws.terminate()
+      }
+    }, timeoutMs)
+  }, intervalMs)
+  ws.on('pong', onPong)
+  return () => {
+    clearInterval(pingInterval)
+    clearTimeout(pongTimeout)
+    ws.off('pong', onPong)
+  }
 }
 
 /**

--- a/packages/streamwall-control-server/src/wsUplinkLiveness.test.ts
+++ b/packages/streamwall-control-server/src/wsUplinkLiveness.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict'
+import { once } from 'node:events'
+import { test } from 'node:test'
+import { setTimeout as delay } from 'node:timers/promises'
+import WebSocket from 'ws'
+import { connectStreamwallUplink, startTestServer } from './testHelpers.ts'
+
+// Liveness probing for the desktop uplink at `/streamwall/:id/ws`: a desktop
+// that disappears without a TCP FIN never fires 'close' on its own, which
+// would leave `ctx.currentStreamwallWs` occupied and block any reconnect.
+// The cadence is injectable via `initApp({ uplinkPing })` (issue #635), so
+// these specs run on short timers instead of the production 5s interval.
+
+test('terminates an uplink that stops answering pings', async () => {
+  const { auth, port, logs } = await startTestServer({
+    uplinkPing: { intervalMs: 100, timeoutMs: 100 },
+  })
+
+  // `autoPong: false` makes the socket ignore incoming pings — the closest a
+  // test can get to a peer that silently vanished mid-connection.
+  const { ws } = await connectStreamwallUplink(auth, port, { autoPong: false })
+  const closed = once(ws, 'close', { signal: AbortSignal.timeout(5000) })
+
+  await logs.waitForMessage('Streamwall timeout: no pong within 100ms')
+  await closed
+  // The server-side 'close' handler released the uplink slot — this log line
+  // is emitted right before `currentStreamwallWs` is cleared.
+  await logs.waitForMessage('Streamwall disconnected')
+})
+
+test('keeps a responsive uplink connected across many ping cycles', async () => {
+  const { auth, port, logs } = await startTestServer({
+    uplinkPing: { intervalMs: 50, timeoutMs: 500 },
+  })
+
+  const { ws } = await connectStreamwallUplink(auth, port)
+  // Span well over a handful of ping intervals; the ws library answers each
+  // ping with a pong automatically, so the deadline never fires.
+  await delay(400)
+
+  assert.equal(ws.readyState, WebSocket.OPEN)
+  assert.ok(
+    !logs.hasMessage('Streamwall timeout'),
+    'expected no liveness timeout',
+  )
+  assert.ok(!logs.hasMessage('Streamwall disconnected'))
+})


### PR DESCRIPTION
## Problem

PR #634 (issue #618) added pong-liveness termination to the client WS route by mirroring the existing uplink pattern, leaving `ws/client.ts` and `ws/uplink.ts` with two near-identical ping/pong heartbeat implementations that were bound to drift. The uplink copy also had two hygiene gaps: its `'close'` handler never cleared a pending pong timeout, and it registered a fresh `ws.once('pong', ...)` listener per ping without removing stale ones. Its cadence was the hardcoded `STREAMWALL_PING_TIMEOUT_MS`, so the uplink liveness path had no regression test.

## Solution

- Extracted a `startHeartbeat(ws, { intervalMs, timeoutMs }, label, log)` helper into `wsSupport.ts` that returns a stop function clearing every timer and listener it registered; both routes now use it and call the stop function from their `'close'` handlers.
- Generalized `ClientPingConfig` to `HeartbeatConfig` and replaced `STREAMWALL_PING_TIMEOUT_MS` with `DEFAULT_UPLINK_PING_CONFIG` (same 5s interval/timeout as before).
- Made the uplink cadence injectable via `initApp({ uplinkPing })`, mirroring `clientPing`.
- Added `wsUplinkLiveness.test.ts` analogous to `wsClientLiveness.test.ts` (terminates a silent uplink, keeps a responsive one connected); `connectStreamwallUplink` now accepts `wsOptions` so a spec can pass `autoPong: false`.

Log messages and production cadences are unchanged.

## Testing

- New uplink liveness tests written first (red without the injectable cadence), green after the change.
- `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` all pass (control-server suite runs via node:test).

Closes #635