### PR TITLE
test(streamwall): remove real-timer flakiness from poll.test.ts

### DIFF
--- a/packages/streamwall/src/main/data/poll.test.ts
+++ b/packages/streamwall/src/main/data/poll.test.ts
@@ -4,6 +4,20 @@ import type { StreamDataContent } from 'streamwall-shared'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { computeFetchTimeoutMs, pollDataURL } from './poll'
 
+// Polls a mock's call count via a real `setImmediate` tick rather than a
+// fixed real delay, so tests that fake setTimeout/clearTimeout (see below)
+// can still synchronize with the real loopback response that delivers a
+// given call - however many event-loop turns that takes under load - without
+// reintroducing an artificial wall-clock wait of their own.
+async function waitForCallCount(
+  mockFn: { mock: { calls: unknown[] } },
+  count: number,
+): Promise<void> {
+  while (mockFn.mock.calls.length < count) {
+    await new Promise<void>((resolve) => setImmediate(resolve))
+  }
+}
+
 describe('pollDataURL', () => {
   let server: Server | undefined
 
@@ -120,93 +134,127 @@ describe('pollDataURL', () => {
     }
   })
 
+  // This test (and the next) used to pace itself with real setTimeout races
+  // (a 100ms poll interval plus a 150ms "still pending" probe window). That
+  // real-time budget stacks with a real timer *inside* pollDataURL itself:
+  // fetchWithTimeout's abort floors at MIN_FETCH_TIMEOUT_MS = 5s regardless
+  // of this test's short interval (see poll.ts), so a loopback response that
+  // is merely slow to be scheduled - not actually hung - under the CPU
+  // contention of the full parallel `npm run test` run could brush against
+  // that real 5s abort and blow the whole per-test budget (issue #774).
+  // Faking setTimeout/clearTimeout removes both real timers from the
+  // equation; only setImmediate/process.nextTick stay real, so the actual
+  // loopback response is still delivered and `waitForCallCount` above can
+  // synchronize with it deterministically instead of racing a fixed delay.
   test('keeps serving the last good data when a later poll returns a non-2xx response', async () => {
-    let statusCode = 200
-    let body: unknown = [{ link: 'https://a.example/s', kind: 'video' }]
-    server = createServer((_req, res) => {
-      res.statusCode = statusCode
-      res.setHeader('content-type', 'application/json')
-      res.end(JSON.stringify(body))
-    })
-    await new Promise<void>((resolve) =>
-      server!.listen(0, '127.0.0.1', resolve),
-    )
-    const { port } = server.address() as AddressInfo
-    const url = `http://127.0.0.1:${port}/`
-
-    const onHealth = vi.fn()
-    const gen = pollDataURL(url, 0.1, onHealth)
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
     try {
-      const first = await gen.next()
-      expect(first.value?.map((s: StreamDataContent) => s.link)).toEqual([
-        'https://a.example/s',
-      ])
-
-      statusCode = 500
-      body = { error: 'server exploded' }
-      const pending = gen.next()
-
-      const stillPending = Symbol('pending')
-      const raceResult = await Promise.race([
-        pending,
-        new Promise((resolve) => setTimeout(() => resolve(stillPending), 150)),
-      ])
-      expect(raceResult).toBe(stillPending)
-      expect(onHealth).toHaveBeenCalledWith(
-        false,
-        expect.stringContaining('500'),
+      let statusCode = 200
+      let body: unknown = [{ link: 'https://a.example/s', kind: 'video' }]
+      server = createServer((_req, res) => {
+        res.statusCode = statusCode
+        res.setHeader('content-type', 'application/json')
+        res.end(JSON.stringify(body))
+      })
+      await new Promise<void>((resolve) =>
+        server!.listen(0, '127.0.0.1', resolve),
       )
+      const { port } = server.address() as AddressInfo
+      const url = `http://127.0.0.1:${port}/`
 
-      statusCode = 200
-      body = [{ link: 'https://b.example/s', kind: 'video' }]
-      const second = await pending
-      expect(second.value?.map((s: StreamDataContent) => s.link)).toEqual([
-        'https://b.example/s',
-      ])
+      const onHealth = vi.fn()
+      const gen = pollDataURL(url, 0.1, onHealth)
+      try {
+        const first = await gen.next()
+        expect(first.value?.map((s: StreamDataContent) => s.link)).toEqual([
+          'https://a.example/s',
+        ])
+
+        statusCode = 500
+        body = { error: 'server exploded' }
+        const pending = gen.next()
+        let pendingSettled = false
+        pending.then(() => {
+          pendingSettled = true
+        })
+
+        // Advance past the inter-poll sleep so the failing request goes out,
+        // then confirm it was reported unhealthy without resolving
+        // `pending` - the cached data must not be dropped on one bad poll.
+        await vi.advanceTimersByTimeAsync(100)
+        await waitForCallCount(onHealth, 2)
+        expect(onHealth).toHaveBeenCalledWith(
+          false,
+          expect.stringContaining('500'),
+        )
+        expect(pendingSettled).toBe(false)
+
+        statusCode = 200
+        body = [{ link: 'https://b.example/s', kind: 'video' }]
+        await vi.advanceTimersByTimeAsync(100)
+        const second = await pending
+        expect(second.value?.map((s: StreamDataContent) => s.link)).toEqual([
+          'https://b.example/s',
+        ])
+      } finally {
+        await gen.return(undefined)
+      }
     } finally {
-      await gen.return(undefined)
+      vi.useRealTimers()
     }
   })
 
   test('retains the last successful batch and keeps polling after an empty response', async () => {
-    let body: unknown[] = [{ link: 'https://a.example/s', kind: 'video' }]
-    server = createServer((_req, res) => {
-      res.setHeader('content-type', 'application/json')
-      res.end(JSON.stringify(body))
-    })
-    await new Promise<void>((resolve) =>
-      server!.listen(0, '127.0.0.1', resolve),
-    )
-    const { port } = server.address() as AddressInfo
-    const url = `http://127.0.0.1:${port}/`
-
-    const gen = pollDataURL(url, 0.1)
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
     try {
-      const first = await gen.next()
-      expect(first.value?.map((s: StreamDataContent) => s.link)).toEqual([
-        'https://a.example/s',
-      ])
+      let body: unknown[] = [{ link: 'https://a.example/s', kind: 'video' }]
+      server = createServer((_req, res) => {
+        res.setHeader('content-type', 'application/json')
+        res.end(JSON.stringify(body))
+      })
+      await new Promise<void>((resolve) =>
+        server!.listen(0, '127.0.0.1', resolve),
+      )
+      const { port } = server.address() as AddressInfo
+      const url = `http://127.0.0.1:${port}/`
 
-      // The endpoint now returns no streams. The cached batch must not be
-      // surfaced as wiped out; the outstanding next() should still be
-      // unresolved while polling continues in the background.
-      body = []
-      const pending = gen.next()
+      // onHealth isn't asserted on here; it exists purely so
+      // waitForCallCount can detect that the empty-response poll cycle has
+      // completed (pollDataURL calls it on every successful fetch,
+      // regardless of how many entries the response carries).
+      const onHealth = vi.fn()
+      const gen = pollDataURL(url, 0.1, onHealth)
+      try {
+        const first = await gen.next()
+        expect(first.value?.map((s: StreamDataContent) => s.link)).toEqual([
+          'https://a.example/s',
+        ])
 
-      const stillPending = Symbol('pending')
-      const raceResult = await Promise.race([
-        pending,
-        new Promise((resolve) => setTimeout(() => resolve(stillPending), 150)),
-      ])
-      expect(raceResult).toBe(stillPending)
+        // The endpoint now returns no streams. The cached batch must not be
+        // surfaced as wiped out; the outstanding next() should still be
+        // unresolved while polling continues in the background.
+        body = []
+        const pending = gen.next()
+        let pendingSettled = false
+        pending.then(() => {
+          pendingSettled = true
+        })
 
-      body = [{ link: 'https://b.example/s', kind: 'video' }]
-      const second = await pending
-      expect(second.value?.map((s: StreamDataContent) => s.link)).toEqual([
-        'https://b.example/s',
-      ])
+        await vi.advanceTimersByTimeAsync(100)
+        await waitForCallCount(onHealth, 2)
+        expect(pendingSettled).toBe(false)
+
+        body = [{ link: 'https://b.example/s', kind: 'video' }]
+        await vi.advanceTimersByTimeAsync(100)
+        const second = await pending
+        expect(second.value?.map((s: StreamDataContent) => s.link)).toEqual([
+          'https://b.example/s',
+        ])
+      } finally {
+        await gen.return(undefined)
+      }
     } finally {
-      await gen.return(undefined)
+      vi.useRealTimers()
     }
   })
 


### PR DESCRIPTION
## Problem

`packages/streamwall/src/main/data/poll.test.ts` — `pollDataURL > keeps serving the last good data when a later poll returns a non-2xx response` failed once during a full `npm run test` run under parallel-suite load, with `timed out after 5000ms waiting for http://127.0.0.1:<port>/`, and passes reliably when the file is run on its own.

## Root cause

The failing test (and its sibling "retains the last successful batch and keeps polling after an empty response") paced itself with real `setTimeout` races: `pollDataURL(url, 0.1, ...)` (a 100ms poll interval) plus an external 150ms "is it still pending" probe window. That real-time budget stacks with a real timer *inside* `pollDataURL` itself: `fetchWithTimeout`'s abort duration is `computeFetchTimeoutMs(refreshIntervalMs)`, which floors at `MIN_FETCH_TIMEOUT_MS = 5_000`ms regardless of how short the test's configured interval is — so for these tests it is always a real 5-second abort timer.

Under the CPU contention of a full parallel `npm run test` run, a loopback response that is merely slow to get scheduled — not actually hung — can brush against that real 5-second abort, at which point the test has already consumed the entirety of Vitest's 5000ms default per-test timeout. That is the exact symptom reported: the error message is literally `fetchWithTimeout`'s own real abort message, not a synthetic hang.

## Fix

Converted both tests to `vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })`, matching the pattern already established later in the same file for the client-side-timeout tests. This removes both real timers (`pollDataURL`'s inter-poll `sleep()` and `fetchWithTimeout`'s abort) from wall-clock time, so the tests can no longer approach the real 5s floor under load.

Only `setTimeout`/`clearTimeout` are faked — `setImmediate`/`process.nextTick` stay real, so the actual loopback HTTP response is still delivered for real. A new `waitForCallCount(mockFn, count)` helper polls a mock's call count via a real `setImmediate` tick, letting the tests synchronize deterministically with that real response instead of racing a fixed real delay.

The third real-timer-paced test in this file, "never issues overlapping requests for a single URL", was deliberately left untouched: its total real budget is three 20ms server-side delays (~100ms), far below the 5s floor that caused this flake, it hasn't been reported as flaky, and converting it would grow this PR's diff for a test that isn't the reported problem.

## Testing performed

`npx vitest run src/main/data/poll.test.ts --reporter=verbose`:
- Before: the two flaky tests took 213ms and 210ms out of 581ms total test time for the file.
- After: 21ms and 8ms out of 150ms total test time for the file.

Ran the file's 11 tests individually multiple times (all pass, consistently), the full `streamwall` package suite (`npx vitest run`, 72 files / 987 tests, all pass), and the full monorepo `npm run test` (2189 tests across 6 suites, all pass). Also `npm run format:check` / `npm run lint` / `npm run typecheck` clean.

No new test was added; this is a determinism refactor of existing tests, so no TDD red/green cycle applies — the existing assertions (cached data preserved across a bad poll, no premature resolution) are unchanged and still fail without the underlying `pollDataURL` correctness they guard.

## Verified: index.test.ts part already fixed

Issue #774's original body described `packages/streamwall/src/main/index.test.ts` (`main() startup sequence > invokes the bootstrap phases in the documented order`), which was already fixed by the separately-merged PR #777 (raised the test's own timeout to 20s and `vi.waitFor`'s to 15s, with a documenting comment). Verified that fix is present on `main` (`packages/streamwall/src/main/index.test.ts` lines 253–270) and left that file untouched in this PR.

## Architecture decisions

- Did not touch `MIN_FETCH_TIMEOUT_MS` / `computeFetchTimeoutMs` in `poll.ts` — the 5s floor is a deliberate production safeguard (see its own comment, referencing #603) for real-world slow endpoints, not a test bug; the test's job is to not exercise it accidentally via wall-clock coincidence.
- Chose fake timers over a scoped per-test timeout increase, since the flake's root cause was two real timers racing each other (not merely a large but legitimate real cost), and fake timers eliminate the flake entirely rather than just widening the odds.

## Risks / breaking changes

None. Test-only change; no production code modified.

## Pre-PR review

One independent reviewer round (fresh subagent, no shared context): `NO FINDINGS`. It separately verified the diff scope, traced `poll.ts`'s control flow against the rewritten tests' timer advances, and confirmed the measured before/after timings. It noted one non-blocking observation (leaving "never issues overlapping requests for a single URL" on real timers is undocumented in-file) — addressed by adding the rationale to this PR body above rather than as a code comment, since it isn't itself at risk of the reported flake.

No findings were dismissed as invalid.

Closes #774