### PR TITLE
fix(control-ui): stop the sidebar stream filter matching the literal text undefined

### DIFF
--- a/packages/streamwall-control-ui/src/hooks/useStreamFilters.test.tsx
+++ b/packages/streamwall-control-ui/src/hooks/useStreamFilters.test.tsx
@@ -91,6 +91,47 @@ describe('filterStreams', () => {
     const [, live, other] = filterStreams(streams, new Set(), new Set(), '')
     expect(live.length + other.length).toBe(2)
   })
+
+  // label/source/state/city are all optional (streamwall-shared schemas), so
+  // a stream carrying only a link - every freshly added custom stream, and
+  // any sparse external source row - has all four undefined. Naively
+  // template-interpolating them produces the literal string
+  // "undefinedundefinedundefinedundefined", which then matches any substring
+  // of "undefined" (issue #747).
+  describe('streams with no label/source/state/city metadata (issue #747)', () => {
+    test('does not match a filter that is a substring of the literal word "undefined"', () => {
+      const bareStream = makeStream('a')
+
+      for (const substring of ['un', 'def', 'ine', 'ned', 'fin']) {
+        const [, , other] = filterStreams(
+          [bareStream],
+          new Set(),
+          new Set(),
+          substring,
+        )
+        expect(other).toEqual([])
+      }
+    })
+
+    test('is excluded by any non-empty filter, having no metadata to match', () => {
+      const bareStream = makeStream('a')
+      const [wall, live, other, favorites] = filterStreams(
+        [bareStream],
+        new Set(),
+        new Set(),
+        'anything',
+      )
+      expect([...wall, ...live, ...other, ...favorites]).toEqual([])
+    })
+
+    test('does not let a match span a field boundary', () => {
+      // Without a separator, label "foo" + source "bar" reads as "foobar",
+      // which would wrongly match a filter for "oob".
+      const stream = makeStream('a', { label: 'foo', source: 'bar' })
+      const [, , other] = filterStreams([stream], new Set(), new Set(), 'oob')
+      expect(other).toEqual([])
+    })
+  })
 })
 
 let container: HTMLDivElement | undefined

--- a/packages/streamwall-control-ui/src/hooks/useStreamFilters.ts
+++ b/packages/streamwall-control-ui/src/hooks/useStreamFilters.ts
@@ -21,6 +21,7 @@ export function filterStreams(
   const liveStreams = []
   const otherStreams = []
   const favoriteStreams = []
+  const lowerFilter = filter.toLowerCase()
   for (const stream of streams) {
     const { _id, kind, status, label, source, state, city, link } = stream
     if (kind && !normalStreamKinds.has(kind)) {
@@ -28,9 +29,11 @@ export function filterStreams(
     }
     if (
       filter !== '' &&
-      !`${label}${source}${state}${city}`
+      ![label, source, state, city]
+        .filter(Boolean)
+        .join(' ')
         .toLowerCase()
-        .includes(filter.toLowerCase())
+        .includes(lowerFilter)
     ) {
       continue
     }


### PR DESCRIPTION
## Problem
`label`, `source`, `state` and `city` are all optional. The sidebar filter's haystack was built by directly template-interpolating them, so a stream with none of them set (e.g. every freshly added custom stream, which only has a `link`) produced the literal string `"undefinedundefinedundefinedundefined"`, which then matched any substring of "undefined" (`un`, `def`, `ine`, `ned`, `fin` — common fragments of real place/source names).

## Solution
- `[label, source, state, city].filter(Boolean).join(' ')` coalesces the optional fields before joining, so an absent field contributes nothing to the haystack, and the space separator stops a match spanning a field boundary (e.g. label "foo" + source "bar" no longer matches filter "oob").
- Hoisted `filter.toLowerCase()` out of the per-stream loop.

## Testing
- New `filterStreams` cases: a stream with no metadata fields does not match any substring of "undefined" and is excluded by any non-empty filter; a field-boundary match ("foo"+"bar" vs. filter "oob") is rejected.
- Verified the new tests fail on the pre-fix code and pass after the fix.
- Full quality gate green: `npm run format`, `npm run lint`, `npm run typecheck` (all workspaces), `npm -w packages/streamwall-control-ui run test` (379/379 passing).
- `Sidebar.tsx` is untouched by this PR (another change is in flight there for issue #732).

## Pre-PR review
One independent review round (fresh subagent, no session context) returned `NO FINDINGS`.

Closes #747