### PR TITLE
fix(ci): retry transient GitHub API errors in the release asset check

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -69,6 +69,11 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: write
+    outputs:
+      # `ok` | `failed` | `inconclusive` — set by the check step below so the
+      # report job can tell a transient GitHub API error (#721) apart from a
+      # real failure without treating either as a plain job result.
+      outcome: ${{ steps.assets.outputs.outcome }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -80,10 +85,31 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      # `check-release-assets.mjs` exits 2 rather than 1 when it could not
+      # reach the GitHub API even after retrying (#721): a 5xx or a rate limit
+      # says nothing about whether the release is broken, so that outcome must
+      # not read as the same failure a missing artifact would be. The step
+      # itself still succeeds (exit 0) so the job result stays clean; the
+      # `outcome` output is how the report job tells the two apart.
       - name: Check the newest tag produced a complete release
+        id: assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node scripts/check-release-assets.mjs
+        run: |
+          set +e
+          node scripts/check-release-assets.mjs
+          code=$?
+          set -e
+          if [ "$code" -eq 2 ]; then
+            echo 'outcome=inconclusive' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$code" -eq 0 ]; then
+            echo 'outcome=ok' >> "$GITHUB_OUTPUT"
+          else
+            echo 'outcome=failed' >> "$GITHUB_OUTPUT"
+          fi
+          exit "$code"
 
   # A failing scheduled run is invisible without this: nobody is emailed about
   # one, so the report goes into the issue tracker instead (#514) — which is
@@ -95,7 +121,13 @@ jobs:
       issues: write
     uses: ./.github/workflows/scheduled-report.yml
     with:
+      # A transient GitHub API error must neither file a fresh "workflow
+      # failing" report nor quietly close an existing one — the run said
+      # nothing about the release either way (#721). `needs.*.result` still
+      # covers every job's real result; only the "success" branch is narrowed,
+      # so an inconclusive `assets` run falls through to `none` instead.
       result: >-
         ${{ contains(needs.*.result, 'failure') && 'failure'
-         || contains(needs.*.result, 'success') && 'success'
+         || (contains(needs.*.result, 'success')
+             && needs.assets.outputs.outcome != 'inconclusive') && 'success'
          || 'none' }}

--- a/scripts/check-release-assets.mjs
+++ b/scripts/check-release-assets.mjs
@@ -89,6 +89,70 @@ export function selectReleaseTag({ version, tags }) {
   return { status: 'check', tag }
 }
 
+// A transient GitHub API error (a 5xx, a rate limit, or a plain network
+// failure) says nothing about whether the release is actually broken. Retried
+// a few times it usually clears on its own; if it still has not after that,
+// this script exits with this dedicated code so the workflow can treat the
+// run as inconclusive instead of reporting "the release is broken" over a
+// blip in GitHub's API (#721).
+export const TRANSIENT_EXIT_CODE = 2
+
+const DEFAULT_RETRIES = 3
+const DEFAULT_BASE_DELAY_MS = 500
+
+function defaultSleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+// A 5xx or a 429 is GitHub having a bad moment; a 403 carrying `retry-after`
+// is its secondary rate limit, which behaves the same way. A plain 403 with
+// no such header is a permissions problem instead — retrying that would only
+// hide a bad token behind a few seconds of silence.
+export function isTransientResponse(response) {
+  if (response.status === 429 || response.status >= 500) {
+    return true
+  }
+  if (response.status === 403) {
+    return response.headers?.get?.('retry-after') != null
+  }
+  return false
+}
+
+function backoffDelayMs(response, attempt, baseDelayMs) {
+  const retryAfter = response?.headers?.get?.('retry-after')
+  if (retryAfter != null) {
+    const seconds = Number(retryAfter)
+    if (Number.isFinite(seconds) && seconds >= 0) {
+      return seconds * 1000
+    }
+  }
+  return baseDelayMs * 2 ** (attempt - 1)
+}
+
+function markTransient(error) {
+  error.transient = true
+  return error
+}
+
+// Translates a `fetchReleaseByTag` failure into what the CLI should do about
+// it: `null` for anything that is a real problem and must keep failing loudly
+// (a bad token, an exhausted page limit), or the exit code and message for a
+// transient one that could not be resolved even after retrying.
+export function classifyFetchError(error) {
+  if (!error?.transient) {
+    return null
+  }
+  return {
+    exitCode: TRANSIENT_EXIT_CODE,
+    message:
+      `::warning::${error.message} Retried and still could not reach the ` +
+      'GitHub API, so this run cannot tell whether the release is complete ' +
+      '— treating it as inconclusive rather than reporting a broken release.',
+  }
+}
+
 export function parseRepository(remoteUrl) {
   const match = /github\.com[/:]([^/]+\/[^/]+?)(?:\.git)?\/?$/.exec(
     remoteUrl.trim(),
@@ -194,6 +258,11 @@ export function findReleaseByTag(releases, tag) {
 // release would be the same misdiagnosis this check exists to avoid.
 //
 // The token the workflow passes in also lifts the anonymous rate limit.
+//
+// Each page request is retried on a transient failure (#721): GitHub having a
+// bad moment does not mean the release is broken, so a 5xx, a rate limit, or
+// a plain network error gets a few attempts with backoff before this gives
+// up and marks the error transient for the caller to report as inconclusive.
 export async function fetchReleaseByTag({
   repository,
   tag,
@@ -201,26 +270,21 @@ export async function fetchReleaseByTag({
   fetchImpl = fetch,
   perPage = 100,
   maxPages = 5,
+  retries = DEFAULT_RETRIES,
+  baseDelayMs = DEFAULT_BASE_DELAY_MS,
+  sleep = defaultSleep,
 }) {
   for (let page = 1; page <= maxPages; page += 1) {
-    const response = await fetchImpl(
-      `https://api.github.com/repos/${repository}/releases` +
-        `?per_page=${perPage}&page=${page}`,
-      {
-        headers: {
-          accept: 'application/vnd.github+json',
-          'x-github-api-version': '2022-11-28',
-          ...(token ? { authorization: `Bearer ${token}` } : {}),
-        },
-      },
-    )
-
-    if (!response.ok) {
-      throw new Error(
-        `GitHub API returned ${response.status} for the releases of ${repository}.`,
-      )
-    }
-    const batch = await response.json()
+    const batch = await fetchReleasesPage({
+      repository,
+      page,
+      perPage,
+      token,
+      fetchImpl,
+      retries,
+      baseDelayMs,
+      sleep,
+    })
     const release = findReleaseByTag(batch, tag)
 
     if (release !== null) {
@@ -234,6 +298,62 @@ export async function fetchReleaseByTag({
     `${tag} is not among the ${maxPages * perPage} most recent releases of ` +
       `${repository}, so this check cannot tell what it produced.`,
   )
+}
+
+async function fetchReleasesPage({
+  repository,
+  page,
+  perPage,
+  token,
+  fetchImpl,
+  retries,
+  baseDelayMs,
+  sleep,
+}) {
+  const url =
+    `https://api.github.com/repos/${repository}/releases` +
+    `?per_page=${perPage}&page=${page}`
+  const init = {
+    headers: {
+      accept: 'application/vnd.github+json',
+      'x-github-api-version': '2022-11-28',
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
+  }
+
+  for (let attempt = 1; attempt <= retries; attempt += 1) {
+    let response
+    try {
+      response = await fetchImpl(url, init)
+    } catch (networkError) {
+      if (attempt === retries) {
+        throw markTransient(
+          new Error(
+            `Could not reach the GitHub API for the releases of ` +
+              `${repository}: ${networkError.message}`,
+          ),
+        )
+      }
+      await sleep(baseDelayMs * 2 ** (attempt - 1))
+      continue
+    }
+
+    if (response.ok) {
+      return response.json()
+    }
+
+    const message = `GitHub API returned ${response.status} for the releases of ${repository}.`
+    if (!isTransientResponse(response)) {
+      throw new Error(message)
+    }
+    if (attempt === retries) {
+      throw markTransient(new Error(message))
+    }
+    await sleep(backoffDelayMs(response, attempt, baseDelayMs))
+  }
+  // Unreachable: `retries` is always at least 1, so the loop above either
+  // returns or throws before falling out the bottom.
+  throw new Error(`Could not fetch the releases of ${repository}.`)
 }
 
 async function main() {
@@ -258,14 +378,24 @@ async function main() {
     process.env.GITHUB_REPOSITORY ||
     parseRepository(await git(['remote', 'get-url', 'origin']))
 
-  const result = evaluateReleaseAssets({
-    tag,
-    release: await fetchReleaseByTag({
+  let release
+  try {
+    release = await fetchReleaseByTag({
       repository,
       tag,
       token: process.env.GH_TOKEN || process.env.GITHUB_TOKEN,
-    }),
-  })
+    })
+  } catch (error) {
+    const classified = classifyFetchError(error)
+    if (!classified) {
+      throw error
+    }
+    console.log(classified.message)
+    process.exitCode = classified.exitCode
+    return
+  }
+
+  const result = evaluateReleaseAssets({ tag, release })
 
   console.log(formatReport(result))
   if (result.status !== 'complete') {

--- a/test/check-release-assets.test.mjs
+++ b/test/check-release-assets.test.mjs
@@ -8,10 +8,13 @@ import { fileURLToPath } from 'node:url'
 import {
   EXPECTED_ASSET_PATTERNS,
   FIRST_CHECKED_VERSION,
+  TRANSIENT_EXIT_CODE,
+  classifyFetchError,
   evaluateReleaseAssets,
   fetchReleaseByTag,
   findReleaseByTag,
   formatReport,
+  isTransientResponse,
   parseRepository,
   selectReleaseTag,
 } from '../scripts/check-release-assets.mjs'
@@ -352,10 +355,169 @@ test('fetchReleaseByTag fails on an API error rather than reading it as absent',
     fetchReleaseByTag({
       repository: 'streamwallhq/streamwall',
       tag: 'v0.9.1',
-      fetchImpl: async () => ({ ok: false, status: 503 }),
+      // A single attempt: this test is about the error message, not retries,
+      // which are covered separately below.
+      retries: 1,
+      fetchImpl: async () => ({ ok: false, status: 503, headers: noHeaders }),
     }),
     /503/,
   )
+})
+
+// A 5xx, a 429, or a 403 carrying `retry-after` says nothing about whether
+// the release is broken — only that the API had a bad moment. A plain 403
+// (no `retry-after`) is a permissions problem and must not be treated the
+// same way, or a bad token would retry forever instead of failing loudly.
+test('isTransientResponse recognizes retryable GitHub API responses', () => {
+  assert.equal(isTransientResponse({ status: 500, headers: noHeaders }), true)
+  assert.equal(isTransientResponse({ status: 502, headers: noHeaders }), true)
+  assert.equal(isTransientResponse({ status: 429, headers: noHeaders }), true)
+  assert.equal(
+    isTransientResponse({ status: 403, headers: retryAfterHeaders('30') }),
+    true,
+  )
+  assert.equal(isTransientResponse({ status: 403, headers: noHeaders }), false)
+  assert.equal(isTransientResponse({ status: 404, headers: noHeaders }), false)
+})
+
+function noSleep() {
+  return Promise.resolve()
+}
+
+const noHeaders = { get: () => null }
+
+function retryAfterHeaders(value) {
+  return { get: (name) => (name === 'retry-after' ? value : null) }
+}
+
+test('fetchReleaseByTag retries a transient response and succeeds once it recovers', async () => {
+  const draft = { tag_name: 'v0.9.1', draft: false, assets: [] }
+  let calls = 0
+  const delays = []
+
+  const release = await fetchReleaseByTag({
+    repository: 'streamwallhq/streamwall',
+    tag: 'v0.9.1',
+    retries: 3,
+    sleep: async (ms) => {
+      delays.push(ms)
+    },
+    fetchImpl: async () => {
+      calls += 1
+      if (calls < 3) {
+        return { ok: false, status: 503, headers: noHeaders }
+      }
+      return listingResponse([draft])
+    },
+  })
+
+  assert.equal(release, draft)
+  assert.equal(calls, 3)
+  assert.equal(delays.length, 2)
+})
+
+test('fetchReleaseByTag honours a Retry-After header when backing off', async () => {
+  let calls = 0
+  const delays = []
+
+  await fetchReleaseByTag({
+    repository: 'streamwallhq/streamwall',
+    tag: 'v0.9.1',
+    retries: 2,
+    sleep: async (ms) => {
+      delays.push(ms)
+    },
+    fetchImpl: async () => {
+      calls += 1
+      if (calls === 1) {
+        return { ok: false, status: 429, headers: retryAfterHeaders('7') }
+      }
+      return listingResponse([])
+    },
+  })
+
+  assert.deepEqual(delays, [7000])
+})
+
+// A network failure (DNS, connection reset, timeout) throws out of `fetch`
+// itself rather than returning a response, and is just as much a blip as a
+// 503 — it must be retried the same way.
+test('fetchReleaseByTag retries a network error thrown by fetch', async () => {
+  let calls = 0
+
+  const release = await fetchReleaseByTag({
+    repository: 'streamwallhq/streamwall',
+    tag: 'v0.9.1',
+    retries: 2,
+    sleep: noSleep,
+    fetchImpl: async () => {
+      calls += 1
+      if (calls === 1) {
+        throw new Error('getaddrinfo ENOTFOUND api.github.com')
+      }
+      return listingResponse([])
+    },
+  })
+
+  assert.equal(release, null)
+  assert.equal(calls, 2)
+})
+
+test('fetchReleaseByTag marks the error transient once retries are exhausted', async () => {
+  await assert.rejects(
+    fetchReleaseByTag({
+      repository: 'streamwallhq/streamwall',
+      tag: 'v0.9.1',
+      retries: 3,
+      sleep: noSleep,
+      fetchImpl: async () => ({ ok: false, status: 503, headers: noHeaders }),
+    }),
+    (error) => {
+      assert.match(error.message, /503/)
+      assert.equal(error.transient, true)
+      return true
+    },
+  )
+})
+
+// A non-transient failure (a bad token, a repository that does not exist) is
+// a real problem, not a blip — retrying it would only delay the report.
+test('fetchReleaseByTag does not retry a non-transient API error', async () => {
+  let calls = 0
+
+  await assert.rejects(
+    fetchReleaseByTag({
+      repository: 'streamwallhq/streamwall',
+      tag: 'v0.9.1',
+      retries: 3,
+      sleep: noSleep,
+      fetchImpl: async () => {
+        calls += 1
+        return { ok: false, status: 404, headers: noHeaders }
+      },
+    }),
+    (error) => {
+      assert.match(error.message, /404/)
+      assert.ok(!error.transient)
+      return true
+    },
+  )
+  assert.equal(calls, 1)
+})
+
+test('classifyFetchError describes a transient failure as inconclusive rather than broken', () => {
+  const error = new Error('GitHub API returned 503 for the releases of x/y.')
+  error.transient = true
+
+  const classified = classifyFetchError(error)
+
+  assert.equal(classified.exitCode, TRANSIENT_EXIT_CODE)
+  assert.match(classified.message, /^::warning::/)
+  assert.match(classified.message, /503/)
+})
+
+test('classifyFetchError leaves a non-transient error for the caller to rethrow', () => {
+  assert.equal(classifyFetchError(new Error('boom')), null)
 })
 
 // "Delete and re-push the tag" throws away the only record of what shipped
@@ -417,4 +579,37 @@ test('the release tag workflow also checks the release assets', () => {
   assert.equal(checkout.with['fetch-depth'], 0)
   // Both failures have to reach the issue the scheduled report files.
   assert.deepEqual(workflow.jobs.report.needs, ['check', 'assets'])
+})
+
+// A transient GitHub API error (#721) exits `scripts/check-release-assets.mjs`
+// with a dedicated code rather than the generic failure code. The step must
+// translate that into a job outcome the report step can tell apart from a
+// real failure, or a network blip would still open "the release is broken".
+test('the asset check step turns a transient exit code into an inconclusive outcome', () => {
+  const workflow = load(
+    readFileSync(join(rootDir, '.github/workflows/release-tag.yml'), 'utf8'),
+  )
+  const job = workflow.jobs.assets
+  const step = job.steps.find((candidate) =>
+    candidate.run?.includes('scripts/check-release-assets.mjs'),
+  )
+
+  assert.equal(step.id, 'assets')
+  assert.match(step.run, /\$GITHUB_OUTPUT/)
+  assert.match(
+    step.run,
+    /\b2\b/,
+    'the step must check for the transient exit code',
+  )
+
+  const report = workflow.jobs.report
+  // The base condition still has to cover every job's real result, or a new
+  // job could fail silently; the inconclusive outcome only narrows the
+  // "success" branch so a transient run neither files nor closes a report.
+  assert.match(String(report.with.result), /needs\.\*\.result/)
+  assert.match(
+    String(report.with.result),
+    /needs\.assets\.outputs\.outcome/,
+    'a transient run must not be reported as success',
+  )
 })


### PR DESCRIPTION
## Problem

`scripts/check-release-assets.mjs` throws on the first non-2xx response from the GitHub releases listing, and `release-tag.yml` treats that as the same failure a genuinely broken release would produce: it files/reopens the "Scheduled workflow failing: Release tag" issue via `scheduled-report.yml`. A single transient 5xx or a secondary rate-limit response is therefore indistinguishable from a real problem, and the false report stays open until the next green run a day later.

## Solution

- `fetchReleaseByTag` now retries each release-listing request on a transient failure: a 5xx, a 429, a 403 carrying a `retry-after` header (GitHub's secondary rate limit), or a network error thrown by `fetch` itself. A plain 403 (no `retry-after`) is treated as a real permissions problem and is not retried. The backoff honours the `Retry-After` header when GitHub sends one, otherwise doubles a base delay per attempt. Retry count, base delay, and the sleep function are all injectable parameters (defaults: 3 attempts, 500ms base).
- If the API still cannot be reached once retries are exhausted, the thrown error is marked `.transient = true`. `classifyFetchError` turns that into a dedicated exit code (`TRANSIENT_EXIT_CODE = 2`, distinct from the normal failure code `1`) and a `::warning::` message that says the run is inconclusive rather than that the release is broken. Any other error (bad token, exhausted paging, malformed repository) still propagates and fails the run the way it always has.
- `.github/workflows/release-tag.yml`'s `assets` job step now inspects the script's exit code: `2` is translated into an `outcome=inconclusive` job output and the step exits `0`; `0`/other nonzero codes set `outcome=ok`/`outcome=failed` and preserve the original exit code. The job exposes that as a job-level `outputs.outcome`.
- The `report` job's `result` expression still derives from `needs.*.result` for real failures, but its `success` branch additionally requires `needs.assets.outputs.outcome != 'inconclusive'`, so a transient run resolves to `none` — it neither files/reopens the report nor wrongly closes a real open one.

## Testing

- `test/check-release-assets.test.mjs`: new coverage for `isTransientResponse` (5xx/429/403-with-retry-after are transient, plain 403/404 are not), retrying-then-recovering, honouring `Retry-After`, retrying a thrown network error, exhausting retries and marking the error transient, not retrying a non-transient error, and `classifyFetchError`'s two branches. All tests inject `fetchImpl` and `sleep` — no real network calls or real waits.
- New workflow assertions confirm the `assets` step writes `$GITHUB_OUTPUT` and checks for the transient exit code, and that the `report` job's `result` expression still contains `needs.*.result` (required by the repo-wide `scheduled-reports.test.mjs` invariant) as well as `needs.assets.outputs.outcome`.
- `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (2092 tests) all pass locally. `actionlint` passes on the modified workflow.

## Pre-PR review

One independent reviewer round (fresh subagent, no session context) came back with `NO FINDINGS`. No fixes were needed and nothing was dismissed.

## Risks / breaking changes

None. The change only affects the daily `Release tag` scheduled workflow's handling of transient API errors; the artifact-completeness logic itself (`evaluateReleaseAssets`) is untouched. `check-release-tag.mjs` (no network calls, git-only) and `check-deprecated-deps.mjs` (npm registry via `npm view`, not the GitHub API) are out of scope for this issue and were left alone.

Closes #721