### PR TITLE
fix(streamwall): count repeated stall-reload cycles against the retry budget

### DIFF
--- a/packages/streamwall/src/main/cliArgs.ts
+++ b/packages/streamwall/src/main/cliArgs.ts
@@ -47,6 +47,7 @@ export interface StreamwallConfig {
     'max-delay': number
     'max-retries': number
     'stalled-timeout': number
+    'healthy-duration': number
   }
   park: {
     pause: boolean
@@ -254,6 +255,7 @@ export function parseArgs({
         'retry.max-delay',
         'retry.max-retries',
         'retry.stalled-timeout',
+        'retry.healthy-duration',
       ],
       'Auto-retry',
     )
@@ -281,6 +283,12 @@ export function parseArgs({
       describe: 'How long (in seconds) a view may stall before it is reloaded',
       number: true,
       default: 30,
+    })
+    .option('retry.healthy-duration', {
+      describe:
+        'How long (in seconds) a view must play without stalling before its retry budget resets',
+      number: true,
+      default: 60,
     })
     .group(['park.pause'], 'Fullscreen Parking')
     .option('park.pause', {

--- a/packages/streamwall/src/main/viewStateMachine.test.ts
+++ b/packages/streamwall/src/main/viewStateMachine.test.ts
@@ -29,6 +29,7 @@ function makeRetry(overrides: Partial<RetryConfig> = {}): RetryConfig {
     maxDelay: 8000,
     maxRetries: 5,
     stalledTimeout: 2000,
+    healthyDuration: 10000,
     ...overrides,
   }
 }
@@ -116,6 +117,7 @@ describe('viewStateMachine error handling and auto-retry', () => {
       maxDelay: expect.any(Number),
       maxRetries: expect.any(Number),
       stalledTimeout: expect.any(Number),
+      healthyDuration: expect.any(Number),
     })
   })
 
@@ -238,8 +240,8 @@ describe('viewStateMachine error handling and auto-retry', () => {
     expect(actor.getSnapshot().context.retryCount).toBe(0)
   })
 
