### PR TITLE
ci(packaging): run the packaging matrix on lockfile and forge config PRs

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -11,15 +11,32 @@ name: Packaging
 # installer is cross-built there, so a native Windows `make` stays this
 # matrix's job.
 #
-# Deliberately not part of PR CI: `make` costs several minutes per platform,
-# while the failure modes shared by every platform (Vite/Forge config, asar
-# packing, native module unpacking) are already covered by the much cheaper
-# `package` smoke job in ci.yml. Weekly is enough to catch Dependabot's Forge
-# and maker bumps well before the next release.
+# Deliberately not part of PR CI for most PRs: `make` costs several minutes
+# per platform, while the failure modes shared by every platform (Vite/Forge
+# config, asar packing, native module unpacking) are already covered by the
+# much cheaper `package` smoke job in ci.yml. Weekly is enough to catch most
+# Forge and maker bumps well before the next release.
+#
+# The exception is the exact class of change that caused the v0.10.5 release
+# to fail a maker after the tag already existed (#697): a lockfile
+# regeneration can silently hoist a package between the workspace root and a
+# nested `node_modules`, which is invisible to `package` but breaks a maker
+# that resolves its dependencies by walking the filesystem (electron-builder
+# did, for `electron`, in #696). Running the real makers on the PRs that can
+# cause that class of regression closes the gap between "weekly" and "the
+# tag already exists" for the changes most likely to need it, without paying
+# the full matrix cost on every PR. This run is advisory only — it is not a
+# required check, so a red leg here does not block the PR from merging.
 on:
   schedule:
     # Mondays, 05:17 UTC — off the hour to avoid GitHub's scheduling peak.
     - cron: '17 5 * * 1'
+  pull_request:
+    paths:
+      - 'package-lock.json'
+      - 'packages/*/package.json'
+      - 'packages/streamwall/forge.*.ts'
+      - '.github/workflows/packaging.yml'
   workflow_dispatch:
     inputs:
       debug:
@@ -30,11 +47,14 @@ on:
 permissions:
   contents: read
 
-# Never cancel a running matrix: a scheduled run and a manual re-run are
-# independent verdicts, and each leg is expensive.
+# A scheduled run and a manual re-run are independent verdicts, and each leg
+# is expensive, so those never cancel each other. A pull_request run is not:
+# a new push supersedes the previous one, so letting it cancel the stale run
+# saves the several-minutes-per-platform cost instead of finishing a verdict
+# nobody will read.
 concurrency:
   group: packaging-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   make:
@@ -89,9 +109,16 @@ jobs:
   # scheduled run, so the report goes into the issue tracker instead (#514).
   # `fail-fast: false` above means one red leg still leaves the others' verdict
   # intact, and `needs.*.result` aggregates the matrix into a single one.
+  #
+  # Restricted to `schedule`: this workflow is now also `pull_request`-
+  # triggered (#697), and a PR's own checks tab already shows a failing leg
+  # to whoever pushed it, so filing or reusing the shared "scheduled workflow
+  # failing" tracking issue for that would be both noise and wrong — that
+  # issue is meant to represent the current state of the *weekly* run, not
+  # any one PR's.
   report:
     needs: [make]
-    if: always()
+    if: always() && github.event_name == 'schedule'
     permissions:
       issues: write
     uses: ./.github/workflows/scheduled-report.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,8 +198,11 @@ keeps this list in sync with the workflows.
 Some workflows intentionally sit outside this gate: `.github/workflows/release.yml`
 (tag-triggered), CodeQL's weekly scheduled scan, which surfaces newly
 disclosed patterns in code that was already merged, and the weekly
-[packaging](#packaging-checks) and [deprecation](#dependency-deprecations)
-checks, which react to upstream changes rather than to anything in a PR.
+[deprecation](#dependency-deprecations) check, which reacts to upstream
+changes rather than to anything in a PR. The [packaging](#packaging-checks)
+matrix is mostly in the same boat, but it also runs — advisory only, not a
+required check — on PRs that touch the lockfile or the packaging config,
+since those are the changes most likely to break a maker.
 
 ### Code scanning alerts
 
@@ -352,7 +355,11 @@ exercised in two other places:
   three platforms every Monday and on manual dispatch — this is the only
   place the darwin zip maker runs outside a release. Run it from the Actions
   tab (optionally with the `debug` input for verbose Forge logging) after a
-  Forge/maker dependency bump.
+  Forge/maker dependency bump. It also runs — advisory only — on PRs that
+  touch `package-lock.json`, a workspace `package.json`, `forge.*.ts`, or the
+  workflow file itself, so a lockfile regeneration that hoists a package like
+  `electron` between the workspace root and a nested `node_modules` gets a
+  real maker run before it can reach a tag (#697).
 
 Two packaging runs can share a machine: `packagerConfig.tmpdir` points each
 run at a directory of its own (`forge.tmpdir.ts`). @electron/packager

--- a/test/ci-gate.test.mjs
+++ b/test/ci-gate.test.mjs
@@ -331,3 +331,81 @@ test('a single prepare-release job creates the draft before the publish matrix',
       'already exists so re-runs do not fail',
   )
 })
+
+// The v0.10.5 release build failed a maker only after the tag already
+// existed, because a lockfile regeneration hoisted `electron` between the
+// workspace root and a nested `node_modules` without any PR ever running a
+// real maker (#697). Gating that class of PR on the packaging matrix closes
+// the gap between "weekly" and "the tag already exists" for the changes most
+// likely to cause it.
+test('packaging.yml also runs on pull requests that can move the maker inputs', () => {
+  const packaging = readWorkflow('packaging.yml')
+
+  assert.ok(
+    packaging.on.schedule,
+    'packaging.yml must keep its weekly schedule alongside the new trigger',
+  )
+
+  const pullRequest = packaging.on.pull_request
+  assert.ok(
+    pullRequest,
+    'packaging.yml must also trigger on pull_request so a lockfile or ' +
+      'packaging config change runs the real makers before it can reach a ' +
+      'tag',
+  )
+
+  const expectedPaths = [
+    'package-lock.json',
+    'packages/*/package.json',
+    'packages/streamwall/forge.*.ts',
+    '.github/workflows/packaging.yml',
+  ]
+  assert.deepEqual(
+    pullRequest.paths,
+    expectedPaths,
+    'packaging.yml must scope its pull_request trigger to exactly the ' +
+      'paths that can move a package between the workspace root and a ' +
+      'nested node_modules, or that change the maker config itself — ' +
+      'otherwise every PR pays the several-minutes-per-platform cost',
+  )
+})
+
+// A pull_request run supersedes itself on every push, unlike the weekly
+// schedule or a manual re-run, each of which is its own independent verdict
+// worth letting finish.
+test('packaging.yml only self-cancels its pull_request runs', () => {
+  const packaging = readWorkflow('packaging.yml')
+
+  assert.equal(
+    packaging.concurrency?.['cancel-in-progress'],
+    "${{ github.event_name == 'pull_request' }}",
+    'packaging.yml must cancel a superseded pull_request run but keep ' +
+      'letting scheduled and manually dispatched runs finish',
+  )
+})
+
+// This workflow is not a required check (advisory only, per #697): a PR run
+// failing a maker must not touch the shared "scheduled workflow failing"
+// tracking issue, which represents the weekly run's state, not any one PR's.
+// The reusable scheduled-report.yml is also only ever reachable from a
+// `schedule`-triggered run of its own scheduled caller (see
+// scheduled-reports.test.mjs) — restricting the call here to that same event
+// keeps the same invariant now that packaging.yml has a second trigger.
+test('packaging.yml only reports to the issue tracker on scheduled runs', () => {
+  const packaging = readWorkflow('packaging.yml')
+  const report = packaging.jobs.report
+
+  assert.match(
+    String(report.if ?? ''),
+    /always\(\)/,
+    'the report job must still run with always() so a failing matrix leg ' +
+      'is reported',
+  )
+  assert.match(
+    String(report.if ?? ''),
+    /github\.event_name == 'schedule'/,
+    'the report job must be restricted to schedule-triggered runs, so a ' +
+      'pull_request failure does not file or reuse the scheduled-failure ' +
+      'issue',
+  )
+})


### PR DESCRIPTION
## Problem

The v0.10.5 release build failed a maker in `Installer smoke (windows makers)` only after the tag already existed, because a lockfile regeneration (#687/#692) hoisted `electron` from `packages/streamwall/node_modules` to the workspace root, which broke electron-builder's version resolution (fixed in #696). Nothing before the tag could have caught it:

- PR CI runs `electron-forge package` only, never `make` — deliberately, since the makers cost several minutes per platform.
- `packaging.yml` does run the real makers, but only weekly, so it can be up to a week stale.
- `release.yml`'s `make` smoke is the first real maker run, and by then the tag already exists and has to be redone.

The trigger was a pure dependency PR — exactly the class of change that moves packages between the workspace root and a nested `node_modules`, and exactly the class that shipped to a tag without ever running a maker.

## Solution

Trigger `.github/workflows/packaging.yml` additionally on `pull_request`, scoped to the paths that can cause this class of regression: `package-lock.json`, `packages/*/package.json`, `packages/streamwall/forge.*.ts`, and the workflow file itself. The weekly `schedule` trigger is unchanged.

The run is **advisory only** — it is not added to the `ci-ok` gate or the branch ruleset, so a red leg does not block merging a PR. Two follow-on adjustments keep the workflow correct now that it has two independent trigger classes:

- **Concurrency**: a `pull_request` run now cancels a run it supersedes (`cancel-in-progress: ${{ github.event_name == 'pull_request' }}`); `schedule` and `workflow_dispatch` runs still never cancel each other, since each is its own independent verdict worth the full runtime.
- **Reporting**: the `report` job files/updates a shared "scheduled workflow failing" GitHub issue via the reusable `scheduled-report.yml` on failure. That issue is meant to reflect the *weekly* run's current state, not any individual PR's — a PR's own failing leg is already visible in its own checks tab. The job is now restricted to `github.event_name == 'schedule'` so a PR-triggered failure never touches that tracking issue. `scheduled-report.yml` itself stays `workflow_call`-only (unchanged), avoiding the known trap where a reusable workflow that is both called and scheduled fails every caller's run at startup once the called job needs elevated permissions.

`CONTRIBUTING.md`'s "Packaging checks" section and the `ci-ok` gate's exceptions list were also updated — they still described `packaging.yml` as schedule/dispatch-only.

## Testing performed

- `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (2061 tests) — all green.
- `actionlint .github/workflows/packaging.yml` — clean.
- New tests in `test/ci-gate.test.mjs` (TDD): written and confirmed red against the pre-change workflow, green after. They assert the `pull_request` trigger and its exact path list, the `cancel-in-progress` expression, and the `report` job's `schedule`-only guard.
- No application code changed, so no `npm run build` was needed.

## Risks / breaking changes

None to runtime behavior. CI cost: qualifying PRs (lockfile or packaging-config changes) now pay the full three-platform `make` matrix in addition to the existing `package` smoke — this is the intended tradeoff, scoped by the path filter to land only on the PRs where the risk actually is.

## Pre-PR review

Two independent review rounds (fresh subagent, no shared context) were run before this PR was opened, per policy:

- **Round 1** found one minor issue: `CONTRIBUTING.md` still described `packaging.yml` as schedule/dispatch-only in two places. Fixed in a follow-up commit since it was directly tied to this change (same workflow, same PR, low risk).
- **Round 2**: `NO FINDINGS`.

No findings were dismissed as invalid.

Closes #697