### PR TITLE
fix(streamwall): remap the fullscreen cell across grid resizes and presets

### DIFF
--- a/packages/streamwall-shared/src/geometry.test.ts
+++ b/packages/streamwall-shared/src/geometry.test.ts
@@ -11,6 +11,7 @@ import {
   hasGridAssignments,
   idxToCoords,
   parseGridDimensionInput,
+  remapCellIdx,
   remapGridAssignments,
 } from './geometry.ts'
 import { asCellIdx, asViewId, type CellIdx } from './viewAddressing.ts'
@@ -377,6 +378,36 @@ describe('fullscreenViewContentMap', () => {
     )
     expect(boxes).toHaveLength(1)
     expect(boxes[0].spaces).toEqual([0])
+  })
+})
+
+describe('remapCellIdx', () => {
+  it('follows a cell to its new index when the grid grows', () => {
+    // 2x2: idx 3 is (1,1); in a 3x3 grid that position is idx 4.
+    expect(remapCellIdx(2, 2, 3, 3, asCellIdx(3))).toBe(4)
+  })
+
+  it('follows a cell to its new index when the grid shrinks', () => {
+    // 3x3: idx 4 is (1,1); in a 2x2 grid that position is idx 3.
+    expect(remapCellIdx(3, 3, 2, 2, asCellIdx(4))).toBe(3)
+  })
+
+  it('returns null when the cell falls outside the new grid', () => {
+    // 3x3: idx 8 is (2,2), which does not exist in a 2x2 grid.
+    expect(remapCellIdx(3, 3, 2, 2, asCellIdx(8))).toBeNull()
+  })
+
+  it('returns null for a cell outside the old grid', () => {
+    // A stale index left over from a previously larger grid (issue #17).
+    expect(remapCellIdx(2, 2, 3, 3, asCellIdx(7))).toBeNull()
+  })
+
+  it('returns null for a null input', () => {
+    expect(remapCellIdx(2, 2, 3, 3, null)).toBeNull()
+  })
+
+  it('keeps the index unchanged when the column count is unchanged', () => {
+    expect(remapCellIdx(3, 3, 3, 2, asCellIdx(4))).toBe(4)
   })
 })
 

