### PR TITLE
fix(control-ui): give grid cell inputs an accessible name

### DIFF
--- a/packages/streamwall-control-ui/src/GridInput.test.tsx
+++ b/packages/streamwall-control-ui/src/GridInput.test.tsx
@@ -49,8 +49,10 @@ function gridInput(
 ): ComponentChildren {
   return (
     <GridInput
+      key={props.idx ?? 0}
       style={{}}
       idx={asCellIdx(0)}
+      cols={1}
       onChangeSpace={() => {}}
       spaceValue=""
       isHighlighted={false}
@@ -171,6 +173,36 @@ describe('GridInput', () => {
     })
 
     expect(input.value).toBe('wok')
+  })
+
+  // A run of up to 64 (8x8) otherwise-identical text inputs is the grid's
+  // primary control, so a screen reader/voice-control user needs a way to
+  // tell them apart (WCAG 4.1.2 Name, Role, Value; issue #746).
+  describe('accessible name (issue #746)', () => {
+    test('gives every cell an accessible name derived from its row/column position', () => {
+      const box = renderInput({ idx: asCellIdx(5), cols: 3 })
+      const input = box.querySelector('input')!
+
+      // idx 5 in a 3-column grid: row 1 (0-based), column 2 (0-based).
+      expect(input.getAttribute('aria-label')).toBe(
+        'Stream for cell row 2, column 3',
+      )
+    })
+
+    test('gives cells in different rows/columns distinct accessible names', () => {
+      const box = renderWithStyles(
+        <>
+          {gridInput({ idx: asCellIdx(0), cols: 4 })}
+          {gridInput({ idx: asCellIdx(1), cols: 4 })}
+          {gridInput({ idx: asCellIdx(4), cols: 4 })}
+        </>,
+      )
+      const labels = Array.from(box.querySelectorAll('input')).map((input) =>
+        input.getAttribute('aria-label'),
+      )
+
+      expect(new Set(labels).size).toBe(labels.length)
+    })
   })
 
   test('paints the tile lighter while it is highlighted', () => {

--- a/packages/streamwall-control-ui/src/GridInput.tsx
+++ b/packages/streamwall-control-ui/src/GridInput.tsx
@@ -71,6 +71,7 @@ const StyledGridInput = styled(LazyChangeInput)<{
 export function GridInput({
   style,
   idx,
+  cols,
   onChangeSpace,
   spaceValue,
   isHighlighted,
@@ -82,6 +83,8 @@ export function GridInput({
   style: JSX.HTMLAttributes['style']
   onPointerDown: JSX.PointerEventHandler<HTMLInputElement>
   idx: CellIdx
+  /** Grid column count, used only to derive the cell's row/column position for its accessible name. */
+  cols: number
   onChangeSpace: (idx: CellIdx, value: string) => void
   spaceValue: string
   isHighlighted: boolean
@@ -101,6 +104,13 @@ export function GridInput({
     },
     [idx, onChangeSpace],
   )
+  // A run of up to 64 (8x8) otherwise-identical text inputs is the grid's
+  // primary control, so each one needs its own name for a screen reader or
+  // voice-control user to tell them apart (WCAG 4.1.2, issue #746) - row/
+  // column position is always present and unique, unlike the stream id.
+  const row = Math.floor(idx / cols)
+  const col = idx % cols
+  const label = `Stream for cell row ${row + 1}, column ${col + 1}`
   return (
     <StyledGridInputContainer style={style}>
       <StyledGridInput
@@ -113,6 +123,7 @@ export function GridInput({
         onPointerDown={onPointerDown}
         onChange={handleChange}
         isEager
+        aria-label={label}
         data-testid="grid-cell"
         data-idx={idx}
       />

--- a/packages/streamwall-control-ui/src/components/ControlGrid.tsx
+++ b/packages/streamwall-control-ui/src/components/ControlGrid.tsx
@@ -135,6 +135,7 @@ export function ControlGrid({
                   top: `${(100 * y) / rows}%`,
                 }}
                 idx={idx}
+                cols={cols}
                 spaceValue={streamId ?? ''}
                 onChangeSpace={onSetView}
                 isHighlighted={isHighlighted}


### PR DESCRIPTION
## Problem
The grid cell inputs — the app's primary control, up to 64 identical text fields in an 8x8 grid — rendered with no accessible name (`aria-label`, `title`, `placeholder`, or associated `<label>`), so a screen reader or voice-control user had no way to tell one cell from another (WCAG 2.1 SC 4.1.2 / 1.3.1).

## Solution
`GridInput` now takes a `cols` prop (already available in `ControlGrid`'s render loop, which computes `idx = cols * y + x`) and derives an `aria-label` from the cell's 1-based row/column position: `Stream for cell row ${row + 1}, column ${col + 1}`, mirroring how #625 solved the same problem for `ResizeHandles` via a computed label. Row/column position is always present and unique, unlike the assigned stream id (which is often empty).

## Testing
- `GridInput.test.tsx`: asserts the derived `aria-label` for a specific `idx`/`cols` combination, and that cells in different rows/columns get distinct labels.
- This file's existing tests use raw DOM `querySelector`/`getAttribute` rather than `@testing-library` (not a dependency of this package), so the new tests follow that same convention instead of the issue's literal `getByRole` suggestion.
- Checked `packages/streamwall-control-e2e` for any Playwright selector targeting grid cells by accessible role/name: none exists — every spec (`smoke`, `role-gating`, `reconnect`, `rate-limit`, `tls`, `multi-client`) selects via `getByTestId('grid-cell')`, which this PR does not touch, so no e2e changes were needed.
- Full quality gate green: `npm run format`, `npm run lint`, `npm run typecheck` (all workspaces), `npm -w packages/streamwall-control-ui run test` (376/376 passing).
- Verified the new tests fail on the pre-fix code and pass after the fix.

## Pre-PR review
One independent review round (fresh subagent, no session context) returned `NO FINDINGS`, including explicit verification of the row/column math and that no e2e selector depends on the old markup.

Closes #746