### PR TITLE
test(ci): guard against a vitest environment resolved only by hoisting

### DIFF
--- a/test/vitest-environment-deps.test.mjs
+++ b/test/vitest-environment-deps.test.mjs
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict'
+import { readFileSync, readdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)))
+
+function readJson(relativePath) {
+  return JSON.parse(readFileSync(join(rootDir, relativePath), 'utf8'))
+}
+
+function readDocIfExists(relativePath) {
+  try {
+    return readFileSync(join(rootDir, relativePath), 'utf8')
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return null
+    }
+    throw err
+  }
+}
+
+function findTestFiles(workspace) {
+  const results = []
+
+  function walk(relativeDir) {
+    for (const entry of readdirSync(join(rootDir, workspace, relativeDir), {
+      withFileTypes: true,
+    })) {
+      if (entry.name === 'node_modules' || entry.name === 'dist') {
+        continue
+      }
+
+      const entryRelativeDir = join(relativeDir, entry.name)
+      if (entry.isDirectory()) {
+        walk(entryRelativeDir)
+      } else if (/\.test\.tsx?$/.test(entry.name)) {
+        results.push(join(workspace, entryRelativeDir))
+      }
+    }
+  }
+
+  walk('.')
+  return results
+}
+
+// vitest resolves a non-default `test.environment` (e.g. happy-dom) as a
+// package import, set either as a workspace-wide config default or a
+// per-file `@vitest-environment` pragma comment overriding it.
+function environmentFromConfig(source) {
+  return source.match(/environment:\s*['"]([^'"]+)['"]/)?.[1]
+}
+
+function environmentFromPragma(source) {
+  return source.match(/^\/\/\s*@vitest-environment\s+(\S+)/m)?.[1]
+}
+
+// Every vitest environment package this repo actually relies on to run its
+// tests, gathered from every workspace's config and test files. `node` is
+// vitest's built-in default and needs no separate package.
+function requiredTestEnvironments() {
+  const environments = new Set()
+
+  for (const workspace of readJson('package.json').workspaces) {
+    const config = readDocIfExists(join(workspace, 'vitest.config.ts'))
+    const configEnvironment = config && environmentFromConfig(config)
+    if (configEnvironment) {
+      environments.add(configEnvironment)
+    }
+
+    for (const testFile of findTestFiles(workspace)) {
+      const pragmaEnvironment = environmentFromPragma(readDocIfExists(testFile))
+      if (pragmaEnvironment) {
+        environments.add(pragmaEnvironment)
+      }
+    }
+  }
+
+  environments.delete('node')
+  return environments
+}
+
+// vitest only declares its DOM environments (happy-dom, jsdom) as *optional
+// peer* dependencies. A workspace `package.json` asking for one is not
+// enough to keep it out of that optional-peer state at the root: vitest
+// itself is hoisted there, resolves the environment relative to its own
+// location, and npm is free to drop an optional peer nothing at the root
+// explicitly requires the next time the lockfile regenerates — which is
+// exactly what the find-my-way bump in #670 did, breaking every `Test` job
+// with `Cannot find package 'happy-dom'` before a single assertion ran
+// (fixed for that instance in #675). Declaring the environment as a root
+// dependency is what turns it into a real, non-optional install.
+test('every vitest environment package is declared as a root dependency', () => {
+  const { dependencies = {}, devDependencies = {} } = readJson('package.json')
+  const declared = { ...dependencies, ...devDependencies }
+
+  for (const environment of requiredTestEnvironments()) {
+    assert.ok(
+      declared[environment],
+      `"${environment}" is used as a vitest environment but is not declared ` +
+        'in the root package.json. Add it to "devDependencies" so npm ' +
+        'installs it as a real dependency instead of inferring it from ' +
+        "vitest's optional peer dependency on it (see #676).",
+    )
+  }
+})
+
+// The declaration above only helps if the lockfile agrees: a stale lockfile
+// can still resolve the environment purely through npm's optional-peer
+// inference, which is the literal failure mode this guard exists to catch.
+test('the lockfile does not resolve a required vitest environment through hoisting alone', () => {
+  const { packages } = readJson('package-lock.json')
+
+  for (const environment of requiredTestEnvironments()) {
+    const entry = packages[`node_modules/${environment}`]
+    assert.ok(
+      entry,
+      `package-lock.json has no node_modules/${environment} entry, but a ` +
+        'vitest config or test file requires that environment',
+    )
+    assert.ok(
+      !(entry.optional && entry.peer),
+      `node_modules/${environment} in package-lock.json is still marked ` +
+        'both "optional" and "peer", meaning npm installed it only because ' +
+        'vitest declares it as an optional peer dependency, not because ' +
+        'any package.json actually requires it. Run `npm install` after ' +
+        'declaring it as a root dependency to regenerate the lockfile ' +
+        'entry (see #676).',
+    )
+  }
+})


