### PR TITLE
fix(control-server): force lingering connections shut on close

### DIFF
--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -125,6 +125,14 @@ export async function initApp({
     injectedTrustProxy ?? parseTrustProxy(process.env.STREAMWALL_TRUST_PROXY)
   const app = Fastify({
     trustProxy,
+    // Force sockets shut on `close()` instead of draining them: without this,
+    // a peer that is mid-request when the server shuts down keeps it alive
+    // until `keepAliveTimeout` (72s). Fastify's default does not cover that
+    // case — see `shutdown.test.ts` for the full rationale and the regression
+    // it guards. Nothing here needs a graceful drain: `@fastify/websocket`'s
+    // preClose hook has already asked every socket to close, and the HTTP
+    // routes are short request/response pairs a client retries anyway.
+    forceCloseConnections: true,
     logger: {
       ...getLoggerOptions(logLevel),
       ...(logStream && { stream: logStream }),

--- a/packages/streamwall-control-server/src/shutdown.test.ts
+++ b/packages/streamwall-control-server/src/shutdown.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict'
+import net from 'node:net'
+import { after, test } from 'node:test'
+import { setTimeout as delay } from 'node:timers/promises'
+import { buildTestApp, listenTestApp } from './testHelpers.ts'
+
+/**
+ * `app.close()` must not block on connections that are still mid-request.
+ *
+ * Node's `server.close()` reaps *idle* keep-alive sockets once, at the moment
+ * it is called; a socket that is busy right then keeps the server open until
+ * its peer hangs up or `keepAliveTimeout` (72s) expires. A real browser tab
+ * always has requests in flight, so shutting the server down underneath one is
+ * the normal case, not an edge case.
+ *
+ * Fastify's default `forceCloseConnections: 'idle'` does not cover this: that
+ * branch only reaches `server.closeIdleConnections()` for apps built with a
+ * custom `serverFactory`, which we do not use. Up to fastify 5.11 the default
+ * still hit `closeAllConnections()` by accident (the check was for
+ * truthiness, and `'idle'` is truthy); 5.12 tightened it to `=== true`, so the
+ * app stopped closing connections at shutdown entirely — which is what made
+ * the control-client e2e suite fail with `Tearing down "harness" exceeded the
+ * test timeout`. We therefore ask for `forceCloseConnections: true`
+ * explicitly instead of relying on a default that has drifted twice.
+ */
+test('close() does not wait for a connection that is still mid-request', async () => {
+  const { app } = await buildTestApp()
+  const port = await listenTestApp(app)
+
+  // A half-sent request: the server has accepted the socket and is waiting for
+  // the rest of the headers, so Node counts it as busy rather than idle — the
+  // assertion below is what proves that, since an idle socket would already be
+  // reaped by the sweep inside `server.close()` and the test could not fail.
+  const socket = net.connect(port, '127.0.0.1')
+  after(() => socket.destroy())
+  await new Promise<void>((resolve, reject) => {
+    socket.once('error', reject)
+    socket.once('connect', () => {
+      socket.write('GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n')
+      resolve()
+    })
+  })
+  await delay(100)
+
+  // Raced rather than awaited: a regression here does not fail, it blocks for
+  // a minute, which would stall the whole suite instead of reporting.
+  const outcome = await Promise.race([
+    app.close().then(() => 'closed' as const),
+    delay(5000).then(() => 'still draining' as const),
+  ])
+
+  assert.equal(
+    outcome,
+    'closed',
+    'app.close() must force lingering connections shut instead of draining them',
+  )
+})


### PR DESCRIPTION
Fixes the `E2E smoke (control client)` job, red on `main` since c471873 (#728): five Playwright tests failed with `Tearing down "harness" exceeded the test timeout of 30000ms` while the tests themselves passed.

## Root cause

The e2e harness tears down by calling `app.close()` on the control server while the Playwright page is still attached. Node's `server.close()` sweeps only the sockets that are **idle at that instant**; a socket that is mid-request right then is never revisited and keeps the server open until `keepAliveTimeout` (72s). A live browser tab always has requests in flight, so this is the normal case, not an edge case.

Fastify's default `forceCloseConnections: 'idle'` does not cover it: that branch only reaches `server.closeIdleConnections()` for apps built with a custom `serverFactory`, which we do not use. Up to fastify 5.11 the default still fell through to `closeAllConnections()` by accident — the check was for truthiness and `'idle'` is truthy:

```js
// fastify 5.11.0
} else if (serverHasCloseAllConnections && forceCloseConnections) {
// fastify 5.12.1
} else if (serverHasCloseAllConnections && forceCloseConnections === true) {
```

So the fastify 5.11 → 5.12.1 bump in #728 silently removed the connection close our teardown had been relying on. Nothing in the harness or the app changed.

### Evidence

- Reproduced locally: 2–4 of the 17 e2e tests hang in teardown per full run (matches the flaky/failing pattern on CI).
- Instrumented teardown: `app.close()` sits for the full 30s with `websocketServer.clients` empty but 3–4 idle Chromium keep-alive sockets still on `app.server`; calling `closeIdleConnections()` by hand at that point drops them to 0 and `close()` returns immediately.
- Swapping `node_modules/fastify` to 5.11.0 with no other change: 17/17 green, every `app.close()` under 12 ms. Swapping back to 5.12.1: hangs return.

## Fix

Ask for `forceCloseConnections: true` explicitly in `initApp()` instead of relying on a default that has now drifted twice. Nothing needs a graceful drain on the way out: `@fastify/websocket`'s preClose hook has already asked every socket to close, and the HTTP routes are short request/response pairs.

The timeout was not touched and no test was marked flaky.

## Regression test

`packages/streamwall-control-server/src/shutdown.test.ts` parks a connection mid-request and races `app.close()` against a 5s timer (raced, not awaited: a regression would otherwise block for a minute instead of reporting). Fails on `main`, passes here.

## Verification

- `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (2079 tests) — all green.
- `npm run test:e2e -w packages/streamwall-control-e2e` — 17/17 green on two consecutive full runs.

## Follow-up

- #751 — the control server still has no `SIGTERM`/`SIGINT` handler, so `app.close()` is never called in production at all.