--- a/packages/streamwall-shared/src/geometry.ts
+++ b/packages/streamwall-shared/src/geometry.ts
@@ -241,6 +241,35 @@ export function hasGridAssignments(
 }
 
 /**
+ * Translates a single grid cell index from one grid geometry to another by its
+ * (x, y) position, mirroring `remapGridAssignments` so an index and the
+ * assignments it points at stay in agreement across a resize.
+ *
+ * Returns null when the cell has no counterpart in the new grid, and likewise
+ * for an index that already lies outside the old grid (a stale value left over
+ * from a previously larger grid, see issue #17).
+ *
+ * Used for `fullscreenViewIdx`, which addresses the expanded tile by cell
+ * rather than by stable view id (issue #739).
+ */
+export function remapCellIdx(
+  oldCols: number,
+  oldRows: number,
+  newCols: number,
+  newRows: number,
+  idx: CellIdx | null,
+): CellIdx | null {
+  if (idx === null || idx < 0 || idx >= oldCols * oldRows) {
+    return null
+  }
+  const { x, y } = idxToCoords(oldCols, idx)
+  if (x >= newCols || y >= newRows) {
+    return null
+  }
+  return asCellIdx(newCols * y + x)
+}
+
+/**
  * Remaps grid cell assignments when the grid dimensions change. Each non-empty
  * assignment is preserved at the same (x, y) position if that position still
  * exists in the new grid; assignments that fall outside the new grid are

--- a/packages/streamwall/src/main/commandHandlers.test.ts
+++ b/packages/streamwall/src/main/commandHandlers.test.ts
@@ -1,4 +1,8 @@
-import { type ControlCommand, type StreamwallState } from 'streamwall-shared'
+import {
+  asCellIdx,
+  type ControlCommand,
+  type StreamwallState,
+} from 'streamwall-shared'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as Y from 'yjs'
 import {
@@ -281,6 +285,50 @@ describe('createOnCommand — grid and layout presets', () => {
 
     expect(streamWindow.setGridSize).toHaveBeenCalledWith(4, 2)
     expect(deps.updateState).toHaveBeenCalledWith({})
+  })
+
+  it('remaps the expanded cell when the grid is resized (issue #739)', async () => {
+    const ctx = makeDeps()
+    ctx.deps.streamWindowConfig.cols = 2
+    ctx.deps.streamWindowConfig.rows = 2
+    ctx.setClientState({ fullscreenViewIdx: asCellIdx(3) })
+    const onCommand = createOnCommand(ctx.deps)
+
+    await onCommand(cmd({ type: 'set-grid-size', cols: 3, rows: 3 }))
+
+    // Cell 3 = (1,1) in a 2x2 grid is cell 4 in a 3x3 grid.
+    expect(ctx.deps.updateState).toHaveBeenCalledWith({ fullscreenViewIdx: 4 })
+    expect(ctx.getClientState().fullscreenViewIdx).toBe(4)
+  })
+
+  it('clears the expansion when its cell falls outside the resized grid (issue #739)', async () => {
+    const ctx = makeDeps()
+    ctx.deps.streamWindowConfig.cols = 3
+    ctx.deps.streamWindowConfig.rows = 3
+    ctx.setClientState({ fullscreenViewIdx: asCellIdx(8) })
+    const onCommand = createOnCommand(ctx.deps)
+
+    await onCommand(cmd({ type: 'set-grid-size', cols: 2, rows: 2 }))
+
+    expect(ctx.getClientState().fullscreenViewIdx).toBeNull()
+  })
+
+  it('clears the expansion when a layout preset is loaded (issue #739)', async () => {
+    const ctx = makeDeps()
+    const preset = buildLayoutPreset(
+      { viewsState: ctx.viewsState, cols: 3, rows: 3 },
+      'preset-id',
+      'Saved',
+    )
+    ctx.setClientState({
+      layoutPresets: [preset],
+      fullscreenViewIdx: asCellIdx(1),
+    })
+    const onCommand = createOnCommand(ctx.deps)
+
+    await onCommand(cmd({ type: 'load-layout-preset', presetId: 'preset-id' }))
+
+    expect(ctx.getClientState().fullscreenViewIdx).toBeNull()
   })
 
   it('saves a layout preset and persists it', async () => {

--- a/packages/streamwall/src/main/commandHandlers.ts
+++ b/packages/streamwall/src/main/commandHandlers.ts
@@ -196,6 +196,9 @@ export function createOnCommand(deps: CommandHandlerDeps) {
           getRows: () => deps.streamWindowConfig.rows,
           setGridSize: (cols, rows) =>
             deps.streamWindow.setGridSize(cols, rows),
+          getFullscreenViewIdx: () => deps.getClientState().fullscreenViewIdx,
+          setFullscreenViewIdx: (fullscreenViewIdx) =>
+            deps.updateState({ fullscreenViewIdx }),
         },
         msg.cols,
         msg.rows,
@@ -239,6 +242,8 @@ export function createOnCommand(deps: CommandHandlerDeps) {
             transact: deps.transact,
             setGridSize: (cols, rows) =>
               deps.streamWindow.setGridSize(cols, rows),
+            setFullscreenViewIdx: (fullscreenViewIdx) =>
+              deps.updateState({ fullscreenViewIdx }),
           },
           preset,
         )

--- a/packages/streamwall/src/main/gridResize.test.ts
+++ b/packages/streamwall/src/main/gridResize.test.ts
@@ -1,5 +1,7 @@
 import {
+  asCellIdx,
   boxesFromViewContentMap,
+  type CellIdx,
   GRID_MAX,
   GRID_MIN,
   type ViewContentMap,
@@ -83,15 +85,33 @@ function setupWall(cols: number, rows: number) {
     wall.setViews(viewContentMap)
   }
 
+  // The expanded cell (issue #362), mirroring `clientState.fullscreenViewIdx`
+  // in the main process.
+  let fullscreenViewIdx: CellIdx | null = null
+
   const ctx: GridResizeContext = {
     viewsState,
     transact: (fn) => doc.transact(fn),
     getCols: () => wall.cols,
     getRows: () => wall.rows,
     setGridSize: (c, r) => wall.setGridSize(c, r),
+    getFullscreenViewIdx: () => fullscreenViewIdx,
+    setFullscreenViewIdx: (idx) => {
+      fullscreenViewIdx = idx
+    },
   }
 
-  return { doc, viewsState, wall, updateViewsFromStateDoc, ctx }
+  return {
+    doc,
+    viewsState,
+    wall,
+    updateViewsFromStateDoc,
+    ctx,
+    getFullscreenViewIdx: () => fullscreenViewIdx,
+    setFullscreenViewIdx: (idx: CellIdx | null) => {
+      fullscreenViewIdx = idx
+    },
+  }
 }
 
 /** Seeds `viewsState` with a full grid; `streams` maps cell index -> streamId. */
