### PR TITLE
fix(streamwall): guard control:devtools against foreign IPC senders

### DIFF
--- a/packages/streamwall/src/main/ControlWindow.test.ts
+++ b/packages/streamwall/src/main/ControlWindow.test.ts
@@ -1,12 +1,12 @@
 import EventEmitter from 'events'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // ControlWindow pulls in Electron directly and via ./loadHTML. Model
 // BrowserWindow as a small EventEmitter so `win.on('close', ...)` wiring can
 // be exercised the same way the real window would drive it, without an
 // Electron runtime.
 class FakeBrowserWindow extends EventEmitter {
-  webContents = { send: vi.fn() }
+  webContents = { send: vi.fn(), openDevTools: vi.fn() }
   removeMenu = vi.fn()
   options: Record<string, unknown>
 
@@ -43,6 +43,12 @@ const configInfo = {
   configPath: '/home/test/.config/Streamwall/config.toml',
   hasUserConfig: false,
 }
+
+// Every test constructs its own ControlWindow, so the registration history has
+// to start empty rather than accumulating across the file.
+beforeEach(() => {
+  handle.mockClear()
+})
 
 describe('ControlWindow close', () => {
   it('forwards the underlying Electron close event so callers can preventDefault', () => {
@@ -350,5 +356,96 @@ describe('ControlWindow app version', () => {
     expect(await ipcHandlers.get('control:app-version')!({ sender })).toBe(
       '0.9.1',
     )
+  })
+})
+
+describe('ControlWindow devtools', () => {
+  it('opens the devtools for the renderer that owns the window', () => {
+    const controlWindow = new ControlWindow(configInfo)
+    const { webContents } = controlWindow.win as unknown as FakeBrowserWindow
+
+    ipcHandlers.get('control:devtools')!({ sender: webContents })
+
+    expect(webContents.openDevTools).toHaveBeenCalledOnce()
+  })
+
+  it('ignores requests from a sender other than its own window', () => {
+    const controlWindow = new ControlWindow(configInfo)
+    const { webContents } = controlWindow.win as unknown as FakeBrowserWindow
+
+    ipcHandlers.get('control:devtools')!({ sender: { send: vi.fn() } })
+
+    expect(webContents.openDevTools).not.toHaveBeenCalled()
+  })
+})
+
+// Every `control:*` channel the window registers, together with the collaborator
+// a successful invocation would reach. Adding a channel forces an author through
+// this list, and the sweep below then demands a sender guard for it (#736).
+const CONTROL_CHANNELS = [
+  'control:load',
+  'control:devtools',
+  'control:command',
+  'control:ydoc',
+  'control:first-run-info',
+  'control:open-config-folder',
+  'control:create-example-config',
+  'control:update-status',
+  'control:app-version',
+  'control:download-update',
+  'control:install-update',
+  'control:open-release-notes',
+]
+
+describe('ControlWindow sender guards', () => {
+  it('registers exactly the known control channels', () => {
+    new ControlWindow(configInfo)
+
+    // Compared as a set: the registration order carries no meaning, and an
+    // order-sensitive assertion would break on a behaviour-neutral reshuffle.
+    expect(handle.mock.calls.map(([channel]) => channel).sort()).toEqual(
+      [...CONTROL_CHANNELS].sort(),
+    )
+  })
+
+  it('ignores every registered channel when the sender is not its own window', async () => {
+    const controlWindow = new ControlWindow(configInfo)
+    const { webContents } = controlWindow.win as unknown as FakeBrowserWindow
+    const load = vi.fn()
+    const ydoc = vi.fn()
+    controlWindow.on('load', load)
+    controlWindow.on('ydoc', ydoc)
+    const commandHandler = vi.fn().mockResolvedValue({ error: 'nope' })
+    controlWindow.setCommandHandler(commandHandler)
+    const updateHandlers = {
+      getAppVersion: vi.fn(() => '0.9.1'),
+      getStatus: vi.fn(() => ({ state: 'idle' as const })),
+      download: vi.fn(),
+      install: vi.fn(),
+      openReleaseNotes: vi.fn(),
+    }
+    controlWindow.setUpdateHandlers(updateHandlers)
+    createExampleConfig.mockClear()
+    openPath.mockClear()
+
+    // Sweeps the pinned list rather than whatever happens to be registered, so
+    // it cannot silently run over a shorter set than the pin test asserts.
+    for (const channel of CONTROL_CHANNELS) {
+      const handler = ipcHandlers.get(channel)
+      expect(handler, `no handler registered for ${channel}`).toBeDefined()
+      expect(await handler!({ sender: { send: vi.fn() } }, {})).toBeUndefined()
+    }
+
+    for (const spy of [
+      load,
+      ydoc,
+      commandHandler,
+      createExampleConfig,
+      openPath,
+      webContents.openDevTools,
+      ...Object.values(updateHandlers),
+    ]) {
+      expect(spy).not.toHaveBeenCalled()
+    }
   })
 })

--- a/packages/streamwall/src/main/ControlWindow.ts
+++ b/packages/streamwall/src/main/ControlWindow.ts
@@ -66,97 +66,82 @@ export default class ControlWindow extends EventEmitter<ControlWindowEventMap> {
       log.warn('error loading control window', err)
     })
 
-    ipcMain.handle('control:load', (ev) => {
-      if (ev.sender !== this.win.webContents) {
-        return
-      }
+    this.handleFromControlWindow('control:load', () => {
       this.emit('load')
     })
 
-    ipcMain.handle('control:devtools', () => {
+    this.handleFromControlWindow('control:devtools', () => {
       this.win.webContents.openDevTools()
     })
 
-    ipcMain.handle('control:command', async (ev, command) => {
-      if (ev.sender !== this.win.webContents) {
-        return
-      }
+    this.handleFromControlWindow('control:command', async (_ev, command) => {
       if (!this.commandHandler) {
         return
       }
       return this.commandHandler(command)
     })
 
-    ipcMain.handle('control:ydoc', (ev, update) => {
-      if (ev.sender !== this.win.webContents) {
-        return
-      }
+    this.handleFromControlWindow('control:ydoc', (_ev, update) => {
       this.emit('ydoc', update)
     })
 
-    ipcMain.handle('control:first-run-info', (ev) => {
-      if (ev.sender !== this.win.webContents) {
-        return
-      }
-      return configInfo
-    })
+    this.handleFromControlWindow('control:first-run-info', () => configInfo)
 
-    ipcMain.handle('control:open-config-folder', (ev) => {
-      if (ev.sender !== this.win.webContents) {
-        return
-      }
+    this.handleFromControlWindow('control:open-config-folder', () => {
       shell.openPath(dirname(configInfo.configPath))
     })
 
-    ipcMain.handle('control:create-example-config', (ev) => {
-      if (ev.sender !== this.win.webContents) {
-        return
-      }
+    this.handleFromControlWindow('control:create-example-config', () => {
       // Lets a write failure (e.g. a file that raced into existence since
       // hasUserConfig was checked) reject the renderer's invoke() call
       // rather than being swallowed (#246).
       createExampleConfig(configInfo.configPath)
     })
 
-    ipcMain.handle('control:update-status', (ev) => {
-      if (ev.sender !== this.win.webContents) {
-        return
-      }
+    this.handleFromControlWindow('control:update-status', () => {
       // The renderer may mount after the updater already moved past `idle`,
       // so it pulls the current status once instead of only listening for
       // future transitions.
       return this.updateHandlers?.getStatus() ?? { state: 'idle' }
     })
 
-    ipcMain.handle('control:app-version', (ev) => {
-      if (ev.sender !== this.win.webContents) {
-        return
-      }
-      return this.updateHandlers?.getAppVersion() ?? ''
-    })
+    this.handleFromControlWindow(
+      'control:app-version',
+      () => this.updateHandlers?.getAppVersion() ?? '',
+    )
 
-    ipcMain.handle('control:download-update', (ev) => {
-      if (ev.sender !== this.win.webContents) {
-        return
-      }
+    this.handleFromControlWindow('control:download-update', () => {
       this.updateHandlers?.download()
     })
 
-    ipcMain.handle('control:install-update', (ev) => {
-      if (ev.sender !== this.win.webContents) {
-        return
-      }
+    this.handleFromControlWindow('control:install-update', () => {
       this.updateHandlers?.install()
     })
 
-    ipcMain.handle('control:open-release-notes', (ev) => {
-      if (ev.sender !== this.win.webContents) {
-        return
-      }
+    this.handleFromControlWindow('control:open-release-notes', () => {
       // Deliberately takes no URL from the renderer: main owns the updater
       // status, so a compromised renderer cannot turn this into an
       // open-anything shell.openExternal gadget.
       this.updateHandlers?.openReleaseNotes()
+    })
+  }
+
+  /**
+   * Registers an `ipcMain.handle` listener that only runs for invocations from
+   * this window's own webContents. `ipcMain` is process-global, so without the
+   * sender check any renderer in the process could reach these channels; making
+   * the guard part of the registration means a newly added channel cannot
+   * forget it (#736).
+   */
+  private handleFromControlWindow(
+    channel: string,
+    listener: Parameters<typeof ipcMain.handle>[1],
+  ) {
+    ipcMain.handle(channel, (ev, ...args) => {
+      if (ev.sender !== this.win.webContents) {
+        return
+      }
+      return listener(ev, ...args)
     })
   }
 


### PR DESCRIPTION
## Problem

`control:devtools` was the only IPC handler in the `ControlWindow` constructor without an `ev.sender` check — it dropped the `ev` parameter entirely. `ipcMain` is process-global, so the channel was reachable from any renderer in the process that can call `ipcRenderer.invoke`, letting it force the operator's control DevTools open and expose the whole `streamwallControl` bridge to inspection. Its eleven siblings all opened with the same hand-written two-line guard.

## Solution

Rather than adding a twelfth copy of the check, the guard now lives in the registration itself: a private `handleFromControlWindow(channel, listener)` helper wraps `ipcMain.handle`, drops any invocation whose `ev.sender` is not this window's `webContents`, and otherwise forwards `ev` plus all rest arguments and returns the listener's value unchanged. All twelve channels go through it, so a newly added channel cannot forget the check — mirroring `StreamWindow`'s existing `registerIpcHandle`.

Behaviour is otherwise preserved: `control:command` still resolves with the dispatch result, `control:create-example-config` still lets a write failure reject the renderer's `invoke()` (#246), and `control:first-run-info` / `control:app-version` / `control:update-status` still return their values.

## Testing

- New: `control:devtools` opens DevTools for its own window, and is ignored for a foreign sender (this test fails against the previous unguarded handler).
- New: a pinned `CONTROL_CHANNELS` list asserted against the actual registrations (order-independent), so adding a channel forces an author through this file.
- New: a sweep over that pinned list invoking every channel with a foreign sender, asserting each returns `undefined` and that none of the collaborators (`load`/`ydoc` emits, the command handler, `createExampleConfig`, `shell.openPath`, `openDevTools`, every update handler) was reached.
- Quality gate green locally: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (2084 tests).

## Risks / breaking changes

None. No public API changes; the only caller-visible behaviour change is that `control:devtools` now ignores foreign senders, and `controlPreload.ts` — the sole in-app invoker — always sends from the control window itself.

## Pre-PR review

Four rounds with an independent reviewer that had none of the implementation context. All findings were accepted and fixed; none were dismissed.

1. The sweep test's comment overstated its guarantee — a future unguarded channel whose side effect was not in the spy list would have passed. Fixed by pinning the channel set and asserting it against the actual registrations.
2. The pin asserted registration *order*, which a behaviour-neutral reshuffle would break; and a one-off `handle.mockClear()` mid-file was an order-dependent trap. Fixed by comparing sorted arrays and moving the reset into a `beforeEach`.
3. The sweep iterated whatever happened to be registered, so it could silently run over a shorter list than the pin asserts. Fixed by sweeping the pinned `CONTROL_CHANNELS` constant and asserting a handler exists for each.
4. Only an out-of-scope finding: the same missing guard on `devtools-overlay` in `StreamWindow` — filed as #764 and deliberately left out of this PR (different window, and that file is under concurrent modification).

## Follow-ups

- #764 — add a sender check to the `devtools-overlay` IPC listener in `StreamWindow`.

Closes #736
