### PR TITLE
fix(streamwall): announce the park during a paused media acquisition

### DIFF
--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -1370,3 +1370,143 @@ describe('mediaPreload initial paused state from view-init (issue #658)', () => 
     expect(video.paused).toBe(false)
   })
 })
+
+describe('mediaPreload paused acquisition announces the park to the page world (issue #667)', () => {
+  // Must match SCAN_THROTTLE in mediaPreload.ts: long enough for the
+  // re-acquisition's throttled scan to find the replacement element.
+  const SCAN_THROTTLE_MS = 500
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.resetModules()
+    invoke.mockClear()
+    send.mockClear()
+    on.mockClear()
+    exposeInMainWorld.mockClear()
+    document.body.innerHTML = ''
+  })
+
+  function registeredHandler(channel: string): () => void {
+    const call = on.mock.calls.find(([ch]) => ch === channel)
+    if (!call) {
+      throw new Error(`no ipcRenderer.on('${channel}', ...) handler registered`)
+    }
+    return call[1] as () => void
+  }
+
+  function viewLoadedCalls() {
+    return send.mock.calls.filter(([channel]) => channel === 'view-loaded')
+  }
+
+  // The bundled HLS player (renderer/playHLS.ts) only stops segment fetching
+  // via these document events (issue #384); its hls.js instance lives in a
+  // closure the preload cannot reach. Records every park/unpark announcement
+  // from registration onward; each call returns a fresh log.
+  function parkEvents(): string[] {
+    const names: string[] = []
+    const record = (event: Event) => names.push(event.type)
+    document.addEventListener('streamwall:media-pause', record)
+    document.addEventListener('streamwall:media-resume', record)
+    return names
+  }
+
+  // happy-dom's HTMLVideoElement never implements videoWidth, so give it a
+  // truthy value to skip findMedia's "wait for playing" branch.
+  function playableVideo(): HTMLVideoElement {
+    const video = document.createElement('video')
+    ;(video as unknown as { videoWidth: number }).videoWidth = 100
+    return video
+  }
+
+  async function loadAcquiredVideo(
+    init: Record<string, unknown> = {},
+  ): Promise<HTMLVideoElement> {
+    const video = playableVideo()
+    document.body.appendChild(video)
+
+    invoke.mockResolvedValueOnce({
+      content: { kind: 'video', link: 'https://example.com/stream' },
+      options: {},
+      volume: 1,
+      ...init,
+    })
+
+    await import('./mediaPreload')
+    document.dispatchEvent(new Event('DOMContentLoaded'))
+    process.emit('loaded' as never)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(viewLoadedCalls()).toHaveLength(1)
+    return video
+  }
+
+  it('announces the park when an acquisition comes up initially paused', async () => {
+    const events = parkEvents()
+
+    await loadAcquiredVideo({ paused: true })
+
+    expect(events).toEqual(['streamwall:media-pause'])
+  })
+
+  it('re-announces the park when a parked view re-acquires after an emptied teardown', async () => {
+    const video = await loadAcquiredVideo()
+    registeredHandler('pause')()
+    expect(video.paused).toBe(true)
+
+    // The teardown that empties the element may also have destroyed and
+    // re-created the page's hls.js instance, which starts loading again and
+    // was never told about the park -- the re-acquisition has to repeat the
+    // announcement (issue #667).
+    const events = parkEvents()
+    video.remove()
+    const next = playableVideo()
+    document.body.appendChild(next)
+    video.dispatchEvent(new Event('emptied'))
+    await vi.advanceTimersByTimeAsync(SCAN_THROTTLE_MS)
+    expect(viewLoadedCalls()).toHaveLength(2)
+
+    expect(events).toEqual(['streamwall:media-pause'])
+    expect(next.paused).toBe(true)
+  })
+
+  it('does not announce a park while acquiring for a view that is not paused', async () => {
+    const events = parkEvents()
+
+    const video = await loadAcquiredVideo()
+
+    expect(events).toEqual([])
+    expect(video.paused).toBe(false)
+  })
+
+  it('does not announce a park when re-acquiring for a view that was resumed before the stall', async () => {
+    const video = await loadAcquiredVideo()
+    registeredHandler('pause')()
+    registeredHandler('resume')()
+    await vi.advanceTimersByTimeAsync(0)
+
+    const events = parkEvents()
+    video.remove()
+    const next = playableVideo()
+    document.body.appendChild(next)
+    video.dispatchEvent(new Event('emptied'))
+    await vi.advanceTimersByTimeAsync(SCAN_THROTTLE_MS)
+    expect(viewLoadedCalls()).toHaveLength(2)
+
+    expect(events).toEqual([])
+  })
+
+  it('still announces the resume symmetrically after an initially-paused acquisition', async () => {
+    const video = await loadAcquiredVideo({ paused: true })
+    const events = parkEvents()
+
+    registeredHandler('resume')()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(events).toEqual(['streamwall:media-resume'])
+    expect(video.paused).toBe(false)
+  })
+})

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -620,6 +620,16 @@ async function main() {
     currentMedia = media
     volumeController = new VolumeController(media, latestVolume)
     if (desiredPaused) {
+      // Announce the park to the page world as well: the bundled HLS player
+      // only stops segment fetching via this document event (issue #384),
+      // and the acquisition that just found this element may come with a
+      // fresh hls.js instance that was never told about the park -- an
+      // initially-paused view (issue #658), or a re-acquisition after an
+      // emptied teardown re-created the player (issue #667). Safe to repeat:
+      // stopLoad() on an already-stopped player is a no-op. Announced only
+      // after findMedia() resolved, so a still-loading acquisition is never
+      // starved of the segments it needs to reach view-loaded.
+      document.dispatchEvent(new CustomEvent(MEDIA_PAUSE_EVENT))
       // Same caveat as the 'pause' handler below: lockdownMediaTags()
       // permanently shadows the element's own `pause` with a no-op, so the
       // native implementation must be called directly.


### PR DESCRIPTION
## Problem

Follow-up to #384/#621/#658. `acquireMedia()`'s `desiredPaused` branch in `packages/streamwall/src/preload/mediaPreload.ts` paused only the media element (via `HTMLMediaElement.prototype.pause.call`, bypassing the lockdown shadow) but never dispatched `MEDIA_PAUSE_EVENT`. The bundled HLS player (`packages/streamwall/src/renderer/playHLS.ts`) only stops segment fetching through that document event (`hls.stopLoad()`, added for #384), so an hls.js instance created during a paused (re-)acquisition kept fetching segments while the element itself was paused:

- **Emptied re-acquisition while parked-paused (#621 path):** the HLS teardown/re-creation builds a fresh hls.js instance, nothing re-sends the `'pause'` IPC, and the new instance keeps loading segments indefinitely while the cell stays parked.
- **Initially-paused acquisition (#658 path):** the preloading view's hls.js keeps buffering until the post-swap `'pause'` IPC arrives (a short window, but the same gap).

## Solution

Dispatch `MEDIA_PAUSE_EVENT` on `document` in the `desiredPaused` branch of `acquireMedia()`, mirroring the `'pause'` IPC handler. Notes on the design:

- **Idempotent:** `stopLoad()` on an already-stopped player is a no-op, so repeating the announcement for a player that already knows about the park is harmless.
- **No preload starvation:** the announcement fires only after `findMedia()` has resolved (the video has frames and `view-loaded` is about to be sent), so a still-loading acquisition is never cut off from the segments it needs.
- **Symmetric recovery:** the `'resume'` IPC handler already dispatches `MEDIA_RESUME_EVENT` unconditionally, so `startLoad()` recovers a player parked through this path exactly like one parked through the IPC path. The playHLS listeners are registered by the same setup code that creates the `<video>` element `findMedia()` finds, so ordering is safe.

## Testing

- New tests: the park is announced for an initially-paused acquisition and re-announced when a parked view re-acquires after an emptied teardown; no announcement happens for unpaused or resumed-before-stall acquisitions; a later resume still announces symmetrically and playback recovers.
- `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` all pass.

Closes #667