@@ -161,6 +181,8 @@ describe('applyGridResize', () => {
         cols = c
         rows = r
       },
+      getFullscreenViewIdx: () => null,
+      setFullscreenViewIdx: () => {},
     }
 
     applyGridResize(ctx, 3, 3)
@@ -303,5 +325,66 @@ describe('applyGridResize', () => {
       expect(viewData.get('streamId')).not.toBe('ghost')
     }
     expect(viewsState.get('0')?.get('streamId')).toBe('stream-a')
+  })
+})
+
+// `fullscreenViewIdx` is a *cell* index, so it has to follow the same (x, y)
+// remapping as the assignments themselves -- otherwise a resize while a stream
+// is expanded silently swaps the wall over to whichever stream now sits at the
+// stale index (issue #739).
+describe('applyGridResize fullscreen expansion (issue #739)', () => {
+  it('follows the expanded cell into the new grid', () => {
+    const { viewsState, ctx, setFullscreenViewIdx, getFullscreenViewIdx } =
+      setupWall(2, 2)
+    seedAssignments(viewsState, 2, 2, { 3: 'stream-a' })
+    // Cell 3 = (1,1) is expanded.
+    setFullscreenViewIdx(asCellIdx(3))
+
+    applyGridResize(ctx, 3, 3)
+
+    // (1,1) is cell 4 in a 3x3 grid -- where 'stream-a' also moved.
+    expect(getFullscreenViewIdx()).toBe(4)
+    expect(viewsState.get('4')?.get('streamId')).toBe('stream-a')
+  })
+
+  it('clears the expansion when the expanded cell falls outside the new grid', () => {
+    const { viewsState, ctx, setFullscreenViewIdx, getFullscreenViewIdx } =
+      setupWall(3, 3)
+    seedAssignments(viewsState, 3, 3, { 8: 'stream-a' })
+    // Cell 8 = (2,2) does not exist in a 2x2 grid.
+    setFullscreenViewIdx(asCellIdx(8))
+
+    applyGridResize(ctx, 2, 2)
+
+    expect(getFullscreenViewIdx()).toBeNull()
+  })
+
+  it('leaves a collapsed wall collapsed', () => {
+    const { viewsState, ctx, getFullscreenViewIdx } = setupWall(2, 2)
+    seedAssignments(viewsState, 2, 2, { 0: 'stream-a' })
+
+    applyGridResize(ctx, 3, 3)
+
+    expect(getFullscreenViewIdx()).toBeNull()
+  })
+
+  it('applies the remapped expansion before the transact observer runs', () => {
+    const { viewsState, ctx, setFullscreenViewIdx, getFullscreenViewIdx } =
+      setupWall(2, 2)
+    seedAssignments(viewsState, 2, 2, { 3: 'stream-a' })
+    setFullscreenViewIdx(asCellIdx(3))
+
+    // The observer re-derives the wall layout synchronously at the end of the
+    // transact and reads the expanded cell, so it must already be remapped --
+    // same ordering constraint as the grid dimensions (issue #15).
+    const observed: (number | null)[] = []
+    viewsState.observeDeep(() => observed.push(getFullscreenViewIdx()))
+
+    applyGridResize(ctx, 3, 3)
+
+    expect(observed.length).toBeGreaterThan(0)
+    for (const idx of observed) {
+      expect(idx).toBe(4)
+    }
   })
 })

