### PR TITLE
fix(streamwall): mute a view while it is parked behind an expansion

### DIFF
--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -614,6 +614,12 @@ function makeReuseTestActor(opts: {
   content: ViewContent | null
   spaces: number[]
   running: boolean
+  /**
+   * Whether the actor is in `displaying` at all. Independent of `running`:
+   * `displaying` also covers `loading` and `error`, which is what
+   * `setListeningView` checks for. Defaults to true.
+   */
+  displaying?: boolean
   desiredAudio?: 'muted' | 'listening' | 'background'
 }) {
   // Mirrors viewStateMachine's `audio` region closely enough for the park
@@ -658,10 +664,9 @@ function makeReuseTestActor(opts: {
       // Accepts both shapes the production code uses: the plain 'displaying'
       // string (setListeningView) and the nested running query (reuse).
       matches: (query: string | { displaying: string }) =>
-        opts.running &&
-        (typeof query === 'string'
-          ? query === 'displaying'
-          : query.displaying === 'running'),
+        typeof query === 'string'
+          ? query === 'displaying' && (opts.displaying ?? true)
+          : opts.running && query.displaying === 'running',
     }),
     send,
     stop,
@@ -1923,9 +1928,11 @@ describe('StreamWindow mutes parked views (issue #740)', () => {
     sw.setListeningView(2)
 
     // The live view is muted as usual, proving the selection was applied at
-    // all -- but the parked one is left alone rather than made audible.
+    // all -- but the parked one is only recorded, never made audible while it
+    // is invisible.
     expect(expanding.send).toHaveBeenCalledWith({ type: 'MUTE' })
     expect(other.send).not.toHaveBeenCalled()
+    expect(sw.parkedAudio.get(2)).toBe('listening')
   })
 
   it('drops the recorded audio state of a parked view when another view is selected', () => {
@@ -1937,6 +1944,7 @@ describe('StreamWindow mutes parked views (issue #740)', () => {
     // come back audible and make two streams play at once.
     sw.setListeningView(1)
     expect(expanding.send).toHaveBeenCalledWith({ type: 'UNMUTE' })
+    expect(sw.parkedAudio.get(2)).toBe('muted')
     other.send.mockClear()
     collapse()
 

--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -151,6 +151,7 @@ function makeStreamWindow(config: StreamWindowConfig) {
   >
   sw.config = config
   sw.parkedViews = new Map()
+  sw.parkedAudio = new Map()
   sw.pauseParkedViews = false
   return sw
 }
@@ -613,6 +614,7 @@ function makeReuseTestActor(opts: {
   content: ViewContent | null
   spaces: number[]
   running: boolean
+  desiredAudio?: 'muted' | 'listening' | 'background'
 }) {
   const send = vi.fn()
   const stop = vi.fn()
@@ -632,6 +634,7 @@ function makeReuseTestActor(opts: {
         id: opts.id,
         content: opts.content,
         pos: { spaces: opts.spaces },
+        desiredAudio: opts.desiredAudio ?? 'muted',
         view,
         win,
         offscreenWin,
@@ -1781,5 +1784,148 @@ describe('StreamWindow.dispose (issue #629)', () => {
     vi.mocked(sw.overlayView.webContents.isDestroyed).mockReturnValue(false)
     devtools({})
     expect(sw.overlayView.webContents.openDevTools).toHaveBeenCalledTimes(1)
+  })
+})
+
+/**
+ * A parked view is completely invisible behind a fullscreen expansion, so it
+ * must also be inaudible -- before #369 the unused views were destroyed, which
+ * silenced them as a side effect (issue #740).
+ */
+describe('StreamWindow mutes parked views (issue #740)', () => {
+  const streamA: ViewContent = { url: 'https://example.com/a', kind: 'video' }
+  const streamB: ViewContent = { url: 'https://example.com/b', kind: 'video' }
+
+  /** Two running views; expanding `streamB` parks the `streamA` one. */
+  function setupExpansion(
+    desiredAudio: 'muted' | 'listening' | 'background' = 'listening',
+  ) {
+    const sw = makeStreamWindow(makeConfig({ cols: 2, rows: 2 }))
+    sw.win = {
+      contentView: { removeChildView: vi.fn() },
+    } as unknown as InstanceType<typeof StreamWindow>['win']
+
+    const expanding = makeReuseTestActor({
+      id: 1,
+      content: streamB,
+      spaces: [1],
+      running: true,
+    })
+    const other = makeReuseTestActor({
+      id: 2,
+      content: streamA,
+      spaces: [0],
+      running: true,
+      desiredAudio,
+    })
+    sw.views = new Map([
+      [1, expanding.actor],
+      [2, other.actor],
+    ])
+    sw.createView = vi.fn()
+
+    const expand = () =>
+      sw.setViews(
+        fullscreenViewContentMap(2, 2, streamB),
+        { byURL: new Map([[streamB.url, {}]]) },
+        { parkUnused: true },
+      )
+    const collapse = () =>
+      sw.setViews(
+        new Map([
+          ['0', streamA],
+          ['1', streamB],
+        ]),
+        {
+          byURL: new Map([
+            [streamA.url, {}],
+            [streamB.url, {}],
+          ]),
+        },
+      )
+
+    return { sw, expanding, other, expand, collapse }
+  }
+
+  it('mutes a view when it is parked, even with pauseParkedViews disabled', () => {
+    const { sw, other, expand } = setupExpansion()
+
+    expand()
+
+    expect(sw.parkedViews.has(2)).toBe(true)
+    expect(other.send).toHaveBeenCalledWith({ type: 'MUTE' })
+  })
+
+  it('silences a background-listening view, which deliberately ignores MUTE', () => {
+    const { other, expand } = setupExpansion('background')
+
+    expand()
+
+    expect(other.send).toHaveBeenCalledWith({ type: 'UNBACKGROUND' })
+  })
+
+  it('restores the pre-park audio state once the view is displayed again', () => {
+    const { other, expand, collapse } = setupExpansion('listening')
+
+    expand()
+    other.send.mockClear()
+    collapse()
+
+    expect(other.send).toHaveBeenCalledWith({ type: 'UNMUTE' })
+  })
+
+  it('restores background listening once the view is displayed again', () => {
+    const { other, expand, collapse } = setupExpansion('background')
+
+    expand()
+    other.send.mockClear()
+    collapse()
+
+    expect(other.send).toHaveBeenCalledWith({ type: 'BACKGROUND' })
+  })
+
+  it('leaves an already-muted view muted on collapse', () => {
+    const { other, expand, collapse } = setupExpansion('muted')
+
+    expand()
+    other.send.mockClear()
+    collapse()
+
+    expect(other.send).not.toHaveBeenCalledWith({ type: 'UNMUTE' })
+    expect(other.send).not.toHaveBeenCalledWith({ type: 'BACKGROUND' })
+  })
+
+  it('never unmutes a parked view when it is selected as the listening view', () => {
+    const { sw, other, expand } = setupExpansion('muted')
+    expand()
+    other.send.mockClear()
+
+    sw.setListeningView(2)
+
+    expect(other.send).not.toHaveBeenCalled()
+  })
+
+  it('drops the recorded audio state of a parked view when another view is selected', () => {
+    const { sw, other, expand, collapse } = setupExpansion('listening')
+    expand()
+
+    // The operator picks the expanded view instead: the parked one must not
+    // come back audible and make two streams play at once.
+    sw.setListeningView(1)
+    other.send.mockClear()
+    collapse()
+
+    expect(other.send).not.toHaveBeenCalledWith({ type: 'UNMUTE' })
+  })
+
+  it('applies a listen selection made while the view was parked on collapse', () => {
+    const { sw, other, expand, collapse } = setupExpansion('muted')
+    expand()
+
+    sw.setListeningView(2)
+    other.send.mockClear()
+    collapse()
+
+    expect(other.send).toHaveBeenCalledWith({ type: 'UNMUTE' })
   })
 })

--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -616,7 +616,21 @@ function makeReuseTestActor(opts: {
   running: boolean
   desiredAudio?: 'muted' | 'listening' | 'background'
 }) {
-  const send = vi.fn()
+  // Mirrors viewStateMachine's `audio` region closely enough for the park
+  // tests: every audio event updates `desiredAudio`, except MUTE while
+  // background-listening, which that state deliberately ignores.
+  let desiredAudio = opts.desiredAudio ?? 'muted'
+  const send = vi.fn((event: { type: string }) => {
+    if (event.type === 'UNMUTE') {
+      desiredAudio = 'listening'
+    } else if (event.type === 'BACKGROUND') {
+      desiredAudio = 'background'
+    } else if (event.type === 'UNBACKGROUND') {
+      desiredAudio = 'muted'
+    } else if (event.type === 'MUTE' && desiredAudio !== 'background') {
+      desiredAudio = 'muted'
+    }
+  })
   const stop = vi.fn()
   const disposeView = vi.fn()
   const setBounds = vi.fn()
@@ -634,15 +648,20 @@ function makeReuseTestActor(opts: {
         id: opts.id,
         content: opts.content,
         pos: { spaces: opts.spaces },
-        desiredAudio: opts.desiredAudio ?? 'muted',
+        desiredAudio,
         view,
         win,
         offscreenWin,
         next: null,
         disposeView,
       },
-      matches: (query: { displaying: string }) =>
-        opts.running && query.displaying === 'running',
+      // Accepts both shapes the production code uses: the plain 'displaying'
+      // string (setListeningView) and the nested running query (reuse).
+      matches: (query: string | { displaying: string }) =>
+        opts.running &&
+        (typeof query === 'string'
+          ? query === 'displaying'
+          : query.displaying === 'running'),
     }),
     send,
     stop,
@@ -1896,26 +1915,60 @@ describe('StreamWindow mutes parked views (issue #740)', () => {
   })
 
   it('never unmutes a parked view when it is selected as the listening view', () => {
-    const { sw, other, expand } = setupExpansion('muted')
+    const { sw, expanding, other, expand } = setupExpansion('muted')
     expand()
+    expanding.send.mockClear()
     other.send.mockClear()
 
     sw.setListeningView(2)
 
+    // The live view is muted as usual, proving the selection was applied at
+    // all -- but the parked one is left alone rather than made audible.
+    expect(expanding.send).toHaveBeenCalledWith({ type: 'MUTE' })
     expect(other.send).not.toHaveBeenCalled()
   })
 
   it('drops the recorded audio state of a parked view when another view is selected', () => {
-    const { sw, other, expand, collapse } = setupExpansion('listening')
+    const { sw, expanding, other, expand, collapse } =
+      setupExpansion('listening')
     expand()
 
     // The operator picks the expanded view instead: the parked one must not
     // come back audible and make two streams play at once.
     sw.setListeningView(1)
+    expect(expanding.send).toHaveBeenCalledWith({ type: 'UNMUTE' })
     other.send.mockClear()
     collapse()
 
     expect(other.send).not.toHaveBeenCalledWith({ type: 'UNMUTE' })
+  })
+
+  // Any state-doc change while an expansion is active re-runs `setViews` with
+  // `parkUnused`, so an already-parked view is parked again -- by which point
+  // its own `desiredAudio` is the muted state the first park imposed, and
+  // re-deriving the restore state from it would strand the view muted for
+  // good.
+  it('keeps the recorded audio state when the expansion is re-applied while parked', () => {
+    const { other, expand, collapse } = setupExpansion('listening')
+
+    expand()
+    expand()
+    other.send.mockClear()
+    collapse()
+
+    expect(other.send).toHaveBeenCalledWith({ type: 'UNMUTE' })
+  })
+
+  it('keeps a listen selection made while parked across a re-applied expansion', () => {
+    const { sw, other, expand, collapse } = setupExpansion('muted')
+
+    expand()
+    sw.setListeningView(2)
+    expand()
+    other.send.mockClear()
+    collapse()
+
+    expect(other.send).toHaveBeenCalledWith({ type: 'UNMUTE' })
   })
 
   it('applies a listen selection made while the view was parked on collapse', () => {

--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -1967,6 +1967,17 @@ describe('StreamWindow mutes parked views (issue #740)', () => {
     expect(other.send).toHaveBeenCalledWith({ type: 'UNMUTE' })
   })
 
+  it('keeps background listening recorded across a re-applied expansion', () => {
+    const { other, expand, collapse } = setupExpansion('background')
+
+    expand()
+    expand()
+    other.send.mockClear()
+    collapse()
+
+    expect(other.send).toHaveBeenCalledWith({ type: 'BACKGROUND' })
+  })
+
   it('keeps a listen selection made while parked across a re-applied expansion', () => {
     const { sw, other, expand, collapse } = setupExpansion('muted')
 

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -452,9 +452,11 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
    * from scratch (issue #369). Mirrors `viewStateMachine`'s `offscreenView`
    * action, which the actor itself uses while a fresh view is loading.
    */
-  private hideView(actor: ViewActor) {
-    const { id, view, win, offscreenWin, desiredAudio } =
-      actor.getSnapshot().context
+  private hideView(
+    actor: ViewActor,
+    previouslyParkedAudio: Map<ViewId, DesiredAudio>,
+  ) {
+    const { id, view, win, offscreenWin } = actor.getSnapshot().context
     win.contentView.removeChildView(view)
     offscreenWin.contentView.addChildView(view)
     const { width, height } = offscreenWin.getBounds()
@@ -465,10 +467,19 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
     // (and, once another tile is selected to listen to, cannot silence) keeps
     // playing over the expansion (issue #740). Unmuting is deferred until the
     // view is displayed again -- see `displayPlannedViews`.
+    //
+    // The state to restore comes from the previous park whenever there was
+    // one: every state-doc change during an expansion re-runs `setViews` with
+    // `parkUnused`, re-parking an already-parked view, and by then its own
+    // `desiredAudio` is the muted state the first park imposed -- re-deriving
+    // from it would strand the view silent for good.
+    const desiredAudio =
+      previouslyParkedAudio.get(id) ?? actor.getSnapshot().context.desiredAudio
     this.parkedAudio.set(id, desiredAudio)
     // `background` is the "keep listening even when another tile is selected"
     // mode and deliberately ignores MUTE (see viewStateMachine's `audio`
-    // region), so silencing it takes UNBACKGROUND.
+    // region), so silencing it takes UNBACKGROUND. Both are idempotent, so a
+    // repeated park is harmless.
     actor.send({
       type: desiredAudio === 'background' ? 'UNBACKGROUND' : 'MUTE',
     })
@@ -643,10 +654,14 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
    * either parked (kept alive but hidden, see `hideView` and the
    * `parkedViews` field) or stopped and fully disposed.
    */
-  private retireUnusedViews(unusedViews: Set<ViewActor>, parkUnused: boolean) {
+  private retireUnusedViews(
+    unusedViews: Set<ViewActor>,
+    parkUnused: boolean,
+    previouslyParkedAudio: Map<ViewId, DesiredAudio>,
+  ) {
     for (const view of unusedViews) {
       if (parkUnused) {
-        this.hideView(view)
+        this.hideView(view, previouslyParkedAudio)
         this.parkedViews.set(view.getSnapshot().context.id, view)
         continue
       }
@@ -701,7 +716,7 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
       previouslyParkedAudio,
       unusedViews,
     )
-    this.retireUnusedViews(unusedViews, parkUnused)
+    this.retireUnusedViews(unusedViews, parkUnused, previouslyParkedAudio)
     this.views = newViews
     this.emitState()
   }

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -33,6 +33,7 @@ import viewStateMachine, {
   DEFAULT_RETRY_CONFIG,
   RetryConfig,
   ViewActor,
+  type DesiredAudio,
 } from './viewStateMachine'
 import { resolveWindowPlacement } from './windowPlacement'
 
@@ -77,6 +78,13 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
   // when called with `{ parkUnused: true }`; cleared and re-considered as
   // reuse candidates on every subsequent `setViews` call.
   parkedViews: Map<ViewId, ViewActor>
+  // The audio state each parked view had when it was parked, to be restored
+  // once it is displayed again. A parked view is invisible, so it is always
+  // silenced while hidden (issue #740); this is the desire to put back, kept
+  // up to date by `setListeningView` so a selection made during the expansion
+  // wins over the pre-park state. Keyed and cleared exactly like
+  // `parkedViews`.
+  parkedAudio: Map<ViewId, DesiredAudio>
   // Routes IPC messages from a specific WebContentsView back to whichever
   // actor owns it. Keyed by live `webContents.id`, unlike `views` (keyed by
   // each actor's stable `context.id`, fixed at creation): once a content swap
@@ -103,6 +111,7 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
     this.pauseParkedViews = pauseParkedViews
     this.views = new Map()
     this.parkedViews = new Map()
+    this.parkedAudio = new Map()
     this.viewsByWebContentsId = new Map()
 
     // Sequenced setup: the window must exist before the layer views can be
@@ -444,11 +453,25 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
    * action, which the actor itself uses while a fresh view is loading.
    */
   private hideView(actor: ViewActor) {
-    const { view, win, offscreenWin } = actor.getSnapshot().context
+    const { id, view, win, offscreenWin, desiredAudio } =
+      actor.getSnapshot().context
     win.contentView.removeChildView(view)
     offscreenWin.contentView.addChildView(view)
     const { width, height } = offscreenWin.getBounds()
     view.setBounds({ x: 0, y: 0, width, height })
+    // A parked view is entirely invisible, so it must be inaudible too:
+    // before #369 these views were destroyed, which silenced them as a side
+    // effect, and leaving one audible means a stream the operator cannot see
+    // (and, once another tile is selected to listen to, cannot silence) keeps
+    // playing over the expansion (issue #740). Unmuting is deferred until the
+    // view is displayed again -- see `displayPlannedViews`.
+    this.parkedAudio.set(id, desiredAudio)
+    // `background` is the "keep listening even when another tile is selected"
+    // mode and deliberately ignores MUTE (see viewStateMachine's `audio`
+    // region), so silencing it takes UNBACKGROUND.
+    actor.send({
+      type: desiredAudio === 'background' ? 'UNBACKGROUND' : 'MUTE',
+    })
     if (this.pauseParkedViews) {
       actor.send({ type: 'PAUSE' })
     }
@@ -569,7 +592,7 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
   private displayPlannedViews(
     viewsToDisplay: Array<{ box: LayoutBox; view: ViewActor }>,
     streams: StreamList,
-    previouslyParkedIds: Set<ViewId>,
+    previouslyParkedAudio: Map<ViewId, DesiredAudio>,
     unusedViews: Set<ViewActor>,
   ): Map<ViewId, ViewActor> {
     const { width, height, cols, rows } = this.config
@@ -595,8 +618,20 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
       view.send({ type: 'DISPLAY', pos, content })
       view.send({ type: 'OPTIONS', options: getDisplayOptions(stream) })
       const viewId = view.getSnapshot().context.id
-      if (this.pauseParkedViews && previouslyParkedIds.has(viewId)) {
-        view.send({ type: 'RESUME' })
+      if (previouslyParkedAudio.has(viewId)) {
+        // Un-parking: put back the audio state the view had when it was
+        // parked, or whichever one was selected for it in the meantime
+        // (issue #740). Nothing to send for `muted` -- parking already left
+        // it that way.
+        const desiredAudio = previouslyParkedAudio.get(viewId)
+        if (desiredAudio === 'listening') {
+          view.send({ type: 'UNMUTE' })
+        } else if (desiredAudio === 'background') {
+          view.send({ type: 'BACKGROUND' })
+        }
+        if (this.pauseParkedViews) {
+          view.send({ type: 'RESUME' })
+        }
       }
       newViews.set(viewId, view)
     }
@@ -641,15 +676,18 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
     const { cols, rows } = this.config
     const boxes = boxesFromViewContentMap(cols, rows, viewContentMap)
 
-    // Snapshot which actor ids were parked coming into this call, so a view
-    // matched back into a box below can be told to resume playback (issue
-    // #374) -- `this.parkedViews` itself is cleared right after and
-    // repopulated with whatever is still unused once this call is done.
-    const previouslyParkedIds = new Set(this.parkedViews.keys())
+    // Snapshot which actors were parked coming into this call, along with the
+    // audio state to restore for them, so a view matched back into a box below
+    // can be told to resume playback (issue #374) and to become audible again
+    // (issue #740). `this.parkedViews`/`this.parkedAudio` themselves are
+    // cleared right after and repopulated with whatever is still unused once
+    // this call is done.
+    const previouslyParkedAudio = new Map(this.parkedAudio)
 
     // Decide reuse vs. teardown vs. creation up front, then just execute it.
     const plan = planViewLayout(boxes, this.reuseCandidates())
     this.parkedViews.clear()
+    this.parkedAudio.clear()
 
     const unusedViews = new Set(plan.unusedViews)
     const viewsToDisplay = [
@@ -660,7 +698,7 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
     const newViews = this.displayPlannedViews(
       viewsToDisplay,
       streams,
-      previouslyParkedIds,
+      previouslyParkedAudio,
       unusedViews,
     )
     this.retireUnusedViews(unusedViews, parkUnused)
@@ -680,6 +718,20 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
       }
       const isSelectedView = viewId != null && id === viewId
       view.send({ type: isSelectedView ? 'UNMUTE' : 'MUTE' })
+    }
+    // Parked views are hidden behind a fullscreen expansion and stay silent
+    // for as long as they are (issue #740), so a selection cannot reach them
+    // now -- record it instead, and `displayPlannedViews` applies it when the
+    // view comes back. A `background` view keeps that mode here for the same
+    // reason its live counterpart above ignores MUTE.
+    for (const [id, desiredAudio] of this.parkedAudio) {
+      if (desiredAudio === 'background') {
+        continue
+      }
+      this.parkedAudio.set(
+        id,
+        viewId != null && id === viewId ? 'listening' : 'muted',
+      )
     }
   }
 

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -74,6 +74,14 @@ function retryBackoffMs(retry: RetryConfig, retryCount: number): number {
 export const STALLED_ERROR_MESSAGE = 'Stream stalled'
 
 /**
+ * The audio mode most recently requested for a view: silent, the one tile the
+ * operator is listening to, or audible alongside the selected tile. Mirrored
+ * in `context.desiredAudio` so a request made while the view is not running is
+ * applied once it is.
+ */
+export type DesiredAudio = 'muted' | 'listening' | 'background'
+
+/**
  * Turns an arbitrary thrown value into a short, serializable reason that can be
  * shown on the wall overlay and in the control UI.
  */
@@ -141,7 +149,7 @@ const viewStateMachine = setup({
       // view. Tracked independent of `displaying.running.audio` so a request
       // made while the view is still loading (or recovering from an error) is
       // applied as soon as `running` is (re-)entered instead of being dropped.
-      desiredAudio: 'muted' | 'listening' | 'background'
+      desiredAudio: DesiredAudio
       // Same idea as `desiredAudio`, for BLUR/UNBLUR.
       desiredBlurred: boolean
       // Same idea as `desiredAudio`, for PAUSE/RESUME: whether this view's


### PR DESCRIPTION
## Summary

`hideView` parked a view on an offscreen host window and, only with the opt-in
`--park.pause`, sent `PAUSE`. It never muted it. With the default configuration
(which is how #374 shipped) a stream the operator was listening to therefore
kept playing its audio from a completely hidden window for the whole duration of
a fullscreen expansion — and selecting a new listening view on the expanded tile
unmuted that one *in addition*, so two streams were audible at once with no UI
affordance to silence the invisible one. `setListeningView` iterates
`this.views`, and parked actors live in the separate `parkedViews` map, so no
later listen change could reach them either. Before #369 the unused views were
destroyed, which silenced them as a side effect; this restores that property.

Parking now always silences the view and records the audio state to restore:

- `hideView` sends `MUTE` — or `UNBACKGROUND` for a background-listening view,
  which deliberately ignores `MUTE` (see the `audio` region's
  `background: { on: { MUTE: {} } }`).
- `displayPlannedViews` puts the recorded state back when the view is displayed
  again, alongside the existing `RESUME`.
- `setListeningView` updates the recorded state for parked views instead of
  sending them events, so a selection made during the expansion wins over the
  pre-park one and exactly one stream is audible on collapse.

Closes #740

## Technical notes

- The state to restore lives in a new `parkedAudio` map, kept in lock-step with
  `parkedViews` (same key, populated in `hideView`, cleared together at the top
  of `setViews`). It replaces the `previouslyParkedIds` set that already existed
  for the `RESUME` on un-park, since its keys are exactly the same.
- `hideView` prefers the *previously recorded* state over the actor's live
  `desiredAudio`. Every state-doc change while an expansion is active re-runs
  `setViews({ parkUnused: true })`, so an already-parked view is parked again —
  by which point its own `desiredAudio` is the muted state the first park
  imposed, and re-deriving from it would strand the view silent for good.
- `desiredAudio`'s inline union in the machine context is now the exported
  `DesiredAudio` type, so `StreamWindow` and the machine cannot drift apart.
- No state regions changed, so `viewStateValueSchema` in `streamwall-shared` is
  unaffected.

## How was this tested?

Ten new cases in `packages/streamwall/src/main/StreamWindow.test.ts` covering:
mute on park with `pauseParkedViews` off; silencing a background-listening view;
restoring `listening` and `background` on collapse; leaving a muted view muted; a
parked view never being unmuted when selected (asserted on the recorded state, so
the case is falsifiable); a selection of another view dropping the parked view's
recorded audio; a selection made while parked being applied on collapse; and
three repeat-park cases (`listening`, `background`, and a selection made while
parked) that pin the clobbering described above.

The test double for a view actor now tracks `desiredAudio` the way the machine's
`audio` region does — including `background` ignoring `MUTE` — and answers
`matches('displaying')` independently of `running`, so these paths are exercised
faithfully rather than against a frozen snapshot.

Locally: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test`
(2130 tests across 6 suites) all pass.

## Pre-PR review

Three rounds with independent reviewers that had none of the implementing
session's context.

- Round 1 found a blocker: `hideView` re-derived the state to restore from the
  actor's live `desiredAudio`, so a repeat park (which happens on every state-doc
  change during an expansion) overwrote the recorded `listening`/`background`
  with the muted state the first park had imposed, stranding the view silent on
  collapse. Fixed in `4fef4aa`, with two regression tests and a faithful test
  double.
- Round 2 found two minors: one new test was not falsifiable, and the test
  double conflated `displaying` with `running`. Both fixed in `c60056f`.
- Round 3 returned no blockers and one optional coverage suggestion (a repeat
  park of a background-listening view), added in the final commit.

## Follow-ups

- #774 — `main() startup sequence` in `index.test.ts` intermittently times out
  under full-suite load. Pre-existing and unrelated to this change; observed
  twice while working on this issue.

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests (or this PR explains why none apply)
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments
