### PR TITLE
fix(control-client): evict unanswered response callbacks and fail fast when disconnected

### DIFF
--- a/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.test.tsx
+++ b/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.test.tsx
@@ -1,7 +1,11 @@
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
 import type { StreamwallConnection } from 'streamwall-control-ui'
-import type { ControlCommand, StreamwallState } from 'streamwall-shared'
+import {
+  asViewId,
+  type ControlCommand,
+  type StreamwallState,
+} from 'streamwall-shared'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as Y from 'yjs'
 
@@ -15,6 +19,10 @@ const { FakeSocket, instances } = vi.hoisted(() => {
     closed = false
     reconnectCount = 0
     listeners = new Map<string, Set<Listener>>()
+    sentMessages: unknown[] = []
+    // Mirrors streamwall-shared's SOCKET_OPEN (1): the existing tests all
+    // assume an already-connected socket, so this defaults open.
+    readyState = 1
 
     constructor(url: string, _protocols: unknown, options: unknown) {
       this.url = url
@@ -33,7 +41,9 @@ const { FakeSocket, instances } = vi.hoisted(() => {
       this.listeners.get(type)?.delete(cb)
     }
 
-    send() {}
+    send(data: unknown) {
+      this.sentMessages.push(data)
+    }
 
     close() {
       this.closed = true
@@ -229,6 +239,120 @@ describe('useStreamwallWebsocketConnection', () => {
     })
 
     expect(cb).toHaveBeenCalledTimes(1)
+  })
+
+  // The control server only ever answers create-invite/delete-token; every
+  // other command is forwarded to the uplink with no reply. Since
+  // createErrorSurfacingSend (streamwall-control-ui) always supplies a
+  // callback so it can surface `{ error }` responses, a forwarded command's
+  // callback would otherwise sit in responseMap forever - not just until the
+  // next close, for the lifetime of the socket (issue #745).
+  describe('pending response eviction for commands the server never answers (issue #745)', () => {
+    const setViewVolumeCommand: ControlCommand = {
+      type: 'set-view-volume',
+      viewId: asViewId(0),
+      volume: 0.5,
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('does not grow responseMap forever for a forwarded command that never gets a reply', () => {
+      const { getConnection } = mount()
+      const socket = instances[0]!
+
+      for (let i = 0; i < 500; i++) {
+        act(() => {
+          getConnection().send(setViewVolumeCommand, vi.fn())
+        })
+      }
+
+      // No reply ever arrives and the socket never closes - only time
+      // passes. Advance well past the eviction window.
+      act(() => {
+        vi.advanceTimersByTime(60_000)
+      })
+
+      // If any of the 500 callbacks were still pending, a late close would
+      // still invoke them. None should fire, because they were already
+      // evicted by the timeout, not by this close.
+      const lateCallbacks = Array.from({ length: 500 }, () => vi.fn())
+      for (const cb of lateCallbacks) {
+        act(() => {
+          getConnection().send(setViewVolumeCommand, cb)
+        })
+      }
+      act(() => {
+        vi.advanceTimersByTime(60_000)
+      })
+      act(() => {
+        socket.dispatch('close')
+      })
+
+      for (const cb of lateCallbacks) {
+        expect(cb).not.toHaveBeenCalled()
+      }
+    })
+
+    it('still resolves a reply that arrives before the eviction window closes', () => {
+      const { getConnection } = mount()
+      const socket = instances[0]!
+      const cb = vi.fn()
+
+      act(() => {
+        getConnection().send(createInviteCommand, cb)
+      })
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+      act(() => {
+        socket.dispatch('message', {
+          data: JSON.stringify({ response: true, id: 0, tokenId: 't' }),
+        })
+      })
+
+      expect(cb).toHaveBeenCalledTimes(1)
+      expect(cb).toHaveBeenCalledWith(
+        expect.objectContaining({ response: true, id: 0, tokenId: 't' }),
+      )
+    })
+  })
+
+  describe('sending while disconnected (issue #745)', () => {
+    it('fails fast with an error instead of silently dropping the frame when the socket is not open', () => {
+      const { getConnection } = mount()
+      const socket = instances[0]!
+      socket.readyState = 3 // CLOSED
+      const cb = vi.fn()
+
+      act(() => {
+        getConnection().send(createInviteCommand, cb)
+      })
+
+      expect(socket.sentMessages).toHaveLength(0)
+      expect(cb).toHaveBeenCalledTimes(1)
+      expect(cb).toHaveBeenCalledWith(
+        expect.objectContaining({ error: expect.any(String) }),
+      )
+    })
+
+    it('still sends normally once the socket is open', () => {
+      const { getConnection } = mount()
+      const socket = instances[0]!
+      const cb = vi.fn()
+
+      act(() => {
+        getConnection().send(createInviteCommand, cb)
+      })
+
+      expect(socket.sentMessages).toHaveLength(1)
+      expect(cb).not.toHaveBeenCalled()
+    })
   })
 
   it('marks the connection open on a full state message', () => {

--- a/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.ts
+++ b/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.ts
@@ -72,6 +72,16 @@ interface WsRef {
 }
 
 /**
+ * How long a pending response callback is kept before being evicted
+ * unanswered. The control server only replies to a couple of request/
+ * response commands; every other command is forwarded with no reply, so this
+ * bounds `responseMap`'s lifetime for those instead of leaking until the next
+ * close (issue #745). A few seconds is ample for a same-machine/LAN control
+ * server to answer the commands that do reply.
+ */
+const RESPONSE_TIMEOUT_MS = 5000
+
+/**
  * WebSocket adapter: the transport-specific half of the collab wiring the
  * shared `useCollabConnection` hook consumes. It owns only what is unique to
  * the socket - the reconnect policy, the JSON message protocol (responses,
@@ -92,9 +102,28 @@ function useWebsocketCollabTransport(wsEndpoint: string): CollabTransport {
           throw new Error('Websocket not initialized')
         }
         const { ws, msgId, responseMap } = wsRef.current
+        if (!isSocketOpen(ws)) {
+          // maxEnqueuedMessages: 0 means the frame would just be dropped
+          // silently; fail the caller's callback immediately instead of
+          // leaving it pending forever (issue #745).
+          cb?.({ response: true, error: 'Not connected' })
+          return
+        }
         ws.send(JSON.stringify({ ...msg, id: msgId }))
         if (cb) {
           responseMap.set(msgId, cb)
+          // The control server only ever answers a handful of commands
+          // (create-invite, delete-token); every other command is forwarded
+          // to the uplink with no reply. createErrorSurfacingSend always
+          // supplies a callback (to surface `{ error }` responses), so
+          // without this eviction a forwarded command's entry - and the
+          // closure it holds - would sit in responseMap for the lifetime of
+          // the socket instead of just until the next close (issue #745). A
+          // reply that does arrive after eviction is simply ignored, same as
+          // any other late reply for an id no longer in the map.
+          setTimeout(() => {
+            responseMap.delete(msgId)
+          }, RESPONSE_TIMEOUT_MS)
         }
         wsRef.current.msgId++
       },


### PR DESCRIPTION
## Problem
The control server only replies to `create-invite`/`delete-token`; every other command is forwarded to the uplink with no response. Since `createErrorSurfacingSend` (control-ui) always supplies a response callback so it can surface `{ error }` replies, every forwarded command's `responseMap` entry (and the closure it holds) was retained for the lifetime of the socket instead of just until the next close — an operator wall left open for a shift accumulates tens of thousands of dead entries. A command sent while the socket was down was also silently dropped, leaving its callback pending indefinitely.

## Solution
Chose the timeout-eviction approach from the two the issue offered, over restricting callback registration to `create-invite`/`delete-token`: the control server's `respond({ error: ... })` path also fires for `unauthorized`/`invalid message`/`streamwall disconnected` rejections on *every* command type, not just those two, so restricting registration would have silently regressed #35's guarantee that error responses always reach `onError`.

- `send()` now schedules a `RESPONSE_TIMEOUT_MS` (5s) eviction for every pending response callback; if no reply arrives in time, the entry is quietly deleted from `responseMap` (no callback invocation — most of the time this just means the forwarded command succeeded silently, which is not an error).
- `send()` now checks `isSocketOpen(ws)` up front and, if not open, invokes the callback immediately with `{ response: true, error: 'Not connected' }` instead of letting `maxEnqueuedMessages: 0` drop the frame silently while the callback stays pending.

## Testing
- New test: 500 forwarded (`set-view-volume`) commands followed only by the passage of time (no close) leave no pending callbacks — verifies the leak is actually bounded, not just cleared on close.
- New test: a reply arriving before the eviction window still resolves normally.
- New tests: sending while the socket is closed invokes the callback synchronously with an error and sends nothing; sending while open still sends normally.
- `FakeSocket` gained a `readyState` (defaulting open, matching every pre-existing test's implicit assumption) and `sentMessages` tracking.
- Full quality gate green: `npm run format`, `npm run lint`, `npm run typecheck` (all workspaces), `npm -w packages/streamwall-control-client run test` (38/38), full existing suite for the touched file re-verified unaffected.

## Pre-PR review
One independent review round (fresh subagent, no session context) returned `NO FINDINGS`, including explicit verification that the timeout-eviction design choice (vs. the issue's alternative) does not regress #35's error-surfacing guarantee.

Closes #745