### PR TITLE
fix(streamwall): stop leaking the packaging tmpdir when packaging never completes

### DIFF
--- a/packages/streamwall/forge.config.test.ts
+++ b/packages/streamwall/forge.config.test.ts
@@ -4,10 +4,20 @@ import { describe, expect, it, vi } from 'vitest'
 const runTypecheck = vi.fn()
 vi.mock('./forge.typecheck', () => ({ runTypecheck: () => runTypecheck() }))
 
+let nextTmpdir = 0
+const createPackagingTmpdir = vi.fn(
+  () => `/tmp/streamwall-packager-${nextTmpdir++}`,
+)
 const removePackagingTmpdir = vi.fn()
+const unregisterFallbackCleanup = vi.fn()
+const registerPackagingTmpdirFallbackCleanup = vi.fn(
+  () => unregisterFallbackCleanup,
+)
 vi.mock('./forge.tmpdir', () => ({
-  createPackagingTmpdir: () => '/tmp/streamwall-packager-test',
+  createPackagingTmpdir: () => createPackagingTmpdir(),
   removePackagingTmpdir: (dir: string) => removePackagingTmpdir(dir),
+  registerPackagingTmpdirFallbackCleanup: (dir: string) =>
+    registerPackagingTmpdirFallbackCleanup(dir),
 }))
 
 const { default: config }: { default: ForgeConfig } =
@@ -32,25 +42,116 @@ describe('forge prePackage hook', () => {
       /typecheck failed/,
     )
   })
+
+  // #749: loading this config (e.g. for `electron-forge start`, or for the
+  // typecheck-failure case above) must never create a tmpdir that would then
+  // need cleaning up. Only a `prePackage` hook that gets past the typecheck
+  // creates one.
+  it('never creates a packaging tmpdir when the typecheck fails', async () => {
+    createPackagingTmpdir.mockClear()
+    runTypecheck.mockImplementationOnce(() => {
+      throw new Error('typecheck failed')
+    })
+
+    await expect(config.hooks?.prePackage?.(config, '', '')).rejects.toThrow(
+      /typecheck failed/,
+    )
+
+    expect(createPackagingTmpdir).not.toHaveBeenCalled()
+  })
 })
 
 // @electron/packager wipes its base temp directory when a run starts, so two
 // packaging runs sharing the default base delete each other's staging tree
