### PR TITLE
docs(contributing): document how to fix an npm hoisting break

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -450,7 +450,7 @@ other packages several workspaces share (`yjs`, `xstate`, `zod`,
 `jsondiffpatch`, `lodash-es`, `react-icons`) are deliberately left to npm's own
 hoisting choice — anchoring every shared dependency pre-emptively would just
 be guessing at which one breaks next, and the guard test above catches it in
-CI if one of them does (#729).
+CI if one of them does (#728).
 
 ### Changelog
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -449,8 +449,9 @@ the root today, because those are the ones that have actually broken. The
 other packages several workspaces share (`yjs`, `xstate`, `zod`,
 `jsondiffpatch`, `lodash-es`, `react-icons`) are deliberately left to npm's own
 hoisting choice — anchoring every shared dependency pre-emptively would just
-be guessing at which one breaks next, and the guard test above catches it in
-CI if one of them does (#728).
+be guessing at which one breaks next, and the
+`shared-dependency-hoisting.test.mjs` guard above catches it in CI if one of
+them does (#728).
 
 ### Changelog
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -405,10 +405,10 @@ extend) — see #728.
 **Symptoms** are rarely about the dependency itself:
 
 - A module-level singleton splits in two across an import boundary. Preact
-  keeps hook state on one such pointer, so two copies fail with `Cannot read
-properties of undefined (reading '__H')` — not a hint that anything is
-  wrong with hooks. `styled-components`' theme context and `yjs`'s
-  `instanceof` checks are the same kind of failure waiting to happen.
+  keeps hook state on one such pointer, so two copies fail with
+  `Cannot read properties of undefined (reading '__H')` — not a hint that
+  anything is wrong with hooks. `styled-components`' theme context and
+  `yjs`'s `instanceof` checks are the same kind of failure waiting to happen.
 - A plugin's type augmentations vanish. TypeScript only merges a
   `declare module 'x'` into the copy of `x` the _augmenting package_ itself
   resolves, so a `@fastify/*` plugin sitting at the root while `fastify` sits

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -390,6 +390,68 @@ When a deprecation cannot be migrated away from right now, add the package to
 issue, so the job stays actionable instead of permanently red. Allowlist
 entries that no longer apply are reported as warnings and should be dropped.
 
+### Fixing a dependency bump that npm un-hoists
+
+Regenerating `package-lock.json` for a routine dependency bump can relocate a
+package that several workspaces share, splitting one hoisted copy into
+several — one per workspace, or one that moved into whichever workspace
+depends on it, cutting every other consumer off. That is what a production
+dependency bump did to `preact` and `styled-components` (each split into a
+copy per workspace) and to `fastify` (moved into
+`packages/streamwall-control-server`, cutting the root-level `@fastify/*`
+plugins off from the module their `declare module 'fastify'` augmentations
+extend) — see #728.
+
+**Symptoms** are rarely about the dependency itself:
+
+- A module-level singleton splits in two across an import boundary. Preact
+  keeps hook state on one such pointer, so two copies fail with `Cannot read
+properties of undefined (reading '__H')` — not a hint that anything is
+  wrong with hooks. `styled-components`' theme context and `yjs`'s
+  `instanceof` checks are the same kind of failure waiting to happen.
+- A plugin's type augmentations vanish. TypeScript only merges a
+  `declare module 'x'` into the copy of `x` the _augmenting package_ itself
+  resolves, so a `@fastify/*` plugin sitting at the root while `fastify` sits
+  inside a workspace produces dozens of otherwise-unrelated-looking errors
+  like `Property 'setCookie' does not exist on type 'FastifyReply'`.
+
+**Fixing it:**
+
+1. `npm install && npm dedupe` — `npm dedupe` hoists most split copies back to
+   a single root install; a plain `npm install` after a lockfile change does
+   not do this on its own.
+2. If a package still resolves separately per workspace after `npm dedupe`
+   (npm decided a single-consumer install belongs inside that workspace
+   rather than at the root), declare it directly in the **root**
+   `package.json` (`dependencies` or `devDependencies`). A root declaration
+   is the anchor that keeps a single copy hoisted there for every workspace to
+   share, regardless of which workspace(s) actually import it — which is why
+   the root now depends on `preact`, `styled-components` and `fastify`
+   (#728), and `happy-dom` (#675), without any code at the root using any of
+   them directly. Do not remove these entries as apparently-dead
+   dependencies: without the anchor, the next version bump is free to split
+   the package again.
+3. `test/shared-dependency-hoisting.test.mjs` and
+   `test/fastify-plugin-resolution.test.mjs` are the guards for exactly these
+   two failure shapes — a shared package installed more than once, and a
+   `@fastify/*` plugin resolving a different `fastify` than the control
+   server does. Run them (`npm test`, or `node --test` on the two files
+   directly) to confirm a fix actually worked.
+4. Do not trust a green run alone: a worktree nested inside the main
+   checkout can resolve a hoisted package from the _parent_ checkout's
+   `node_modules`, so a real split can still pass tests locally. Check what
+   `package-lock.json` actually installed for the package (or rely on the
+   guard tests above, which read the lockfile directly) rather than the test
+   result by itself.
+
+Only `preact`, `styled-components`, `fastify` and `happy-dom` are anchored at
+the root today, because those are the ones that have actually broken. The
+other packages several workspaces share (`yjs`, `xstate`, `zod`,
+`jsondiffpatch`, `lodash-es`, `react-icons`) are deliberately left to npm's own
+hoisting choice — anchoring every shared dependency pre-emptively would just
+be guessing at which one breaks next, and the guard test above catches it in
+CI if one of them does (#729).
+
 ### Changelog
 
 [`CHANGELOG.md`](CHANGELOG.md) is generated, not hand-edited. Because PRs are


### PR DESCRIPTION
## Problem

The production-dependency group bump (dependabot #714 / #716, shipped as #728) was red for a reason unrelated to the new releases: npm relocated `preact` and `styled-components` into a copy per workspace, and moved `fastify` into `packages/streamwall-control-server`, cutting the root-level `@fastify/*` plugins off from the module their `declare module 'fastify'` augmentations extend. #728 fixed the breakage and added guard tests (`test/shared-dependency-hoisting.test.mjs`, `test/fastify-plugin-resolution.test.mjs`), so CI now names the problem instead of failing with `Cannot read properties of undefined (reading '__H')` or dozens of unrelated-looking type errors — but the recipe for *fixing* such a failure was nowhere in the repo.

## Solution

Adds a "Fixing a dependency bump that npm un-hoists" section to `CONTRIBUTING.md`, right after the existing "Dependency deprecations" section:

- **Symptoms**: a module-level singleton splitting across an import boundary (the preact/styled-components/yjs shape), and a plugin's TypeScript module augmentations vanishing when it and the module it augments resolve to different copies (the fastify shape).
- **Fix**: `npm install && npm dedupe` first (`npm dedupe` hoists most split copies; a plain `npm install` after a lockfile change does not); if a package still resolves separately per workspace after that, declare it directly in the **root** `package.json` — the anchor that is why the root now depends on `preact`, `styled-components`, `fastify` (#728) and `happy-dom` (#675) without any code at the root using them directly, so they are not mistaken for dead entries and removed.
- Points at the two guard tests to verify a fix actually worked.
- The nested-worktree caveat: a worktree inside the main checkout can resolve a hoisted package from the *parent* checkout's `node_modules`, so a green local run does not by itself prove a split is fixed.
- Explains, without acting on it, why the other cross-workspace singletons (`yjs`, `xstate`, `zod`, `jsondiffpatch`, `lodash-es`, `react-icons`) are deliberately left unanchored today — the issue's "optional follow-on" is intentionally out of scope here.

## Testing

Docs-only change; no tests were added, per the TDD exemption for documentation changes in `CONTRIBUTING.md`'s own "Making changes" section. `npm run format`, `npm run lint`, `npm run typecheck`, and `npm run test` (2105 tests) all pass locally and are unaffected by this change.

## Pre-PR review

Four independent reviewer rounds (fresh subagent each round, no session context). Rounds 1–3 each found one minor wording/attribution/formatting nit, all fixed in their own commits:
1. A closing citation said `#729` (self-referential) instead of `#728` for a guard test's origin.
2. A wrapped sentence lost a continuation line's list-item indent because of an awkwardly placed code span — fixed by rewording.
3. "the guard test above" was ambiguous with two guard tests in scope, and only one of them actually applies to a future split of a currently-unanchored package — fixed by naming it explicitly.

Round 4 returned `NO FINDINGS`.

## Risks / breaking changes

None — documentation only.

Closes #729