-  it('resets retry state and clears the error once running is reached', async () => {
-    const actor = makeActor(makeRetry())
+  it('keeps the retry streak on reaching running until playback stays healthy (issue #645)', async () => {
+    const actor = makeActor(makeRetry({ healthyDuration: 5000 }))
     actor.start()
     display(actor)
     actor.send({ type: 'VIEW_ERROR', error: new Error('boom') })
@@ -249,8 +251,20 @@ describe('viewStateMachine error handling and auto-retry', () => {
     actor.send({ type: 'VIEW_INIT' })
     actor.send({ type: 'VIEW_LOADED' })
 
-    const snapshot = actor.getSnapshot()
+    // Reaching running is not yet proof of recovery: the streak survives so a
+    // stream that fails again right away keeps consuming its budget.
+    let snapshot = actor.getSnapshot()
     expect(matchesState('displaying.running', snapshot.value)).toBe(true)
+    expect(snapshot.context.retryCount).toBe(1)
+    expect(snapshot.context.error).toBe(null)
+
+    await vi.advanceTimersByTimeAsync(4999)
+    expect(actor.getSnapshot().context.retryCount).toBe(1)
+
+    // Only after healthyDuration of uninterrupted playback is the streak
+    // forgotten.
+    await vi.advanceTimersByTimeAsync(1)
+    snapshot = actor.getSnapshot()
     expect(snapshot.context.retryCount).toBe(0)
     expect(snapshot.context.error).toBe(null)
   })
@@ -289,8 +303,8 @@ describe('viewStateMachine error handling and auto-retry', () => {
 
   it('surfaces a terminal error when a stalled view has no retry budget', async () => {
     // maxRetries: 0 means the budget is already spent when the stall happens
-    // (reaching `running` resets the streak, so a nonzero budget always allows
-    // at least one stall-reload).
+    // (a freshly displayed view starts with a clean streak, so a nonzero
+    // budget always allows at least one stall-reload).
     const actor = makeActor(makeRetry({ maxRetries: 0 }))
     actor.start()
     await reachRunning(actor)
@@ -313,6 +327,122 @@ describe('viewStateMachine error handling and auto-retry', () => {
     expect(matchesState('displaying.error', actor.getSnapshot().value)).toBe(
       true,
     )
+  })
+
+  // Drives a view that just began an automatic reload (displaying.loading)
+  // back into running, mirroring reachRunning for mid-test reload cycles.
+  async function finishReload(actor: ReturnType<typeof makeActor>) {
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'VIEW_INIT' })
+    actor.send({ type: 'VIEW_LOADED' })
+  }
+
+  it('counts consecutive stall-reload cycles against the retry budget (issue #645)', async () => {
+    const actor = makeActor(makeRetry({ maxRetries: 2 }))
+    actor.start()
+    await reachRunning(actor)
+
+    // 1st stall-reload: fires at the base stalledTimeout.
+    actor.send({ type: 'VIEW_STALLED' })
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(matchesState('displaying.loading', actor.getSnapshot().value)).toBe(
+      true,
+    )
+    expect(actor.getSnapshot().context.retryCount).toBe(1)
+
+    // Stalling again shortly after the reload continues the streak instead of
+    // starting a fresh one.
+    await finishReload(actor)
+    actor.send({ type: 'VIEW_STALLED' })
+    await vi.advanceTimersByTimeAsync(2000 + 2000) // stalledTimeout + backoff (1000 * 2^1)
+    expect(matchesState('displaying.loading', actor.getSnapshot().value)).toBe(
+      true,
+    )
+    expect(actor.getSnapshot().context.retryCount).toBe(2)
+
+    // Budget exhausted: the next stall becomes a terminal error instead of
+    // churning through reloads forever.
+    await finishReload(actor)
+    actor.send({ type: 'VIEW_STALLED' })
+    await vi.advanceTimersByTimeAsync(2000 + 4000) // stalledTimeout + backoff (1000 * 2^2)
+
+    const snapshot = actor.getSnapshot()
+    expect(matchesState('displaying.error', snapshot.value)).toBe(true)
+    expect(snapshot.context.error).toBe(STALLED_ERROR_MESSAGE)
+  })
+
+  it('spaces consecutive stall-reloads with growing backoff (issue #645)', async () => {
+    const actor = makeActor(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+
+    actor.send({ type: 'VIEW_STALLED' })
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(actor.getSnapshot().context.retryCount).toBe(1)
+
+    // The second cycle's watchdog waits stalledTimeout + the same exponential
+    // backoff the error state would apply (1000 * 2^1 = 2000).
+    await finishReload(actor)
+    actor.send({ type: 'VIEW_STALLED' })
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(
+      matchesState(
+        'displaying.running.playback.stalled',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(matchesState('displaying.loading', actor.getSnapshot().value)).toBe(
+      true,
+    )
+    expect(actor.getSnapshot().context.retryCount).toBe(2)
+  })
+
+  it('resets the stall streak after sustained healthy playback (issue #645)', async () => {
+    const actor = makeActor(makeRetry({ healthyDuration: 5000 }))
+    actor.start()
+    await reachRunning(actor)
+
+    actor.send({ type: 'VIEW_STALLED' })
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(actor.getSnapshot().context.retryCount).toBe(1)
+
+    // The reloaded view plays healthily past healthyDuration: the streak is
+    // forgotten.
+    await finishReload(actor)
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(actor.getSnapshot().context.retryCount).toBe(0)
+
+    // A later stall starts a fresh streak with the base watchdog delay again.
+    actor.send({ type: 'VIEW_STALLED' })
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(matchesState('displaying.loading', actor.getSnapshot().value)).toBe(
+      true,
+    )
+    expect(actor.getSnapshot().context.retryCount).toBe(1)
+  })
+
+  it('restarts the healthy-playback clock when a stall clears on its own (issue #645)', async () => {
+    const actor = makeActor(makeRetry({ healthyDuration: 5000 }))
+    actor.start()
+    await reachRunning(actor)
+
+    actor.send({ type: 'VIEW_STALLED' })
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(actor.getSnapshot().context.retryCount).toBe(1)
+    await finishReload(actor)
+
+    // A transient stall that self-heals before the watchdog fires spends no
+    // budget, but playback time before it does not count as sustained health.
+    await vi.advanceTimersByTimeAsync(3000)
+    actor.send({ type: 'VIEW_STALLED' })
+    actor.send({ type: 'VIEW_LOADED' })
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(actor.getSnapshot().context.retryCount).toBe(1)
+
+    // Only healthyDuration of uninterrupted playback resets the streak.
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(actor.getSnapshot().context.retryCount).toBe(0)
   })
 
   it('resets the retry budget on a manual RELOAD', () => {

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -38,6 +38,14 @@ export interface RetryConfig {
   maxRetries: number
   /** How long a view may stay stalled before it is reloaded, in milliseconds. */
   stalledTimeout: number
+  /**
+   * How long a view must keep playing without stalling before its failure
+   * streak is forgotten, in milliseconds. Merely reaching the running state
+   * does not reset the retry budget: a stream that stalls again right after
+   * every reload would otherwise cycle forever without ever exhausting it
+   * (issue #645).
+   */
+  healthyDuration: number
 }
 
 export const DEFAULT_RETRY_CONFIG: RetryConfig = {
@@ -46,6 +54,16 @@ export const DEFAULT_RETRY_CONFIG: RetryConfig = {
   maxDelay: 60 * 1000,
   maxRetries: 5,
   stalledTimeout: 30 * 1000,
+  healthyDuration: 60 * 1000,
+}
+
+/**
+ * How long to wait before the next automatic reload: exponential in the number
+ * of attempts already spent on the current failure streak, capped at maxDelay.
+ * Shared by the error state's backoff and the stalled watchdog's growth.
+ */
+function retryBackoffMs(retry: RetryConfig, retryCount: number): number {
+  return Math.min(retry.delay * 2 ** retryCount, retry.maxDelay)
 }
 
 /**
@@ -376,12 +394,19 @@ const viewStateMachine = setup({
     // Exponential backoff, capped, computed from how many attempts have already
     // been spent on the current failure streak.
     retryBackoff: ({ context }) =>
-      Math.min(
-        context.retry.delay * 2 ** context.retryCount,
-        context.retry.maxDelay,
-      ),
+      retryBackoffMs(context.retry, context.retryCount),
 
-    stalledTimeout: ({ context }) => context.retry.stalledTimeout,
+    // The first stall of a streak gets the plain watchdog window to self-heal;
+    // consecutive stall-reload cycles extend it by the same exponential
+    // backoff the error state applies, so repeated stalls slow down instead of
+    // reloading at a fixed cadence (issue #645).
+    stalledTimeout: ({ context }) =>
+      context.retry.stalledTimeout +
+      (context.retryCount > 0
+        ? retryBackoffMs(context.retry, context.retryCount)
+        : 0),
+
+    healthyDuration: ({ context }) => context.retry.healthyDuration,
   },
 
   actors: {
@@ -606,9 +631,13 @@ const viewStateMachine = setup({
         },
         running: {
           type: 'parallel',
-          // Reaching running means the view recovered: clear any error streak so
-          // the next failure starts its backoff from scratch.
-          entry: ['positionView', 'resetRetryState'],
+          // Reaching running is not yet proof of recovery: a stream that
+          // stalls again right after each reload would otherwise reset its
+          // streak on every cycle and never exhaust the retry budget or grow
+          // its backoff (issue #645). The streak is instead cleared once the
+          // view has stayed healthy for retry.healthyDuration -- see
+          // `playback.playing` below.
+          entry: 'positionView',
           // Leaving `running` for any reason (manual RELOAD, a renderer-
           // reported VIEW_ERROR, or a stalled-view auto-reload) abandons any
           // preload that was in flight for this cell, so its WebContentsView
@@ -668,7 +697,19 @@ const viewStateMachine = setup({
                 VIEW_LOADED: '.playing',
               },
               states: {
-                playing: {},
+                playing: {
+                  // Only sustained playback counts as recovery: after
+                  // healthyDuration without a stall (a VIEW_STALLED or a
+                  // re-entered VIEW_LOADED restarts this clock by re-entering
+                  // `playing`), the failure streak is forgotten so a later
+                  // failure starts its budget and backoff from scratch
+                  // (issue #645).
+                  after: {
+                    healthyDuration: {
+                      actions: 'resetRetryState',
+                    },
+                  },
+                },
                 stalled: {
                   // A view that stays stalled past the watchdog is reloaded
                   // (as long as it still has retry budget). A stall that clears

--- a/packages/streamwall/src/main/windowConfig.test.ts
+++ b/packages/streamwall/src/main/windowConfig.test.ts
@@ -28,6 +28,7 @@ function baseArgv(overrides: Partial<StreamwallConfig> = {}): StreamwallConfig {
       'max-delay': 60,
       'max-retries': 4,
       'stalled-timeout': 30,
+      'healthy-duration': 60,
     },
     park: { pause: false },
     twitch: {
@@ -70,6 +71,7 @@ describe('buildRetryConfig', () => {
       maxDelay: 60000,
       maxRetries: 4,
       stalledTimeout: 30000,
+      healthyDuration: 60000,
     })
   })
 
@@ -82,11 +84,13 @@ describe('buildRetryConfig', () => {
           'max-delay': 10,
           'max-retries': 0,
           'stalled-timeout': 15,
+          'healthy-duration': 45,
         },
       }),
     )
     expect(config.enabled).toBe(false)
     expect(config.maxRetries).toBe(0)
     expect(config.delay).toBe(2000)
+    expect(config.healthyDuration).toBe(45000)
   })
 })

--- a/packages/streamwall/src/main/windowConfig.ts
+++ b/packages/streamwall/src/main/windowConfig.ts
@@ -40,5 +40,6 @@ export function buildRetryConfig(argv: StreamwallConfig): RetryConfig {
     maxDelay: argv.retry['max-delay'] * 1000,
     maxRetries: argv.retry['max-retries'],
     stalledTimeout: argv.retry['stalled-timeout'] * 1000,
+    healthyDuration: argv.retry['healthy-duration'] * 1000,
   }
 }


### PR DESCRIPTION
## Problem

Found while fixing #622 (PR #642): the retry budget could never be partially consumed while a view sat in `displaying.running.playback.stalled`, because entering `running` ran `resetRetryState` and `stalled` is a substate of `running`. A stream that repeatedly stalls shortly after each successful reload therefore cycled `stalled -> loading -> running -> stalled` forever:

- the `retryBackoff` delay never grew (each reload reset the streak), and
- the budget was never exhausted, so the terminal error fallback from PR #642 was only reachable with `retry.enabled: false` or `maxRetries: 0`.

A wall tile could churn through reloads indefinitely at a fixed cadence with no operator signal.

## Solution

Treat only *sustained* healthy playback as a recovery:

- `running` no longer resets the retry state on entry. Instead, `playback.playing` clears the failure streak after the view has played without stalling for a new `retry.healthy-duration` config option (default 60s, wired through `cliArgs.ts` / `buildRetryConfig` like the other retry options). A transient stall or a re-acquisition restarts that clock by re-entering `playing`.
- Consecutive stall-reload cycles now also grow their spacing: the stalled watchdog window is extended by the same capped exponential backoff the error state applies (`stalledTimeout + min(delay * 2^retryCount, maxDelay)` once the streak is non-empty). The first stall of a streak keeps the plain `stalledTimeout`, so single-stall behavior is unchanged.
- With the streak preserved across reloads, repeated stalls now exhaust `maxRetries` and reach the terminal `Stream stalled` error state added in PR #642.

Fresh content (`DISPLAY`), manual `RELOAD`, and a completed content swap still reset the streak as before. No state values were added or changed, so `viewStateValueSchema` is untouched (the schema drift guard passes).

## Testing

- New tests: consecutive stall-reload cycles consume the budget and end in the terminal error; watchdog backoff grows across cycles; sustained healthy playback resets the streak; a self-healing stall restarts the healthy-playback clock.
- Updated the running-entry reset test to the new semantics and `buildRetryConfig`/default-config tests for the new field.
- `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` all pass.

Closes #645
