### PR TITLE
fix(streamwall): resume the renderer when RESUME arrives before running

### DIFF
--- a/packages/streamwall/src/main/viewStateMachine.test.ts
+++ b/packages/streamwall/src/main/viewStateMachine.test.ts
@@ -1548,6 +1548,86 @@ describe('viewStateMachine pause/resume IPC (issue #374)', () => {
 
     expect(sendViewResume).toHaveBeenCalledTimes(1)
   })
+
+  // A parked (paused) view whose stream stalls is reloaded automatically and
+  // comes back up paused (the `view-init` reply carries `paused:
+  // desiredPaused`). If the operator collapses the expansion while that
+  // reload is still in flight, the RESUME lands in `displaying.loading`,
+  // where recording `desiredPaused: false` alone leaves the renderer paused
+  // forever: `running.pause` starts in `unpaused`, so its `always` guard no
+  // longer fires and nothing ever tells the renderer to play again.
+  it('sends a resume message when RESUME arrives during a stalled reload (issue #738)', async () => {
+    const { actor, sendViewPause, sendViewResume } =
+      makeActorWithPauseSpies(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+
+    // Parked behind a fullscreen expansion.
+    actor.send({ type: 'PAUSE' })
+    expect(sendViewPause).toHaveBeenCalledTimes(1)
+
+    // While parked the stream stalls and the watchdog reloads it.
+    actor.send({ type: 'VIEW_STALLED' })
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(matchesState('displaying.loading', actor.getSnapshot().value)).toBe(
+      true,
+    )
+
+    // The operator collapses the expansion mid-reload.
+    actor.send({ type: 'DISPLAY', pos: POS, content: CONTENT })
+    actor.send({ type: 'RESUME' })
+
+    expect(sendViewResume).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'VIEW_INIT' })
+    actor.send({ type: 'VIEW_LOADED' })
+
+    expect(
+      matchesState(
+        'displaying.running.pause.unpaused',
+        actor.getSnapshot().value,
+      ),
+    ).toBe(true)
+    // The reloaded view must not be paused again on the way back to running.
+    expect(sendViewPause).toHaveBeenCalledTimes(1)
+  })
+
+  it('sends a resume message when RESUME arrives while recovering from an error (issue #738)', async () => {
+    const { actor, sendViewResume } = makeActorWithPauseSpies(makeRetry())
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'PAUSE' })
+
+    actor.send({ type: 'VIEW_ERROR', error: new Error('boom') })
+    expect(matchesState('displaying.error', actor.getSnapshot().value)).toBe(
+      true,
+    )
+
+    actor.send({ type: 'RESUME' })
+
+    expect(sendViewResume).toHaveBeenCalledTimes(1)
+  })
+
+  // The counterpart PAUSE stays deferred on purpose: the renderer's 'pause'
+  // handler stops HLS segment fetching, which would starve an acquisition
+  // that has not reached view-loaded yet. `running.pause.unpaused`'s `always`
+  // guard applies it as soon as the view is running again.
+  it('does not send a pause message while the view is still loading', async () => {
+    const { actor, sendViewPause } = makeActorWithPauseSpies(makeRetry())
+    actor.start()
+    display(actor)
+
+    actor.send({ type: 'PAUSE' })
+
+    expect(sendViewPause).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'VIEW_INIT' })
+    actor.send({ type: 'VIEW_LOADED' })
+
+    expect(sendViewPause).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('viewStateMachine resyncSwappedView pause re-send (issue #621)', () => {

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -574,8 +574,29 @@ const viewStateMachine = setup({
             UNBACKGROUND: { actions: assign({ desiredAudio: 'muted' }) },
             BLUR: { actions: assign({ desiredBlurred: true }) },
             UNBLUR: { actions: assign({ desiredBlurred: false }) },
+            // PAUSE stays deferred: the renderer's 'pause' handler also
+            // stops HLS segment fetching, which would starve an acquisition
+            // that has not reached view-loaded yet; `running.pause.unpaused`'s
+            // `always` guard applies it as soon as the view is running.
             PAUSE: { actions: assign({ desiredPaused: true }) },
-            RESUME: { actions: assign({ desiredPaused: false }) },
+            // RESUME, unlike the events above, cannot wait for `running`: a
+            // reload of an already-paused cell comes back up paused (the
+            // `view-init` reply carries `paused: desiredPaused`), and
+            // `running.pause` re-enters in `unpaused`, whose `always` guard
+            // no longer matches once the desire has been cleared -- so
+            // nothing would ever tell the renderer to play again and the
+            // tile stays frozen (issue #738). Sending the IPC mid-load is
+            // safe: the renderer clears its own `desiredPaused` before
+            // touching any media element, so an acquisition still in flight
+            // comes up playing, and unlike 'pause' it never stops segment
+            // fetching. A resume that lands before the renderer registered
+            // its handlers is simply dropped, but then the `view-init` reply
+            // (which carries `paused: desiredPaused`) has not been sent yet
+            // either, so the fresh view starts unpaused anyway -- except for
+            // the sub-tick window tracked in #756.
+            RESUME: {
+              actions: [assign({ desiredPaused: false }), 'sendViewResume'],
+            },
           },
           // If the whole loading phase stalls (e.g. the renderer never sends
           // VIEW_INIT/VIEW_LOADED), fail the view instead of hanging forever.
@@ -982,7 +1003,11 @@ const viewStateMachine = setup({
             BLUR: { actions: assign({ desiredBlurred: true }) },
             UNBLUR: { actions: assign({ desiredBlurred: false }) },
             PAUSE: { actions: assign({ desiredPaused: true }) },
-            RESUME: { actions: assign({ desiredPaused: false }) },
+            // Mirrored to the renderer immediately for the same reason as in
+            // `loading` above (issue #738).
+            RESUME: {
+              actions: [assign({ desiredPaused: false }), 'sendViewResume'],
+            },
           },
           // Automatically reload after the backoff delay until the retry budget
           // is spent; then this is a terminal state surfaced to the operator.


### PR DESCRIPTION
## Summary

`sendViewResume` was only reachable from the `running.pause` region. A `RESUME`
that arrived while the view sat in `displaying.loading` or `displaying.error`
only recorded `desiredPaused: false` and never told the renderer anything, and
re-entering `running` did not help either: `pause` starts in `unpaused`, whose
`always` guard no longer matches once the desire is cleared.

That is exactly the park -> stall -> collapse sequence: a parked view is paused,
its stream stalls while hidden, the watchdog reloads it and the reload comes back
up paused (the `view-init` reply carries `paused: desiredPaused`). When the
operator collapses the expansion, `displayPlannedViews` sends `DISPLAY` +
`RESUME` while the reload is still in flight — the tile returns to the wall,
the machine and control UI report it as running-and-unpaused, and it stays frozen
on a still frame with HLS segment fetching stopped until it is reloaded by hand.

The fix mirrors `RESUME` to the renderer from `displaying.loading` and
`displaying.error` as well.

Closes #738

## Technical notes

- `PAUSE` deliberately stays deferred. The renderer's `pause` handler dispatches
  `MEDIA_PAUSE_EVENT` unconditionally, which makes the bundled HLS player call
  `hls.stopLoad()` — sending it mid-load would starve an acquisition that has not
  reached `view-loaded` yet. `running.pause.unpaused`'s `always` guard already
  applies a deferred `PAUSE` as soon as the view is running, so nothing is lost.
  A regression test now pins that asymmetry.
- `RESUME` is safe to send at any point of the load: the renderer's handler
  clears its own `desiredPaused` *before* touching any media element, so an
  acquisition still in flight comes up playing instead of being paused by
  `acquireMedia`.
- No state regions were added, renamed or removed, so `viewStateValueSchema` in
  `streamwall-shared` is unaffected (`viewStateMachineSchemaDrift.test.ts` stays
  green).

## How was this tested?

Three new cases in `packages/streamwall/src/main/viewStateMachine.test.ts`:

- the full park -> stall-reload -> collapse sequence asserts `sendViewResume` is
  called while the view is reloading, that the view ends in
  `displaying.running.pause.unpaused`, and that it is not paused again on the way
  back to `running`;
- `RESUME` while recovering from an error;
- the deliberate asymmetry: no pause IPC while still loading, exactly one once
  `running` is reached.

Both resume cases fail against `main` ("Number of calls: 0"). Locally:
`npm run format`, `npm run lint`, `npm run typecheck`, `npm run test`
(2083 tests across 6 suites) all pass.

## Pre-PR review

Two rounds with independent reviewers that had none of the implementing session's
context.

- Round 1 raised one minor finding: a `resume` IPC delivered before the renderer
  registered its `ipcRenderer.on('resume')` handler (registered only after
  `await Promise.all([viewInit, pageReady])` in `mediaPreload.ts`) would be
  dropped, and the code comment overstated the guarantee. The comment was
  corrected. The underlying renderer-side hardening lives in a different package
  layer and a bug-magnet file, so it is tracked as follow-up #756 rather than
  bundled here; the shipped fix is fully effective for this issue's scenario,
  because the `view-init` handler reads the actor's live `desiredPaused` at
  invocation time.
- Round 2 returned `NO FINDINGS` (including an explicit check that the new tests
  fail without the production change).

## Follow-ups

- #756 — register the media preload's `pause`/`resume` IPC handlers before
  awaiting `view-init`, so no message can be dropped.

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests (or this PR explains why none apply)
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments
