### PR TITLE
build: declare happy-dom as a root devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "eslint-plugin-import-x": "^4.17.1",
         "eslint-plugin-react-hooks": "^7.1.1",
         "globals": "^17.7.0",
+        "happy-dom": "^20.11.0",
         "js-yaml": "^4.3.0",
         "prettier": "^3.9.5",
         "prettier-plugin-organize-imports": "^4.3.0",
@@ -10401,13 +10402,11 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/happy-dom": {
-      "version": "20.10.6",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz",
-      "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
+      "version": "20.11.1",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.1.tgz",
+      "integrity": "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -10427,8 +10426,6 @@
       "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.12"
       },

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint-plugin-import-x": "^4.17.1",
     "eslint-plugin-react-hooks": "^7.1.1",
     "globals": "^17.7.0",
+    "happy-dom": "^20.11.0",
     "js-yaml": "^4.3.0",
     "prettier": "^3.9.5",
     "prettier-plugin-organize-imports": "^4.3.0",


### PR DESCRIPTION
## Problem

The vitest test environment resolved `happy-dom` only through npm's peer hoisting. On `main` the root lockfile entry looks like this:

```json
"node_modules/happy-dom": {
  "version": "20.10.6",
  "dev": true,
  "optional": true,
  "peer": true,
```

`optional: true, peer: true` means nothing in this repo asked for that entry — it exists solely because vitest declares `happy-dom` as an optional peer dependency. The three packages that actually use it (`streamwall`, `streamwall-control-ui`, `streamwall-control-client`) each declare `happy-dom: ^20.11.0`, but they resolve to workspace-local copies under `packages/*/node_modules/happy-dom`, because the hoisted 20.10.6 occupied the root slot.

vitest imports `happy-dom` from its own location in the root `node_modules`, so the workspace-local copies are invisible to it. The moment a lockfile regeneration drops the inferred root entry, every test run dies before a single test executes:

```
Error: [vitest-pool]: Failed to start forks worker for test files .../ServerVersionLabel.test.tsx
Caused by: Error: Cannot find package 'happy-dom' imported from node_modules/vitest/dist/chunks/index.DC7d2Pf8.js
 Test Files  no tests
     Errors  49 errors
```

That is exactly what happened in #670 (`bump find-my-way 9.6.0 → 9.7.0`): a 3-line dependency bump whose lockfile regeneration deleted 50 lines, almost all of them the `happy-dom` root entry and its `entities` subtree. All three `Test` jobs (ubuntu/macos/windows) fail, and with them `CI OK`, while the other 15 checks stay green. Nothing about find-my-way is at fault — any dependency bump could have triggered it.

## Fix

Declare `happy-dom: ^20.11.0` in the root `package.json` under `devDependencies`. The root entry is now backed by an explicit dependency rather than a hoisting coincidence:

```diff
     "node_modules/happy-dom": {
-      "version": "20.10.6",
+      "version": "20.11.1",
       "dev": true,
-      "optional": true,
-      "peer": true,
```

## Verification

- `npm run test` — all workspaces green locally (200 node:test + 371 vitest control-ui tests, 49 test files).
- `npm run lint` and `prettier --check` clean.
- Reproduced the #670 scenario on this branch: `npm update find-my-way --package-lock-only` bumps find-my-way to 9.7.0 and the root `happy-dom` entry survives at 20.11.1. Before this change the same operation removed it.

## Follow-up

#670 needs a rebase once this lands; its lockfile conflicts with this one and Dependabot will regenerate it against the fixed `package.json`.
