### PR TITLE
ci: skip release-please while the released version has no tag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,17 +18,25 @@ name: Release PR
 # and reopening the release PR raises a real `pull_request` event and is the
 # documented release step (CONTRIBUTING.md, "Releasing"); a PAT or GitHub App
 # token would remove the workaround entirely (#549).
+#
+# The tag trigger is not cosmetic: merging the release PR and pushing its tag
+# are two steps, and the run that fires on the merge is skipped below because
+# the new version has no tag yet (#684). The tag push is what brings
+# release-please back for the commits of that window.
 on:
   push:
     branches: [main]
+    tags: ['v*']
   workflow_dispatch:
 
 permissions: {}
 
 # Two runs racing on the same release branch would clobber each other's
-# changelog; never cancel one mid-write either.
+# changelog; never cancel one mid-write either. The group must not depend on
+# `github.ref`, or the tag run and the `main` run would sit in different groups
+# and race for the same branch.
 concurrency:
-  group: release-please-${{ github.workflow }}-${{ github.ref }}
+  group: release-please-${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:
@@ -40,7 +48,33 @@ jobs:
       contents: write # commits the version bump and changelog to the release branch
       pull-requests: write # opens, updates and labels the release PR
     steps:
-      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      # release-please anchors the changelog on the tag matching the version in
+      # its manifest. Right after a release PR merges that tag does not exist
+      # yet — the tag is pushed by hand, because one pushed with GITHUB_TOKEN
+      # would never start release.yml. Running in that window makes
+      # release-please report "No latest release found" and rebuild the release
+      # PR from every commit in the repository: #674 came out of it proposing
+      # 0.11.0 with 251 already-released changelog entries, and release-please
+      # does not retract such a PR once the tag appears. So skip instead; the
+      # tag push re-runs this workflow with the anchor in place (#684).
+      - name: Check that the released version is tagged
+        id: anchor
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          version="$(jq -r '.["."]' .release-please-manifest.json)"
+          if gh api "repos/$REPO/git/ref/tags/v$version" >/dev/null 2>&1; then
+            echo "tagged=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tagged=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::v$version is not tagged yet; skipping so the release PR is not rebuilt from an unanchored history (#684)."
+          fi
+      - if: steps.anchor.outputs.tagged == 'true'
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -435,6 +435,16 @@ breaking change bumps the minor version.
    start [`release.yml`](.github/workflows/release.yml) and no installers would
    be built. That is also why release-please runs with `skip-github-release`.
 
+   Between step 2 and this one, `main` claims a version that has no tag yet.
+   `release-please.yml` deliberately does nothing in that window — it checks
+   for the tag of the manifest version first and skips with a notice when it
+   is missing. Without that check release-please finds no anchor, treats the
+   whole history as unreleased and rewrites the release PR with hundreds of
+   already-shipped entries, which is how #674 came to propose 0.11.0 with 251
+   duplicated changelog lines (#684). Pushing the tag re-runs the workflow, so
+   nothing is lost by the skip — but do not be surprised by a release PR that
+   stays untouched until the tag is up.
+
 4. `release.yml` runs the full quality gate, publishes the installers via
    electron-forge, and then copies the `CHANGELOG.md` section for that version
    into the GitHub Release body (`scripts/changelog-section.mjs`).

--- a/test/release-please.test.mjs
+++ b/test/release-please.test.mjs
@@ -149,6 +149,69 @@ test('the release-please workflow maintains the release PR on main', () => {
   assert.equal(step.with['skip-github-release'], true)
 })
 
+// Merging the release PR and pushing its tag are two steps, and between them
+// `main` claims a version no tag exists for yet. release-please then finds no
+// anchor ("No latest release found ... Considering: 382 commits") and rewrites
+// the release PR from the entire repository history: #674 proposed 0.11.0 with
+// 251 changelog entries that had all shipped long ago. It never retracts such a
+// PR once the tag lands, so the only safe answer is not to write one at all
+// while the released version is untagged (#684).
+test('release-please skips while the released version has no tag (#684)', () => {
+  const job = readWorkflow('release-please.yml').jobs['release-please']
+
+  const anchor = job.steps.find((step) =>
+    /\.release-please-manifest\.json/.test(step.run ?? ''),
+  )
+  assert.ok(
+    anchor?.id,
+    'release-please.yml must check, in an identifiable step, whether the ' +
+      'manifest version is tagged before it writes a release PR',
+  )
+  assert.match(
+    anchor.run,
+    /git\/ref\/tags\/v|refs\/tags\/v/,
+    'the check must look for the vX.Y.Z tag of the manifest version',
+  )
+
+  const step = job.steps.find((candidate) =>
+    candidate.uses?.startsWith('googleapis/release-please-action@'),
+  )
+  assert.match(
+    step.if ?? '',
+    new RegExp(`steps\\.${anchor.id}\\.outputs\\.`),
+    'the release-please step must be gated on that check, or it will rebuild ' +
+      'the release PR from an unanchored history (#684)',
+  )
+})
+
+// Skipping the unanchored run leaves the commits of that window unprocessed,
+// so the tag push itself has to bring release-please back for them.
+test('release-please runs again once the tag lands (#684)', () => {
+  const push = readWorkflow('release-please.yml').on.push
+
+  assert.deepEqual(push.branches, ['main'])
+  assert.ok(
+    push.tags?.some((pattern) => pattern.startsWith('v')),
+    'a tag push must re-run release-please, otherwise the release PR waits ' +
+      'for the next unrelated merge to `main`',
+  )
+})
+
+// Two runs racing on the same release branch clobber each other's changelog.
+// Keying the group on `github.ref` used to be enough because only `main`
+// triggered the workflow; with the tag trigger above, a ref-keyed group would
+// put the tag run and the main run in different groups and let them race.
+test('release-please serialises every run onto one concurrency group (#684)', () => {
+  const { concurrency } = readWorkflow('release-please.yml')
+
+  assert.equal(concurrency['cancel-in-progress'], false)
+  assert.doesNotMatch(
+    concurrency.group,
+    /github\.ref/,
+    'all runs write the same release branch, so they must share one group',
+  )
+})
+
 // The dispatch shim added in #547 was meant to start the required checks for
 // the release PR, whose `pull_request` events GitHub never delivers because
 // the PR is opened with a workflow's GITHUB_TOKEN. It never worked: a


### PR DESCRIPTION
## Problem

Merging the release PR and pushing its `vX.Y.Z` tag are two separate steps — deliberately, since a tag pushed with `GITHUB_TOKEN` raises no workflow events and would never start `release.yml`.

The `push: branches: [main]` trigger fires on the merge, which is exactly the moment `main` claims a version that has no tag yet. release-please then finds no anchor and falls back to the whole history:

```
❯ looking for tagName: v0.10.4
✔ No latest release found for path: ., component: , but a previous version (0.10.4) was specified in the manifest.
⚠ No latest release pull request found.
✔ Considering: 382 commits
```

#674 was born in that window: it proposed **0.11.0 with 251 changelog entries**, including #199, #220, #341, #430, #444 and #448 — all already in released sections of `CHANGELOG.md`. Merging it would have duplicated the entire project history into one bogus section and bumped the minor version without a single unreleased `feat`. Its body said *"This release is too large to preview in the pull request body"*, which is precisely what stops anyone from noticing.

And release-please does not repair it: once `v0.10.4` existed, a fresh run correctly reported `Considering: 0 commits` — but #674 stayed open, unchanged, with its wrong contents. It had to be closed by hand.

## Solution

1. **Do not write a release PR from an unanchored state.** A new step reads the version from `.release-please-manifest.json` and asks the API for the matching `v<version>` tag. Missing tag → the release-please step is skipped and the run leaves a `::notice::` saying why.
2. **Come back once the tag lands.** `push: tags: ['v*']` re-runs the workflow after the tag exists, so the commits of the skipped window are picked up right away instead of waiting for the next unrelated merge to `main`.
3. **Serialise both triggers.** The concurrency group drops `github.ref`: with two triggers writing the same release branch, a ref-keyed group would put the tag run and the `main` run in different groups and let them race — the exact clobbering the group exists to prevent.

## Verification

The failure and the fix are both reproducible from the workflow logs:

| Run | When | Result |
| --- | --- | --- |
| 30208136268 | right after the 0.10.4 merge, before the tag | `Considering: 382 commits` → the bogus PR |
| 30208834870 | after `v0.10.4` was tagged and released | `Considering: 0 commits` |
| 30082077144 | well after `v0.10.3` was tagged | `Considering: 4 commits` |

So the failure is specific to the untagged window, not a permanent misconfiguration — which is why the fix gates on exactly that condition rather than changing how release-please is configured.

## Testing

Three new guards in `test/release-please.test.mjs`:

- the release-please step must be gated on a step that looks for the manifest version's tag,
- a `v*` tag push must re-run the workflow,
- the concurrency group must not depend on `github.ref` and must not cancel in progress.

`npm run format:check`, `npm run lint` and the full `node --test test/*.test.mjs` (163 tests) pass locally; `actionlint` reports the workflow clean.

The behaviour itself is a workflow trigger condition and cannot be exercised by a unit test — the guards pin the wiring, and the log evidence above pins the diagnosis.

Closes #684