### PR TITLE
fix(deps): update brace-expansion to 5.0.8 for CVE-2026-14257

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2003,16 +2003,16 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
@@ -2371,15 +2371,15 @@
       }
     },
     "node_modules/@fastify/static/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@fastify/static/node_modules/glob": {
@@ -6334,16 +6334,16 @@
       }
     },
     "node_modules/app-builder-lib/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/app-builder-lib/node_modules/ejs": {
@@ -9050,16 +9050,16 @@
       }
     },
     "node_modules/eslint-plugin-import-x/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/eslint-plugin-import-x/node_modules/minimatch": {
@@ -9148,16 +9148,16 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/eslint/node_modules/eslint-scope": {


### PR DESCRIPTION
Closes #689. Resolves Dependabot alert [#28](https://github.com/NilsR0711/streamwall/security/dependabot/28) (GHSA-mh99-v99m-4gvg, CVE-2026-14257, high — unbounded brace expansion exhausts memory and crashes the process).

## What changed

`npm update brace-expansion` — lockfile only. Every 5.x copy moves 5.0.7 → 5.0.8, including the single **production** path:

```
@fastify/static -> glob@13 -> minimatch@10.2.5 -> brace-expansion
```

No override was needed: all five consumers already declare `^5.0.5`, so the patched release is inside their existing range.

| node | before | after | scope |
| --- | --- | --- | --- |
| `@fastify/static` | 5.0.7 | **5.0.8** | production |
| `eslint` | 5.0.7 | 5.0.8 | dev |
| `@eslint/config-array` | 5.0.7 | 5.0.8 | dev |
| `eslint-plugin-import-x` | 5.0.7 | 5.0.8 | dev |
| `app-builder-lib` | 5.0.7 | 5.0.8 | dev |

## What deliberately did not change

Four dev-only copies stay on the 1.x/2.x lines, and no blanket override can move them:

| node | version | required by |
| --- | --- | --- |
| `node_modules/brace-expansion` | 1.1.16 | `minimatch@3.1.5` (`^1.1.7`) |
| `@electron/node-gyp`, `cacache`, `filelist` | 2.1.2 | `minimatch@5.1.9` (`^2.0.1`) |
| `@electron/universal` | 2.1.2 | `minimatch@9.0.9` (`^2.0.2`) |

1.x and 2.x export a **callable** (`module.exports = expand`); 5.x exports an **object** (`{ expand, EXPANSION_MAX, … }`). Forcing those consumers onto 5.x turns `expand(...)` into a TypeError at runtime — which is exactly why the existing `@electron/asar` → `minimatch` → `brace-expansion@^1.1.13` override in `package.json` is scoped the way it is (#190).

Upstream has published no backport for either line: `1.1.16` and `2.1.2` both predate the fix (2026-07-08 vs. `5.0.8` on 2026-07-23; only `3.0.3` followed on 2026-07-27, and it is ESM-only). Every one of these paths is `dev: true` build tooling — electron-forge's native rebuild, the npm cache, and jake's file listing — none of it ships in the packaged app or the control-server image.

## Verification

`npm run test` (2056 tests), `npm run lint`, `npm run typecheck` and the license check all pass.