### PR TITLE
fix(streamwall): keep a swap promoted while parked off the wall

### DIFF
--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -457,6 +457,9 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
     previouslyParkedAudio: Map<ViewId, DesiredAudio>,
   ) {
     const { id, view, win, offscreenWin } = actor.getSnapshot().context
+    // Taking a running view out of the wall window happens here and nowhere
+    // else, which is how viewStateMachine's `performSwap` recognizes a parked
+    // cell (issue #741) -- keep the two in step.
     win.contentView.removeChildView(view)
     offscreenWin.contentView.addChildView(view)
     const { width, height } = offscreenWin.getBounds()

--- a/packages/streamwall/src/main/viewStateMachine.test.ts
+++ b/packages/streamwall/src/main/viewStateMachine.test.ts
@@ -1744,12 +1744,20 @@ describe('viewStateMachine performSwap while the cell is parked (issue #741)', (
     vi.useRealTimers()
   })
 
-  /** Minimal stand-in for electron's `contentView` child list. */
+  /**
+   * Minimal stand-in for electron's `contentView` child list. A view has at
+   * most one parent there, so re-adding an existing child moves it rather
+   * than duplicating it.
+   */
   function makeFakeContentView() {
     const children: unknown[] = []
     return {
       children,
       addChildView: vi.fn((child: unknown, index?: number) => {
+        const existing = children.indexOf(child)
+        if (existing !== -1) {
+          children.splice(existing, 1)
+        }
         if (index === undefined) {
           children.push(child)
         } else {
@@ -1765,40 +1773,36 @@ describe('viewStateMachine performSwap while the cell is parked (issue #741)', (
     }
   }
 
-  function makeFakeWindow(width = 100, height = 100) {
+  function makeFakeWindow(width: number, height: number) {
     return {
       contentView: makeFakeContentView(),
       getBounds: () => ({ width, height }),
     }
   }
 
+  const NEW_POS = { x: 10, y: 20, width: 50, height: 60, spaces: [1] }
+
   /**
-   * Runs the *real* `performSwap` (every other electron-touching action is
-   * stubbed) against fake windows/views, driving a full preload swap.
+   * Runs the *real* `performSwap`, `positionView` and `offscreenView` (the
+   * remaining electron-touching actions are stubbed) against fake
+   * windows/views, so the whole park -> swap -> un-park sequence is exercised
+   * against the same child-list bookkeeping production does.
    */
-  function runSwap({ parked }: { parked: boolean }) {
+  function setup() {
     const win = makeFakeWindow(1920, 1080)
     const overlay = { setBounds: vi.fn() }
     const view = { setBounds: vi.fn() }
-    const offscreenWin = makeFakeWindow()
+    const offscreenWin = makeFakeWindow(100, 100)
     const nextView = { setBounds: vi.fn() }
     const nextOffscreenWin = makeFakeWindow(640, 360)
     const disposeView = vi.fn()
 
-    // The overlay always sits on top of the wall; the current view is a child
-    // of the wall window only while the cell is actually on it.
-    if (!parked) {
-      win.contentView.children.push(view)
-    } else {
-      offscreenWin.contentView.children.push(view)
-    }
+    // The overlay always sits on top of the wall's view layers.
     win.contentView.children.push(overlay)
     nextOffscreenWin.contentView.children.push(nextView)
 
     const machine = viewStateMachine.provide({
       actions: {
-        offscreenView: noop,
-        positionView: noop,
         offscreenNextView: noop,
         resyncSwappedView: noop,
         muteAudio: noop,
@@ -1829,6 +1833,20 @@ describe('viewStateMachine performSwap while the cell is parked (issue #741)', (
       },
     })
 
+    /** Exactly what `StreamWindow.hideView` does to park a running view. */
+    const park = () => {
+      win.contentView.removeChildView(view)
+      offscreenWin.contentView.addChildView(view)
+    }
+
+    /** Drives the running actor through a content swap to its promotion. */
+    const swap = async () => {
+      actor.send({ type: 'DISPLAY', pos: POS, content: OTHER_CONTENT })
+      await vi.advanceTimersByTimeAsync(0)
+      actor.send({ type: 'NEXT_VIEW_INIT' })
+      actor.send({ type: 'NEXT_VIEW_LOADED' })
+    }
+
     return {
       actor,
       win,
@@ -1838,23 +1856,17 @@ describe('viewStateMachine performSwap while the cell is parked (issue #741)', (
       nextView,
       nextOffscreenWin,
       disposeView,
+      park,
+      swap,
     }
   }
 
-  /** Drives a running actor through a content swap to its promotion. */
-  async function swap(actor: ReturnType<typeof runSwap>['actor']) {
-    actor.start()
-    await reachRunning(actor)
-    actor.send({ type: 'DISPLAY', pos: POS, content: OTHER_CONTENT })
-    await vi.advanceTimersByTimeAsync(0)
-    actor.send({ type: 'NEXT_VIEW_INIT' })
-    actor.send({ type: 'NEXT_VIEW_LOADED' })
-  }
-
   it('adds the promoted view to the wall at the retired view index when the cell is visible', async () => {
-    const ctx = runSwap({ parked: false })
+    const ctx = setup()
+    ctx.actor.start()
+    await reachRunning(ctx.actor)
 
-    await swap(ctx.actor)
+    await ctx.swap()
 
     expect(ctx.win.contentView.children).toContain(ctx.nextView)
     // Takes the retired view's z-index, i.e. still below the overlay.
@@ -1867,9 +1879,12 @@ describe('viewStateMachine performSwap while the cell is parked (issue #741)', (
   })
 
   it('leaves the promoted view offscreen when the cell is parked', async () => {
-    const ctx = runSwap({ parked: true })
+    const ctx = setup()
+    ctx.actor.start()
+    await reachRunning(ctx.actor)
+    ctx.park()
 
-    await swap(ctx.actor)
+    await ctx.swap()
 
     // Nothing new on the wall: the expansion keeps the whole window.
     expect(ctx.win.contentView.children).toEqual([ctx.overlay])
@@ -1889,13 +1904,42 @@ describe('viewStateMachine performSwap while the cell is parked (issue #741)', (
   })
 
   it('adopts the promoted view and its offscreen window as the actor context', async () => {
-    const ctx = runSwap({ parked: true })
+    const ctx = setup()
+    ctx.actor.start()
+    await reachRunning(ctx.actor)
+    ctx.park()
 
-    await swap(ctx.actor)
+    await ctx.swap()
 
     const { context } = ctx.actor.getSnapshot()
     expect(context.view).toBe(ctx.nextView)
     expect(context.offscreenWin).toBe(ctx.nextOffscreenWin)
     expect(context.next).toBeNull()
+  })
+
+  // The whole reason the swap is finished offscreen rather than abandoned:
+  // `context.content` is already the new content, so the DISPLAY that
+  // un-parks the cell is a reposition (the `contentUnchanged` guard), and it
+  // has to put the *promoted* view on the wall showing that new content.
+  it('puts the promoted view on the wall when the cell is un-parked', async () => {
+    const ctx = setup()
+    ctx.actor.start()
+    await reachRunning(ctx.actor)
+    ctx.park()
+    await ctx.swap()
+
+    // What `StreamWindow.setViews` sends for a reused, previously parked
+    // cell on collapse: the content the cell now holds, at its new rect.
+    ctx.actor.send({ type: 'DISPLAY', pos: NEW_POS, content: OTHER_CONTENT })
+
+    expect(ctx.win.contentView.children).toEqual([ctx.nextView, ctx.overlay])
+    expect(ctx.nextOffscreenWin.contentView.children).not.toContain(
+      ctx.nextView,
+    )
+    expect(ctx.nextView.setBounds).toHaveBeenLastCalledWith(NEW_POS)
+    // Still running: un-parking must not restart the load.
+    expect(
+      matchesState('displaying.running', ctx.actor.getSnapshot().value),
+    ).toBe(true)
   })
 })

--- a/packages/streamwall/src/main/viewStateMachine.test.ts
+++ b/packages/streamwall/src/main/viewStateMachine.test.ts
@@ -1727,3 +1727,175 @@ describe('viewStateMachine resyncSwappedView pause re-send (issue #621)', () => 
     expect(nextSend).not.toHaveBeenCalledWith('pause')
   })
 })
+
+/**
+ * `performSwap` moves a finished preload into the wall in place of the view it
+ * replaces. A cell parked behind a fullscreen expansion (issue #369) is no
+ * longer a child of the wall window at all, so the swap must not put its
+ * replacement there either -- it would pop up on top of the expansion at the
+ * parked cell's old rectangle, playing, with nothing to remove it until the
+ * next layout change (issue #741).
+ */
+describe('viewStateMachine performSwap while the cell is parked (issue #741)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  /** Minimal stand-in for electron's `contentView` child list. */
+  function makeFakeContentView() {
+    const children: unknown[] = []
+    return {
+      children,
+      addChildView: vi.fn((child: unknown, index?: number) => {
+        if (index === undefined) {
+          children.push(child)
+        } else {
+          children.splice(index, 0, child)
+        }
+      }),
+      removeChildView: vi.fn((child: unknown) => {
+        const idx = children.indexOf(child)
+        if (idx !== -1) {
+          children.splice(idx, 1)
+        }
+      }),
+    }
+  }
+
+  function makeFakeWindow(width = 100, height = 100) {
+    return {
+      contentView: makeFakeContentView(),
+      getBounds: () => ({ width, height }),
+    }
+  }
+
+  /**
+   * Runs the *real* `performSwap` (every other electron-touching action is
+   * stubbed) against fake windows/views, driving a full preload swap.
+   */
+  function runSwap({ parked }: { parked: boolean }) {
+    const win = makeFakeWindow(1920, 1080)
+    const overlay = { setBounds: vi.fn() }
+    const view = { setBounds: vi.fn() }
+    const offscreenWin = makeFakeWindow()
+    const nextView = { setBounds: vi.fn() }
+    const nextOffscreenWin = makeFakeWindow(640, 360)
+    const disposeView = vi.fn()
+
+    // The overlay always sits on top of the wall; the current view is a child
+    // of the wall window only while the cell is actually on it.
+    if (!parked) {
+      win.contentView.children.push(view)
+    } else {
+      offscreenWin.contentView.children.push(view)
+    }
+    win.contentView.children.push(overlay)
+    nextOffscreenWin.contentView.children.push(nextView)
+
+    const machine = viewStateMachine.provide({
+      actions: {
+        offscreenView: noop,
+        positionView: noop,
+        offscreenNextView: noop,
+        resyncSwappedView: noop,
+        muteAudio: noop,
+        unmuteAudio: noop,
+        openDevTools: noop,
+        sendViewOptions: noop,
+        sendViewVolume: noop,
+        sendViewPause: noop,
+        sendViewResume: noop,
+        logError: noop,
+      },
+      actors: {
+        loadPage: fromPromise(async () => {}),
+      },
+    })
+    const actor = createActor(machine, {
+      input: {
+        id: 1,
+        view: view as never,
+        win: win as never,
+        offscreenWin: offscreenWin as never,
+        retry: makeRetry(),
+        createNextView: () => ({
+          view: nextView as never,
+          offscreenWin: nextOffscreenWin as never,
+        }),
+        disposeView,
+      },
+    })
+
+    return {
+      actor,
+      win,
+      overlay,
+      view,
+      offscreenWin,
+      nextView,
+      nextOffscreenWin,
+      disposeView,
+    }
+  }
+
+  /** Drives a running actor through a content swap to its promotion. */
+  async function swap(actor: ReturnType<typeof runSwap>['actor']) {
+    actor.start()
+    await reachRunning(actor)
+    actor.send({ type: 'DISPLAY', pos: POS, content: OTHER_CONTENT })
+    await vi.advanceTimersByTimeAsync(0)
+    actor.send({ type: 'NEXT_VIEW_INIT' })
+    actor.send({ type: 'NEXT_VIEW_LOADED' })
+  }
+
+  it('adds the promoted view to the wall at the retired view index when the cell is visible', async () => {
+    const ctx = runSwap({ parked: false })
+
+    await swap(ctx.actor)
+
+    expect(ctx.win.contentView.children).toContain(ctx.nextView)
+    // Takes the retired view's z-index, i.e. still below the overlay.
+    expect(ctx.win.contentView.children.indexOf(ctx.nextView)).toBeLessThan(
+      ctx.win.contentView.children.indexOf(ctx.overlay),
+    )
+    expect(ctx.nextView.setBounds).toHaveBeenCalledWith(POS)
+    expect(ctx.win.contentView.children).not.toContain(ctx.view)
+    expect(ctx.disposeView).toHaveBeenCalledWith(ctx.view, ctx.offscreenWin)
+  })
+
+  it('leaves the promoted view offscreen when the cell is parked', async () => {
+    const ctx = runSwap({ parked: true })
+
+    await swap(ctx.actor)
+
+    // Nothing new on the wall: the expansion keeps the whole window.
+    expect(ctx.win.contentView.children).toEqual([ctx.overlay])
+    // The promoted view stays on the offscreen host it already lives on --
+    // the one `promoteNextView` adopts as this actor's offscreen window.
+    expect(ctx.nextOffscreenWin.contentView.children).toContain(ctx.nextView)
+    // Sized to the offscreen host, never to the parked cell's stale rect.
+    expect(ctx.nextView.setBounds).not.toHaveBeenCalledWith(POS)
+    expect(ctx.nextView.setBounds).toHaveBeenCalledWith({
+      x: 0,
+      y: 0,
+      width: 640,
+      height: 360,
+    })
+    // The retired view and its host window are reclaimed either way.
+    expect(ctx.disposeView).toHaveBeenCalledWith(ctx.view, ctx.offscreenWin)
+  })
+
+  it('adopts the promoted view and its offscreen window as the actor context', async () => {
+    const ctx = runSwap({ parked: true })
+
+    await swap(ctx.actor)
+
+    const { context } = ctx.actor.getSnapshot()
+    expect(context.view).toBe(ctx.nextView)
+    expect(context.offscreenWin).toBe(ctx.nextOffscreenWin)
+    expect(context.next).toBeNull()
+  })
+})

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -324,6 +324,10 @@ const viewStateMachine = setup({
       // it on the offscreen host it already lives on -- the one
       // `promoteNextView` adopts as this actor's offscreen window -- and let
       // the DISPLAY that un-parks the cell position it via `positionView`.
+      //
+      // `StreamWindow.hideView` is the only thing that takes a *running*
+      // view out of the wall window, so a missing child means exactly that:
+      // parked. Keep the two in step if that ever changes.
       const existingIdx = win.contentView.children.indexOf(oldView)
       if (existingIdx === -1) {
         const { width, height } = next.offscreenWin.getBounds()

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -316,14 +316,24 @@ const viewStateMachine = setup({
       } = context
       assert(next)
 
+      // A cell parked behind a fullscreen expansion (issue #369) has its view
+      // re-parented onto an offscreen host, so it is not a child of the wall
+      // window. Putting the promoted view there anyway would pop it up on top
+      // of the expansion at the parked cell's stale rectangle, playing, with
+      // nothing to remove it until the next layout change (issue #741). Leave
+      // it on the offscreen host it already lives on -- the one
+      // `promoteNextView` adopts as this actor's offscreen window -- and let
+      // the DISPLAY that un-parks the cell position it via `positionView`.
       const existingIdx = win.contentView.children.indexOf(oldView)
-      next.offscreenWin.contentView.removeChildView(next.view)
-      win.contentView.addChildView(
-        next.view,
-        existingIdx !== -1 ? existingIdx : win.contentView.children.length - 1,
-      )
-      if (pos) {
-        next.view.setBounds(pos)
+      if (existingIdx === -1) {
+        const { width, height } = next.offscreenWin.getBounds()
+        next.view.setBounds({ x: 0, y: 0, width, height })
+      } else {
+        next.offscreenWin.contentView.removeChildView(next.view)
+        win.contentView.addChildView(next.view, existingIdx)
+        if (pos) {
+          next.view.setBounds(pos)
+        }
       }
 
       win.contentView.removeChildView(oldView)


### PR DESCRIPTION
## Summary

`performSwap` moves a finished preload into the wall in place of the view it
replaces, taking that view's z-index — or, when the lookup fails, appending at
the end. A cell parked behind a fullscreen expansion (#369) has its view
re-parented onto an offscreen host, so the lookup always failed there and the
promoted view was appended to the *visible* wall window and given the parked
cell's stale rectangle.

A playlist advance (or any content reassignment) whose preload started just
before the operator expanded another view therefore ended with the parked cell's
newly loaded view popping up on top of the expansion, at its old grid rect,
playing. `setViews` never placed it there, so nothing repositioned or removed it
until the next layout change.

The swap now finishes offscreen for a parked cell: the promoted view stays on
its own offscreen host — the one `promoteNextView` adopts as the actor's
offscreen window — sized to that host rather than to the stale cell rect, and
the `DISPLAY` that un-parks the cell puts it on the wall via `positionView` as
usual.

Closes #741

## Technical notes

- The issue offered two options; this takes the second. Abandoning the preload
  on park would leave `context.content` already pointing at the new content
  (it is assigned when the `DISPLAY` enters `preloading`) while the live view
  still shows the old stream, so the `DISPLAY` that un-parks the cell would hit
  the `contentUnchanged` guard, reposition only, and strand the cell on the old
  stream indefinitely.
- Finishing the swap offscreen also composes with the surrounding behavior:
  `resyncSwappedView` reapplies the recorded mute and pause state, and the
  preloaded view's `view-init` already carries `paused: desiredPaused` (#658),
  so a swap that completes while parked comes up silent — and, with
  `--park.pause`, paused.
- `existingIdx === -1` means "parked" because `StreamWindow.hideView` is the only
  thing that takes a running view out of the wall window. That coupling is now
  spelled out on both sides.

## How was this tested?

A new `describe` block in `packages/streamwall/src/main/viewStateMachine.test.ts`
runs the real `performSwap`, `positionView` and `offscreenView` against fake
windows and views, so the whole park → swap → un-park sequence is exercised
against the same child-list bookkeeping production does (the fake `contentView`
moves an existing child rather than duplicating it, matching electron's
one-parent semantics):

- the visible cell still swaps in place, at the retired view's z-index below the
  overlay and at its rect (regression guard for the unchanged path);
- a parked cell adds nothing to the wall, leaves the promoted view on its
  offscreen host, and sizes it to that host rather than the stale rect — this
  case fails against `main`;
- the actor adopts the promoted view and its offscreen window;
- un-parking with a `DISPLAY` for the same content puts the promoted view on the
  wall at the new rect without restarting the load. This one is a design guard
  for the rationale above rather than a reproduction of the bug: it passes
  either way, since the pre-fix code also ends with the view on the wall — just
  at the wrong time and rect, which the second test covers.

Locally: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test`
(2171 tests across 6 suites) all pass.

## Pre-PR review

Two rounds with independent reviewers that had none of the implementing
session's context.

- Round 1 raised one major (no test drove the un-parking `DISPLAY`, which is
  exactly what the chosen design leans on) and one minor (the
  `existingIdx === -1` ⇔ parked coupling was implicit). Both addressed in
  `5c8408d`.
- Round 2 returned `NO FINDINGS`, including an independent check that the
  parked-cell test fails without the production change.

## Follow-ups

- #774 — pre-existing flakes under full-suite load (`index.test.ts`,
  `data/poll.test.ts`); unrelated to this change, observed while working on it.

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests (or this PR explains why none apply)
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments
