### PR TITLE
ci: fail loudly when a test suite executes zero tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,29 @@ failing assertion. `test/workspace-metadata.test.mjs` keeps the configured
 timeout above a floor that leaves the live-server WebSocket suites room to
 finish under load.
 
+### `npm test` proves that tests actually ran
+
+The root `npm test` goes through `scripts/run-tests.mjs` instead of calling the
+runners directly. It runs the same legs in the same order — the repository
+invariant tests in `test/`, then every workspace with a `test` script, stopping
+at the first failure — but asks each runner for a JUnit report next to its
+usual output and checks that the report contains at least one test case:
+
+```
+✖ streamwall-shared: 0 tests executed - this is a runtime/setup failure, not a
+  test failure. …
+```
+
+A suite that dies at worker startup — a missing test environment package, a
+broken transform, a glob that matches nothing — otherwise looks exactly like a
+failing assertion, because both are just a non-zero exit code (#671, #676,
+#678). A successful run ends with a per-leg count, so a leg that quietly stops
+executing tests cannot pass as green either.
+
+Adding a workspace whose `test` script uses a different runner means teaching
+the wrapper how to get a count out of it; `test/run-tests.test.mjs` fails until
+you do.
+
 ### End-to-end tests
 
 The E2E smoke tests need a browser that is not installed by `npm ci`. They are

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "npm run typecheck --workspaces --if-present",
-    "test": "node --test test/*.test.mjs && npm run test --workspaces --if-present",
+    "test": "node scripts/run-tests.mjs",
     "test:e2e": "npm -w streamwall-control-e2e run test:e2e",
     "licenses:check": "node scripts/check-licenses.mjs",
     "release:version": "node scripts/release-version.mjs"

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+// Runs every test suite in the repository and fails loudly when one of them
+// reported zero tests (#678).
+//
+// The `Test` job used to be a plain `npm test`, so it had exactly one signal:
+// the exit code. That made a runtime failure look like a test failure. When the
+// find-my-way bump in #670 dropped `happy-dom` from the install, all three OS
+// legs died at vitest worker startup with `Cannot find package 'happy-dom'`
+// before a single assertion ran (#671/#675) - the same red check a broken
+// assertion produces, which is slow to tell apart at a glance. The inverse is
+// worse: a future config change (`--passWithNoTests`, a glob that matches
+// nothing, a workspace silently skipped) could make a suite that executes
+// nothing exit zero and be reported as success.
+//
+// So every suite is asked for a machine-readable JUnit report in addition to
+// its usual output, and a leg whose report contains no test case fails with a
+// message that names the cause instead of blaming the tests.
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, readFileSync, rmSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)))
+
+// Written per leg, always relative to the directory the runner executes in, so
+// that no absolute path (with its platform-specific separators and possible
+// spaces) has to survive a trip through NODE_OPTIONS on Windows. `node_modules`
+// keeps the report out of git and out of Prettier's way.
+export const TEST_REPORT_FILE = 'node_modules/.streamwall-test-report.junit.xml'
+
+// The reporter both runners write the count into. JUnit rather than each
+// runner's own JSON: node:test has no JSON reporter, and this way a single
+// parser covers every leg.
+const NODE_TEST_REPORTER_FLAGS = [
+  // Keep a readable log next to the machine-readable report. Without an
+  // explicit reporter node:test would fall back to `tap` whenever CI's stdout
+  // is not a TTY.
+  '--test-reporter=spec',
+  '--test-reporter-destination=stdout',
+  '--test-reporter=junit',
+  `--test-reporter-destination=${TEST_REPORT_FILE}`,
+]
+
+const VITEST_REPORTER_FLAGS = [
+  '--reporter=default',
+  '--reporter=junit',
+  `--outputFile.junit=${TEST_REPORT_FILE}`,
+]
+
+/**
+ * Classifies a workspace `test` script by the runner it invokes. Only runners
+ * this file knows how to get a test count out of are accepted; anything else
+ * throws, because silently running it would produce a report-less leg that
+ * looks identical to a suite that executed nothing.
+ */
+export function detectRunner(testScript) {
+  if (/(^|\s)vitest(\s|$)/.test(testScript)) {
+    return 'vitest'
+  }
+  if (/(^|\s)--test(\s|$)/.test(testScript)) {
+    return 'node-test'
+  }
+  throw new Error(
+    `Cannot determine the test runner of "${testScript}". scripts/run-tests.mjs ` +
+      'has to ask each runner for a JUnit report to verify that tests actually ' +
+      'ran, so teach it about this runner before wiring it up (#678).',
+  )
+}
+
+/**
+ * Builds the ordered list of test legs: the repository invariant tests in
+ * `test/` first (they are the cheapest and guard the setup itself), then one
+ * leg per workspace that has a `test` script.
+ */
+export function planLegs(workspaces) {
+  const legs = [
+    {
+      name: 'test/ (repository invariants)',
+      command: process.execPath,
+      args: ['--test', ...NODE_TEST_REPORTER_FLAGS, 'test/*.test.mjs'],
+      nodeOptions: null,
+      reportPath: TEST_REPORT_FILE,
+    },
+  ]
+
+  for (const { name, dir, runner } of workspaces) {
+    legs.push({
+      name,
+      command: 'npm',
+      args:
+        runner === 'vitest'
+          ? ['run', 'test', '-w', name, '--', ...VITEST_REPORTER_FLAGS]
+          : ['run', 'test', '-w', name],
+      // `node --test` only reads flags that precede its file arguments, so a
+      // node:test workspace cannot take the reporter through `npm run -- …`
+      // the way vitest does; NODE_OPTIONS reaches it either way.
+      nodeOptions:
+        runner === 'vitest' ? null : NODE_TEST_REPORTER_FLAGS.join(' '),
+      reportPath: join(dir, TEST_REPORT_FILE),
+    })
+  }
+
+  return legs
+}
+
+/**
+ * Environment for one leg: the caller's, with the leg's extra NODE_OPTIONS
+ * merged into any the caller already set rather than replacing them.
+ */
+export function buildEnv(baseEnv, leg) {
+  const env = { ...baseEnv }
+
+  // A `node --test` process that inherits this reports its results back to the
+  // parent runner over IPC and ignores `--test-reporter` entirely, so the leg
+  // would write no report and be counted as zero tests. It is only ever set
+  // when something already running under node:test shells out to `npm test`.
+  delete env.NODE_TEST_CONTEXT
+
+  if (leg.nodeOptions) {
+    env.NODE_OPTIONS = [baseEnv.NODE_OPTIONS, leg.nodeOptions]
+      .filter(Boolean)
+      .join(' ')
+  }
+
+  return env
+}
+
+/** Number of `<testcase>` elements a JUnit report contains. */
+export function countTestCases(report) {
+  if (!report) {
+    return 0
+  }
+  return report.match(/<testcase[\s/>]/g)?.length ?? 0
+}
+
+export function evaluateLeg(leg, { status, signal = null, testCount }) {
+  if (testCount === 0) {
+    return {
+      ok: false,
+      reason: 'no-tests',
+      message:
+        `${leg.name}: 0 tests executed - this is a runtime/setup failure, ` +
+        'not a test failure. The runner produced no JUnit report, so it never ' +
+        'got as far as an assertion: look for a module resolution, config or ' +
+        'transform error above (#676 was one such instance).',
+    }
+  }
+
+  if (status !== 0) {
+    return {
+      ok: false,
+      reason: 'failed',
+      message:
+        `${leg.name}: ${testCount} tests ran and the runner ` +
+        (signal ? `was killed by ${signal}.` : `exited with ${status}.`),
+    }
+  }
+
+  return { ok: true, testCount }
+}
+
+function readWorkspaces() {
+  const { workspaces } = JSON.parse(
+    readFileSync(join(rootDir, 'package.json'), 'utf8'),
+  )
+
+  return workspaces
+    .map((dir) => ({
+      dir,
+      manifest: JSON.parse(
+        readFileSync(join(rootDir, dir, 'package.json'), 'utf8'),
+      ),
+    }))
+    .filter(({ manifest }) => manifest.scripts?.test)
+    .map(({ dir, manifest }) => ({
+      name: manifest.name,
+      dir,
+      runner: detectRunner(manifest.scripts.test),
+    }))
+}
+
+/**
+ * Runs one leg to completion and judges it. The report is read from disk after
+ * the runner exited, so a runner that died before writing one counts as zero
+ * tests - which is the whole point of this file.
+ */
+export function runLeg(leg, { stdio = 'inherit' } = {}) {
+  const reportPath = join(rootDir, leg.reportPath)
+  // A stale report from an earlier run would otherwise be credited to a leg
+  // that crashed before writing its own.
+  rmSync(reportPath, { force: true })
+  mkdirSync(dirname(reportPath), { recursive: true })
+
+  const result = spawnSync(leg.command, leg.args, {
+    cwd: rootDir,
+    stdio,
+    env: buildEnv(process.env, leg),
+    // On Windows npm is only reachable as the `npm.cmd` shim, which Node
+    // refuses to spawn without a shell since the CVE-2024-27980 fix (#586).
+    // Every argument is a fixed literal or a workspace name from package.json.
+    shell: leg.command === 'npm' && process.platform === 'win32',
+  })
+
+  if (result.error) {
+    throw result.error
+  }
+
+  let report = null
+  try {
+    report = readFileSync(reportPath, 'utf8')
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error
+    }
+  }
+  rmSync(reportPath, { force: true })
+
+  return evaluateLeg(leg, {
+    status: result.status,
+    signal: result.signal,
+    testCount: countTestCases(report),
+  })
+}
+
+function main() {
+  const legs = planLegs(readWorkspaces())
+  const counts = []
+
+  for (const leg of legs) {
+    const result = runLeg(leg)
+    if (!result.ok) {
+      console.error(`\n✖ ${result.message}`)
+      process.exit(1)
+    }
+    counts.push({ name: leg.name, testCount: result.testCount })
+  }
+
+  const total = counts.reduce((sum, { testCount }) => sum + testCount, 0)
+  console.log(`\n✔ ${total} tests executed across ${legs.length} suites:`)
+  for (const { name, testCount } of counts) {
+    console.log(`  - ${name}: ${testCount}`)
+  }
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  main()
+}