### PR DESCRIPTION
## Summary

Adds a CI-enforced invariant guarding against the class of failure from #671/#675: a vitest DOM environment (e.g. `happy-dom`) resolving only through npm's optional-peer hoisting instead of an explicit dependency. That inference is silently dropped by a lockfile regeneration unrelated to the environment package itself — the find-my-way bump in #670 did exactly this, turning all three `Test` jobs red with `Cannot find package 'happy-dom'` before a single assertion ran.

#675 fixed that specific instance by declaring `happy-dom` as a root `devDependency`. This closes the gap the issue identifies: nothing stopped the same class of failure from recurring for `happy-dom` again, or for any future test-environment package.

Closes #676

## Technical solution

`test/vitest-environment-deps.test.mjs` adds two invariant checks, run as part of `npm test`:

1. **Every vitest environment package actually used is declared as a root dependency.** The check scans every workspace's `vitest.config.ts` for a configured `test.environment`, and every `*.test.ts(x)` file for a `// @vitest-environment` pragma override, then asserts each distinct environment name (excluding vitest's built-in `node` default) appears in the root `package.json`'s `dependencies`/`devDependencies`.
2. **The lockfile doesn't resolve it through hoisting alone.** For the same set of environments, asserts the corresponding `package-lock.json` `node_modules/<name>` entry isn't still marked both `"optional": true` and `"peer": true` — the literal symptom of "installed only because vitest's peer dependency happened to pull it in."

Both checks currently pass with `happy-dom` as the only environment in use (configured in `streamwall-control-client` and `streamwall-control-ui`'s `vitest.config.ts`, and via pragma in several `streamwall` renderer/preload test files).

## Architecture decisions

- Followed the existing `test/ci-gate.test.mjs` / `test/workspace-metadata.test.mjs` convention: a plain `node:test` file reading real repository files directly, no separate `scripts/` module or standalone CLI entry point, since this only needs to run as part of `npm test` (unlike e.g. `check-deprecated-deps.mjs`, which is also invoked from its own scheduled workflow).
- Chose the issue's first suggested guard shape (declaration check in `test/`) and folded in its second shape (lockfile optional/peer grep) as a cheap second assertion, since both map naturally onto the same test file. The issue's third suggested shape — distinguishing "zero tests ran" from "tests passed" at the CI job level — is a materially separate, more invasive change to the test job's success detection across all three OS legs, so it's filed as its own follow-up instead of bundled in here.
- The root-dependency requirement (rather than "declared anywhere") deliberately matches the actual fix in #675: vitest itself is hoisted to the root `node_modules` and resolves its environment relative to its own location, so a workspace-local declaration alone does not prevent the root copy from being inferred as optional/peer (that state existed in this repo before #670 even though `streamwall`, `streamwall-control-client`, and `streamwall-control-ui` had already declared `happy-dom` in their own `package.json`s via an earlier Dependabot bump).

## Testing performed

- TDD red/green: temporarily restored `package.json`/`package-lock.json` to their pre-#675 (`f82eaa7~1`) state and confirmed both new assertions fail with the intended message; restored the current files and confirmed both pass.
- `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm test` (root + all workspaces) all pass locally.

## Risks/breaking changes

None — this only adds a new test file; no production code changes.