### PR TITLE
fix(streamwall): initialize a fresh view's paused state from view-init

### DIFF
--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -1533,6 +1533,102 @@ describe('StreamWindow constructor', () => {
   })
 })
 
+describe('StreamWindow view-init payload (issue #658)', () => {
+  beforeEach(() => {
+    electronStub.windows.length = 0
+    electronStub.webContentsViews.length = 0
+    electronStub.resetIpc()
+    vi.mocked(loadHTML).mockClear()
+  })
+
+  function viewInitHandler() {
+    const call = electronStub.ipcMain.handle.mock.calls.find(
+      ([channel]) => channel === 'view-init',
+    )
+    if (!call) {
+      throw new Error('no view-init handler registered')
+    }
+    return call[1] as (ev: {
+      sender: { id: number }
+    }) => Promise<Record<string, unknown> | undefined>
+  }
+
+  const content = { url: 'https://example.com/stream', kind: 'video' }
+  const options = { rotation: 90 }
+
+  function makeActor(context: Record<string, unknown>) {
+    return {
+      getSnapshot: () => ({ context }),
+      send: vi.fn(),
+    }
+  }
+
+  it('includes the desired paused state so a parked cell initializes paused', async () => {
+    const sw = new StreamWindow(makeConfig())
+    const actor = makeActor({
+      content,
+      options,
+      volume: 0.5,
+      desiredPaused: true,
+      next: null,
+    })
+    sw.viewsByWebContentsId.set(42, actor as never)
+
+    await expect(viewInitHandler()({ sender: { id: 42 } })).resolves.toEqual({
+      content,
+      options,
+      volume: 0.5,
+      paused: true,
+    })
+    expect(actor.send).toHaveBeenCalledWith({ type: 'VIEW_INIT' })
+    sw.dispose()
+  })
+
+  it('reports paused: false for a cell that is not parked-paused', async () => {
+    const sw = new StreamWindow(makeConfig())
+    const actor = makeActor({
+      content,
+      options,
+      volume: 1,
+      desiredPaused: false,
+      next: null,
+    })
+    sw.viewsByWebContentsId.set(42, actor as never)
+
+    await expect(viewInitHandler()({ sender: { id: 42 } })).resolves.toEqual({
+      content,
+      options,
+      volume: 1,
+      paused: false,
+    })
+    sw.dispose()
+  })
+
+  it("sends the cell's paused state to a preloading next view too", async () => {
+    // A background preload for a parked-paused cell is exactly the window
+    // issue #658 is about: the swapped-in view must come up paused instead
+    // of playing until the swap completes.
+    const sw = new StreamWindow(makeConfig())
+    const actor = makeActor({
+      content,
+      options,
+      volume: 1,
+      desiredPaused: true,
+      next: { view: { webContents: { id: 43 } } },
+    })
+    sw.viewsByWebContentsId.set(43, actor as never)
+
+    await expect(viewInitHandler()({ sender: { id: 43 } })).resolves.toEqual({
+      content,
+      options,
+      volume: 1,
+      paused: true,
+    })
+    expect(actor.send).toHaveBeenCalledWith({ type: 'NEXT_VIEW_INIT' })
+    sw.dispose()
+  })
+})
+
 describe('StreamWindow.dispose (issue #629)', () => {
   beforeEach(() => {
     electronStub.windows.length = 0

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -252,13 +252,18 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
       if (!view) {
         return
       }
-      const { content, options, volume } = view.getSnapshot().context
+      const { content, options, volume, desiredPaused } =
+        view.getSnapshot().context
       view.send({
         type: isFromNextView(view, ev.sender.id)
           ? 'NEXT_VIEW_INIT'
           : 'VIEW_INIT',
       })
-      return { content, options, volume }
+      // The desired paused state rides along so a fresh view -- in
+      // particular a background preload for a parked (paused) cell --
+      // initializes paused instead of playing until the post-swap 'pause'
+      // IPC arrives (issue #658).
+      return { content, options, volume, paused: desiredPaused }
     })
     this.registerIpcOn('view-loaded', (ev) => {
       const view = this.viewsByWebContentsId.get(ev.sender.id)

--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -1237,3 +1237,136 @@ describe('mediaPreload re-acquisition keeps operator-set state (issues #620/#621
     expect(next.paused).toBe(false)
   })
 })
+
+describe('mediaPreload initial paused state from view-init (issue #658)', () => {
+  // Must match SCAN_THROTTLE in mediaPreload.ts: long enough for the
+  // re-acquisition's throttled scan to find the replacement element.
+  const SCAN_THROTTLE_MS = 500
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.resetModules()
+    invoke.mockClear()
+    send.mockClear()
+    on.mockClear()
+    exposeInMainWorld.mockClear()
+    document.body.innerHTML = ''
+  })
+
+  function registeredHandler(
+    channel: string,
+  ): (ev: unknown, ...args: unknown[]) => void {
+    const call = on.mock.calls.find(([ch]) => ch === channel)
+    if (!call) {
+      throw new Error(`no ipcRenderer.on('${channel}', ...) handler registered`)
+    }
+    return call[1] as (ev: unknown, ...args: unknown[]) => void
+  }
+
+  function viewLoadedCalls() {
+    return send.mock.calls.filter(([channel]) => channel === 'view-loaded')
+  }
+
+  // happy-dom's HTMLVideoElement never implements videoWidth, so give it a
+  // truthy value to skip findMedia's "wait for playing" branch.
+  function playableVideo(): HTMLVideoElement {
+    const video = document.createElement('video')
+    ;(video as unknown as { videoWidth: number }).videoWidth = 100
+    return video
+  }
+
+  async function loadAcquiredVideo(
+    init: Record<string, unknown> = {},
+  ): Promise<HTMLVideoElement> {
+    const video = playableVideo()
+    document.body.appendChild(video)
+
+    invoke.mockResolvedValueOnce({
+      content: { kind: 'video', link: 'https://example.com/stream' },
+      options: {},
+      volume: 1,
+      ...init,
+    })
+
+    await import('./mediaPreload')
+    document.dispatchEvent(new Event('DOMContentLoaded'))
+    process.emit('loaded' as never)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(viewLoadedCalls()).toHaveLength(1)
+    return video
+  }
+
+  it('pauses the acquired media when view-init reports the cell as parked-paused', async () => {
+    const video = await loadAcquiredVideo({ paused: true })
+
+    expect(video.paused).toBe(true)
+  })
+
+  it('bypasses an instance-level pause override when honoring the initial paused state', async () => {
+    // Mirrors lockdownMediaTags(), which permanently shadows the element's
+    // own `pause` with a no-op: the initial pause must go through
+    // HTMLMediaElement.prototype.pause to have any effect.
+    const shadowedPause = vi.fn()
+    const video = playableVideo()
+    Object.defineProperty(video, 'pause', {
+      writable: false,
+      value: shadowedPause,
+    })
+    document.body.appendChild(video)
+
+    invoke.mockResolvedValueOnce({
+      content: { kind: 'video', link: 'https://example.com/stream' },
+      options: {},
+      volume: 1,
+      paused: true,
+    })
+    await import('./mediaPreload')
+    document.dispatchEvent(new Event('DOMContentLoaded'))
+    process.emit('loaded' as never)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(viewLoadedCalls()).toHaveLength(1)
+    expect(video.paused).toBe(true)
+    expect(shadowedPause).not.toHaveBeenCalled()
+  })
+
+  it('resumes an initially-paused acquisition on a later resume message', async () => {
+    const video = await loadAcquiredVideo({ paused: true })
+    expect(video.paused).toBe(true)
+
+    registeredHandler('resume')()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(video.paused).toBe(false)
+  })
+
+  it('keeps an initially-paused view paused across an emptied re-acquisition', async () => {
+    const video = await loadAcquiredVideo({ paused: true })
+
+    video.remove()
+    const next = playableVideo()
+    document.body.appendChild(next)
+    video.dispatchEvent(new Event('emptied'))
+    await vi.advanceTimersByTimeAsync(SCAN_THROTTLE_MS)
+    expect(viewLoadedCalls()).toHaveLength(2)
+
+    expect(next.paused).toBe(true)
+  })
+
+  it('leaves playback running when view-init reports the cell as not paused', async () => {
+    const video = await loadAcquiredVideo({ paused: false })
+
+    expect(video.paused).toBe(false)
+  })
+
+  it('defaults to playing when view-init omits the paused field', async () => {
+    const video = await loadAcquiredVideo()
+
+    expect(video.paused).toBe(false)
+  })
+})

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -581,8 +581,14 @@ async function main() {
   const viewInit = ipcRenderer.invoke('view-init')
   const pageReady = new Promise((resolve) => process.once('loaded', resolve))
 
-  const [{ content, options: initialOptions, volume: initialVolume }] =
-    await Promise.all([viewInit, pageReady])
+  const [
+    {
+      content,
+      options: initialOptions,
+      volume: initialVolume,
+      paused: initialPaused,
+    },
+  ] = await Promise.all([viewInit, pageReady])
 
   const snapshotController = new SnapshotController()
 
@@ -595,10 +601,13 @@ async function main() {
   // recovery, so the tracked value is re-applied below (issue #620).
   let latestRotation: number | undefined = initialOptions?.rotation
   // Whether the operator asked this view's playback to stay paused (a parked
-  // view, issue #374). Tracked so a re-acquisition -- whose findMedia()
+  // view, issue #374). Initialized from the view-init payload so a fresh view
+  // for an already-paused cell -- in particular a background preload for a
+  // parked cell -- never starts playing before the post-swap 'pause' IPC
+  // arrives (issue #658). Tracked so a re-acquisition -- whose findMedia()
   // unconditionally starts playback -- can re-assert the pause instead of
   // silently resuming a hidden view (issue #621).
-  let desiredPaused = false
+  let desiredPaused = initialPaused ?? false
   // The most recently acquired media element (reassigned across a re-
   // acquisition, e.g. the 'emptied' handler below), so a PAUSE/RESUME
   // message received at any point can act on whichever one is current.


### PR DESCRIPTION
## Problem

Follow-up to #621 (fixed in PR #657). That fix re-sends `'pause'` to the swapped-in view in `resyncSwappedView`, so a parked cell no longer *stays* playing after an in-place content swap. During the preloading phase itself, however, the second view was not paused: the `view-init` response (`StreamWindow.ts`) carried `content`/`options`/`volume` but not the paused state, and the fresh preload's own `desiredPaused` started `false` until the post-swap `'pause'` IPC arrived. A background preload for a parked (paused) cell therefore acquired media and kept decoding/fetching for up to the 45s preload timeout (audio stays muted via `webContents.audioMuted` during load, so this was a resource-usage gap rather than an audible one).

## Solution

- `StreamWindow`'s `view-init` handler now includes `paused: desiredPaused` from the actor context in its response. The same actor context serves both the current and the preloading next view, so a preload for a parked cell sees the cell's paused state.
- `mediaPreload.ts` initializes its `desiredPaused` tracking from that field (`initialPaused ?? false`, so older payloads without the field behave as before). The existing `acquireMedia()` pause path then pauses the element right after acquisition -- via `HTMLMediaElement.prototype.pause.call(media)`, since `lockdownMediaTags()` permanently shadows the element's own `pause()` as a no-op.

The post-swap `'pause'` re-send from PR #657 stays in place as the steady-state safety net.

## Testing

- New `mediaPreload` tests: an acquisition with `paused: true` comes up paused (including through an instance-level `pause` shadow), resumes on a later `resume` message, stays paused across an emptied re-acquisition, and defaults to playing when the field is `false` or absent.
- New `StreamWindow` tests: the `view-init` handler returns the desired paused state for both the current view and a preloading next view.
- `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` all pass.

## Out of scope

Filed #667 for a related pre-existing gap found while working on this: `acquireMedia()`'s paused branch never dispatches `MEDIA_PAUSE_EVENT`, so the bundled HLS player keeps fetching segments after a paused (re-)acquisition even though the element is paused.

Closes #658