-// mid-run (#510). Every run therefore stages in its own directory.
+// mid-run (#510). Every run therefore stages in its own directory, created
+// once `prePackage` actually runs rather than at module load (#749).
 describe('forge packaging temp directory', () => {
-  it('stages the app in a directory of its own', () => {
-    expect(config.packagerConfig.tmpdir).toBe('/tmp/streamwall-packager-test')
+  it('stages the app in a directory of its own once prePackage runs', async () => {
+    createPackagingTmpdir.mockClear()
+
+    await config.hooks?.prePackage?.(config, '', '')
+
+    expect(createPackagingTmpdir).toHaveBeenCalledTimes(1)
+    expect(config.packagerConfig.tmpdir).toBe(
+      await createPackagingTmpdir.mock.results[0]?.value,
+    )
   })
 
-  it('removes that directory once packaging is done', async () => {
+  // A run that fails after prePackage has already staged a directory but
+  // before postPackage runs (e.g. the packaging step itself throwing) would
+  // otherwise strand that directory; a process-exit fallback stands in for
+  // the cleanup postPackage never gets to perform (#749).
+  it('registers a process-exit fallback cleanup once a directory is staged', async () => {
+    registerPackagingTmpdirFallbackCleanup.mockClear()
+
+    await config.hooks?.prePackage?.(config, '', '')
+
+    expect(registerPackagingTmpdirFallbackCleanup).toHaveBeenCalledWith(
+      config.packagerConfig.tmpdir,
+    )
+  })
+
+  it('removes that directory and stands down the fallback once packaging is done', async () => {
+    await config.hooks?.prePackage?.(config, '', '')
+    const tmpdir = config.packagerConfig.tmpdir
+    unregisterFallbackCleanup.mockClear()
+    removePackagingTmpdir.mockClear()
+
     await config.hooks?.postPackage?.(config, {
       platform: 'darwin',
       arch: 'arm64',
       outputPaths: [],
     })
 
-    expect(removePackagingTmpdir).toHaveBeenCalledWith(
-      '/tmp/streamwall-packager-test',
-    )
+    expect(unregisterFallbackCleanup).toHaveBeenCalledTimes(1)
+    expect(removePackagingTmpdir).toHaveBeenCalledWith(tmpdir)
+  })
+
+  // `make` can run this packaging pipeline more than once in the same
+  // process (e.g. across multiple platform/arch targets), so a second
+  // prePackage/postPackage cycle must not reuse or double-free the first
+  // cycle's directory.
+  it('stages and removes a fresh directory on each successive prePackage/postPackage cycle', async () => {
+    removePackagingTmpdir.mockClear()
+    await config.hooks?.prePackage?.(config, '', '')
+    const firstTmpdir = config.packagerConfig.tmpdir
+    await config.hooks?.postPackage?.(config, {
+      platform: 'darwin',
+      arch: 'arm64',
+      outputPaths: [],
+    })
+
+    await config.hooks?.prePackage?.(config, '', '')
+    const secondTmpdir = config.packagerConfig.tmpdir
+    await config.hooks?.postPackage?.(config, {
+      platform: 'linux',
+      arch: 'x64',
+      outputPaths: [],
+    })
+
+    expect(secondTmpdir).not.toBe(firstTmpdir)
+    expect(removePackagingTmpdir).toHaveBeenCalledWith(firstTmpdir)
+    expect(removePackagingTmpdir).toHaveBeenCalledWith(secondTmpdir)
+    expect(removePackagingTmpdir).toHaveBeenCalledTimes(2)
+  })
+
+  it('does nothing on postPackage when no directory was ever staged', async () => {
+    // Simulates postPackage running without a preceding prePackage having
+    // created a directory - not a real forge sequence, but the hook must
+    // stay defensive rather than assume prePackage always ran first. Uses a
+    // fresh module instance so this test does not depend on the shared
+    // `config` singleton's state left over from earlier tests in this file.
+    vi.resetModules()
+    removePackagingTmpdir.mockClear()
+    const { default: freshConfig }: { default: ForgeConfig } =
+      await import('./forge.config')
+
+    await freshConfig.hooks?.postPackage?.(freshConfig, {
+      platform: 'darwin',
+      arch: 'arm64',
+      outputPaths: [],
+    })
+
+    expect(removePackagingTmpdir).not.toHaveBeenCalled()
   })
 })

--- a/packages/streamwall/forge.config.ts
+++ b/packages/streamwall/forge.config.ts
@@ -13,7 +13,11 @@ import {
   getWindowsSigningConfig,
   isSigningConfigured,
 } from './forge.signing'
-import { createPackagingTmpdir, removePackagingTmpdir } from './forge.tmpdir'
+import {
+  createPackagingTmpdir,
+  registerPackagingTmpdirFallbackCleanup,
+  removePackagingTmpdir,
+} from './forge.tmpdir'
 import { runTypecheck } from './forge.typecheck'
 import { appendUpdateMetadata } from './forge.updateMetadata'
 import packageJson from './package.json'
@@ -22,21 +26,36 @@ const macSigning = getMacSigningConfig(process.env)
 const windowsSigning = getWindowsSigningConfig(process.env)
 const signingConfigured = isSigningConfigured(process.env)
 const publishRepository = parseGithubRepository(packageJson.repository)
-const packagingTmpdir = createPackagingTmpdir()
+
+// Created lazily from within the `prePackage` hook below, not here at
+// module-evaluation time (#749): this config is also loaded by commands that
+// never run a full package step - `electron-forge start` in particular, plus
+// any `package`/`make` that fails before reaching `postPackage` (a routine
+// typecheck rejection from the `prePackage` hook itself) - and creating the
+// directory unconditionally at load time stranded it in every one of those
+// cases. `unregisterTmpdirFallbackCleanup` clears the safety net registered
+// alongside creation once `postPackage` performs its own explicit cleanup.
+let packagingTmpdir: string | undefined
+let unregisterTmpdirFallbackCleanup: (() => void) | undefined
+
+// Declared separately (rather than inline in `config` below) so the
+// `prePackage`/`postPackage` hooks can assign `.tmpdir` on it without TypeScript
+// treating `packagerConfig` as possibly undefined - it's `ForgeConfig`'s type
+// that makes the property optional, not anything about this file's own object.
+const packagerConfig: NonNullable<ForgeConfig['packagerConfig']> = {
+  // No explicit executableName: it defaults to the product name
+  // ("Streamwall"), which the NSIS installer template requires the
+  // executable to match. The Linux makers still install a lowercase
+  // `streamwall` command via their `bin` option below.
+  asar: true,
+  // Left unset here; the `prePackage` hook below assigns a directory of
+  // this run's own before the packaging step reads this config (#510, see
+  // forge.tmpdir.ts).
+  ...macSigning,
+}
 
 const config: ForgeConfig = {
-  packagerConfig: {
-    // No explicit executableName: it defaults to the product name
-    // ("Streamwall"), which the NSIS installer template requires the
-    // executable to match. The Linux makers still install a lowercase
-    // `streamwall` command via their `bin` option below.
-    asar: true,
-    // Stage in a directory of this run's own: packager wipes its base temp
-    // directory on start, so runs sharing the default base kill each other
-    // (#510, see forge.tmpdir.ts).
-    tmpdir: packagingTmpdir,
-    ...macSigning,
-  },
+  packagerConfig,
   rebuildConfig: {},
   makers: [
     // NSIS instead of Squirrel.Windows (#432): electron-updater - which
@@ -66,10 +85,31 @@ const config: ForgeConfig = {
     // and `publish` both run the package step, so this one hook covers every
     // command that produces a distributable; `start` stays unchecked to keep
     // the dev loop fast (`npm run typecheck` still covers it in CI).
-    prePackage: async () => runTypecheck(),
+    //
+    // The tmpdir is created here, after the typecheck succeeds, rather than
+    // at module load (#749): a typecheck failure now never creates a
+    // directory that would need cleaning up, and `start` - which never runs
+    // this hook at all - never creates one either.
+    prePackage: async () => {
+      await runTypecheck()
+      packagingTmpdir = createPackagingTmpdir()
+      packagerConfig.tmpdir = packagingTmpdir
+      unregisterTmpdirFallbackCleanup =
+        registerPackagingTmpdirFallbackCleanup(packagingTmpdir)
+    },
     // The staged app has been moved to `out/` by now, so the run's private
-    // temp directory is only an empty shell (#510).
-    postPackage: async () => removePackagingTmpdir(packagingTmpdir),
+    // temp directory is only an empty shell (#510). Also stands down the
+    // process-exit fallback registered in `prePackage`, since this explicit
+    // cleanup already handled it (#749).
+    postPackage: async () => {
+      if (!packagingTmpdir) {
+        return
+      }
+      unregisterTmpdirFallbackCleanup?.()
+      removePackagingTmpdir(packagingTmpdir)
+      packagingTmpdir = undefined
+      unregisterTmpdirFallbackCleanup = undefined
+    },
     // latest.yml / latest-mac.yml for electron-updater (#432); uploaded to
     // the release alongside the installers by the GitHub publisher.
     postMake: async (_forgeConfig, makeResults) =>

--- a/packages/streamwall/forge.tmpdir.test.ts
+++ b/packages/streamwall/forge.tmpdir.test.ts
@@ -12,6 +12,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import {
   createPackagingTmpdir,
   PACKAGING_TMPDIR_PREFIX,
+  registerPackagingTmpdirFallbackCleanup,
   removePackagingTmpdir,
 } from './forge.tmpdir'
 
@@ -79,5 +80,47 @@ describe('removePackagingTmpdir', () => {
     expect(path.basename(create())).toMatch(
       new RegExp(`^${PACKAGING_TMPDIR_PREFIX}`),
     )
+  })
+})
+
+describe('registerPackagingTmpdirFallbackCleanup', () => {
+  // A packaging run that fails between creating its tmpdir and reaching
+  // `postPackage` (e.g. the packaging step itself throwing) never gets to
+  // call removePackagingTmpdir explicitly. The CLI's own error path calls
+  // process.exit(), which synchronously fires 'exit' listeners before the
+  // process actually goes away - this fallback rides that event to remove
+  // whatever the run staged, even when nothing else cleans up.
+  it('removes the directory when the process exits without explicit cleanup', () => {
+    const dir = create()
+    registerPackagingTmpdirFallbackCleanup(dir)
+
+    process.emit('exit', 1)
+
+    expect(existsSync(dir)).toBe(false)
+  })
+
+  it('does nothing once the caller has already cleaned up and unregistered it', () => {
+    const dir = create()
+    const unregister = registerPackagingTmpdirFallbackCleanup(dir)
+    removePackagingTmpdir(dir)
+    unregister()
+
+    // No 'not a packaging temp directory' or fs error should escape here -
+    // the point of unregistering is that the fallback stays silent.
+    expect(() => process.emit('exit', 0)).not.toThrow()
+    expect(existsSync(dir)).toBe(false)
+  })
+
+  it('leaves other registered directories alone when one is unregistered', () => {
+    const dirA = create()
+    const dirB = create()
+    const unregisterA = registerPackagingTmpdirFallbackCleanup(dirA)
+    registerPackagingTmpdirFallbackCleanup(dirB)
+    unregisterA()
+
+    process.emit('exit', 1)
+
+    expect(existsSync(dirA)).toBe(true)
+    expect(existsSync(dirB)).toBe(false)
   })
 })

--- a/packages/streamwall/forge.tmpdir.ts
+++ b/packages/streamwall/forge.tmpdir.ts
@@ -34,3 +34,27 @@ export function removePackagingTmpdir(dir: string): void {
 
   rmSync(dir, { recursive: true, force: true })
 }
+
+/**
+ * Best-effort safety net for a packaging run that never reaches its own
+ * cleanup (#749): forge only calls `postPackage` after the whole packaging
+ * step *succeeds*, so a run that fails partway through - after this module
+ * already staged a tmpdir - would otherwise strand it. `@electron-forge/cli`
+ * responds to that kind of failure by calling `process.exit(1)`, which fires
+ * 'exit' listeners synchronously before the process actually goes away, so
+ * removing the directory there catches what the normal `postPackage` path
+ * misses.
+ *
+ * Call the returned function once the caller performs its own explicit
+ * cleanup, so this fallback does not also fire (harmlessly, since removal is
+ * idempotent, but needlessly) on every ordinary successful run.
+ */
+export function registerPackagingTmpdirFallbackCleanup(
+  dir: string,
+): () => void {
+  const cleanup = () => removePackagingTmpdir(dir)
+  process.once('exit', cleanup)
+  return () => {
+    process.removeListener('exit', cleanup)
+  }
+}


### PR DESCRIPTION
## Problem
`createPackagingTmpdir()` ran at module-evaluation time in `forge.config.ts`, but the matching cleanup only ran from the `postPackage` hook. Any load of the config that does not complete a `package` step — `electron-forge start`, or a `package`/`make` run that fails earlier (e.g. the `prePackage` typecheck hook rejecting the build) — stranded an empty `streamwall-packager-<random>` directory in the OS temp directory. These accumulate indefinitely on a developer's or self-hosted CI runner's machine.

## Technical solution
`createPackagingTmpdir()` is now called lazily from inside the `prePackage` hook, after `runTypecheck()` succeeds, and mutates `packagerConfig.tmpdir` on the same object instance `@electron-forge/core` later reads when it builds the real `@electron/packager` options — so the directory is created only once packaging is actually about to run. A typecheck failure, or loading the config for `start` (which never runs `prePackage`/`postPackage` at all), now never creates a directory.

The installed `@electron/packager` (18.4.4) types `tmpdir` as `string | false` only — no function form — so a resolver-function approach (as one option in the issue suggested) wasn't available; mutating the config object in place before the packaging step reads it is the mechanism that works with this version.

For the residual gap — a run that fails *after* `prePackage` has staged a directory but *before* `postPackage` runs (e.g. the packaging step itself throwing) — `registerPackagingTmpdirFallbackCleanup` in `forge.tmpdir.ts` registers a `process.once('exit', ...)` listener alongside creation. `@electron-forge/cli` calls `process.exit(1)` on that kind of failure, which fires `exit` listeners synchronously before the process actually goes away, so the fallback removes the directory `postPackage` never got a chance to. The normal `postPackage` path unregisters this fallback once it performs the explicit cleanup itself, so a successful run doesn't accumulate listeners, and repeated `prePackage`/`postPackage` cycles in one process (e.g. `make` across multiple platform/arch targets) each stage and remove their own directory independently.

## Testing performed
- `forge.tmpdir.test.ts`: new cases for `registerPackagingTmpdirFallbackCleanup` — removes the directory on process exit when nothing else cleaned up; is a no-op once the caller has cleaned up and unregistered it; leaves other registered directories untouched when one is unregistered.
- `forge.config.test.ts`: new cases — no tmpdir is created when the typecheck fails; a tmpdir is created only once `prePackage` actually runs; the fallback cleanup is registered once a directory is staged and stood down by `postPackage`; `postPackage` is a no-op when nothing was staged; two consecutive `prePackage`/`postPackage` cycles each stage and remove distinct directories without reuse or double-free.
- Full quality gate: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (2109 tests) — all green.

## Risks / breaking changes
None. `packagerConfig.tmpdir` is set to the same kind of value as before (a per-run directory path), just assigned at a later point in the hook sequence; the packaging step reads it at the same point in the pipeline it always did.

## Pre-PR review
Two independent review rounds by fresh subagents with no session context.
- Round 1: one minor finding — no test covered two consecutive `prePackage`/`postPackage` cycles in the same process. Fixed by adding that test (folded into the existing test commit via fixup + autosquash).
- Round 2 (after the fix and a rebase onto a newer `main`): `NO FINDINGS`. The reviewer additionally verified the new/changed assertions are load-bearing by reverting the source files to their pre-fix state and confirming 8 of the new tests then fail.

Closes #749