--- a/packages/streamwall/src/main/gridResize.ts
+++ b/packages/streamwall/src/main/gridResize.ts
@@ -2,6 +2,7 @@ import {
   asCellIdx,
   type CellIdx,
   clampGridDimension,
+  remapCellIdx,
   remapGridAssignments,
 } from 'streamwall-shared'
 import * as Y from 'yjs'
@@ -27,6 +28,10 @@ export interface GridResizeContext {
   getRows: () => number
   /** Applies the new grid dimensions to the wall (mutates the shared config). */
   setGridSize: (cols: number, rows: number) => void
+  /** The cell currently expanded to fill the wall, or null (issue #362). */
+  getFullscreenViewIdx: () => CellIdx | null
+  /** Publishes the expanded cell remapped into the new grid (issue #739). */
+  setFullscreenViewIdx: (idx: CellIdx | null) => void
 }
 
 /**
@@ -73,6 +78,16 @@ export function applyGridResize(
   // Update the grid dimensions BEFORE the transact so the synchronous observer
   // lays the wall out against the new grid. See the ordering note above.
   ctx.setGridSize(cols, rows)
+
+  // `fullscreenViewIdx` addresses the expanded tile by *cell*, so it has to
+  // follow the same (x, y) mapping as the assignments -- otherwise the resize
+  // silently expands whichever stream now sits at the stale index, or collapses
+  // the expansion if that cell is empty (issue #739). Published before the
+  // transact for the same reason as the dimensions: the observer re-derives the
+  // wall layout from it synchronously.
+  ctx.setFullscreenViewIdx(
+    remapCellIdx(oldCols, oldRows, cols, rows, ctx.getFullscreenViewIdx()),
+  )
 
   ctx.transact(() => {
     for (const key of [...ctx.viewsState.keys()]) {

--- a/packages/streamwall/src/main/layoutPresets.test.ts
+++ b/packages/streamwall/src/main/layoutPresets.test.ts
@@ -1,4 +1,9 @@
-import { MAX_LAYOUT_PRESETS, type LayoutPreset } from 'streamwall-shared'
+import {
+  asCellIdx,
+  MAX_LAYOUT_PRESETS,
+  type CellIdx,
+  type LayoutPreset,
+} from 'streamwall-shared'
 import { describe, expect, it } from 'vitest'
 import * as Y from 'yjs'
 import {
@@ -105,6 +110,7 @@ describe('applyLayoutPreset', () => {
         cols = c
         rows = r
       },
+      setFullscreenViewIdx: () => {},
     }
 
     const preset: LayoutPreset = {
@@ -144,6 +150,7 @@ describe('applyLayoutPreset', () => {
         cols = c
         rows = r
       },
+      setFullscreenViewIdx: () => {},
     }
 
     applyLayoutPreset(ctx, {
@@ -157,6 +164,36 @@ describe('applyLayoutPreset', () => {
     expect(observedDims.length).toBeGreaterThan(0)
     for (const dims of observedDims) {
       expect(dims).toEqual([2, 2])
+    }
+  })
+})
+
+// A preset replaces the grid assignments wholesale, so a cell index recorded
+// before the load means nothing afterwards: the expansion has to be dropped
+// rather than pointed at whatever the preset put in that cell (issue #739).
+describe('applyLayoutPreset fullscreen expansion (issue #739)', () => {
+  it('clears the expansion before the transact observer runs', () => {
+    const { doc, viewsState } = makeViewsState({ 0: 'a', 1: 'b' })
+    let fullscreenViewIdx: CellIdx | null = asCellIdx(1)
+    const observed: (number | null)[] = []
+    viewsState.observeDeep(() => observed.push(fullscreenViewIdx))
+
+    applyLayoutPreset(
+      {
+        viewsState,
+        transact: (fn: () => void) => doc.transact(fn),
+        setGridSize: () => {},
+        setFullscreenViewIdx: (idx) => {
+          fullscreenViewIdx = idx
+        },
+      },
+      { id: 'p', name: 'Saved', cols: 2, rows: 2, views: {} },
+    )
+
+    expect(fullscreenViewIdx).toBeNull()
+    expect(observed.length).toBeGreaterThan(0)
+    for (const idx of observed) {
+      expect(idx).toBeNull()
     }
   })
 })

--- a/packages/streamwall/src/main/layoutPresets.ts
+++ b/packages/streamwall/src/main/layoutPresets.ts
@@ -48,6 +48,8 @@ export interface LayoutPresetLoadContext {
   transact: (fn: () => void) => void
   /** Applies the preset's grid dimensions to the wall (mutates the shared config). */
   setGridSize: (cols: number, rows: number) => void
