### PR TITLE
fix(streamwall): pin the electron version for the NSIS maker

### DIFF
--- a/packages/streamwall/forge.makerNsis.test.ts
+++ b/packages/streamwall/forge.makerNsis.test.ts
@@ -1,6 +1,9 @@
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { buildNsisPackagerOptions } from './forge.makerNsis'
+import {
+  buildNsisPackagerOptions,
+  resolveInstalledElectronVersion,
+} from './forge.makerNsis'
 
 const makeContext = {
   dir: '/tmp/out/Streamwall-win32-x64',
@@ -8,21 +11,23 @@ const makeContext = {
   targetArch: 'x64' as const,
 }
 
+const electronVersion = '43.2.0'
+
 describe('buildNsisPackagerOptions', () => {
   it('points electron-builder at the forge-packaged app instead of repacking', () => {
-    const options = buildNsisPackagerOptions(makeContext, {})
+    const options = buildNsisPackagerOptions(makeContext, {}, electronVersion)
 
     expect(options.prepackaged).toBe(path.resolve(makeContext.dir))
   })
 
   it('never publishes from the maker, leaving uploads to the forge GitHub publisher', () => {
-    const options = buildNsisPackagerOptions(makeContext, {})
+    const options = buildNsisPackagerOptions(makeContext, {}, electronVersion)
 
     expect(options.publish).toBe('never')
   })
 
   it('writes the installer into an arch-scoped make subdirectory like other makers', () => {
-    const options = buildNsisPackagerOptions(makeContext, {})
+    const options = buildNsisPackagerOptions(makeContext, {}, electronVersion)
 
     expect(options.config).toMatchObject({
       directories: { output: path.join('/tmp/out/make', 'nsis', 'x64') },
@@ -30,7 +35,7 @@ describe('buildNsisPackagerOptions', () => {
   })
 
   it('names the installer without spaces, since GitHub Releases mangles asset names containing them', () => {
-    const options = buildNsisPackagerOptions(makeContext, {})
+    const options = buildNsisPackagerOptions(makeContext, {}, electronVersion)
 
     expect(options.config).toMatchObject({
       nsis: { artifactName: '${name}-setup-${version}.${ext}' },
@@ -38,16 +43,20 @@ describe('buildNsisPackagerOptions', () => {
   })
 
   it('pins the appId so updates keep installing over the same identity', () => {
-    const options = buildNsisPackagerOptions(makeContext, {})
+    const options = buildNsisPackagerOptions(makeContext, {}, electronVersion)
 
     expect(options.config).toMatchObject({ appId: 'com.electron.streamwall' })
   })
 
   it('passes the signing certificate through when configured', () => {
-    const options = buildNsisPackagerOptions(makeContext, {
-      certificateFile: '/secrets/cert.pfx',
-      certificatePassword: 'hunter2',
-    })
+    const options = buildNsisPackagerOptions(
+      makeContext,
+      {
+        certificateFile: '/secrets/cert.pfx',
+        certificatePassword: 'hunter2',
+      },
+      electronVersion,
+    )
 
     expect(options.config).toMatchObject({
       win: {
@@ -60,8 +69,20 @@ describe('buildNsisPackagerOptions', () => {
   })
 
   it('leaves builds unsigned when no certificate is configured, as before', () => {
-    const options = buildNsisPackagerOptions(makeContext, {})
+    const options = buildNsisPackagerOptions(makeContext, {}, electronVersion)
 
     expect(options.config).not.toHaveProperty('win')
+  })
+
+  it('pins the packaged electron version, which electron-builder cannot derive itself once npm hoists electron to the workspace root', () => {
+    const options = buildNsisPackagerOptions(makeContext, {}, electronVersion)
+
+    expect(options.config).toMatchObject({ electronVersion })
+  })
+})
+
+describe('resolveInstalledElectronVersion', () => {
+  it('resolves electron regardless of whether npm hoisted it to the workspace root', () => {
+    expect(resolveInstalledElectronVersion()).toMatch(/^\d+\.\d+\.\d+/)
   })
 })

--- a/packages/streamwall/forge.makerNsis.ts
+++ b/packages/streamwall/forge.makerNsis.ts
@@ -1,6 +1,7 @@
 import { MakerBase, type MakerOptions } from '@electron-forge/maker-base'
 import type { ForgePlatform } from '@electron-forge/shared-types'
 import type { Configuration, PackagerOptions } from 'app-builder-lib'
+import { createRequire } from 'node:module'
 import path from 'node:path'
 import type { WindowsSigningConfig } from './forge.signing'
 
@@ -17,18 +18,37 @@ import type { WindowsSigningConfig } from './forge.signing'
 export type MakerNsisConfig = Partial<WindowsSigningConfig>
 
 /**
+ * Reads the version of the electron install forge packaged against.
+ *
+ * electron-builder only looks for electron under its own projectDir
+ * (packages/streamwall), so it fails the moment npm hoists electron to the
+ * workspace root: it then sees only the semver range from package.json and
+ * aborts with "version ... is not fixed in project". Whether electron lands in
+ * the root or in the workspace's node_modules is npm's call and flips whenever
+ * the lockfile is regenerated, so the version is resolved the way node does -
+ * walking up into the root - and handed to electron-builder explicitly.
+ */
+export function resolveInstalledElectronVersion(): string {
+  const require = createRequire(import.meta.url)
+  const { version } = require('electron/package.json') as { version: string }
+  return version
+}
+
+/**
  * Derives the electron-builder invocation from forge's make context. Pure, so
  * the mapping is testable without running a build.
  */
 export function buildNsisPackagerOptions(
   options: Pick<MakerOptions, 'dir' | 'makeDir' | 'targetArch'>,
   config: MakerNsisConfig,
+  electronVersion: string,
 ): PackagerOptions & { publish: 'never' } {
   const builderConfig: Configuration = {
     // Freezes electron-builder's documented default: NSIS derives the
     // per-machine install/registry identity from the appId, so it must never
     // drift between releases or updates would install side-by-side.
     appId: 'com.electron.streamwall',
+    electronVersion,
     directories: {
       output: path.join(options.makeDir, 'nsis', options.targetArch),
     },
@@ -75,7 +95,11 @@ export default class MakerNsis extends MakerBase<MakerNsisConfig> {
     const { Arch, Platform, build } = await import('app-builder-lib')
     const arch = Arch[options.targetArch as keyof typeof Arch] ?? Arch.x64
     const artifacts = await build({
-      ...buildNsisPackagerOptions(options, this.config),
+      ...buildNsisPackagerOptions(
+        options,
+        this.config,
+        resolveInstalledElectronVersion(),
+      ),
       targets: Platform.WINDOWS.createTarget('nsis', arch),
     })
     // electron-builder may emit its own latest.yml when it can infer a


### PR DESCRIPTION
## Problem

The v0.10.5 release build failed in `Installer smoke (windows makers)` ([run 30313005996](https://github.com/NilsR0711/streamwall/actions/runs/30313005996/job/90132524670)):

```
⨯ Electron version "^43.2.0" is a range, not a fixed version.
  Cannot compute electron version from installed node modules
```

electron-builder looks for electron only under its own `projectDir`
(`packages/streamwall`). Regenerating the lockfile (#687/#692) moved electron
from `packages/streamwall/node_modules/electron` to the workspace root, so
electron-builder no longer found an install and fell back to the semver range
in `package.json`, which it refuses to resolve.

| | v0.10.4 (green) | v0.10.5 (red) |
|---|---|---|
| lockfile path | `packages/streamwall/node_modules/electron` | `node_modules/electron` |

Whether npm hoists electron to the root or keeps it nested is npm's call and
flips on any lockfile regeneration, so pinning the range in `package.json`
would only paper over it.

## Fix

`resolveInstalledElectronVersion()` resolves electron the way node does —
walking up into the workspace root — and the maker passes the result to
electron-builder as an explicit `electronVersion`, which is the resolution the
error message itself recommends.

## Tests

- `buildNsisPackagerOptions` sets `electronVersion` in the builder config.
- `resolveInstalledElectronVersion` resolves electron regardless of hoisting —
  this is the guard that fails again if the module moves out of reach.
- `Installer smoke (windows makers)` exercises the real path end to end.

Blocks the v0.10.5 release: the publish jobs were skipped, so the tag has no
artifacts yet.