### PR TITLE
fix(control-server): release the uplink slot when the desktop dies during validation

### DIFF
--- a/packages/streamwall-control-server/src/multiplexing.test.ts
+++ b/packages/streamwall-control-server/src/multiplexing.test.ts
@@ -9,7 +9,6 @@ import {
   type ClientStateDeltaMessage,
   type StreamwallState,
 } from 'streamwall-shared'
-import { DEFAULT_SCRYPT_PARAMS } from './auth.ts'
 import {
   bootServerWithUplink,
   isCommandType,
@@ -356,10 +355,33 @@ test('releases the uplink slot when the desktop dies during token validation', a
   // Token validation is an `await` on a real scrypt derivation, so a socket
   // that dies inside that window fires `close` before the route's own close
   // handler exists. The single uplink slot must not stay claimed by that dead
-  // socket (issue #743). Run with the production work factor so the window is
-  // as wide here as it is in production.
-  const { auth, port, logs } = await startTestServer({
-    scryptParams: DEFAULT_SCRYPT_PARAMS,
+  // socket (issue #743).
+  const { app, auth, port, logs } = await startTestServer()
+
+  // Hold the first uplink inside that window deterministically instead of
+  // betting on the production work factor outrunning a TCP reset: the gate
+  // stands in for the derivation's duration, so the spec exercises the race on
+  // any host at the cheap test work factor.
+  const realValidateToken = auth.validateToken.bind(auth)
+  let openValidationGate = () => {}
+  const validationGate = new Promise<void>((resolve) => {
+    openValidationGate = resolve
+  })
+  let gateNextValidation = true
+  auth.validateToken = async (id: string, secret: string) => {
+    const info = await realValidateToken(id, secret)
+    if (gateNextValidation) {
+      gateNextValidation = false
+      await validationGate
+    }
+    return info
+  }
+
+  // Observed on the server's own socket, so the gate opens only once the
+  // uplink's death has actually been delivered to the route's `close`
+  // listener — not merely once the client-side socket reports itself closed.
+  const serverSawClose = new Promise<void>((resolve) => {
+    app.server.once('connection', (socket) => socket.once('close', resolve))
   })
 
   const first = await mintUplinkToken(auth, port)
@@ -369,16 +391,17 @@ test('releases the uplink slot when the desktop dies during token validation', a
   after(() => firstWs.terminate())
   await once(firstWs, 'open')
   firstWs.terminate()
+  await serverSawClose
+  openValidationGate()
 
-  // Wait for the server to have finished handling that connection rather than
-  // sleeping: it either claims the slot or unwinds because the socket is
-  // already gone, and both outcomes are logged.
+  // The server now finishes handling a connection whose socket is already
+  // gone: it either claims the slot (the bug) or unwinds (the fix), and both
+  // outcomes are logged, so there is nothing to sleep for.
   await logs.waitFor(
     (entry) =>
       typeof entry.msg === 'string' &&
       (entry.msg.includes('Streamwall connecting') ||
         entry.msg.includes('closed during authorization')),
-    10000,
   )
 
   const second = await mintUplinkToken(auth, port)
@@ -388,17 +411,23 @@ test('releases the uplink slot when the desktop dies during token validation', a
   after(() => secondWs.terminate())
   const nextMessage = messageCollector(secondWs)
   await once(secondWs, 'open')
+  secondWs.send(JSON.stringify({ type: 'state', state: VALID_STATE }))
 
+  // Whichever comes first decides: a refusal frame, or the server logging the
+  // reconnected uplink as fully connected.
+  const refusal = await Promise.race([
+    nextMessage(5000),
+    logs.waitForMessage('Streamwall connected', 5000).then(() => null),
+  ])
   assert.equal(
-    await nextMessage(1000),
+    refusal,
     null,
     'the reconnecting uplink must not be refused: the slot must have been released',
   )
   assert.equal(secondWs.readyState, WebSocket.OPEN)
-  // Pin the premise: the first socket really did die inside the validation
-  // window. Without this the spec would silently degrade into a no-op should
-  // the race window ever close (a faster host, cheaper scrypt params, or the
-  // `await` moving), because that timeline passes even unfixed.
+  // Guard the premise last, so a genuine regression fails on the assertion
+  // above rather than here: the first uplink really has to have died inside
+  // the validation window for this spec to mean anything.
   assert.ok(
     logs.hasMessage('Streamwall uplink closed during authorization'),
     'the first uplink must have closed while its token was still being validated',

--- a/packages/streamwall-control-server/src/multiplexing.test.ts
+++ b/packages/streamwall-control-server/src/multiplexing.test.ts
@@ -9,6 +9,7 @@ import {
   type ClientStateDeltaMessage,
   type StreamwallState,
 } from 'streamwall-shared'
+import { DEFAULT_SCRYPT_PARAMS } from './auth.ts'
 import {
   bootServerWithUplink,
   isCommandType,
@@ -349,4 +350,49 @@ test('an admin revoking their own session via delete-token closes their own sock
 
   await closed
   assert.equal(adminWs.readyState, WebSocket.CLOSED)
+})
+
+test('releases the uplink slot when the desktop dies during token validation', async () => {
+  // Token validation is an `await` on a real scrypt derivation, so a socket
+  // that dies inside that window fires `close` before the route's own close
+  // handler exists. The single uplink slot must not stay claimed by that dead
+  // socket (issue #743). Run with the production work factor so the window is
+  // as wide here as it is in production.
+  const { auth, port, logs } = await startTestServer({
+    scryptParams: DEFAULT_SCRYPT_PARAMS,
+  })
+
+  const first = await mintUplinkToken(auth, port)
+  const firstWs = new WebSocket(first.base, {
+    headers: { authorization: `Bearer ${first.secret}` },
+  })
+  after(() => firstWs.terminate())
+  await once(firstWs, 'open')
+  firstWs.terminate()
+
+  // Wait for the server to have finished handling that connection rather than
+  // sleeping: it either claims the slot or unwinds because the socket is
+  // already gone, and both outcomes are logged.
+  await logs.waitFor(
+    (entry) =>
+      typeof entry.msg === 'string' &&
+      (entry.msg.includes('Streamwall connecting') ||
+        entry.msg.includes('closed during authorization')),
+    10000,
+  )
+
+  const second = await mintUplinkToken(auth, port)
+  const secondWs = new WebSocket(second.base, {
+    headers: { authorization: `Bearer ${second.secret}` },
+  })
+  after(() => secondWs.terminate())
+  const nextMessage = messageCollector(secondWs)
+  await once(secondWs, 'open')
+
+  assert.equal(
+    await nextMessage(1000),
+    null,
+    'the reconnecting uplink must not be refused: the slot must have been released',
+  )
+  assert.equal(secondWs.readyState, WebSocket.OPEN)
 })

--- a/packages/streamwall-control-server/src/multiplexing.test.ts
+++ b/packages/streamwall-control-server/src/multiplexing.test.ts
@@ -395,4 +395,12 @@ test('releases the uplink slot when the desktop dies during token validation', a
     'the reconnecting uplink must not be refused: the slot must have been released',
   )
   assert.equal(secondWs.readyState, WebSocket.OPEN)
+  // Pin the premise: the first socket really did die inside the validation
+  // window. Without this the spec would silently degrade into a no-op should
+  // the race window ever close (a faster host, cheaper scrypt params, or the
+  // `await` moving), because that timeline passes even unfixed.
+  assert.ok(
+    logs.hasMessage('Streamwall uplink closed during authorization'),
+    'the first uplink must have closed while its token was still being validated',
+  )
 })

--- a/packages/streamwall-control-server/src/multiplexing.test.ts
+++ b/packages/streamwall-control-server/src/multiplexing.test.ts
@@ -424,5 +424,7 @@ test('releases the uplink slot when the desktop dies during token validation', a
     null,
     'the reconnecting uplink must not be refused: the slot must have been released',
   )
+  // Not being refused is only half of it: the reconnect has to complete.
+  await logs.waitForMessage('Streamwall connected')
   assert.equal(secondWs.readyState, WebSocket.OPEN)
 })

--- a/packages/streamwall-control-server/src/multiplexing.test.ts
+++ b/packages/streamwall-control-server/src/multiplexing.test.ts
@@ -425,11 +425,4 @@ test('releases the uplink slot when the desktop dies during token validation', a
     'the reconnecting uplink must not be refused: the slot must have been released',
   )
   assert.equal(secondWs.readyState, WebSocket.OPEN)
-  // Guard the premise last, so a genuine regression fails on the assertion
-  // above rather than here: the first uplink really has to have died inside
-  // the validation window for this spec to mean anything.
-  assert.ok(
-    logs.hasMessage('Streamwall uplink closed during authorization'),
-    'the first uplink must have closed while its token was still being validated',
-  )
 })

--- a/packages/streamwall-control-server/src/ws/uplink.ts
+++ b/packages/streamwall-control-server/src/ws/uplink.ts
@@ -75,8 +75,6 @@ export function registerUplinkRoute(
         return
       }
 
-      ctx.currentStreamwallWs = ws
-
       // Liveness check: without it, a desktop that disappears mid-connection
       // would keep the single uplink slot occupied and block any reconnect.
       const stopHeartbeat = startHeartbeat(
@@ -86,6 +84,10 @@ export function registerUplinkRoute(
         log,
       )
 
+      // Claiming the slot and arming its release stay adjacent and free of any
+      // `await`, so no future statement can slip in between and reintroduce a
+      // narrower version of the window this fix closes.
+      ctx.currentStreamwallWs = ws
       releaseSlot = () => {
         // The slot is released exactly once, no matter how often `close` fires.
         releaseSlot = null

--- a/packages/streamwall-control-server/src/ws/uplink.ts
+++ b/packages/streamwall-control-server/src/ws/uplink.ts
@@ -32,6 +32,19 @@ export function registerUplinkRoute(
       ws.binaryType = 'arraybuffer'
       const handleMessage = queueWebSocketMessages(ws, request.log)
 
+      // Token validation below awaits a real scrypt derivation, so a socket
+      // that dies inside that window fires `close` long before this handler
+      // could be registered further down. Subscribing up front — and only
+      // running the release once the slot has actually been claimed — is what
+      // keeps a flapping desktop from wedging the single uplink slot on a dead
+      // socket forever (issue #743).
+      let closed = false
+      let releaseSlot: (() => void) | null = null
+      ws.on('close', () => {
+        closed = true
+        releaseSlot?.()
+      })
+
       const { id } = request.params
       const token = bearerToken(request.headers.authorization)
 
@@ -49,6 +62,11 @@ export function registerUplinkRoute(
       }
 
       const log = request.log.child(identityFields(tokenInfo))
+
+      if (closed) {
+        log.warn('Streamwall uplink closed during authorization')
+        return
+      }
 
       if (ctx.currentStreamwallWs != null) {
         log.warn('Rejecting Streamwall connection (already connected)')
@@ -68,7 +86,9 @@ export function registerUplinkRoute(
         log,
       )
 
-      ws.on('close', () => {
+      releaseSlot = () => {
+        // The slot is released exactly once, no matter how often `close` fires.
+        releaseSlot = null
         log.info('Streamwall disconnected')
         ctx.currentStreamwallWs = null
         ctx.currentStreamwallConn = null
@@ -77,7 +97,7 @@ export function registerUplinkRoute(
         for (const client of ctx.clients.values()) {
           client.ws.close()
         }
-      })
+      }
 
       let clientState: StateWrapper | null = null
       const stateDoc = new Y.Doc()


### PR DESCRIPTION
## Problem

The desktop uplink route claimed the single uplink slot and only afterwards registered the `close` listener that releases it. Token validation in between is an `await` on a real scrypt derivation (`N=16384`, tens of milliseconds), so a socket that died inside that window had already fired `close` by the time the handler subscribed: the slot stayed set on a dead socket forever.

The result is a control server that bricks itself when a desktop flaps at the wrong moment (lid closed, Wi-Fi handover, crash right after connect): every later uplink is refused with `streamwall already connected`, every operator's browser with `streamwall disconnected`, and nothing short of a restart recovers it.

## Solution

`packages/streamwall-control-server/src/ws/uplink.ts`:

- The `close` listener is now registered before the first `await`, up front, and only sets a `closed` flag plus invokes a nullable `releaseSlot` callback. Until the slot is actually claimed, `releaseSlot` is `null`, so a rejected or unauthorized socket can never release a slot it never took.
- Right after validation the handler bails out when `closed` is already true, logging `Streamwall uplink closed during authorization` — the socket is gone, so no slot is claimed at all.
- `releaseSlot` is armed immediately after the claim, with no statement (and therefore no possible future `await`) in between, and nulls itself before running so repeated `close` events cannot release twice.

## Testing

New regression spec in `multiplexing.test.ts`: it gates `auth.validateToken` behind a promise the test controls, kills the uplink socket while the server sits inside that window, waits for the server's own socket to observe the close, then releases the gate and reconnects a second uplink. The reconnect must not be refused and must complete.

The window is made deterministic by the gate rather than by betting on the production scrypt factor outrunning a TCP reset, so the spec runs at the cheap test work factor and does not sleep. Verified red against `origin/main` (`{ error: 'streamwall already connected' }`) and green with the fix over repeated runs.

Full quality gate green locally: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (2081 tests).

## Risks

None expected: the change is confined to the uplink route's teardown wiring; the connected-uplink behaviour and the "already connected" rejection are unchanged and still covered by their existing specs.

## Pre-PR review

Five rounds with independent reviewers, each with a freshly generated diff and no context from the implementation:

1. The spec accepted either outcome of the race without ever pinning that the race was hit — added a premise guard (later superseded, see 3).
2. The slot claim and the arming of its release were eleven lines apart, an invariant nothing enforced — hoisted `startHeartbeat` so claim and arming are adjacent and provably `await`-free.
3. The premise guard rested on a timing bet (production scrypt vs. TCP reset) and the spec cost a second of wall clock — replaced the timing bet with a gated `validateToken` that makes the window deterministic, dropped the production work factor and the fixed negative wait.
4. Two findings. The redundant premise guard (now guaranteed by construction) was removed. The claim that `/client/ws` has the same race was **dismissed**: probed empirically, `@fastify/websocket` completes the route's `preHandler` before upgrading the socket, so a client socket that dies during the cookie's scrypt derivation never reaches the handler and never registers in `ctx.clients` — no `Client connected` is ever logged and nothing leaks into the registry.
5. The success assertion only proved the absence of a refusal — added an explicit positive assertion that the reconnected uplink completes.

Round six returned `NO FINDINGS`.

Closes #743
