### PR TITLE
test(streamwall): raise timeouts on the flaky bootstrap-order test

### DIFF
--- a/packages/streamwall/src/main/index.test.ts
+++ b/packages/streamwall/src/main/index.test.ts
@@ -242,13 +242,30 @@ describe('main() startup sequence', () => {
       .spyOn(process, 'exit')
       .mockImplementation((() => undefined) as never)
 
+    // Unlike every other mock in this file, `./index` itself is imported
+    // for real (see the file-level comment above): its on-demand
+    // transform pulls in ~20 real modules (yjs, StreamdelayClient, the
+    // real `cliArgs`/`data` branches left in place by their partial
+    // mocks, etc.), none of which are pre-bundled since the import only
+    // happens when this test runs. That transform cost is a few hundred
+    // ms in isolation but scales with CPU contention, not with anything
+    // this test controls, so it can blow past Vitest's 5s default test
+    // timeout when many worktrees/suites run in parallel (issue #769)
+    // even though nothing here is actually hung. Raise both the test and
+    // the `vi.waitFor` timeouts well above the observed baseline instead
+    // of racing the default.
     await import('./index')
 
-    await vi.waitFor(() => {
-      expect(mocks.bootstrap.createDataSourceHealthReporter).toHaveBeenCalled()
-    })
+    await vi.waitFor(
+      () => {
+        expect(
+          mocks.bootstrap.createDataSourceHealthReporter,
+        ).toHaveBeenCalled()
+      },
+      { timeout: 15_000 },
+    )
 
     expect(exitSpy).not.toHaveBeenCalled()
     expect(actualPhaseOrder()).toEqual(EXPECTED_PHASE_ORDER)
-  })
+  }, 20_000)
 })


### PR DESCRIPTION
## Problem

`src/main/index.test.ts > main() startup sequence > invokes the bootstrap phases in the documented order` occasionally fails with `Error: Test timed out in 5000ms.` under heavy parallel load, then passes cleanly on an immediate rerun (#769).

## Root cause

Unlike every other collaborator in this test file, `./index` is imported for real via `await import('./index')` — that's the whole point of the test (it asserts the real entry module's bootstrap call order). That dynamic import triggers an on-demand transform of the real module graph it pulls in: `yjs`, `StreamdelayClient`, and the real branches of `./cliArgs` and `./data` (both partially mocked via `importOriginal`, so their actual exports still run/transform), none of which are pre-bundled ahead of time.

Measured locally with temporary timing instrumentation (removed before commit):
- `await import('./index')` alone took ~775ms in one run and ~2612ms for the whole test in another, on an otherwise idle machine.
- Once the import resolves, `vi.waitFor(...)` resolves in ~1ms — `main()`'s mocked bootstrap chain is effectively synchronous, so the callback under test fires almost immediately.

The bottleneck is entirely the transform cost of the real dynamic import, which scales with CPU contention from other concurrent processes (this repo is routinely worked in many parallel git worktrees) rather than with anything the test itself controls. That is close enough to Vitest's 5s default test timeout that it can occasionally tip over under load, even though nothing is actually hung — matching the issue's own analysis (the failure surfaced at the `afterEach` line, i.e. mid-teardown, not inside the test body).

## Fix

- Gave the test itself an explicit 20000ms timeout (up from the 5000ms default) as the third argument to `it(...)`.
- Gave the `vi.waitFor(...)` call an explicit `{ timeout: 15_000 }` (up from its 1000ms default), so it isn't independently squeezed even though it wasn't the observed bottleneck in isolation.
- Added a comment above the import explaining exactly why the real import is expensive and CPU-contention-sensitive, so a future reader doesn't mistake the headroom for masking a real hang.

No mocking was added to avoid the real import, since exercising the real entry module against its real (non-mocked) leaf dependencies is the test's explicit purpose (see the file's existing top-of-file comment referencing issue #598).

## Testing performed

- `npx vitest run src/main/index.test.ts --reporter=verbose` before the fix: ~780ms–2.6s per run depending on machine load (confirms the timing budget is tight, not the failure itself — I was not able to force a real timeout locally).
- Same command after the fix: passes consistently (~2s).
- Full package suite: `npx vitest run` — 72 test files, 981 tests, all passing.
- `npx prettier --check`, `npx eslint`, `npx tsc --noEmit -p tsconfig.json` all clean on the changed file.

No new test was added for the timeout increase itself (there is no independently-testable behavior beyond "does this reduce flakiness under load", which cannot be asserted deterministically) — the existing test's assertions (bootstrap phase order, no process.exit) are untouched and still fail without the fix's underlying behavior.

## Architecture decisions

- Left `./index`'s real import in place rather than mocking more of its dependency graph, since that would defeat the test's purpose of validating the real entry module.
- Did not touch `src/main/index.ts` or `src/main/bootstrap.ts` — out of scope for this issue, and another concurrent change touches those files.

## Risks / breaking changes

None. Test-only change; no production code modified. Worst case, a genuinely hung bootstrap now takes up to 20s to fail instead of 5s — an acceptable trade-off for eliminating false-positive flakes.

## Pre-PR review

Two independent reviewer rounds (fresh subagent per round, no shared context):
- Round 1: one minor finding — the added comment inaccurately claimed "ControlWindow's real collaborators" contributed to the import cost, when `./ControlWindow` is fully mocked in this file. Fixed by rewording the comment to cite the real `cliArgs`/`data` branches (both use `importOriginal` and spread in real exports) instead.
- Round 2: `NO FINDINGS`.

No findings were dismissed as invalid.

Closes #769