### PR TITLE
fix(ci): let the release check see draft releases

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -50,12 +50,37 @@ jobs:
       - name: Check the release version is tagged
         run: node scripts/check-release-tag.mjs
 
-      # A tag alone proves nothing: the publish matrix may have failed
-      # half-way through, or never run for the tag at all (#533). Runs even
-      # when the step above failed — the two report different halves of the
-      # same pipeline, and one missing tag must not hide a broken release.
+  # A tag alone proves nothing: the publish matrix may have failed half-way
+  # through, never have run for the tag at all (#533), or have left the release
+  # as an unpublished draft (#698). Deliberately independent of `check` — the
+  # two report different halves of the same pipeline, and one missing tag must
+  # not hide a broken release.
+  #
+  # A job of its own rather than a step of `check`, because it is the only part
+  # of this workflow that needs `contents: write`: GitHub lists draft releases
+  # only to a token with push access, and a draft is exactly what this check
+  # has to be able to see. With `contents: read` the unpublished release of
+  # v0.10.5 read as a tag that had produced nothing at all, and the report told
+  # the maintainer to re-push the tag. The scripts only read, and the checkout
+  # keeps `persist-credentials: false`, so the token never reaches git either.
+  assets:
+    name: Check the newest tag produced a complete release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # The version's tag has to be visible to `git tag --list` here too.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+
       - name: Check the newest tag produced a complete release
-        if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/check-release-assets.mjs
@@ -64,7 +89,7 @@ jobs:
   # one, so the report goes into the issue tracker instead (#514) — which is
   # also where a forgotten tag belongs.
   report:
-    needs: [check]
+    needs: [check, assets]
     if: always()
     permissions:
       issues: write

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -470,18 +470,24 @@ up to date. Run it from the Actions tab, or locally:
 node scripts/check-release-tag.mjs
 ```
 
-The same job then checks what that tag actually produced: a tag can exist while
-its release is still broken — a publish leg of `release.yml` failed and left a
+A second job checks what that tag actually produced: a tag can exist while its
+release is still broken — a publish leg of `release.yml` failed and left a
 partially populated release behind (#453), the workflow never ran for the tag,
-or the release was never taken out of draft. The check asks the GitHub API for
-the release of the version on `main` and asserts the artifact kinds the `make`
-job builds (`*.deb`, `*.rpm`, `*-setup-*.exe`, `latest.yml`, `*.zip`,
-`latest-mac.yml`). Releases before v0.9.2 carry Squirrel's artifact names and
-are skipped.
+or the release was never taken out of draft (#698). The check reads the
+repository's release listing, picks the release of the version on `main` and
+asserts the artifact kinds the `make` job builds (`*.deb`, `*.rpm`,
+`*-setup-*.exe`, `latest.yml`, `*.zip`, `latest-mac.yml`). Releases before
+v0.9.2 carry Squirrel's artifact names and are skipped.
 
 ```sh
-node scripts/check-release-assets.mjs
+GH_TOKEN=$(gh auth token) node scripts/check-release-assets.mjs
 ```
+
+The token is not optional for a local run: GitHub returns draft releases only
+to a token with push access, and without one an unpublished release looks
+exactly like a tag that produced nothing at all. That is why the job runs with
+`contents: write` — it writes nothing — while the tag check above stays
+read-only.
 
 Both checks anchor on the version the manifest claims rather than on the
 highest `vX.Y.Z` tag they can find. A higher tag is not proof of a newer

--- a/scripts/check-release-assets.mjs
+++ b/scripts/check-release-assets.mjs
@@ -9,7 +9,9 @@
 //   - one leg of `release.yml`'s three-platform publish matrix failed, so the
 //     GitHub Release is missing that platform's installers (#453),
 //   - `release.yml` never ran for the tag at all — pushed from a workflow
-//     token, or the run was cancelled — so there is no release behind the tag.
+//     token, or the run was cancelled — so there is no release behind the tag,
+//   - the release was built but never taken out of draft (#698), so nothing
+//     outside the maintainer's releases page can see it.
 //
 // Both point self-hosters and the app's updater at a release that cannot be
 // installed, and neither shows up anywhere. The expected artifact kinds are
@@ -145,7 +147,7 @@ export function formatReport({ status, tag, missing }) {
     return (
       `::error::${tag} has no GitHub Release, so the tag shipped no ` +
       'installers. Re-run release.yml for the tag (Actions → Release → Run ' +
-      `workflow) or delete and re-push ${tag}.`
+      'workflow); the tag stays, it is the record of what was released.'
     )
   }
   if (status === 'draft') {
@@ -166,30 +168,72 @@ async function git(args) {
   return stdout
 }
 
-// The releases endpoint answers 404 both for an unknown tag and for a draft
-// release that the token may not read — hence the token, which the workflow
-// passes in and which also lifts the anonymous rate limit.
-async function fetchReleaseByTag({ repository, tag, token }) {
-  const response = await fetch(
-    `https://api.github.com/repos/${repository}/releases/tags/${tag}`,
-    {
-      headers: {
-        accept: 'application/vnd.github+json',
-        'x-github-api-version': '2022-11-28',
-        ...(token ? { authorization: `Bearer ${token}` } : {}),
-      },
-    },
-  )
+// A draft release carries its `tag_name` but is not attached to the tag yet,
+// so `GET /releases/tags/<tag>` answers 404 for one no matter how privileged
+// the token is (#698). Reading the listing instead is the only way to see a
+// draft — and the listing only includes drafts for a token with push access,
+// which is why the workflow's job runs with `contents: write`.
+export function findReleaseByTag(releases, tag) {
+  const matches = releases.filter((release) => release.tag_name === tag)
 
-  if (response.status === 404) {
+  if (matches.length === 0) {
     return null
   }
-  if (!response.ok) {
-    throw new Error(
-      `GitHub API returned ${response.status} for the release of ${tag}.`,
+  // One tag has carried two releases here before: with no draft present yet,
+  // two publish legs each created their own (#671). The published one is what
+  // the updater and a self-hoster see, so it decides the verdict whatever
+  // order the listing returns them in.
+  return matches.find((release) => !release.draft) ?? matches[0]
+}
+
+// Paged rather than asked for by tag, for the reason above. The release this
+// check is after is the newest one and the listing is newest-first, so the
+// first page all but always answers it; the later pages cover a release
+// published out of order. Exhausting them without a match is reported as its
+// own error rather than as "no release": blaming a paging limit on a missing
+// release would be the same misdiagnosis this check exists to avoid.
+//
+// The token the workflow passes in also lifts the anonymous rate limit.
+export async function fetchReleaseByTag({
+  repository,
+  tag,
+  token,
+  fetchImpl = fetch,
+  perPage = 100,
+  maxPages = 5,
+}) {
+  for (let page = 1; page <= maxPages; page += 1) {
+    const response = await fetchImpl(
+      `https://api.github.com/repos/${repository}/releases` +
+        `?per_page=${perPage}&page=${page}`,
+      {
+        headers: {
+          accept: 'application/vnd.github+json',
+          'x-github-api-version': '2022-11-28',
+          ...(token ? { authorization: `Bearer ${token}` } : {}),
+        },
+      },
     )
+
+    if (!response.ok) {
+      throw new Error(
+        `GitHub API returned ${response.status} for the releases of ${repository}.`,
+      )
+    }
+    const batch = await response.json()
+    const release = findReleaseByTag(batch, tag)
+
+    if (release !== null) {
+      return release
+    }
+    if (batch.length < perPage) {
+      return null
+    }
   }
-  return response.json()
+  throw new Error(
+    `${tag} is not among the ${maxPages * perPage} most recent releases of ` +
+      `${repository}, so this check cannot tell what it produced.`,
+  )
 }
 
 async function main() {

--- a/test/check-release-assets.test.mjs
+++ b/test/check-release-assets.test.mjs
@@ -9,6 +9,8 @@ import {
   EXPECTED_ASSET_PATTERNS,
   FIRST_CHECKED_VERSION,
   evaluateReleaseAssets,
+  fetchReleaseByTag,
+  findReleaseByTag,
   formatReport,
   parseRepository,
   selectReleaseTag,
@@ -237,20 +239,182 @@ test('formatReport notes a release predating the check without failing', () => {
   assert.match(report, /v0\.9\.1/)
 })
 
+// A draft release has no tag association on GitHub yet, so
+// `GET /releases/tags/<tag>` answers 404 for it however privileged the token
+// is (#698). Only the listing carries drafts, and matching on `tag_name` is
+// what tells a draft release apart from a tag that produced nothing at all.
+test('findReleaseByTag finds a draft release the tag endpoint cannot return', () => {
+  const draft = { tag_name: 'v0.9.1', draft: true, assets: [] }
+
+  assert.equal(
+    findReleaseByTag([{ tag_name: 'v0.9.0', draft: false }, draft], 'v0.9.1'),
+    draft,
+  )
+})
+
+test('findReleaseByTag reports no release when the listing holds none for the tag', () => {
+  assert.equal(
+    findReleaseByTag([{ tag_name: 'v0.9.0', draft: false }], 'v0.9.1'),
+    null,
+  )
+})
+
+// Two publish legs racing on a tag with no draft yet each created their own
+// release (#671). The published one is the one anybody can install.
+test('findReleaseByTag prefers the published release when a tag carries two', () => {
+  const published = { tag_name: 'v0.9.1', draft: false, assets: [] }
+
+  assert.equal(
+    findReleaseByTag(
+      [{ tag_name: 'v0.9.1', draft: true, assets: [] }, published],
+      'v0.9.1',
+    ),
+    published,
+  )
+})
+
+function listingResponse(releases) {
+  return { ok: true, status: 200, json: async () => releases }
+}
+
+// The endpoint is the fix: `GET /releases/tags/<tag>` cannot see a draft, the
+// listing can.
+test('fetchReleaseByTag reads the listing rather than the tag endpoint', async () => {
+  const draft = { tag_name: 'v0.9.1', draft: true, assets: [] }
+  const urls = []
+
+  const release = await fetchReleaseByTag({
+    repository: 'streamwallhq/streamwall',
+    tag: 'v0.9.1',
+    token: 'secret',
+    fetchImpl: async (url, init) => {
+      urls.push(url)
+      assert.equal(init.headers.authorization, 'Bearer secret')
+      return listingResponse([draft])
+    },
+  })
+
+  assert.equal(release, draft)
+  assert.deepEqual(urls, [
+    'https://api.github.com/repos/streamwallhq/streamwall/releases?per_page=100&page=1',
+  ])
+})
+
+test('fetchReleaseByTag stops at the page holding the release', async () => {
+  let pages = 0
+
+  const release = await fetchReleaseByTag({
+    repository: 'streamwallhq/streamwall',
+    tag: 'v0.9.1',
+    perPage: 2,
+    fetchImpl: async () => {
+      pages += 1
+      return listingResponse(
+        pages === 1
+          ? [{ tag_name: 'v1.0.0' }, { tag_name: 'v0.9.2' }]
+          : [{ tag_name: 'v0.9.1' }, { tag_name: 'v0.9.0' }],
+      )
+    },
+  })
+
+  assert.equal(release.tag_name, 'v0.9.1')
+  assert.equal(pages, 2)
+})
+
+test('fetchReleaseByTag reports no release once the listing is exhausted', async () => {
+  const release = await fetchReleaseByTag({
+    repository: 'streamwallhq/streamwall',
+    tag: 'v0.9.1',
+    perPage: 2,
+    fetchImpl: async () => listingResponse([{ tag_name: 'v1.0.0' }]),
+  })
+
+  assert.equal(release, null)
+})
+
+// Blaming a paging limit on a release that was never built would be the same
+// misdiagnosis this check exists to avoid.
+test('fetchReleaseByTag fails loudly when it runs out of pages', async () => {
+  await assert.rejects(
+    fetchReleaseByTag({
+      repository: 'streamwallhq/streamwall',
+      tag: 'v0.9.1',
+      perPage: 1,
+      maxPages: 2,
+      fetchImpl: async () => listingResponse([{ tag_name: 'v1.0.0' }]),
+    }),
+    /most recent releases/,
+  )
+})
+
+test('fetchReleaseByTag fails on an API error rather than reading it as absent', async () => {
+  await assert.rejects(
+    fetchReleaseByTag({
+      repository: 'streamwallhq/streamwall',
+      tag: 'v0.9.1',
+      fetchImpl: async () => ({ ok: false, status: 503 }),
+    }),
+    /503/,
+  )
+})
+
+// "Delete and re-push the tag" throws away the only record of what shipped
+// and, for a release that is merely unpublished, fixes nothing.
+test('formatReport does not advise deleting the tag of a missing release', () => {
+  const report = formatReport({
+    status: 'no-release',
+    tag: 'v0.9.1',
+    missing: EXPECTED_ASSET_PATTERNS,
+  })
+
+  assert.doesNotMatch(report, /delete/i)
+  assert.match(report, /release\.yml/)
+})
+
+// Drafts are listed only for a token with push access; with contents: read the
+// check read the v0.10.5 draft as a release that never existed and demanded
+// the tag be re-pushed (#698). The elevated permission is confined to this
+// job, which is why the asset check is not a step of the tag check.
+test('the asset check runs with the push access that reveals draft releases', () => {
+  const workflow = load(
+    readFileSync(join(rootDir, '.github/workflows/release-tag.yml'), 'utf8'),
+  )
+
+  assert.equal(
+    workflow.jobs.assets.permissions?.contents,
+    'write',
+    'the asset check needs push access to see draft releases',
+  )
+  assert.equal(
+    workflow.jobs.check.permissions?.contents,
+    'read',
+    'the tag check must stay read-only',
+  )
+})
+
 test('the release tag workflow also checks the release assets', () => {
   const workflow = load(
     readFileSync(join(rootDir, '.github/workflows/release-tag.yml'), 'utf8'),
   )
-  const job = workflow.jobs.check
+  const job = workflow.jobs.assets
   const step = job.steps.find((candidate) =>
     candidate.run?.includes('scripts/check-release-assets.mjs'),
   )
 
   assert.ok(step, 'release-tag.yml must run the release asset check')
-  // The asset check must still report when the tag check above it failed.
-  assert.match(step.if ?? '', /cancelled/)
+  // A missing tag must not hide a broken release: the two checks report
+  // different halves of the same pipeline, so neither may gate the other.
+  assert.equal(job.needs, undefined)
   assert.ok(
     step.env?.GH_TOKEN,
     'the GitHub API call needs a token to stay within the API rate limit',
   )
+  // `git tag --list` decides which release is inspected, so this job needs the
+  // tags as much as the tag check does.
+  const checkout = job.steps.find((candidate) =>
+    candidate.uses?.startsWith('actions/checkout@'),
+  )
+  assert.equal(checkout.with['fetch-depth'], 0)
+  // Both failures have to reach the issue the scheduled report files.
+  assert.deepEqual(workflow.jobs.report.needs, ['check', 'assets'])
 })


### PR DESCRIPTION
## What was wrong

The daily `Release tag` run has failed on every scheduled run since 2026-07-28
(#698). Two things went wrong at once:

1. **The release for `v0.10.5` was never taken out of draft.** `release.yml`
   creates the release as a draft for the publish matrix to append to;
   publishing it is a manual step and was forgotten.
2. **The check could not say so.** `check-release-assets.mjs` asked
   `GET /repos/{owner}/{repo}/releases/tags/{tag}`, and GitHub attaches a
   release to its tag only once it is published — a draft answers 404 there no
   matter how privileged the token is. The check read the complete, ready-to-go
   draft as a tag that had produced nothing at all and reported:

   > `v0.10.5` has no GitHub Release, so the tag shipped no installers. Re-run
   > release.yml for the tag … or delete and re-push `v0.10.5`.

   Following that advice would have deleted the tag and thrown away the record
   of what shipped, without touching the actual problem.

## What this changes

- The release is looked up in the repository's release **listing**, which does
  carry drafts. Paging stops at the page that holds the release, and a tag past
  the paged window raises its own error instead of masquerading as "no
  release".
- When one tag carries two releases — the publish-matrix race of #671 — the
  published one decides the verdict.
- The listing includes drafts only for a token with push access, so the asset
  check moved into a job of its own with `contents: write` (it writes nothing;
  the checkout keeps `persist-credentials: false`). The tag check stays
  `contents: read`, and the two jobs are independent so a missing tag cannot
  hide a broken release.
- The missing-release report no longer suggests deleting a tag.
- `CONTRIBUTING.md` documents the job split and that a local run needs
  `GH_TOKEN` to see drafts at all.

## Verification

- The draft release `v0.10.5` was published (`--draft=false --latest`); its 7
  assets cover every expected artifact kind. Nothing was deleted.
- Against the live repository, the patched script reported
  `The release for v0.10.5 is still a draft … Publish it in the releases UI.`
  before publishing and
  `v0.10.5 has a published release with every expected artifact kind.` after —
  the exact diagnosis the old code could not produce.
- `node --test test/*.test.mjs`: 177 passing; `actionlint`, `eslint` and
  `prettier --check` clean.
- The next scheduled run closes #698 automatically; `release-tag.yml` is also
  dispatched manually after merge.

Refs #698
