### PR TITLE
fix(shared-streamwall): bound the remaining page-influenced strings in the shared state schema

### DIFF
--- a/packages/streamwall-shared/src/schemas.test.ts
+++ b/packages/streamwall-shared/src/schemas.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'vitest'
 import {
   type ControlCommand,
+  MAX_URL_LENGTH,
+  MAX_VIEW_ERROR_LENGTH,
   MAX_VIEW_IDX,
   MAX_VIEW_INFO_TITLE_LENGTH,
   type ServerStatus,
@@ -355,6 +357,41 @@ describe('controlCommandMessageSchema', () => {
     ).toBe(false)
   })
 
+  // Issue #770: command `url` fields ultimately originate from operator
+  // input, but were unbounded, the same class of gap #734 fixed for
+  // document.title. 2048 (MAX_URL_LENGTH) mirrors common browser URL limits.
+  describe.each([
+    { type: 'rotate-stream', extra: { rotation: 0 } },
+    {
+      type: 'update-custom-stream',
+      extra: { data: { link: 'x', kind: 'video' } },
+    },
+    { type: 'delete-custom-stream', extra: {} },
+    { type: 'browse', extra: {} },
+  ])('bounds the url field on $type', ({ type, extra }) => {
+    test('rejects a url longer than the allowed length', () => {
+      expect(
+        controlCommandMessageSchema.safeParse({
+          id: 1,
+          type,
+          url: 'x'.repeat(MAX_URL_LENGTH + 1),
+          ...extra,
+        }).success,
+      ).toBe(false)
+    })
+
+    test('accepts a url at exactly the allowed length', () => {
+      expect(
+        controlCommandMessageSchema.safeParse({
+          id: 1,
+          type,
+          url: 'x'.repeat(MAX_URL_LENGTH),
+          ...extra,
+        }).success,
+      ).toBe(true)
+    })
+  })
+
   test('accepts create-invite with a known role', () => {
     expect(
       controlCommandMessageSchema.safeParse({
@@ -518,6 +555,31 @@ describe('controlCommandMessageSchema', () => {
       }).success,
     ).toBe(false)
   })
+
+  describe.each(['add-favorite', 'remove-favorite'] as const)(
+    'bounds the url field on %s',
+    (type) => {
+      test('rejects a url longer than the allowed length', () => {
+        expect(
+          controlCommandMessageSchema.safeParse({
+            id: 1,
+            type,
+            url: 'x'.repeat(MAX_URL_LENGTH + 1),
+          }).success,
+        ).toBe(false)
+      })
+
+      test('accepts a url at exactly the allowed length', () => {
+        expect(
+          controlCommandMessageSchema.safeParse({
+            id: 1,
+            type,
+            url: 'x'.repeat(MAX_URL_LENGTH),
+          }).success,
+        ).toBe(true)
+      })
+    },
+  )
 
   test('parsed commands remain assignable to the ControlCommand type', () => {
     const result = controlCommandMessageSchema.safeParse({
@@ -683,6 +745,94 @@ describe('streamwallStateSchema', () => {
             info: { title: 'x'.repeat(MAX_VIEW_INFO_TITLE_LENGTH) },
             pos: null,
             error: null,
+            volume: 1,
+          },
+        },
+      ],
+    }
+    expect(streamwallStateSchema.safeParse(atLimit).success).toBe(true)
+  })
+
+  // Issue #770: a view's displayed content `url` is re-broadcast on every
+  // state update, the same class of gap #734 fixed for the info.title field.
+  test('rejects a view content url longer than the allowed length', () => {
+    const tooLong = {
+      ...VALID_STATE,
+      views: [
+        {
+          state: 'empty',
+          context: {
+            id: 0,
+            content: {
+              url: 'https://example.com/' + 'x'.repeat(MAX_URL_LENGTH),
+              kind: 'video',
+            },
+            info: null,
+            pos: null,
+            error: null,
+            volume: 1,
+          },
+        },
+      ],
+    }
+    expect(streamwallStateSchema.safeParse(tooLong).success).toBe(false)
+  })
+
+  test('accepts a view content url at exactly the allowed length', () => {
+    const atLimit = {
+      ...VALID_STATE,
+      views: [
+        {
+          state: 'empty',
+          context: {
+            id: 0,
+            content: { url: 'x'.repeat(MAX_URL_LENGTH), kind: 'video' },
+            info: null,
+            pos: null,
+            error: null,
+            volume: 1,
+          },
+        },
+      ],
+    }
+    expect(streamwallStateSchema.safeParse(atLimit).success).toBe(true)
+  })
+
+  // Issue #770: a view's `error` reason can wrap a rejection derived from
+  // page-supplied content; it flows into the broadcast state, the same
+  // class of gap #734 fixed for the info.title field.
+  test('rejects a view error reason longer than the allowed length', () => {
+    const tooLong = {
+      ...VALID_STATE,
+      views: [
+        {
+          state: 'empty',
+          context: {
+            id: 0,
+            content: { url: 'https://example.com/s', kind: 'video' },
+            info: null,
+            pos: null,
+            error: 'x'.repeat(MAX_VIEW_ERROR_LENGTH + 1),
+            volume: 1,
+          },
+        },
+      ],
+    }
+    expect(streamwallStateSchema.safeParse(tooLong).success).toBe(false)
+  })
+
+  test('accepts a view error reason at exactly the allowed length', () => {
+    const atLimit = {
+      ...VALID_STATE,
+      views: [
+        {
+          state: 'empty',
+          context: {
+            id: 0,
+            content: { url: 'https://example.com/s', kind: 'video' },
+            info: null,
+            pos: null,
+            error: 'x'.repeat(MAX_VIEW_ERROR_LENGTH),
             volume: 1,
           },
         },

--- a/packages/streamwall-shared/src/schemas.ts
+++ b/packages/streamwall-shared/src/schemas.ts
@@ -75,6 +75,22 @@ const layoutPresetNameSchema = z
   .max(MAX_LAYOUT_PRESET_NAME_LENGTH)
 const layoutPresetIdSchema = z.string().min(1).max(100)
 
+/**
+ * Longest allowed URL anywhere it crosses a trust boundary: a control command
+ * argument (`rotate-stream`, `update-custom-stream`, `delete-custom-stream`,
+ * `browse`, `add-favorite`, `remove-favorite`) or a view's displayed content
+ * URL in the broadcast `StreamwallState` (issue #770, following up on #734).
+ * These ultimately originate from operator input or a data source, both of
+ * which are untrusted, and the content URL in particular is re-broadcast on
+ * every state update - an unbounded value could grow a `state` frame past
+ * the uplink's `maxPayload`, the same denial-of-service loop #734 fixed for
+ * `document.title`. 2048 mirrors the URL length browsers themselves treat as
+ * a practical limit, generous enough for any real stream or page URL.
+ */
+export const MAX_URL_LENGTH = 2048
+const urlSchema = z.string().max(MAX_URL_LENGTH)
+const nonEmptyUrlSchema = z.string().min(1).max(MAX_URL_LENGTH)
+
 /** Optional descriptive fields shared by every stream-data shape. */
 const streamMetaFields = {
   label: z.string().optional(),
@@ -170,17 +186,17 @@ export const controlCommandSchema = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal('rotate-stream'),
-    url: z.string(),
+    url: urlSchema,
     rotation: rotationSchema,
   }),
   z.object({
     type: z.literal('update-custom-stream'),
-    url: z.string(),
+    url: urlSchema,
     data: localStreamDataSchema,
   }),
   z.object({
     type: z.literal('delete-custom-stream'),
-    url: z.string(),
+    url: urlSchema,
   }),
   z.object({
     type: z.literal('reload-view'),
@@ -193,7 +209,7 @@ export const controlCommandSchema = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal('browse'),
-    url: z.string(),
+    url: urlSchema,
   }),
   z.object({
     type: z.literal('dev-tools'),
@@ -235,11 +251,11 @@ export const controlCommandSchema = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal('add-favorite'),
-    url: z.string().min(1),
+    url: nonEmptyUrlSchema,
   }),
   z.object({
     type: z.literal('remove-favorite'),
-    url: z.string().min(1),
+    url: nonEmptyUrlSchema,
   }),
 ])
 
@@ -307,7 +323,7 @@ const streamDataSchema = localStreamDataSchema.extend({
 })
 
 const viewContentSchema = z.object({
-  url: z.string(),
+  url: urlSchema,
   kind: contentKindSchema,
 })
 
@@ -377,6 +393,21 @@ export const viewStateValueSchema = z.union([
   }),
 ])
 
+/**
+ * Longest allowed reason string for a view's `error` context field (issue
+ * #770, following up on #734). `formatError()`
+ * (packages/streamwall/src/main/viewStateMachine.ts) derives this from
+ * whatever a page's `main()` promise rejects with - in some paths that
+ * wraps a real `Error` thrown while loading page-supplied content, so its
+ * `.message` could in principle carry attacker-influenced text. The reason
+ * flows into the broadcast `StreamwallState`, so left unbounded it is the
+ * same denial-of-service vector #734 fixed for `document.title`.
+ * `formatError()` truncates to this length before the reason ever reaches
+ * this schema; the bound here is the server-side backstop in case that
+ * truncation is ever bypassed.
+ */
+export const MAX_VIEW_ERROR_LENGTH = 1000
+
 const viewStateSchema = z.object({
   state: viewStateValueSchema,
   context: z.object({
@@ -386,7 +417,7 @@ const viewStateSchema = z.object({
     content: viewContentSchema.nullable(),
     info: contentViewInfoSchema.nullable(),
     pos: viewPosSchema.nullable(),
-    error: z.string().nullable(),
+    error: z.string().max(MAX_VIEW_ERROR_LENGTH).nullable(),
     volume: volumeSchema,
   }),
 })

--- a/packages/streamwall/src/main/viewStateMachine.test.ts
+++ b/packages/streamwall/src/main/viewStateMachine.test.ts
@@ -1,3 +1,4 @@
+import { MAX_VIEW_ERROR_LENGTH } from 'streamwall-shared'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import log from './logger'
 
@@ -141,6 +142,35 @@ describe('viewStateMachine error handling and auto-retry', () => {
     actor.send({ type: 'VIEW_ERROR', error: 'plain string failure' })
 
     expect(actor.getSnapshot().context.error).toBe('plain string failure')
+  })
+
+  // Issue #770: a rejection reason can wrap a real Error thrown while
+  // loading page-supplied content, so its .message could in principle carry
+  // attacker-influenced text. Truncating here - the same fix issue #734
+  // applied to document.title - keeps an oversized reason from ever pushing
+  // a broadcast state frame over the uplink's maxPayload.
+  it('truncates an oversized error reason to MAX_VIEW_ERROR_LENGTH', () => {
+    const actor = makeActor(makeRetry({ enabled: false }))
+    actor.start()
+    display(actor)
+
+    const oversized = 'x'.repeat(MAX_VIEW_ERROR_LENGTH + 500)
+    actor.send({ type: 'VIEW_ERROR', error: new Error(oversized) })
+
+    expect(actor.getSnapshot().context.error).toBe(
+      'x'.repeat(MAX_VIEW_ERROR_LENGTH),
+    )
+  })
+
+  it('does not truncate an error reason at exactly MAX_VIEW_ERROR_LENGTH', () => {
+    const actor = makeActor(makeRetry({ enabled: false }))
+    actor.start()
+    display(actor)
+
+    const atLimit = 'x'.repeat(MAX_VIEW_ERROR_LENGTH)
+    actor.send({ type: 'VIEW_ERROR', error: new Error(atLimit) })
+
+    expect(actor.getSnapshot().context.error).toBe(atLimit)
   })
 
   it('auto-retries from the error state after the backoff delay', () => {

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -6,7 +6,12 @@ import {
   WebContentsView,
 } from 'electron'
 import { isEqual } from 'lodash-es'
-import { ViewContent, ViewId, ViewPos } from 'streamwall-shared'
+import {
+  MAX_VIEW_ERROR_LENGTH,
+  ViewContent,
+  ViewId,
+  ViewPos,
+} from 'streamwall-shared'
 import {
   ContentDisplayOptions,
   ContentViewInfo,
@@ -84,15 +89,23 @@ export type DesiredAudio = 'muted' | 'listening' | 'background'
 /**
  * Turns an arbitrary thrown value into a short, serializable reason that can be
  * shown on the wall overlay and in the control UI.
+ *
+ * Some rejection paths (e.g. `main()` in `mediaPreload.ts`) wrap a real
+ * `Error` thrown while loading page-supplied content, so `.message` could in
+ * principle carry attacker-influenced text. This flows into the broadcast
+ * `StreamwallState` (`context.error`), so it is truncated here - the same
+ * denial-of-service vector issue #734 fixed for `document.title` - rather
+ * than left for the schema to reject outright (issue #770). The schema's
+ * `MAX_VIEW_ERROR_LENGTH` bound is the backstop in case this is ever bypassed.
  */
 function formatError(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message
-  }
-  if (typeof error === 'string') {
-    return error
-  }
-  return String(error)
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : String(error)
+  return message.slice(0, MAX_VIEW_ERROR_LENGTH)
 }
 
 const viewStateMachine = setup({


### PR DESCRIPTION
## Summary

#734 bounded `contentViewInfoSchema.title` (the page-controlled `document.title`) after it was found unbounded and could grow the broadcast `StreamwallState` past the uplink's `maxPayload`, causing a denial-of-service loop. A second independent reviewer of that fix noted that the same class of gap exists elsewhere in `packages/streamwall-shared/src/schemas.ts`: the per-view `error` string and several `url` fields on control commands and the broadcast view content had no upper bound.

This closes that gap:

- Added `MAX_URL_LENGTH` (2048, mirroring the URL length browsers themselves treat as a practical limit) and applied it to the `rotate-stream`, `update-custom-stream`, `delete-custom-stream`, `browse`, `add-favorite`, `remove-favorite` command url fields and to `viewContentSchema.url`.
- Added `MAX_VIEW_ERROR_LENGTH` (1000) and applied it to the view context's `error` field.
- `formatError()` in `packages/streamwall/src/main/viewStateMachine.ts` (which derives that `error` string from whatever a page-load rejection carries — in some paths a real `Error` whose `.message` could in principle be attacker-influenced) now truncates its result to `MAX_VIEW_ERROR_LENGTH` before returning, so a legitimately long reason is shortened rather than causing the whole state update to fail schema validation and get dropped by the control server. This mirrors the truncate-at-producer pattern #734/#771 used for `document.title`.

The command `url` fields are bounded but not truncated at the producer: they're one-shot operator commands (no UI `maxLength` currently constrains them — checked `packages/streamwall-control-ui` and the e2e suite, neither imposes one), so rejecting an implausibly long value outright is acceptable and matches how a browser itself would treat such a URL.

Closes #778

## Architecture decisions

- `streamDataInputSchema.link` / `localStreamDataSchema.link` (the stream URL as it originates from a TOML file or polled JSON data source, one hop upstream of `viewContentSchema.url`) were deliberately left unbounded here — they aren't cited in #770's evidence and are config-data-influenced rather than page-influenced. The independent pre-PR reviewer flagged this as worth a separate look, so I filed #778 to track it (a link exceeding `MAX_URL_LENGTH` from a data source would now cause the *entire* state broadcast to be rejected, not just that field — worth fixing with its own truncate-at-producer treatment rather than folding into this PR).

## How was this tested?

- TDD: added boundary tests (at-limit accepted, over-limit rejected/truncated) for every field named in #770's evidence, in `packages/streamwall-shared/src/schemas.test.ts` and `packages/streamwall/src/main/viewStateMachine.test.ts`.
- `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` all pass locally (2185 tests).

## Pre-PR review

One independent reviewer round (fresh subagent, no session context) against the pushed branch: **NO FINDINGS**. It verified the new tests are genuine regressions (fail against the pre-fix schema/code), confirmed all 7 evidence sites from #770 are addressed, and flagged the `link`-field scope boundary noted above, which is now tracked as #778.

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments