### PR TITLE
test(control-e2e): exercise the control client over TLS via a terminating proxy

### DIFF
--- a/packages/streamwall-control-e2e/README.md
+++ b/packages/streamwall-control-e2e/README.md
@@ -10,8 +10,13 @@ networking and real layout:
 
 - the invite-link → session-cookie sign-in flow and grid render from injected state,
 - unauthorized access being rejected,
-- a grid-cell edit propagating over the wire to the Streamwall peer (Yjs), and
-- horizontal-overflow layout regressions (issue #225/#239) that no unit test can catch.
+- a grid-cell edit propagating over the wire to the Streamwall peer (Yjs),
+- horizontal-overflow layout regressions (issue #225/#239) that no unit test can catch, and
+- the client connecting via `wss://` from a secure context (issue #617/#639):
+  [tests/tls.spec.ts](tests/tls.spec.ts) fronts the server with a
+  TLS-terminating proxy ([tests/tlsProxy.ts](tests/tlsProxy.ts), self-signed
+  throwaway certificate generated with the system `openssl`) so mixed-content
+  bugs — which browsers only enforce on secure pages — fail in CI.
 
 ## Running
 

--- a/packages/streamwall-control-e2e/tests/harness.ts
+++ b/packages/streamwall-control-e2e/tests/harness.ts
@@ -17,6 +17,7 @@ import {
 } from 'streamwall-shared'
 import WebSocket from 'ws'
 import * as Y from 'yjs'
+import { startTlsProxy } from './tlsProxy.ts'
 
 const COLS = 3
 const ROWS = 3
@@ -91,6 +92,20 @@ const E2E_STATE: StreamwallState = {
   dataSourceHealth: [],
 }
 
+/** Options for {@link startHarness}, exposed to specs via `test.use(...)`. */
+export interface StartHarnessOptions {
+  /**
+   * Front the control server with a TLS-terminating proxy (throwaway
+   * self-signed certificate) and hand the browser an `https://` origin. This
+   * is the only way the suite can exercise the mixed-content class of bugs
+   * (issue #639): browsers only block insecure `ws://` sockets when the page
+   * itself is served from a secure context, so plain-http runs can never
+   * catch a client that fails to open `wss://` (issue #617). Specs using this
+   * must also set Playwright's `ignoreHTTPSErrors`.
+   */
+  tls?: boolean
+}
+
 /** A handle to one running control server + connected fake Streamwall uplink. */
 export interface Harness {
   /** Origin the browser must use (matches the server's expected WS origin). */
@@ -163,7 +178,9 @@ function toUint8Array(data: WebSocket.RawData): Uint8Array {
  * connects a fake Streamwall uplink to it, and seeds a `COLS*ROWS` grid of
  * (empty) view cells into the shared Yjs doc so the browser can edit them.
  */
-export async function startHarness(): Promise<Harness> {
+export async function startHarness(
+  options: StartHarnessOptions = {},
+): Promise<Harness> {
   if (!existsSync(path.join(CLIENT_DIST, 'index.html'))) {
     throw new Error(
       `Control client build not found at ${CLIENT_DIST}. Run ` +
@@ -177,7 +194,15 @@ export async function startHarness(): Promise<Harness> {
   process.env.STREAMWALL_RATE_LIMIT_MAX ??= '100000'
 
   const port = await getFreePort()
-  const baseURL = `http://127.0.0.1:${port}`
+  // With TLS, the browser-facing origin is the proxy: the control server keeps
+  // speaking plain HTTP on `port` (like behind a real reverse proxy), but its
+  // `baseURL` — and with it invite links, the expected WS `Origin`, and the
+  // `Secure` cookie attribute — must be the `https://` origin the browser sees.
+  // The uplink and the seed probe below still dial `port` directly.
+  const tlsProxy = options.tls ? await startTlsProxy(port) : null
+  const baseURL = tlsProxy
+    ? `https://127.0.0.1:${tlsProxy.port}`
+    : `http://127.0.0.1:${port}`
 
   const initialData: StoredData = {
     auth: { salt: null, tokens: [] },
@@ -383,6 +408,7 @@ export async function startHarness(): Promise<Harness> {
   const close = async () => {
     ws.terminate()
     peerDoc.destroy()
+    await tlsProxy?.close()
     await app.close()
   }
 
@@ -399,11 +425,18 @@ export async function startHarness(): Promise<Harness> {
   }
 }
 
-/** Playwright fixture that provides a fresh, isolated harness per test. */
-export const test = base.extend<{ harness: Harness }>({
-  // eslint-disable-next-line no-empty-pattern
-  harness: async ({}, use) => {
-    const harness = await startHarness()
+/**
+ * Playwright fixture that provides a fresh, isolated harness per test. Specs
+ * can reconfigure it via `test.use({ harnessOptions: { ... } })` — see the TLS
+ * spec, which opts into the https/wss proxy this way.
+ */
+export const test = base.extend<{
+  harnessOptions: StartHarnessOptions
+  harness: Harness
+}>({
+  harnessOptions: [{}, { option: true }],
+  harness: async ({ harnessOptions }, use) => {
+    const harness = await startHarness(harnessOptions)
     try {
       await use(harness)
     } finally {

--- a/packages/streamwall-control-e2e/tests/tls.spec.ts
+++ b/packages/streamwall-control-e2e/tests/tls.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from './harness.ts'
+
+/**
+ * TLS smoke coverage (issue #639): serves the built control client from a
+ * secure context — a TLS-terminating proxy in front of the control server —
+ * and proves the shipped bundle actually connects, i.e. that it opens `wss://`
+ * sockets. Browsers only block insecure `ws://` from secure contexts, so the
+ * plain-http specs in the rest of the suite can never catch the mixed-content
+ * bug class fixed in #638 (hardcoded `ws://` scheme, issue #617).
+ */
+
+test.use({
+  harnessOptions: { tls: true },
+  // The proxy's certificate is self-signed and throwaway; the test exercises
+  // the secure context, not certificate validation.
+  ignoreHTTPSErrors: true,
+})
+
+test('served over https, the client connects via wss:// and round-trips a grid edit', async ({
+  page,
+  harness,
+}) => {
+  expect(harness.baseURL).toMatch(/^https:\/\//)
+
+  // Record every WebSocket the page opens — subscribed before navigation so
+  // the client's initial connection attempt cannot be missed. A blocked
+  // mixed-content `ws://` attempt would still show up here.
+  const wsUrls: string[] = []
+  page.on('websocket', (ws) => wsUrls.push(ws.url()))
+
+  // The invite exchange (POST + session cookie + redirect) now runs entirely
+  // over https, including the `Secure` cookie the server issues for it.
+  await page.goto(await harness.createInviteLink())
+
+  const grid = page.getByTestId('grid')
+  await expect(grid).toBeVisible()
+  // "connected" requires an open client socket plus injected state — a client
+  // stuck on a blocked `ws://` attempt stays disconnected forever (#617).
+  await expect(page.getByTestId('header-connection-status')).toContainText(
+    'connected',
+  )
+
+  // The client must have derived `wss://` from the page protocol — nothing
+  // less survives a secure context.
+  expect(wsUrls.length).toBeGreaterThan(0)
+  for (const url of wsUrls) {
+    expect(url).toMatch(/^wss:\/\//)
+  }
+
+  // Full round trip through the TLS terminator: browser edit → wss → control
+  // server → fake Streamwall uplink observes the shared-doc update.
+  const cells = page.getByTestId('grid-cell')
+  await expect(cells).toHaveCount(harness.cols * harness.rows)
+
+  const targetIdx = 4 // center cell of the 3×3 grid
+  const [streamId] = harness.streamIds
+
+  await grid.hover()
+  await cells.nth(targetIdx).fill(streamId)
+  await cells.nth(targetIdx).blur()
+
+  await harness.waitForViewAssignment(targetIdx, streamId)
+  await expect(cells.nth(targetIdx)).toHaveValue(streamId)
+})

--- a/packages/streamwall-control-e2e/tests/tlsProxy.ts
+++ b/packages/streamwall-control-e2e/tests/tlsProxy.ts
@@ -1,0 +1,105 @@
+import { execFile } from 'node:child_process'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import type { AddressInfo } from 'node:net'
+import net from 'node:net'
+import os from 'node:os'
+import path from 'node:path'
+import tls from 'node:tls'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+/**
+ * Generates a throwaway self-signed certificate for the TLS proxy. The
+ * `openssl` binary is available on the Linux CI runners and on macOS
+ * (LibreSSL). The TLS spec runs Playwright with `ignoreHTTPSErrors`, so the
+ * certificate only has to exist — it is never validated by the browser.
+ */
+async function generateSelfSignedCert(): Promise<{
+  key: string
+  cert: string
+}> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'streamwall-e2e-tls-'))
+  try {
+    const keyPath = path.join(dir, 'key.pem')
+    const certPath = path.join(dir, 'cert.pem')
+    await execFileAsync('openssl', [
+      'req',
+      '-x509',
+      '-newkey',
+      'rsa:2048',
+      '-keyout',
+      keyPath,
+      '-out',
+      certPath,
+      '-days',
+      '1',
+      '-nodes',
+      '-subj',
+      '/CN=streamwall-e2e',
+    ])
+    const [key, cert] = await Promise.all([
+      readFile(keyPath, 'utf8'),
+      readFile(certPath, 'utf8'),
+    ])
+    return { key, cert }
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}
+
+/** A running TLS terminator in front of a plain-HTTP control server. */
+export interface TlsProxy {
+  /** Port the browser connects to over `https://` / `wss://`. */
+  readonly port: number
+  close(): Promise<void>
+}
+
+/**
+ * Starts a raw TLS terminator in front of `backendPort`: every decrypted byte
+ * stream is piped verbatim into a plain TCP connection against the control
+ * server, so HTTP requests and WebSocket upgrades both pass through untouched
+ * — the same shape as the reverse proxy (Caddy, nginx, ...) in the documented
+ * self-hosting setup.
+ */
+export async function startTlsProxy(backendPort: number): Promise<TlsProxy> {
+  const { key, cert } = await generateSelfSignedCert()
+  const sockets = new Set<tls.TLSSocket>()
+
+  const server = tls.createServer({ key, cert }, (clientSocket) => {
+    const backend = net.connect(backendPort, '127.0.0.1')
+    sockets.add(clientSocket)
+    // Either side dropping (browser tab teardown, server close) tears down the
+    // pair; without the error handlers a routine ECONNRESET would crash the
+    // test process.
+    const teardown = () => {
+      sockets.delete(clientSocket)
+      clientSocket.destroy()
+      backend.destroy()
+    }
+    clientSocket.on('error', teardown)
+    clientSocket.on('close', teardown)
+    backend.on('error', teardown)
+    backend.on('close', teardown)
+    clientSocket.pipe(backend)
+    backend.pipe(clientSocket)
+  })
+  // A client aborting mid-handshake surfaces here, not on a connection socket.
+  server.on('tlsClientError', () => {})
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const port = (server.address() as AddressInfo).port
+
+  const close = () =>
+    new Promise<void>((resolve) => {
+      for (const socket of sockets) {
+        socket.destroy()
+      }
+      server.close(() => resolve())
+    })
+
+  return { port, close }
+}


### PR DESCRIPTION
## Summary

Closes #639.

The Playwright E2E suite ran the whole stack over plain `http://127.0.0.1`, where browsers allow `ws://` sockets — so mixed-content bugs like the hardcoded `ws://` scheme (issue #617, fixed in #638) could never surface in CI. This adds a TLS smoke path to the existing suite (and thus to the existing Linux E2E job — no workflow changes needed):

- **`tests/tlsProxy.ts`** — a raw TLS terminator: decrypted bytes are piped verbatim into a plain TCP connection against the control server, so HTTP requests and WebSocket upgrades pass through untouched, the same shape as the reverse proxy in the documented self-hosting setup. The self-signed certificate is throwaway, generated at runtime with the system `openssl` (present on the ubuntu runners and macOS), never checked in.
- **`tests/harness.ts`** — `startHarness` gains a `tls` option, exposed to specs as a Playwright option fixture (`test.use({ harnessOptions: { tls: true } })`). With TLS, the server's `baseURL` (and with it invite links, the expected WS `Origin`, and the `Secure` cookie attribute) is the browser-facing `https://` origin, while the fake uplink and the seed probe keep dialing the plain-HTTP backend directly — like peers behind a real reverse proxy.
- **`tests/tls.spec.ts`** — navigates the invite link over `https://` with `ignoreHTTPSErrors`, asserts the client reaches the `connected` state, asserts every WebSocket the page opened used `wss://` (a blocked mixed-content `ws://` attempt would still be recorded by Playwright's `websocket` event), and round-trips a grid-cell edit through the TLS terminator to the uplink.
- **`README.md`** — documents the new coverage.

## Verification

- Full E2E suite run locally on macOS: 17/17 passed, including the new TLS spec.
- Repo quality gates run locally: `npm run format` (no diff), `npm run lint`, `npm run typecheck`, `npm run test` — all clean.
- Sanity-checked against the #638 bug class: the assertion path requires the `connected` header state, which a client stuck on a blocked `ws://` socket never reaches, plus an explicit `wss://`-only check on all opened sockets.