### PR TITLE
fix(shared): bound the unbounded stream link field feeding the shared state schema

### DIFF
--- a/packages/streamwall-shared/src/schemas.test.ts
+++ b/packages/streamwall-shared/src/schemas.test.ts
@@ -61,6 +61,24 @@ describe('streamDataInputSchema', () => {
     expect(streamDataInputSchema.safeParse({ link: 42 }).success).toBe(false)
   })
 
+  // Issue #778: `link` feeds `viewContentSchema.url` (issue #770) one hop
+  // downstream, so an unbounded link would let a data source produce a state
+  // update that fails that bounded schema and gets rejected wholesale.
+  test('rejects a link over MAX_URL_LENGTH', () => {
+    expect(
+      streamDataInputSchema.safeParse({
+        link: 'https://example.com/' + 'x'.repeat(MAX_URL_LENGTH),
+      }).success,
+    ).toBe(false)
+  })
+
+  test('accepts a link at exactly MAX_URL_LENGTH', () => {
+    expect(
+      streamDataInputSchema.safeParse({ link: 'x'.repeat(MAX_URL_LENGTH) })
+        .success,
+    ).toBe(true)
+  })
+
   test('strips internal identity fields from untrusted input', () => {
     const result = streamDataInputSchema.safeParse({
       link: 'https://example.com/s',
@@ -129,6 +147,19 @@ describe('parseStreamList', () => {
     expect(errors.map((e) => e.index)).toEqual([1, 2])
   })
 
+  // Issue #778: an oversized link from a data source must be dropped like any
+  // other invalid entry, not allowed through to later break the downstream
+  // bounded viewContentSchema.url and reject the whole state broadcast.
+  test('drops an entry whose link exceeds MAX_URL_LENGTH but keeps the rest', () => {
+    const { streams, errors } = parseStreamList([
+      { link: 'a' },
+      { link: 'https://example.com/' + 'x'.repeat(MAX_URL_LENGTH) },
+      { link: 'c' },
+    ])
+    expect(streams.map((s) => s.link)).toEqual(['a', 'c'])
+    expect(errors.map((e) => e.index)).toEqual([1])
+  })
+
   test('returns an empty list for non-array input', () => {
     expect(parseStreamList('nope').streams).toEqual([])
     expect(parseStreamList(null).streams).toEqual([])
@@ -149,6 +180,26 @@ describe('localStreamDataSchema', () => {
     expect(
       localStreamDataSchema.safeParse({ link: '', kind: 'video' }).success,
     ).toBe(false)
+  })
+
+  // Issue #778: same bound as streamDataInputSchema.link, for the
+  // update-custom-stream command payload.
+  test('rejects a link over MAX_URL_LENGTH', () => {
+    expect(
+      localStreamDataSchema.safeParse({
+        link: 'https://example.com/' + 'x'.repeat(MAX_URL_LENGTH),
+        kind: 'video',
+      }).success,
+    ).toBe(false)
+  })
+
+  test('accepts a link at exactly MAX_URL_LENGTH', () => {
+    expect(
+      localStreamDataSchema.safeParse({
+        link: 'x'.repeat(MAX_URL_LENGTH),
+        kind: 'video',
+      }).success,
+    ).toBe(true)
   })
 })
 

--- a/packages/streamwall-shared/src/schemas.ts
+++ b/packages/streamwall-shared/src/schemas.ts
@@ -78,14 +78,22 @@ const layoutPresetIdSchema = z.string().min(1).max(100)
 /**
  * Longest allowed URL anywhere it crosses a trust boundary: a control command
  * argument (`rotate-stream`, `update-custom-stream`, `delete-custom-stream`,
- * `browse`, `add-favorite`, `remove-favorite`) or a view's displayed content
- * URL in the broadcast `StreamwallState` (issue #770, following up on #734).
+ * `browse`, `add-favorite`, `remove-favorite`), a stream entry's `link` from
+ * an external data source or an `update-custom-stream` payload
+ * ({@link streamDataInputSchema}, {@link localStreamDataSchema}), or a view's
+ * displayed content URL in the broadcast `StreamwallState` (issue #770,
+ * following up on #734; extended to the upstream `link` fields by #778).
  * These ultimately originate from operator input or a data source, both of
  * which are untrusted, and the content URL in particular is re-broadcast on
  * every state update - an unbounded value could grow a `state` frame past
  * the uplink's `maxPayload`, the same denial-of-service loop #734 fixed for
- * `document.title`. 2048 mirrors the URL length browsers themselves treat as
- * a practical limit, generous enough for any real stream or page URL.
+ * `document.title`. Left unbounded upstream, an oversized `link` would still
+ * fail the bounded `viewContentSchema.url` it feeds, and
+ * `streamwallStateSchema.safeParse` rejects an entire state update (not just
+ * the offending view) on any field failure - a full state-broadcast outage
+ * for that desktop rather than a single bad stream. 2048 mirrors the URL
+ * length browsers themselves treat as a practical limit, generous enough for
+ * any real stream or page URL.
  */
 export const MAX_URL_LENGTH = 2048
 const urlSchema = z.string().max(MAX_URL_LENGTH)
@@ -113,7 +121,7 @@ const streamMetaFields = {
  * identity or provenance — unknown keys are stripped by default.
  */
 export const streamDataInputSchema = z.object({
-  link: z.string().min(1),
+  link: nonEmptyUrlSchema,
   kind: contentKindSchema.optional(),
   ...streamMetaFields,
 })
@@ -125,7 +133,7 @@ export type StreamDataInput = z.infer<typeof streamDataInputSchema>
  * this carries a resolved `kind`, matching the shared `LocalStreamData` type.
  */
 export const localStreamDataSchema = z.object({
-  link: z.string().min(1),
+  link: nonEmptyUrlSchema,
   kind: contentKindSchema,
   ...streamMetaFields,
 })

--- a/packages/streamwall/src/main/data/parse.test.ts
+++ b/packages/streamwall/src/main/data/parse.test.ts
@@ -1,4 +1,4 @@
-import type { StreamDataContent } from 'streamwall-shared'
+import { MAX_URL_LENGTH, type StreamDataContent } from 'streamwall-shared'
 import { describe, expect, test, vi } from 'vitest'
 import log from '../logger'
 import { parseStreamEntries, StreamIDGenerator } from './parse'
@@ -9,6 +9,32 @@ describe('parseStreamEntries', () => {
     try {
       const streams = parseStreamEntries(
         [{ link: 'https://a.example/s', kind: 'video' }, { kind: 'audio' }],
+        'from https://feed.example/',
+      )
+      expect(streams.map((s) => s.link)).toEqual(['https://a.example/s'])
+      expect(warnSpy).toHaveBeenCalledWith(
+        'ignoring 1 invalid stream(s) from https://feed.example/',
+      )
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  // Issue #778: an oversized link from a data source (a TOML file or polled
+  // JSON feed) must be dropped like any other invalid entry, not passed
+  // through to later break the downstream bounded viewContentSchema.url and
+  // reject the whole state broadcast.
+  test('drops an entry whose link exceeds MAX_URL_LENGTH and warns, keeping the rest', () => {
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {})
+    try {
+      const streams = parseStreamEntries(
+        [
+          { link: 'https://a.example/s', kind: 'video' },
+          {
+            link: 'https://oversized.example/' + 'x'.repeat(MAX_URL_LENGTH),
+            kind: 'video',
+          },
+        ],
         'from https://feed.example/',
       )
       expect(streams.map((s) => s.link)).toEqual(['https://a.example/s'])


### PR DESCRIPTION
## Problem

#770 bounded `viewContentSchema.url` (and the other operator/page-influenced url and error strings) in `packages/streamwall-shared/src/schemas.ts` with `MAX_URL_LENGTH`. That field's value ultimately originates one hop upstream from `streamDataInputSchema.link` / `localStreamDataSchema.link`, which stayed unbounded (`z.string().min(1)` with no `.max(...)`).

`packages/streamwall/src/main/wallViews.ts` sets a view's `content.url` from `stream.link`, so an oversized `link` from a data source (a TOML file or polled JSON URL) would produce a `viewContentSchema.url` exceeding `MAX_URL_LENGTH` and fail validation. `streamwallStateSchema.safeParse` in `packages/streamwall-control-server/src/ws/uplink.ts` rejects the *entire* state update on any field failure, so one oversized `link` would drop every state update from that desktop - a full state-broadcast outage, worse than the DoS #734/#770 were fixing and self-inflicted by #770's new bound.

## Technical solution

Bound both `streamDataInputSchema.link` (external data-source entries) and `localStreamDataSchema.link` (`update-custom-stream` payload) with the same `nonEmptyUrlSchema`/`MAX_URL_LENGTH` already used for `viewContentSchema.url`, in `packages/streamwall-shared/src/schemas.ts`.

On the data-ingestion side (`packages/streamwall/src/main/data/parse.ts`), no separate truncate-at-producer step was needed: `parseStreamList` already validates each entry with `streamDataInputSchema.safeParse` and drops/reports invalid entries by index rather than failing the whole batch, and `parseStreamEntries` already logs a warning for dropped entries. Bounding `link` in the schema itself means an oversized-link entry from a TOML file or polled JSON feed is now dropped with a logged warning like any other invalid entry, while the rest of the list is kept - exactly the desired behavior, achieved without touching the ingestion code.

Updated the `MAX_URL_LENGTH` doc comment to mention the two `link` fields and the full-state-rejection failure mode.

## Testing performed

- `packages/streamwall-shared/src/schemas.test.ts`: `streamDataInputSchema` and `localStreamDataSchema` each get a case rejecting a link over `MAX_URL_LENGTH` and a case accepting one at exactly the limit; `parseStreamList` gets a case asserting an oversized-link entry is dropped while sibling entries are kept.
- `packages/streamwall/src/main/data/parse.test.ts`: `parseStreamEntries` gets a case asserting the ingestion layer warns and drops an oversized-link entry from a simulated data-source feed while keeping the valid one.
- Verified red (all new assertions fail against pre-fix `z.string().min(1)`) before applying the fix, then green.
- Full quality gate green: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (2191 tests, 0 failures).

## Architecture decisions

- Reused the existing `nonEmptyUrlSchema` (already `z.string().min(1).max(MAX_URL_LENGTH)`) instead of a new bound, keeping the two `link` fields consistent with `viewContentSchema.url` and the command `url` fields bounded by #770.
- Did not add a separate truncate-at-producer step in `dataSources.ts`, unlike #770's approach for the view `error` field: `parseStreamList`'s existing per-entry validation with drop-and-report already gives the requested "drop the bad entry, keep the rest, log a warning" behavior for free once `link` is bounded in the schema. Truncating instead of dropping would silently rewrite an operator/data-source-supplied identifier (streams are keyed by `link`), which is worse than dropping a malformed entry with a clear log message.

## Risks / breaking changes

None expected. A stream entry with a `link` over 2048 characters (unusual for a real stream/page URL) is now dropped instead of accepted; `parseStreamList` was already designed to tolerate and report such drops without failing the batch.

## Pre-PR review

One independent review round (fresh subagent, no session context) against the full diff and issue text: **NO FINDINGS**.

Closes #778