### PR TITLE
fix(ci): publish the release automatically once every asset kind is present

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -525,3 +525,36 @@ jobs:
           notes="$RUNNER_TEMP/release-notes.md"
           node scripts/changelog-section.mjs "${TAG#v}" > "$notes"
           gh release edit "$TAG" --notes-file "$notes"
+
+  # Takes the release out of draft once there is nothing left to check: the
+  # three-platform publish matrix and the release notes have both succeeded.
+  # `prepare-release` creates the draft only so the matrix has one release to
+  # append assets to (#671); nothing used to take it back out of draft, which
+  # made publishing a step a maintainer could forget entirely — v0.10.5 was
+  # tagged and fully built on 2026-07-27 and sat unpublished, invisible to the
+  # updater and to `docker compose pull` alike, until 2026-09-02 (#698, #720).
+  #
+  # Needing both `publish` and `release-notes` (rather than just `publish`)
+  # means the release only goes live once the notes are in place too — the
+  # same order a human would check by hand. `scripts/publish-release.mjs`
+  # asks the same "does every expected artifact kind actually exist"
+  # question `check-release-assets.mjs` asks the next day, so a leg that
+  # reported success but left nothing behind still keeps the release a draft
+  # instead of publishing it half-built — the safety net stays in place.
+  publish-release:
+    name: Publish the release
+    needs: [publish, release-notes]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write # taking the release out of draft
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Publish the release once every artifact kind is present
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: node scripts/publish-release.mjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -465,6 +465,25 @@ breaking change bumps the minor version.
    reports the blockage. That is how thirteen commits sat on `main` without a
    release PR after v0.10.0 (#611).
 
+5. Once the three-platform publish matrix and `release-notes` have both
+   succeeded, `publish-release` takes the release out of draft
+   (`gh release edit <tag> --draft=false --latest`) and there is nothing left
+   to do by hand. It checks the same artifact kinds
+   `check-release-assets.mjs` does first (`scripts/publish-release.mjs`); if
+   any are missing — a leg that reported success but somehow left nothing
+   behind, an upload that never finished — the release stays a draft and the
+   job fails loudly instead of quietly going live half-built. Publish it by
+   hand once the missing leg is fixed:
+
+   ```sh
+   gh release edit v<x.y.z> --draft=false --latest
+   ```
+
+   This replaces what used to be a manual step: `v0.10.5` was tagged and
+   fully built on 2026-07-27 and sat as an unpublished draft — invisible to
+   the updater and to `docker compose pull` alike — until 2026-09-02 (#698,
+   #720).
+
 Because that tag is the one manual step,
 [`.github/workflows/release-tag.yml`](.github/workflows/release-tag.yml) checks
 every morning that the version on `main` has a matching `vX.Y.Z` tag and fails

--- a/scripts/publish-release.mjs
+++ b/scripts/publish-release.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// Publishes the draft release for the current tag once every expected
+// installer kind has actually landed on it (#720).
+//
+// `prepare-release` creates the release as a draft so the three-platform
+// `publish` matrix has one place to append assets to (#671); nothing used to
+// take it back out of draft, so publishing was a manual step a maintainer
+// could forget — v0.10.5 sat unpublished for over a month while its tag and
+// its build were both green (#698).
+//
+// This asks the same question `check-release-assets.mjs` asks the *next*
+// day — does the release actually carry every expected artifact kind — right
+// after the matrix and the release notes are in place, which is exactly the
+// condition a human would check before publishing by hand. If anything is
+// missing (a leg that reported success but somehow left nothing behind, an
+// upload that never finished), the release stays a draft rather than going
+// live half-built, and this job fails loudly instead of silently.
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+import { evaluateReleaseAssets } from './check-release-assets.mjs'
+
+const execFileAsync = promisify(execFile)
+
+async function gh(args) {
+  const { stdout } = await execFileAsync('gh', args, { env: process.env })
+  return stdout
+}
+
+// Reuses `evaluateReleaseAssets`'s missing-artifact computation rather than
+// its `status` field: that field reports `draft` for any draft release
+// regardless of completeness, since a draft is exactly what
+// `check-release-assets.mjs` normally treats as its own kind of problem.
+// Here the release *is* still a draft by design — what decides publishing is
+// only whether every expected artifact kind made it on.
+export function describeOutcome({ tag, missing }) {
+  if (missing.length === 0) {
+    return {
+      shouldPublish: true,
+      message: `${tag} has every expected artifact kind — publishing.`,
+    }
+  }
+  return {
+    shouldPublish: false,
+    message:
+      `::error::${tag} is missing ${missing.join(', ')}, so it is staying ` +
+      'a draft rather than going live half-built. Re-run the failed ' +
+      `publish leg, then publish by hand: gh release edit ${tag} ` +
+      '--draft=false --latest',
+  }
+}
+
+async function main() {
+  const tag = process.env.TAG
+  if (!tag) {
+    throw new Error('TAG must be set to the tag of the release to publish.')
+  }
+
+  const release = JSON.parse(
+    await gh(['release', 'view', tag, '--json', 'assets,isDraft']),
+  )
+  const { missing } = evaluateReleaseAssets({
+    tag,
+    release: { draft: release.isDraft, assets: release.assets },
+  })
+  const outcome = describeOutcome({ tag, missing })
+
+  console.log(outcome.message)
+  if (!outcome.shouldPublish) {
+    process.exitCode = 1
+    return
+  }
+
+  await gh(['release', 'edit', tag, '--draft=false', '--latest'])
+  console.log(`::notice::Published ${tag}.`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}

--- a/test/ci-gate.test.mjs
+++ b/test/ci-gate.test.mjs
@@ -409,3 +409,44 @@ test('packaging.yml only reports to the issue tracker on scheduled runs', () => 
       'issue',
   )
 })
+
+// Publishing the release used to be a manual `gh release edit <tag>
+// --draft=false --latest` step, easy to forget: v0.10.5 was tagged and fully
+// built on 2026-07-27 and sat as an unpublished draft — invisible to the
+// updater and to `docker compose pull` alike — until 2026-09-02 (#698, #720).
+test('release.yml publishes the release automatically once it is complete', () => {
+  const release = readWorkflow('release.yml')
+  const job = release.jobs['publish-release']
+
+  assert.ok(job, 'release.yml must have a publish-release job')
+
+  // The release only goes live once the publish matrix AND the release notes
+  // have both landed — the same order a human would check by hand — and only
+  // for a real tag push, exactly like prepare-release.
+  assert.deepEqual(job.needs, ['publish', 'release-notes'])
+  assert.match(
+    String(job.if ?? ''),
+    /startsWith\(github\.ref, 'refs\/tags\/v'\)/,
+    'publish-release must be tag-gated like prepare-release, or a ' +
+      'workflow_dispatch run (whose ref names no release) would try to ' +
+      'publish one',
+  )
+  assert.equal(
+    job.permissions?.contents,
+    'write',
+    'publish-release needs contents: write to take the release out of draft',
+  )
+
+  const step = job.steps.find((candidate) =>
+    candidate.run?.includes('scripts/publish-release.mjs'),
+  )
+  assert.ok(step, 'publish-release must run scripts/publish-release.mjs')
+  assert.ok(
+    step.env?.GH_TOKEN,
+    'publish-release needs a token to read the release and publish it',
+  )
+  assert.ok(
+    step.env?.TAG,
+    'publish-release must tell the script which tag to publish',
+  )
+})

--- a/test/publish-release.test.mjs
+++ b/test/publish-release.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { describeOutcome } from '../scripts/publish-release.mjs'
+
+test('describeOutcome publishes a release with no missing artifact kinds', () => {
+  const outcome = describeOutcome({ tag: 'v0.10.6', missing: [] })
+
+  assert.equal(outcome.shouldPublish, true)
+  assert.match(outcome.message, /v0\.10\.6/)
+  assert.doesNotMatch(outcome.message, /::error::/)
+})
+
+// A leg that reported success but somehow left nothing behind, or an upload
+// that never finished, must keep the release a draft rather than publish a
+// half-built one — the exact failure mode #698 exists to prevent.
+test('describeOutcome refuses to publish when an artifact kind is missing', () => {
+  const outcome = describeOutcome({
+    tag: 'v0.10.6',
+    missing: ['*-setup-*.exe', 'latest.yml'],
+  })
+
+  assert.equal(outcome.shouldPublish, false)
+  assert.match(outcome.message, /^::error::/)
+  assert.match(outcome.message, /\*-setup-\*\.exe/)
+  assert.match(outcome.message, /latest\.yml/)
+  // Still points at the manual fallback so the maintainer is not stuck.
+  assert.match(outcome.message, /gh release edit v0\.10\.6 --draft=false/)
+})


### PR DESCRIPTION
## Problem

`release.yml` builds the release, uploads every installer, and copies the changelog section into the release body — and then leaves the release as a draft. Taking it out of draft is a manual step (`gh release edit <tag> --draft=false --latest`), and it is easy to forget: `v0.10.5` was tagged and fully built on 2026-07-27 and sat unpublished until 2026-09-02 (#698). While it sat there, the updater and self-hosters saw `v0.10.4` as the newest release, and the daily `Release tag` run was red for over a month.

## Solution

- Adds a `publish-release` job to `release.yml` that `needs: [publish, release-notes]` and is tag-gated the same way `prepare-release` is (`if: startsWith(github.ref, 'refs/tags/v')`), so a `workflow_dispatch` run — whose ref names no release — never tries to publish one. It holds `contents: write`.
- `scripts/publish-release.mjs` reads the release via `gh release view <tag> --json assets,isDraft`, then reuses `evaluateReleaseAssets` from `scripts/check-release-assets.mjs` to compute the same `missing` artifact-kind list the daily `check-release-assets.mjs` check uses. `evaluateReleaseAssets` returns `status: 'draft'` for any still-draft release regardless of completeness (since a draft is normally what the daily check itself treats as the problem), so `publish-release.mjs` deliberately looks at the `missing` array rather than `status`, which would never read `'complete'` for a release that is still a draft at this point.
- If every expected artifact kind (`*.deb`, `*.rpm`, `*-setup-*.exe`, `latest.yml`, `*.zip`, `latest-mac.yml`) is present, it runs `gh release edit <tag> --draft=false --latest`. If anything is missing — a leg that reported success but somehow left nothing behind, an upload that never finished — the release stays a draft and the job fails loudly (`::error::` plus a non-zero exit), rather than either publishing something half-built or silently succeeding.
- `needs: [publish, release-notes]` (not just `publish`) means the release only goes live once the notes are in place too — the same order a human would check by hand.
- Updates CONTRIBUTING.md's "Releasing" section with a new step 5 describing the automatic publish and the manual fallback command for the missing-asset case. The separate "Release notes: the Windows upgrade notice" subsection is untouched.

## Testing

- `test/publish-release.test.mjs` (new): covers `describeOutcome` publishing when nothing is missing, and refusing (with the manual fallback command in the message) when an artifact kind is missing.
- `test/ci-gate.test.mjs`: new assertions that `publish-release` needs both `publish` and `release-notes`, is tag-gated like `prepare-release`, holds `contents: write`, and runs `scripts/publish-release.mjs` with `GH_TOKEN` and `TAG` set.
- `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (2098 tests) all pass locally. `actionlint` passes on the modified workflow.

## Pre-PR review

One independent reviewer round (fresh subagent, no session context, explicitly asked to verify the `status` vs `missing` distinction in `evaluateReleaseAssets`) came back with `NO FINDINGS`. No fixes were needed and nothing was dismissed.

## Risks / breaking changes

None functionally: a complete release now publishes itself instead of waiting for a maintainer to run the `gh release edit` command by hand. An incomplete release still stays a draft exactly as it does today — this only removes the *forgettable* manual step for the common case. `docker-image`/`docker-manifest` (the separate GHCR image publish) are untouched.

Closes #720