### PR TITLE
chore(deps): upgrade @playwright/test to 1.62.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,13 +16,6 @@ updates:
       - dependency-name: typescript
         update-types:
           - version-update:semver-major
-      # Playwright 1.62 resolves tsconfig `extends` only in the tsconfig's own
-      # node_modules, which misses our hoisted `@tsconfig/*` bases and kills
-      # the E2E job during config load. Drop as part of #691.
-      - dependency-name: '@playwright/test'
-        update-types:
-          - version-update:semver-minor
-          - version-update:semver-major
     # Grouped PRs are all-or-nothing, so a group is split by update-type: a
     # blocked major (see the `ignore` comment above) never holds back the
     # low-risk minor/patch updates that ship alongside it (#690).

--- a/package-lock.json
+++ b/package-lock.json
@@ -3616,19 +3616,19 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.1"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@preact/preset-vite": {
@@ -12334,35 +12334,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.1"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/playwright/node_modules/fsevents": {
@@ -15361,7 +15361,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@playwright/test": "~1.61.1",
+        "@playwright/test": "~1.62.1",
         "@tsconfig/node-ts": "^23.6.4",
         "@tsconfig/node22": "^22.0.6",
         "@tsconfig/recommended": "^1.0.13",

--- a/packages/streamwall-control-e2e/package.json
+++ b/packages/streamwall-control-e2e/package.json
@@ -12,7 +12,7 @@
   "author": "Nils Reeh <info@nilsreeh.de>",
   "license": "MIT",
   "devDependencies": {
-    "@playwright/test": "~1.61.1",
+    "@playwright/test": "~1.62.1",
     "@tsconfig/node-ts": "^23.6.4",
     "@tsconfig/node22": "^22.0.6",
     "@tsconfig/recommended": "^1.0.13",

--- a/test/dependabot-config.test.mjs
+++ b/test/dependabot-config.test.mjs
@@ -77,10 +77,9 @@ test('the old undifferentiated npm groups are gone', () => {
   )
 })
 
-// The typescript/@playwright/test ignore entries are the reason a single
-// blocked major used to stall the whole group; they must stay untouched by
-// this split (typescript majors: #426, @playwright/test: #691).
-test('the existing major-version ignore entries are preserved', () => {
+// The typescript ignore entry is the reason a single blocked major used to
+// stall the whole group; it must stay untouched by this split (#426).
+test('the existing typescript major-version ignore entry is preserved', () => {
   const { ignore } = findNpmUpdate(readDependabotConfig())
 
   const typescriptIgnore = ignore.find(
@@ -90,16 +89,16 @@ test('the existing major-version ignore entries are preserved', () => {
   assert.deepEqual(typescriptIgnore['update-types'], [
     'version-update:semver-major',
   ])
+})
 
-  const playwrightIgnore = ignore.find(
-    (entry) => entry['dependency-name'] === '@playwright/test',
-  )
+// @playwright/test was ignored only until upstream stopped hard-failing on
+// unresolved hoisted tsconfig `extends` paths (#691); once upgraded, the
+// entry must not linger and keep blocking future Dependabot updates.
+test('the @playwright/test ignore entry is gone now that it has been upgraded', () => {
+  const { ignore } = findNpmUpdate(readDependabotConfig())
+
   assert.ok(
-    playwrightIgnore,
-    'the @playwright/test ignore entry must stay in place',
+    !ignore.some((entry) => entry['dependency-name'] === '@playwright/test'),
+    'the @playwright/test ignore entry should have been removed as part of #691',
   )
-  assert.deepEqual(playwrightIgnore['update-types'], [
-    'version-update:semver-minor',
-    'version-update:semver-major',
-  ])
 })


### PR DESCRIPTION
## Problem

`@playwright/test` was held at `~1.61.1` in `packages/streamwall-control-e2e/package.json` because the 1.62.0 bump in #688 broke the E2E job before a single test ran:

```
Error: Failed to load tsconfig file at packages/streamwall-control-e2e/tsconfig.json:
Failed to resolve "extends" path "@tsconfig/recommended/tsconfig" referenced from packages/streamwall-control-e2e/tsconfig.json
```

Playwright 1.62's tsconfig loader resolves a package-style `extends` only inside the tsconfig's own directory's `node_modules`, never walking up parent directories the way Node/tsc do. Since npm hoists `@tsconfig/recommended`, `@tsconfig/node22` and `@tsconfig/node-ts` to the repo root in this single-lockfile workspace, the lookup missed and Playwright 1.62.0 turned that into a hard, fatal error.

## Research

- Confirmed with npm's registry that 1.62.1 is the current `latest` `@playwright/test` release.
- Installed 1.62.1 in a scratch directory and inspected `node_modules/playwright/lib/common/index.js`: `resolveConfigFile` still does not walk up `node_modules` — the underlying hoisting gap is unchanged.
- However, the *fatal* behavior introduced in 1.62.0 is gone in 1.62.1. Tracked this to upstream microsoft/playwright issue [#41989](https://github.com/microsoft/playwright/issues/41989) ("[Regression]: tsconfig \"extends\" bare specifier isn't resolved via node_modules walk-up like tsc (fatal since 1.62)"), fixed by merged PR [#42005](https://github.com/microsoft/playwright/pull/42005) ("fix(tsconfig): do not throw when extends/references cannot be resolved"). That PR explicitly **reverts the hard error** rather than implementing tsc-compatible resolution — an unresolved `extends` is silently ignored again, matching 1.61 behavior. It shipped in `@playwright/test` 1.62.1 (2026-07-30).

## Solution

- Bump `@playwright/test` to `~1.62.1` in `packages/streamwall-control-e2e/package.json` (no separate `playwright` dependency exists elsewhere in the repo to bump).
- Regenerate `package-lock.json` scoped to that workspace so the diff only touches the `@playwright/test` / `playwright` / `playwright-core` version triplet.
- Remove the now-unnecessary `@playwright/test` ignore entry from `.github/dependabot.yml`.

## Testing performed

- `npm ci` (clean install from the regenerated lockfile)
- `npm run format:check`, `npm run lint`, `npm run typecheck` (all workspaces, including `streamwall-control-e2e`)
- `npm run test` — 2058 tests across all 6 suites, all passing
- `packages/streamwall-control-e2e`: `npx playwright install chromium && npm run test:e2e` — 17/17 passing, no tsconfig resolution error

No production code changed, so no new tests were added — this is a dependency bump plus a CI-config cleanup, verified by the full existing suite (including the previously-broken E2E job) passing locally.

## Risks / breaking changes

None expected. The upstream hoisting gap itself (no `node_modules` walk-up for package-style `extends`) is still open, but it's harmless again: an unresolved `extends` is silently skipped rather than aborting spec collection, exactly as it behaved on 1.61.1.

## Pre-PR review

Three independent review rounds by fresh subagents with no prior context:
- Round 1: found `package-lock.json` had incidentally dropped `"libc"` metadata fields on unrelated optional platform packages (`@rolldown/binding-linux-*`, `lightningcss-linux-*`), caused by a local npm-version formatting difference when the lockfile was rewritten. Fixed by restoring those fields so the lockfile diff is scoped strictly to the playwright triplet.
- Round 2: found the same root cause had also re-escaped three literal `"GitHub Sponsors ❤"` strings elsewhere in the lockfile. Fixed by restoring the literal character.
- Round 3: `NO FINDINGS`.

No findings were dismissed as invalid; all were valid and fixed.

Closes #691