### PR TITLE
ci: create the draft release once before the publish matrix fans out

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,9 +175,51 @@ jobs:
       - uses: ./.github/actions/setup
       - run: npm run licenses:check
 
+  # Create the draft release exactly once, before the three-platform publish
+  # matrix fans out. Each publish leg runs electron-forge's GitHub publisher,
+  # which looks the release up by tag and only creates it when none exists
+  # (check-then-create). With no draft present yet, two legs can pass that check
+  # concurrently and each creates its own draft: the release splits into one
+  # draft holding the notes and the mac/windows assets and a second, notes-less
+  # draft holding just the Linux installers, so `latest.yml` never references
+  # them and `gh release edit <tag>` becomes ambiguous (#671). Materializing the
+  # draft here first means every forge publisher finds it and only appends
+  # assets.
+  #
+  # The step is gated on a tag ref rather than the whole job so a
+  # workflow_dispatch run (whose ref carries no version to name a release by)
+  # still satisfies the publish matrix's `needs` and behaves exactly as before.
+  prepare-release:
+    name: Prepare draft release
+    needs: [checks, test, build, make, e2e, licenses]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write # electron-forge's publishers append assets to this draft
+    steps:
+      - name: Create the draft release if it does not exist
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The job never checks the repository out, so `gh` cannot infer the
+          # target from a git remote.
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          # Idempotent: a re-run of an already-handled tag — or a forge
+          # publisher that raced ahead of this job — must not fail here.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::notice::Release $TAG already exists — nothing to prepare."
+            exit 0
+          fi
+          # Empty notes: release-notes below fills the body once every asset is
+          # uploaded. Draft so the publish matrix appends before it goes live.
+          gh release create "$TAG" --draft --title "$TAG" --notes ""
+          echo "::notice::Created draft release $TAG for the publish matrix to append to."
+
   publish:
     name: Publish (${{ matrix.platform.name }})
-    needs: [checks, test, build, make, e2e, licenses]
+    needs: [checks, test, build, make, e2e, licenses, prepare-release]
     runs-on: ${{ matrix.platform.os }}
     timeout-minutes: 30
     permissions:

--- a/test/ci-gate.test.mjs
+++ b/test/ci-gate.test.mjs
@@ -265,3 +265,69 @@ test('the release quality gate makes each platform on its own runner', () => {
     '"Install Linux maker tooling" must be restricted to the Linux leg',
   )
 })
+
+// The three `publish` legs each run electron-forge's GitHub publisher, which
+// looks the release up by tag and creates it when absent (check-then-create).
+// With no draft yet, two legs can pass that check concurrently and each creates
+// its own draft, splitting the release into two — one with the notes and the
+// mac/windows assets, one with just the Linux installers (#671). Creating the
+// draft exactly once before the matrix fans out means every publisher finds it
+// and only appends assets.
+test('a single prepare-release job creates the draft before the publish matrix', () => {
+  const release = readWorkflow('release.yml')
+  const prepare = release.jobs['prepare-release']
+
+  assert.ok(
+    prepare,
+    'release.yml must have a prepare-release job that creates the draft once',
+  )
+
+  // The draft must not be created before the quality gate has passed, or a
+  // failing test leaves an empty draft behind. prepare-release gates on the
+  // same jobs the publish matrix does.
+  const gate = ['checks', 'test', 'build', 'make', 'e2e', 'licenses']
+  for (const job of gate) {
+    assert.ok(
+      prepare.needs.includes(job),
+      `prepare-release must wait for the "${job}" gate job before creating ` +
+        'the draft',
+    )
+  }
+
+  assert.equal(
+    prepare.permissions?.contents,
+    'write',
+    'prepare-release needs contents: write to create the release',
+  )
+
+  // The publish matrix must depend on the draft already existing, otherwise it
+  // races to create it — the very split this job prevents.
+  assert.ok(
+    release.jobs.publish.needs.includes('prepare-release'),
+    'the publish matrix must wait for prepare-release so the draft exists ' +
+      'before any forge publisher looks it up',
+  )
+
+  const createStep = prepare.steps.find((step) =>
+    /gh release create\b/.test(step.run ?? ''),
+  )
+  assert.ok(
+    createStep,
+    'prepare-release must create the release with `gh release create`',
+  )
+  assert.match(
+    createStep.run,
+    /--draft\b/,
+    'the release must be created as a draft so the publishers append to it ' +
+      'before it is published',
+  )
+  // A re-run of an already-handled tag (or one the forge publisher raced to
+  // create first) must not fail the job, so the creation is guarded on the
+  // release not already existing.
+  assert.match(
+    createStep.run,
+    /gh release view\b/,
+    'prepare-release must be idempotent: skip creation when the release ' +
+      'already exists so re-runs do not fail',
+  )
+})

