### PR TITLE
fix(control-ui): compose caller focus/blur handlers in LazyChangeInput

### DIFF
--- a/packages/streamwall-control-ui/src/GridInput.test.tsx
+++ b/packages/streamwall-control-ui/src/GridInput.test.tsx
@@ -137,6 +137,42 @@ describe('GridInput', () => {
     expect(input.getAttribute('data-idx')).toBe('3')
   })
 
+  // GridInput passes its own onFocus/onBlur (to track focusedInputIdx). Those
+  // used to shadow LazyChangeInput's internal handlers via prop-spread
+  // ordering, so a mistyped edit that never committed (not a known stream id)
+  // stuck around forever - not cleared by blur, a drag/swap's
+  // activeElement.blur(), or a later spaceValue update (issue #744).
+  test('does not retain a stale, uncommitted edit once the cell loses focus', () => {
+    const onBlur = vi.fn()
+    const box = renderInput({ spaceValue: 'old-stream', onBlur })
+    const input = box.querySelector('input')!
+
+    act(() => {
+      input.value = 'zzz'
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    act(() => {
+      // As in useTileDrag.handleSwapView, blurring the input deselects it so
+      // its edit is not persisted by GridInput's internal editingValue.
+      input.dispatchEvent(new FocusEvent('focusout', { bubbles: true }))
+    })
+
+    expect(onBlur).toHaveBeenCalledTimes(1)
+
+    // A later re-render with a fresh spaceValue (e.g. from the wall's real
+    // state) must not be masked by the stale local edit.
+    act(() => {
+      render(
+        <StyleSheetManager target={styleTarget}>
+          {gridInput({ spaceValue: 'wok', onBlur })}
+        </StyleSheetManager>,
+        container!,
+      )
+    })
+
+    expect(input.value).toBe('wok')
+  })
+
   test('paints the tile lighter while it is highlighted', () => {
     expect(cellColor(idColor('stream-1')).lightness()).toBe(75)
     expect(cellColor(idColor('stream-1'), true).lightness()).toBe(90)

--- a/packages/streamwall-control-ui/src/LazyChangeInput.test.tsx
+++ b/packages/streamwall-control-ui/src/LazyChangeInput.test.tsx
@@ -13,11 +13,9 @@ afterEach(() => {
   }
 })
 
-function renderInput(props: {
-  value: string
-  isEager?: boolean
-  onChange: (value: string) => void
-}): HTMLInputElement {
+function renderInput(
+  props: Parameters<typeof LazyChangeInput>[0],
+): HTMLInputElement {
   container = document.createElement('div')
   document.body.appendChild(container)
   act(() => {
@@ -118,5 +116,65 @@ describe('LazyChangeInput', () => {
     // Enter must not commit a second time in eager mode.
     pressEnter(input)
     expect(onChange).toHaveBeenCalledTimes(2)
+  })
+
+  // GridInput passes its own onFocus/onBlur (to track focusedInputIdx). Those
+  // must be composed with, not replace, the internal handlers - otherwise
+  // editingValue is never seeded/cleared and a stale edit lingers forever
+  // (issue #744).
+  describe('when the caller supplies its own onFocus/onBlur', () => {
+    test('still seeds and commits the edit, and still calls the caller handlers', () => {
+      const onChange = vi.fn()
+      const callerOnFocus = vi.fn()
+      const callerOnBlur = vi.fn()
+      const input = renderInput({
+        value: 'old',
+        onChange,
+        onFocus: callerOnFocus,
+        onBlur: callerOnBlur,
+      })
+
+      // Under preact/compat, onFocus is wired to the (bubbling) focusin
+      // event, mirroring onBlur/focusout.
+      act(() => {
+        input.dispatchEvent(new FocusEvent('focusin', { bubbles: true }))
+      })
+      expect(callerOnFocus).toHaveBeenCalledTimes(1)
+
+      type(input, 'new')
+      blur(input)
+
+      expect(callerOnBlur).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith('new')
+    })
+
+    test('still clears editingValue on blur, so a later prop update is not masked by the stale edit', () => {
+      const onChange = vi.fn()
+      const input = renderInput({
+        value: 'old',
+        onChange,
+        onFocus: vi.fn(),
+        onBlur: vi.fn(),
+      })
+
+      type(input, 'zzz')
+      blur(input)
+
+      // Re-render with a fresh value, as a parent does after committing
+      // elsewhere (e.g. a drag/swap calling activeElement.blur()).
+      act(() => {
+        render(
+          <LazyChangeInput
+            value="fresh"
+            onChange={onChange}
+            onFocus={vi.fn()}
+            onBlur={vi.fn()}
+          />,
+          container!,
+        )
+      })
+
+      expect(input.value).toBe('fresh')
+    })
   })
 })

--- a/packages/streamwall-control-ui/src/LazyChangeInput.tsx
+++ b/packages/streamwall-control-ui/src/LazyChangeInput.tsx
@@ -6,6 +6,9 @@ export function LazyChangeInput({
   value = '',
   onChange,
   isEager = false,
+  onFocus: onFocusProp,
+  onBlur: onBlurProp,
+  onKeyDown: onKeyDownProp,
   ...props
 }: {
   value: string
@@ -18,24 +21,34 @@ export function LazyChangeInput({
       if (ev.target instanceof HTMLInputElement) {
         setEditingValue(ev.target.value)
       }
+      onFocusProp?.(ev)
     },
-    [],
+    [onFocusProp],
   )
 
-  const handleBlur = useCallback(() => {
+  const commitEdit = useCallback(() => {
     if (!isEager && editingValue !== undefined) {
       onChange(editingValue)
     }
     setEditingValue(undefined)
   }, [editingValue, isEager, onChange])
 
+  const handleBlur = useCallback<JSX.FocusEventHandler<HTMLInputElement>>(
+    (ev) => {
+      commitEdit()
+      onBlurProp?.(ev)
+    },
+    [commitEdit, onBlurProp],
+  )
+
   const handleKeyDown = useCallback<JSX.KeyboardEventHandler<HTMLInputElement>>(
     (ev) => {
       if (ev.key === 'Enter') {
-        handleBlur()
+        commitEdit()
       }
+      onKeyDownProp?.(ev)
     },
-    [handleBlur],
+    [commitEdit, onKeyDownProp],
   )
 
   const handleChange = useCallback<JSX.InputEventHandler<HTMLInputElement>>(
@@ -51,12 +64,12 @@ export function LazyChangeInput({
 
   return (
     <input
+      {...props}
       value={editingValue !== undefined ? editingValue : value}
       onFocus={handleFocus}
       onBlur={handleBlur}
       onKeyDown={handleKeyDown}
       onChange={handleChange}
-      {...props}
     />
   )
 }


### PR DESCRIPTION
## Problem
`LazyChangeInput` rendered the internal `onFocus`/`onBlur`/`onKeyDown` handlers before spreading the caller's own props onto the `<input>`, so a caller passing its own `onFocus`/`onBlur` silently replaced the internal handlers instead of composing with them. `GridInput` does exactly that (to track `focusedInputIdx`), so the internal `editingValue` was never seeded on focus and, crucially, never cleared on blur — a mistyped or partial grid-cell edit could linger indefinitely, surviving blur, drag/swap (`useTileDrag.handleSwapView`'s `activeElement.blur()`), and reconnect resyncs.

## Solution
- `LazyChangeInput` now destructures the caller's `onFocus`/`onBlur`/`onKeyDown` out of `props` and calls them from within its own internal handlers, after running its internal logic.
- `{...props}` is spread before the internal handler props on the `<input>`, so the internal handlers always win the JSX prop position (composition happens inside the handlers themselves, not via spread order).
- `onChange` is not part of this composition: it already has a non-DOM-passthrough signature (`(value: string) => void`), so it isn't part of the spread `props` and needed no change.
- `GridInput.tsx` itself required no behavior change — the bug was entirely in `LazyChangeInput`.

## Testing
- `LazyChangeInput.test.tsx`: new tests assert the caller's `onFocus`/`onBlur` are still invoked, and that the internal `editingValue` reset still happens on blur even when the caller supplies its own `onBlur` (i.e. a stale/uncommitted edit is not masked once a fresh `value` prop arrives).
- `GridInput.test.tsx`: new regression test reproducing the exact scenario from the issue — type an uncommitted value, blur (`focusout`, as `useTileDrag`'s swap path does), then re-render with a fresh `spaceValue` — and assert the fresh value wins.
- Verified both new tests fail on the pre-fix code and pass after the fix.
- Full quality gate green: `npm run format`, `npm run lint`, `npm run typecheck`, `npm -w packages/streamwall-control-ui run test` (374/374 passing).

## Pre-PR review
One independent review round (fresh subagent, no session context) returned `NO FINDINGS`.

Closes #744