--- a/test/fixtures/two-passing.test.mjs
+++ b/test/fixtures/two-passing.test.mjs
@@ -1,0 +1,8 @@
+// Fixture for test/run-tests.test.mjs: a suite with a known number of tests,
+// used to verify that scripts/run-tests.mjs really gets a test count out of a
+// live `node --test` run. It lives in `fixtures/` so the root leg's
+// `test/*.test.mjs` glob does not pick it up as a repository invariant test.
+import { test } from 'node:test'
+
+test('first', () => {})
+test('second', () => {})

--- a/test/run-tests.test.mjs
+++ b/test/run-tests.test.mjs
@@ -1,0 +1,308 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import {
+  TEST_REPORT_FILE,
+  buildEnv,
+  countTestCases,
+  detectRunner,
+  evaluateLeg,
+  planLegs,
+  runLeg,
+} from '../scripts/run-tests.mjs'
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)))
+
+// The leg under test must not write to the report the outer `npm test` run is
+// using for this very file, whose reporter still holds it open.
+const FIXTURE_REPORT_FILE =
+  'node_modules/.streamwall-test-report.fixture.junit.xml'
+
+function readJson(relativePath) {
+  return JSON.parse(readFileSync(join(rootDir, relativePath), 'utf8'))
+}
+
+// Reuses the reporter wiring planLegs produces for the root leg, pointed at a
+// fixture instead of the repository's own tests, so these run against the real
+// `node --test` rather than a hand-written command line.
+function fixtureLeg(pattern) {
+  const [rootLeg] = planLegs([])
+
+  return {
+    ...rootLeg,
+    name: `fixture (${pattern})`,
+    args: rootLeg.args.map((arg) =>
+      arg === 'test/*.test.mjs'
+        ? pattern
+        : arg.replace(TEST_REPORT_FILE, FIXTURE_REPORT_FILE),
+    ),
+    reportPath: FIXTURE_REPORT_FILE,
+  }
+}
+
+test('detectRunner recognises the two runners this repository uses', () => {
+  assert.equal(detectRunner('vitest run'), 'vitest')
+  assert.equal(
+    detectRunner('node --import tsx --test --test-force-exit "src/**/*.ts"'),
+    'node-test',
+  )
+})
+
+test('detectRunner rejects a runner it cannot count tests for', () => {
+  assert.throws(
+    () => detectRunner('jest --ci'),
+    /jest --ci/,
+    'an unknown runner must fail loudly instead of being counted as zero tests',
+  )
+})
+
+// The wrapper has to know each runner to ask it for a machine-readable report.
+// A workspace that switches runners without teaching the wrapper about it would
+// otherwise report zero tests and fail the whole suite, so catch it here where
+// the message can say why.
+test('every workspace test script is a runner the wrapper understands', () => {
+  for (const workspace of readJson('package.json').workspaces) {
+    const { name, scripts = {} } = readJson(join(workspace, 'package.json'))
+    if (!scripts.test) {
+      continue
+    }
+    assert.doesNotThrow(
+      () => detectRunner(scripts.test),
+      `workspace "${name}" runs its tests with a runner scripts/run-tests.mjs ` +
+        'cannot extract a test count from',
+    )
+  }
+})
+
+test('the root test script runs the wrapper rather than the runners directly', () => {
+  assert.match(
+    readJson('package.json').scripts.test,
+    /scripts\/run-tests\.mjs/,
+    'bypassing the wrapper would restore the failure mode #678 is about: a ' +
+      'suite that runs zero tests looking exactly like one that passed',
+  )
+})
+
+test('countTestCases counts the cases in a node:test JUnit report', () => {
+  const report = `<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+\t<testsuite name="GET /admin/status" tests="2" failures="0">
+\t\t<testcase name="answers" time="0.4" classname="test"/>
+\t\t<testcase name="rejects" time="0.1" classname="test"/>
+\t</testsuite>
+\t<!-- tests 2 -->
+</testsuites>`
+
+  assert.equal(countTestCases(report), 2)
+})
+
+test('countTestCases counts the cases in a vitest JUnit report', () => {
+  const report = `<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites name="vitest tests" tests="3" failures="1">
+    <testsuite name="src/geometry.test.ts" tests="3">
+        <testcase classname="src/geometry.test.ts" name="a" time="0.001" />
+        <testcase classname="src/geometry.test.ts" name="b" time="0.002">
+            <failure message="expected 1 to be 2">AssertionError</failure>
+        </testcase>
+        <testcase classname="src/geometry.test.ts" name="c" time="0.003" />
+    </testsuite>
+</testsuites>`
+
+  assert.equal(countTestCases(report), 3)
+})
+
+// A suite that dies at worker startup leaves either no report at all or an
+// empty shell of one - which is exactly the case that must not read as success.
+test('countTestCases reports zero for a missing or empty report', () => {
+  assert.equal(countTestCases(null), 0)
+  assert.equal(countTestCases(''), 0)
+  assert.equal(
+    countTestCases('<?xml version="1.0"?>\n<testsuites></testsuites>'),
+    0,
+  )
+})
+
+test('evaluateLeg accepts a leg that ran tests and exited cleanly', () => {
+  const result = evaluateLeg({ name: 'shared' }, { status: 0, testCount: 343 })
+
+  assert.equal(result.ok, true)
+  assert.equal(result.testCount, 343)
+})
+
+test('evaluateLeg rejects a leg that ran zero tests with a distinct message', () => {
+  const result = evaluateLeg(
+    { name: 'streamwall-shared' },
+    { status: 1, testCount: 0 },
+  )
+
+  assert.equal(result.ok, false)
+  assert.equal(result.reason, 'no-tests')
+  assert.match(result.message, /0 tests executed/)
+  assert.match(result.message, /not a test failure/)
+  assert.match(result.message, /streamwall-shared/)
+})
+
+// The runner crashing before the first assertion is the #671/#675/#676 failure
+// mode; a green exit code with nothing executed would be a future workflow bug.
+// Both have to end up in the same, unmistakable message.
+test('evaluateLeg reports zero tests even when the runner exited successfully', () => {
+  const result = evaluateLeg({ name: 'shared' }, { status: 0, testCount: 0 })
+
+  assert.equal(result.ok, false)
+  assert.equal(result.reason, 'no-tests')
+})
+
+test('evaluateLeg keeps a genuine test failure distinguishable', () => {
+  const result = evaluateLeg({ name: 'shared' }, { status: 1, testCount: 343 })
+
+  assert.equal(result.ok, false)
+  assert.equal(result.reason, 'failed')
+  assert.match(result.message, /343 tests/)
+  assert.match(result.message, /exited with 1/)
+  assert.doesNotMatch(result.message, /0 tests executed/)
+})
+
+test('evaluateLeg reports a leg killed by a signal', () => {
+  const result = evaluateLeg(
+    { name: 'shared' },
+    { status: null, signal: 'SIGKILL', testCount: 12 },
+  )
+
+  assert.equal(result.ok, false)
+  assert.equal(result.reason, 'failed')
+  assert.match(result.message, /SIGKILL/)
+})
+
+test('planLegs runs the repository invariants before the workspaces', () => {
+  const [first] = planLegs([
+    {
+      name: 'streamwall-shared',
+      dir: 'packages/streamwall-shared',
+      runner: 'vitest',
+    },
+  ])
+
+  assert.match(first.name, /test\//)
+  assert.equal(first.command, process.execPath)
+  assert.ok(
+    first.args.includes('test/*.test.mjs'),
+    'the root leg must keep running the repository invariant tests',
+  )
+  assert.equal(first.reportPath, TEST_REPORT_FILE)
+})
+
+test('planLegs asks a vitest workspace for a JUnit report next to its default output', () => {
+  const [, leg] = planLegs([
+    {
+      name: 'streamwall-shared',
+      dir: 'packages/streamwall-shared',
+      runner: 'vitest',
+    },
+  ])
+
+  assert.equal(leg.command, 'npm')
+  assert.deepEqual(leg.args, [
+    'run',
+    'test',
+    '-w',
+    'streamwall-shared',
+    '--',
+    '--reporter=default',
+    '--reporter=junit',
+    `--outputFile.junit=${TEST_REPORT_FILE}`,
+  ])
+  assert.equal(leg.nodeOptions, null)
+  assert.equal(
+    leg.reportPath,
+    join('packages/streamwall-shared', TEST_REPORT_FILE),
+    'the report is written relative to the workspace npm runs the script in',
+  )
+})
+
+// `node --test` only accepts flags before its file arguments, so the reporter
+// cannot be appended to the workspace's own test script the way vitest's can.
+test('planLegs configures a node:test workspace through NODE_OPTIONS', () => {
+  const [, leg] = planLegs([
+    {
+      name: 'streamwall-control-server',
+      dir: 'packages/streamwall-control-server',
+      runner: 'node-test',
+    },
+  ])
+
+  assert.deepEqual(leg.args, ['run', 'test', '-w', 'streamwall-control-server'])
+  assert.match(leg.nodeOptions, /--test-reporter=junit/)
+  assert.ok(
+    leg.nodeOptions.includes(`--test-reporter-destination=${TEST_REPORT_FILE}`),
+    'the JUnit reporter needs a destination the wrapper can read back',
+  )
+  assert.match(
+    leg.nodeOptions,
+    /--test-reporter=spec/,
+    'the human-readable reporter must stay on stdout alongside the JUnit file',
+  )
+})
+
+// The unit tests above pin the parsing; these two pin the part that can rot
+// silently - whether the reporter flags planLegs passes still make a live
+// runner produce a report this file can count. If a runner ever changes those
+// flags, every leg would report zero tests and the suite would fail everywhere
+// at once; this says so in one place instead.
+test('runLeg counts the tests of a suite that really ran', () => {
+  const result = runLeg(fixtureLeg('test/fixtures/two-passing.test.mjs'), {
+    stdio: 'ignore',
+  })
+
+  assert.equal(result.ok, true)
+  assert.equal(result.testCount, 2)
+})
+
+test('runLeg reports a suite that executed nothing as a setup failure', () => {
+  const result = runLeg(fixtureLeg('test/fixtures/no-such-file.test.mjs'), {
+    stdio: 'ignore',
+  })
+
+  assert.equal(result.ok, false)
+  assert.equal(result.reason, 'no-tests')
+  assert.match(result.message, /0 tests executed/)
+})
+
+test('buildEnv appends the leg options to a NODE_OPTIONS the caller already set', () => {
+  const env = buildEnv(
+    { NODE_OPTIONS: '--max-old-space-size=4096', PATH: '/usr/bin' },
+    { nodeOptions: '--test-reporter=junit' },
+  )
+
+  assert.equal(
+    env.NODE_OPTIONS,
+    '--max-old-space-size=4096 --test-reporter=junit',
+  )
+  assert.equal(env.PATH, '/usr/bin')
+})
+
+test('buildEnv drops the node:test context a parent runner would pass down', () => {
+  const env = buildEnv(
+    { NODE_TEST_CONTEXT: 'child-v8', PATH: '/usr/bin' },
+    { nodeOptions: null },
+  )
+
+  assert.equal(
+    'NODE_TEST_CONTEXT' in env,
+    false,
+    'a leg inheriting it would silently report to the parent runner instead ' +
+      'of writing the JUnit report this wrapper counts',
+  )
+})
+
+test('buildEnv leaves NODE_OPTIONS untouched for a leg that does not need it', () => {
+  const env = buildEnv(
+    { NODE_OPTIONS: '--enable-source-maps' },
+    {
+      nodeOptions: null,
+    },
+  )
+
+  assert.equal(env.NODE_OPTIONS, '--enable-source-maps')
+})


### PR DESCRIPTION
## Problem

The `Test` job had exactly one signal: the exit code of `npm test`. Nothing distinguished *"zero tests executed because the runtime crashed at worker startup"* from *"every test ran and one failed"*.

That is precisely what the find-my-way bump in #670 produced — all three OS legs red with `Cannot find package 'happy-dom'` before a single assertion ran (#671, #675, #676). Both cases are just a non-zero exit code, which is enough for CI to catch them but slow for a maintainer to tell apart.

The inverse is the more dangerous half: a future change (`--passWithNoTests`, a glob that stops matching, a workspace silently skipped) could make a suite that executes nothing exit zero and be reported as **success**.

## Solution

The root `npm test` now runs `scripts/run-tests.mjs` instead of chaining the runners directly. It

- runs the same legs in the same order (repository invariants in `test/`, then every workspace with a `test` script) and still stops at the first failure,
- asks each runner for a **JUnit report** next to its usual human-readable output,
- fails with a distinct message when a leg's report contains no test case:

  ```
  ✖ streamwall-shared: 0 tests executed - this is a runtime/setup failure, not a
    test failure. The runner produced no JUnit report, so it never got as far as
    an assertion: look for a module resolution, config or transform error above.
  ```

- and prints per-leg counts on success, so a leg that quietly stops executing tests cannot pass as green either:

  ```
  ✔ 2049 tests executed across 6 suites:
    - test/ (repository invariants): 160
    - streamwall: 941
    …
  ```

A genuine test failure keeps its own, clearly different message (`… 343 tests ran and the runner exited with 1`).

## Architecture decisions

- **In the test script, not in `ci.yml`.** The issue suggested wrapping the invocations in the workflow. Putting the check in `npm test` covers all three OS legs *and* local runs with a single mechanism, and keeps `ci.yml` a plain `npm test`.
- **JUnit as the common report format.** `node --test` has no JSON reporter, so JUnit is the one machine-readable format both runners produce — a single parser covers every leg.
- **Reporter wiring differs per runner.** vitest takes it through `npm run test -- …`; `node --test` only reads flags that precede its file arguments, so it gets it through `NODE_OPTIONS`. An unknown runner throws rather than being counted as zero tests, and `test/run-tests.test.mjs` fails if a workspace ever switches to one.
- **Workspace-relative report paths under `node_modules`.** No absolute path (with platform separators or spaces) has to survive a trip through `NODE_OPTIONS` on Windows, and the reports stay out of git and Prettier's way.
- **`NODE_TEST_CONTEXT` is stripped per leg.** A `node --test` process that inherits it reports over IPC and ignores `--test-reporter` entirely — which would make every leg count as zero tests. Found while writing the integration tests below.

## Testing

- 20 new tests in `test/run-tests.test.mjs`: runner detection, JUnit counting for both runners' report shapes, leg evaluation (zero tests / genuine failure / signal), leg planning, and env merging.
- Two of them are **integration tests against the live runner** (`test/fixtures/two-passing.test.mjs`): one proves the planned reporter flags really yield a countable report, the other proves a suite that executes nothing is reported as a setup failure. If a runner ever changes those flags, this says so in one place instead of every leg reporting zero.
- Guard tests: every workspace `test` script must be a runner the wrapper understands, and the root `test` script must go through the wrapper.
- Full quality gate green locally: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` (2049 tests across 6 suites), `npm run licenses:check`.
- Manually verified that a broken vitest environment is still caught by the #677 guard and reported as a test failure, not as a zero-test run.

## Risks

- Low. Same legs, same order, same fail-fast behaviour; only the invocation and the post-processing are new.
- `node --test` legs now use the `spec` reporter explicitly instead of falling back to `tap` on non-TTY CI output — the log gets more readable, nothing else changes.
- The E2E suite (`npm run test:e2e`) stays outside this: Playwright already fails a run that matches no tests.

Closes #678

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments
