### PR TITLE
fix(streamwall): treat non-2xx data-source responses as unhealthy

### DIFF
--- a/packages/streamwall/src/main/data/poll.test.ts
+++ b/packages/streamwall/src/main/data/poll.test.ts
@@ -13,7 +13,15 @@ describe('pollDataURL', () => {
   })
 
   async function serveJson(body: unknown): Promise<string> {
+    return serveJsonWithStatus(200, body)
+  }
+
+  async function serveJsonWithStatus(
+    statusCode: number,
+    body: unknown,
+  ): Promise<string> {
     server = createServer((_req, res) => {
+      res.statusCode = statusCode
       res.setHeader('content-type', 'application/json')
       res.end(JSON.stringify(body))
     })
@@ -73,6 +81,88 @@ describe('pollDataURL', () => {
     try {
       await gen.next()
       expect(onHealth).toHaveBeenCalledWith(false, expect.any(String))
+    } finally {
+      await gen.return(undefined)
+    }
+  })
+
+  test('reports unhealthy status with the status code on a 4xx response with a JSON body', async () => {
+    const url = await serveJsonWithStatus(429, { error: 'rate limited' })
+    const onHealth = vi.fn()
+    const gen = pollDataURL(url, 999, onHealth)
+    try {
+      const { value } = await gen.next()
+      expect(onHealth).toHaveBeenCalledWith(
+        false,
+        expect.stringContaining('429'),
+      )
+      expect(value).toEqual([])
+    } finally {
+      await gen.return(undefined)
+    }
+  })
+
+  test('reports unhealthy status with the status code on a 5xx response with a JSON body', async () => {
+    const url = await serveJsonWithStatus(500, [
+      { link: 'https://a.example/s', kind: 'video' },
+    ])
+    const onHealth = vi.fn()
+    const gen = pollDataURL(url, 999, onHealth)
+    try {
+      const { value } = await gen.next()
+      expect(onHealth).toHaveBeenCalledWith(
+        false,
+        expect.stringContaining('500'),
+      )
+      expect(value).toEqual([])
+    } finally {
+      await gen.return(undefined)
+    }
+  })
+
+  test('keeps serving the last good data when a later poll returns a non-2xx response', async () => {
+    let statusCode = 200
+    let body: unknown = [{ link: 'https://a.example/s', kind: 'video' }]
+    server = createServer((_req, res) => {
+      res.statusCode = statusCode
+      res.setHeader('content-type', 'application/json')
+      res.end(JSON.stringify(body))
+    })
+    await new Promise<void>((resolve) =>
+      server!.listen(0, '127.0.0.1', resolve),
+    )
+    const { port } = server.address() as AddressInfo
+    const url = `http://127.0.0.1:${port}/`
+
+    const onHealth = vi.fn()
+    const gen = pollDataURL(url, 0.1, onHealth)
+    try {
+      const first = await gen.next()
+      expect(first.value?.map((s: StreamDataContent) => s.link)).toEqual([
+        'https://a.example/s',
+      ])
+
+      statusCode = 500
+      body = { error: 'server exploded' }
+      const pending = gen.next()
+
+      const stillPending = Symbol('pending')
+      const raceResult = await Promise.race([
+        pending,
+        new Promise((resolve) => setTimeout(() => resolve(stillPending), 150)),
+      ])
+      expect(raceResult).toBe(stillPending)
+      expect(onHealth).toHaveBeenCalledWith(
+        false,
+        expect.stringContaining('500'),
+      )
+
+      statusCode = 200
+      body = [{ link: 'https://b.example/s', kind: 'video' }]
+      const second = await pending
+      expect(second.value?.map((s: StreamDataContent) => s.link)).toEqual([
+        'https://b.example/s',
+      ])
     } finally {
       await gen.return(undefined)
     }

--- a/packages/streamwall/src/main/data/poll.ts
+++ b/packages/streamwall/src/main/data/poll.ts
@@ -84,6 +84,11 @@ export async function* pollDataURL(
     let data: StreamDataContent[] = []
     try {
       const resp = await fetchWithTimeout(url, fetchTimeout)
+      if (!resp.ok) {
+        throw new Error(
+          `received HTTP ${resp.status} ${resp.statusText} from ${url}`,
+        )
+      }
       data = parseStreamEntries(await resp.json(), `from ${url}`)
       onHealth?.(true)
     } catch (err) {


### PR DESCRIPTION
## Problem
`pollDataURL` never inspected `resp.ok` or `resp.status`. `node-fetch` does not throw for 4xx/5xx, so an error response whose body happens to be valid JSON (e.g. `{"error":"rate limited"}`) parsed fine, yielded zero streams, and still reported the data source as healthy via `onHealth?.(true)`. If a prior successful poll existed, the wall kept silently serving increasingly stale data while the control UI showed a green "ok" status.

## Technical solution
After `fetchWithTimeout` resolves, check `resp.ok` and throw before reading the body if it is false. The existing `catch` block already logs the error and calls `onHealth?.(false, err.message)`, so the fix reuses that path — the thrown message surfaces the HTTP status and status text, mirroring the existing timeout-error message style in the same file. Because `data` stays `[]` on this path, the existing `!data.length && lastData.length` branch continues to preserve the last good data.

## Testing performed
- Added `poll.test.ts` cases for a 429 and a 500 response with valid JSON bodies, asserting `onHealth(false, ...)` with the status code in the message.
- Added a case verifying that a later non-2xx response keeps serving the last successfully polled data instead of wiping it.
- Full quality gate: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (2083 tests) — all green.

## Risks / breaking changes
None. This only changes an unhealthy-response classification; the response-handling contract (`onHealth` callback, cached-data fallback) is unchanged.

## Pre-PR review
One independent review round by a fresh subagent with no session context. Result: effectively `NO FINDINGS` (the reviewer's single note explicitly confirmed a checked edge case behaves correctly, not a problem).

Closes #742