### PR TITLE
fix(streamwall): guard devtools-overlay against foreign IPC senders

### DIFF
--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -1796,18 +1796,33 @@ describe('StreamWindow.dispose (issue #629)', () => {
     const sw = new StreamWindow(makeConfig())
     const devtools = electronStub.ipcMain.on.mock.calls.find(
       ([channel]) => channel === 'devtools-overlay',
-    )?.[1] as (ev: unknown) => void
+    )?.[1] as (ev: { sender: unknown }) => void
 
     // The handler outlives the window: firing it after the overlay's
     // webContents is gone must not call (and throw inside) openDevTools.
     vi.mocked(sw.overlayView.webContents.isDestroyed).mockReturnValue(true)
-    devtools({})
+    devtools({ sender: sw.overlayView.webContents })
     expect(sw.overlayView.webContents.openDevTools).not.toHaveBeenCalled()
 
     // While the webContents is alive it still opens devtools as before.
     vi.mocked(sw.overlayView.webContents.isDestroyed).mockReturnValue(false)
-    devtools({})
+    devtools({ sender: sw.overlayView.webContents })
     expect(sw.overlayView.webContents.openDevTools).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores devtools-overlay from a sender other than the overlay webContents (issue #764)', () => {
+    // `ipcMain` is process-global, so any renderer in the process --
+    // including a compromised media view loading operator-supplied remote
+    // content -- could otherwise force the wall's overlay DevTools open.
+    const sw = new StreamWindow(makeConfig())
+    const devtools = electronStub.ipcMain.on.mock.calls.find(
+      ([channel]) => channel === 'devtools-overlay',
+    )?.[1] as (ev: { sender: unknown }) => void
+
+    devtools({ sender: sw.backgroundView.webContents })
+    devtools({ sender: {} })
+
+    expect(sw.overlayView.webContents.openDevTools).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -308,7 +308,15 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
         error,
       })
     })
-    this.registerIpcOn('devtools-overlay', () => {
+    this.registerIpcOn('devtools-overlay', (ev) => {
+      // `ipcMain` is process-global, so without this check any renderer in
+      // the process -- including a compromised media view loading
+      // operator-supplied remote content -- could force the overlay's
+      // DevTools open. Only the overlay's own preload legitimately sends
+      // this channel (issue #764, same bug class as #736).
+      if (ev.sender !== this.overlayView.webContents) {
+        return
+      }
       // The handler outlives the window, so the overlay's webContents may
       // already be gone by the time this fires; opening devtools on a
       // destroyed webContents throws.


### PR DESCRIPTION
## Problem
`StreamWindow`'s `devtools-overlay` IPC listener dropped the `ev` parameter and had no sender check. Because `ipcMain` is process-global, any renderer in the process — including a compromised media view loading operator-supplied remote content — could `ipcRenderer.send('devtools-overlay')` and force the wall's overlay DevTools open. This was the same bug class as #736, already fixed for the Control Window, but left inconsistent on the wall window.

## Technical solution
- `devtools-overlay` now takes `ev` and returns early unless `ev.sender === this.overlayView.webContents`, before the existing `isDestroyed()` liveness check — the same pattern already used by the sibling `layer:load` handler in this file and by the `control:devtools` fix for #736.
- On rejection the handler returns silently, matching the established convention for both sibling guards (neither logs a rejected sender).

## Testing performed
- Added a regression test asserting a foreign sender (another view's webContents, and an arbitrary object) never reaches `openDevTools()`. Verified it fails on `main` (before the fix) and passes with the fix.
- Updated the existing `devtools-overlay` destroyed-webContents test to pass a legitimate sender, since the handler now requires one.
- Full quality gate: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (2196 tests) — all green.

## Architecture decisions
- Reused the exact guard shape (`if (ev.sender !== <owning webContents>) { return }`) already established by `layer:load` in this file and by the #736 fix in `ControlWindow.ts`, rather than introducing a new abstraction — this file only has one handler needing the guard, so a registration-helper refactor (as used in ControlWindow for its eleven handlers) would be disproportionate here and risks colliding with a concurrent edit to a nearby function (`createLayerView`) in this same file for a different issue.

## Risks / breaking changes
None. This tightens an existing IPC channel to reject senders it was never meant to accept; the only legitimate caller (`packages/streamwall/src/preload/layerPreload.ts`, invoked from the overlay renderer) is unaffected.

## Pre-PR review
Two independent reviewer rounds (fresh subagent, no session context) were run before this PR was opened:
- Round 1: one minor finding — the added guard logged a warning on a rejected sender, which was inconsistent with this file's and `ControlWindow.ts`'s established silent-return convention for the same bug class, and could enable a log-flood from an adversarial sender. Fixed by removing the log line to match the existing convention.
- Round 2: `NO FINDINGS`.

Closes #764