--- a/test/release-docker.test.mjs
+++ b/test/release-docker.test.mjs
@@ -206,10 +206,16 @@ test('the multi-arch manifest is merged and verified', () => {
 
 // The image must not ship code that would have failed a pull request, and a
 // `latest` tag pointing at an untested build is worse than no image at all.
+// `prepare-release` is not a quality gate but the binaries' draft-release
+// setup, which the image (published straight to GHCR) does not use, so it is
+// excluded from the shared gate the image must also wait for.
 test('the image publish waits for the release quality gate', () => {
   const release = readYaml('.github/workflows/release.yml')
 
-  for (const job of release.jobs.publish.needs) {
+  const gate = release.jobs.publish.needs.filter(
+    (job) => job !== 'prepare-release',
+  )
+  for (const job of gate) {
     assert.ok(
       release.jobs['docker-image'].needs.includes(job),
       `release.yml job "${job}" gates the binaries but not the image`,


### PR DESCRIPTION
## Problem

The v0.10.2 release run produced **two** draft releases for the same tag: one holding the mac/Windows assets plus `latest.yml`/`latest-mac.yml` and the generated notes, and a second, notes-less draft holding only the Linux `.rpm`/`.deb` installers.

The three `Publish (<os>)` legs run in parallel and each lets electron-forge's GitHub publisher look up the release for the tag; the publisher creates it only on a 404 (`listReleases` → `createRelease`). With no draft present yet, two legs can pass that check concurrently and each creates its own draft — a classic check-then-create race. v0.10.1 serialized by chance, so the split is intermittent.

Impact: `gh release edit <tag>` becomes ambiguous, the published release silently misses the Linux installers, and the update feeds (`latest.yml`) never reference them.

## Solution

Add a `prepare-release` job that materializes the draft **exactly once**, after the same quality gate the publish matrix waits on and before the matrix fans out. Every forge publisher then finds the existing draft (its `listReleases` lookup includes drafts) and only appends assets — no leg ever hits the create path.

Details:
- **Idempotent:** the step skips creation when the release already exists (`gh release view`), so a re-run of an already-handled tag — or a publisher that somehow raced ahead — does not fail.
- **workflow_dispatch preserved:** the create step is gated at the *step* level on a `refs/tags/v` ref, not the job. A dispatch run (whose ref carries no version) still satisfies the publish matrix's `needs` and behaves exactly as before.
- **Empty notes:** `release-notes` still fills the body once every asset is uploaded; the draft is created with empty notes as a placeholder.
- The draft stays a draft, matching the existing publish-then-`--draft=false` flow.

## Architecture decisions

- Chose the `prepare-release` approach over serializing the publish matrix (`max-parallel: 1` / `needs:` chain), which the issue notes would cost wall-clock time on every release.
- `docker-image` deliberately does **not** depend on `prepare-release`: it publishes straight to GHCR and needs no GitHub-release draft. The `release-docker.test.mjs` gate assertion was updated to exclude `prepare-release` from the shared quality gate it compares against, keeping its original intent (the image waits on the same gate as the binaries).

## Testing

- New `test/ci-gate.test.mjs` case asserts the `prepare-release` job exists, gates on the full quality gate, holds `contents: write`, is depended on by the publish matrix, and creates a draft idempotently.
- Full quality gate green locally: `format:check`, `lint`, `typecheck`, `npm test` (all workspaces), `actionlint` (clean, incl. shellcheck on the new `run:` block).
- No runtime behavior changes; this is CI config, covered by the structural workflow tests above.

Closes #671