+  /** Drops the cell-based fullscreen expansion, if any (issue #739). */
+  setFullscreenViewIdx: (idx: null) => void
 }
 
 /**
@@ -64,6 +66,13 @@ export function applyLayoutPreset(
   preset: LayoutPreset,
 ): void {
   ctx.setGridSize(preset.cols, preset.rows)
+
+  // The preset replaces every assignment wholesale, so a cell index recorded
+  // before the load addresses nothing meaningful afterwards: drop the expansion
+  // instead of pointing it at whatever the preset happened to put there
+  // (issue #739). Cleared before the transact, like the dimensions above, so
+  // the synchronous observer never re-derives the wall from a stale index.
+  ctx.setFullscreenViewIdx(null)
 
   ctx.transact(() => {
     for (const key of [...ctx.viewsState.keys()]) {


### PR DESCRIPTION
## Summary

`clientState.fullscreenViewIdx` addresses the expanded tile by *grid cell*, but
neither `applyGridResize` nor `applyLayoutPreset` touched it while rewriting the
grid underneath it. A `set-grid-size` or preset load while a stream was expanded
therefore left the index pointing at a different cell: the wall silently swapped
over to whatever stream now sat there — a wrong stream going full-screen on air
with no operator action — or collapsed the expansion when that cell was empty.

- `applyGridResize` now translates the index through the same `(x, y)` mapping
  the assignments themselves go through, so the expansion follows its stream,
  and clears it when the cell has no counterpart in the new grid.
- `applyLayoutPreset` replaces every assignment wholesale, so a pre-load cell
  index means nothing afterwards: the expansion is cleared outright.

Closes #739

## Technical notes

- The mapping lives in a new pure helper `remapCellIdx` in
  `streamwall-shared/src/geometry.ts`, right next to `remapGridAssignments` and
  built on the existing `idxToCoords`/`asCellIdx`, so the single-index and the
  whole-map remaps cannot drift apart. It also drops a stale index that already
  lay outside the old grid, matching `remapGridAssignments`' `oldRows` guard
  (issue #17).
- Both paths publish the new value BEFORE the transact. The stateDoc's
  `observeDeep` observer runs synchronously at the end of `transact` and
  re-derives the wall layout from the expanded cell, so a late update would let
  it lay the wall out from a stale index — the same ordering constraint the grid
  dimensions already carry (issue #15). A dedicated test pins that for each path.
- The expansion stays cell-addressed rather than moving to a stable `ViewId`
  (the alternative floated in the issue). That is a much larger change across
  the shared schema, the control UI and the server, and `set-view-fullscreen`
  already resolves a stable view id to its current cell on the way in
  (issue #397); this PR only makes the stored cell index survive a layout change.

## How was this tested?

New cases, all verified to fail against `main` (7 of them; the eighth is a
"stays null" guard):

- `streamwall-shared/src/geometry.test.ts` — `remapCellIdx` on grow, shrink,
  falling outside the new grid, an index outside the old grid, `null`, and an
  unchanged column count.
- `streamwall/src/main/gridResize.test.ts` — the expansion follows its cell into
  the new grid, is cleared when the cell disappears, stays null when nothing was
  expanded, and is already remapped when the transact observer runs.
- `streamwall/src/main/layoutPresets.test.ts` — the expansion is cleared before
  the observer runs.
- `streamwall/src/main/commandHandlers.test.ts` — `set-grid-size` broadcasts the
  remapped index, clears it when the cell falls outside the new grid, and
  `load-layout-preset` clears it.

Locally: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test`
(2112 tests across 6 suites) all pass.

## Pre-PR review

One round with an independent reviewer that had none of the implementing
session's context; it returned `NO FINDINGS`.

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests (or this PR explains why none apply)
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments
