### PR TITLE
fix(shared-streamwall): bound the page-controlled document.title before it enters the shared state

### DIFF
--- a/packages/streamwall-shared/src/schemas.test.ts
+++ b/packages/streamwall-shared/src/schemas.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest'
 import {
   type ControlCommand,
   MAX_VIEW_IDX,
+  MAX_VIEW_INFO_TITLE_LENGTH,
   type ServerStatus,
   controlCommandMessageSchema,
   controlStateMessageSchema,
@@ -644,6 +645,50 @@ describe('streamwallStateSchema', () => {
     }
     const result = streamwallStateSchema.safeParse(full)
     expect(result.success).toBe(true)
+  })
+
+  // #734: an untrusted stream page controls document.title, which flows
+  // unbounded into a view's info.title. Without a cap, a hostile page can
+  // grow it without limit and push a broadcast state frame over the
+  // uplink's maxPayload, repeatedly dropping the connection.
+  test('rejects a view info title longer than the allowed length', () => {
+    const tooLong = {
+      ...VALID_STATE,
+      views: [
+        {
+          state: 'empty',
+          context: {
+            id: 0,
+            content: { url: 'https://example.com/s', kind: 'video' },
+            info: { title: 'x'.repeat(MAX_VIEW_INFO_TITLE_LENGTH + 1) },
+            pos: null,
+            error: null,
+            volume: 1,
+          },
+        },
+      ],
+    }
+    expect(streamwallStateSchema.safeParse(tooLong).success).toBe(false)
+  })
+
+  test('accepts a view info title at exactly the allowed length', () => {
+    const atLimit = {
+      ...VALID_STATE,
+      views: [
+        {
+          state: 'empty',
+          context: {
+            id: 0,
+            content: { url: 'https://example.com/s', kind: 'video' },
+            info: { title: 'x'.repeat(MAX_VIEW_INFO_TITLE_LENGTH) },
+            pos: null,
+            error: null,
+            volume: 1,
+          },
+        },
+      ],
+    }
+    expect(streamwallStateSchema.safeParse(atLimit).success).toBe(true)
   })
 
   test('rejects a state missing the required streams field', () => {

--- a/packages/streamwall-shared/src/schemas.ts
+++ b/packages/streamwall-shared/src/schemas.ts
@@ -311,8 +311,20 @@ const viewContentSchema = z.object({
   kind: contentKindSchema,
 })
 
+/**
+ * Longest allowed `document.title` reported by a stream page (issue #734).
+ * The page is untrusted and this value crosses into the shared,
+ * server-broadcast state, so it needs the same kind of bound every other
+ * externally-supplied growable string in this file has (e.g.
+ * {@link MAX_LAYOUT_PRESET_NAME_LENGTH}) - otherwise a hostile page can grow
+ * its title without limit and push a `state` frame over the uplink's
+ * `maxPayload`, repeatedly dropping the connection. The preload truncates to
+ * the same length before this ever reaches the wire; this bound is the
+ * server-side backstop in case that truncation is ever bypassed.
+ */
+export const MAX_VIEW_INFO_TITLE_LENGTH = 200
 const contentViewInfoSchema = z.object({
-  title: z.string(),
+  title: z.string().max(MAX_VIEW_INFO_TITLE_LENGTH),
 })
 
 const viewPosSchema = z.object({

--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment happy-dom
+import { MAX_VIEW_INFO_TITLE_LENGTH } from 'streamwall-shared'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const executeJavaScript = vi.fn()
@@ -170,6 +171,79 @@ describe('mediaPreload initial acquireMedia rejection', () => {
     importedMediaApi().reportError('hls-unsupported')
 
     expect(viewErrorCalls()).toHaveLength(1)
+  })
+})
+
+describe('mediaPreload view-info title bound (issue #734)', () => {
+  // Must match INITIAL_TIMEOUT in mediaPreload.ts; not exported since it's an
+  // implementation detail, not part of the module's public surface.
+  const INITIAL_TIMEOUT_MS = 10 * 1000
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.resetModules()
+    invoke.mockClear()
+    send.mockClear()
+    on.mockClear()
+    exposeInMainWorld.mockClear()
+  })
+
+  function viewInfoCalls() {
+    return send.mock.calls.filter(([channel]) => channel === 'view-info')
+  }
+
+  // Resolves view-init with 'video' content, which is what makes main() send
+  // the view-info message containing document.title. Since no <video>
+  // element is ever placed in the document and DOMContentLoaded is never
+  // dispatched, findMedia's own search stays pending until its INITIAL_TIMEOUT
+  // elapses; fully advancing past that here (as the sibling "initial
+  // acquireMedia rejection" describe block above does) settles it and
+  // releases its MutationObserver, rather than leaving it dangling on the
+  // shared happy-dom `document` to affect a later, unrelated test.
+  async function loadWithVideoContent() {
+    invoke.mockResolvedValueOnce({
+      content: { kind: 'video', link: 'https://example.com/stream' },
+      options: {},
+      volume: 1,
+    })
+    await import('./mediaPreload')
+    process.emit('loaded' as never)
+    await vi.advanceTimersByTimeAsync(0)
+  }
+
+  async function settleAcquireMedia() {
+    await vi.advanceTimersByTimeAsync(INITIAL_TIMEOUT_MS)
+  }
+
+  it('truncates a page-controlled document.title before sending it as view-info', async () => {
+    document.title = 'x'.repeat(MAX_VIEW_INFO_TITLE_LENGTH + 300)
+
+    await loadWithVideoContent()
+
+    expect(viewInfoCalls()).toEqual([
+      [
+        'view-info',
+        { info: { title: 'x'.repeat(MAX_VIEW_INFO_TITLE_LENGTH) } },
+      ],
+    ])
+
+    await settleAcquireMedia()
+  })
+
+  it('leaves a title within the limit untouched', async () => {
+    document.title = 'a short stream title'
+
+    await loadWithVideoContent()
+
+    expect(viewInfoCalls()).toEqual([
+      ['view-info', { info: { title: 'a short stream title' } }],
+    ])
+
+    await settleAcquireMedia()
   })
 })
 

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -1,6 +1,9 @@
 import { contextBridge, ipcRenderer, webFrame } from 'electron'
 import { throttle } from 'lodash-es'
-import { ContentDisplayOptions } from 'streamwall-shared'
+import {
+  ContentDisplayOptions,
+  MAX_VIEW_INFO_TITLE_LENGTH,
+} from 'streamwall-shared'
 import { MEDIA_PAUSE_EVENT, MEDIA_RESUME_EVENT } from './mediaParkEvents'
 import { VolumeController } from './volumeController'
 
@@ -692,9 +695,14 @@ async function main() {
       hasReportedMediaError = true
       ipcRenderer.send('view-error', { error })
     })
+    // document.title is fully page-controlled and unbounded; truncate before
+    // it crosses the IPC boundary so an untrusted page cannot grow the
+    // shared, server-broadcast state without limit (issue #734). The schema
+    // (MAX_VIEW_INFO_TITLE_LENGTH, streamwall-shared/src/schemas.ts) enforces
+    // the same bound as a backstop in case this truncation is ever bypassed.
     ipcRenderer.send('view-info', {
       info: {
-        title: document.title,
+        title: document.title.slice(0, MAX_VIEW_INFO_TITLE_LENGTH),
       },
     })
   } else if (content.kind === 'web') {


### PR DESCRIPTION
## Problem
The media preload reported the untrusted remote page's `document.title` into the shared state with no length bound anywhere along the path — not in the preload, not in the state machine, and not in the zod schema. It becomes `views[].context.info.title` in the broadcast `StreamwallState`, which is size-capped on the wire by the control server's `maxPayload`. A hostile stream page setting `document.title` to roughly 2 MB would push the desktop's next `state` frame over that cap, causing the uplink to close and the desktop to reconnect and resend the same oversized snapshot — a persistent denial of the whole remote-control plane from a single untrusted page on the wall.

## Technical solution
- Added `MAX_VIEW_INFO_TITLE_LENGTH = 200` to `streamwall-shared/src/schemas.ts` and bounded `contentViewInfoSchema.title` with `.max(MAX_VIEW_INFO_TITLE_LENGTH)`, matching the pattern already used for other externally-supplied growable strings in that file (e.g. `layoutPresetNameSchema`).
- Truncated `document.title` to that same shared constant in the preload (`mediaPreload.ts`) before it ever crosses the IPC boundary via `ipcRenderer.send('view-info', ...)`, so an honest client never produces an oversized title in the first place. The schema bound is the server-side backstop in case that truncation is ever bypassed.
- `StreamWindow.ts` and `viewStateMachine.ts` (also on the pass-through path per the issue's evidence trail) are left untouched — they only forward/store whatever `info` they're given, and the preload is the only place `document.title` is ever read, so bounding at the source and the schema is sufficient.

## Testing performed
- `schemas.test.ts`: a view info title one character over the limit is rejected by `streamwallStateSchema.safeParse`; one at exactly the limit is accepted.
- `mediaPreload.test.ts`: an over-limit `document.title` is truncated to `MAX_VIEW_INFO_TITLE_LENGTH` before being sent as `view-info`; a short title is left untouched.
- Full quality gate: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (2132 tests) — all green.

## Risks / breaking changes
None functionally. An operator-visible stream title longer than 200 characters will now be visually truncated in the control UI where it's displayed; this is the intended fix, not a regression.

## Pre-PR review
Two independent review rounds by fresh subagents with no session context.
- Round 1: one minor finding — the preload test hardcoded a local `200` constant instead of importing the real `MAX_VIEW_INFO_TITLE_LENGTH` from `streamwall-shared`, risking silent drift if the bound is ever changed. Fixed by importing the shared constant (folded into the existing test commit via fixup + autosquash). The same round also noted, as an explicitly out-of-scope observation, that other page-influenced fields (e.g. `view-error`'s `error` message, several unbounded `url` fields) remain unbounded elsewhere in the schema — filed as follow-up #770 rather than expanding this PR's scope.
- Round 2 (after the fix and a rebase onto a newer `main`): `NO FINDINGS`.

Closes #734

Follow-up: #770 (bound other unbounded page-influenced strings in the schema, out of scope for this fix)