### PR TITLE
fix(streamwall): keep the control window on its own UI

### DIFF
--- a/packages/streamwall-control-ui/src/ServerUpdateBanner.test.tsx
+++ b/packages/streamwall-control-ui/src/ServerUpdateBanner.test.tsx
@@ -94,6 +94,10 @@ describe('ServerUpdateBanner', () => {
     expect(banner?.textContent).toContain('0.9.1')
     const link = banner?.querySelector('a') as HTMLAnchorElement
     expect(link.href).toBe(AVAILABLE_STATUS.releaseUrl)
+    // The URL comes from the control server, so the link must open away from
+    // the control UI without handing the target an opener (#732).
+    expect(link.getAttribute('target')).toBe('_blank')
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer')
   })
 
   test('renders English copy', () => {

--- a/packages/streamwall-control-ui/src/ServerUpdateBanner.tsx
+++ b/packages/streamwall-control-ui/src/ServerUpdateBanner.tsx
@@ -87,7 +87,11 @@ export function ServerUpdateBanner({
             {status.version}).
           </span>
           {status.releaseUrl && (
-            <a href={status.releaseUrl} target="_blank" rel="noreferrer">
+            <a
+              href={status.releaseUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               Release notes
             </a>
           )}

--- a/packages/streamwall-control-ui/src/Sidebar.test.tsx
+++ b/packages/streamwall-control-ui/src/Sidebar.test.tsx
@@ -535,3 +535,51 @@ describe('CreateCustomStreamInput', () => {
     expect(labelInput.value).toBe('')
   })
 })
+
+// Stream links point at operator- (or control-server-) supplied URLs. In the
+// browser-hosted control UI they must not replace the app; inside Electron the
+// control window's window-open handler turns them into `shell.openExternal`
+// calls, which only works if they ask for a new browsing context (#732).
+describe('stream links open away from the control UI', () => {
+  test('a stream list row links out in a new context without leaking an opener', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      render(
+        <StreamList
+          rows={[baseRow()]}
+          disabled={false}
+          onClickId={() => {}}
+          favorites={new Set()}
+        />,
+        container!,
+      )
+    })
+
+    const link = container.querySelector('a') as HTMLAnchorElement
+    expect(link.getAttribute('href')).toBe('https://example.com/stream')
+    expect(link.getAttribute('target')).toBe('_blank')
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+
+  test('a custom stream row links out in a new context without leaking an opener', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      render(
+        <CustomStreamInput
+          link="https://custom.example/stream"
+          kind="video"
+          onChange={() => {}}
+          onDelete={() => {}}
+        />,
+        container!,
+      )
+    })
+
+    const link = container.querySelector('a') as HTMLAnchorElement
+    expect(link.getAttribute('href')).toBe('https://custom.example/stream')
+    expect(link.getAttribute('target')).toBe('_blank')
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+})

--- a/packages/streamwall-control-ui/src/Sidebar.tsx
+++ b/packages/streamwall-control-ui/src/Sidebar.tsx
@@ -157,7 +157,7 @@ function StreamLine({
             <strong>{source}</strong>{' '}
             <OrientationIndicator orientation={orientation} />{' '}
             {city ? `(${city} ${state}) ` : ''}
-            <a href={link} target="_blank">
+            <a href={link} target="_blank" rel="noopener noreferrer">
               {truncate(link, { length: 55 })}
             </a>{' '}
             {notes}
@@ -221,7 +221,10 @@ export function CustomStreamInput({
         onChange={handleChangeLabel}
         placeholder="Label (optional)"
       />{' '}
-      <a href={props.link}>{props.link}</a> <span>({props.kind})</span>{' '}
+      <a href={props.link} target="_blank" rel="noopener noreferrer">
+        {props.link}
+      </a>{' '}
+      <span>({props.kind})</span>{' '}
       <button
         aria-label={`Delete custom stream ${props.label || props.link}`}
         onClick={handleDeleteClick}

--- a/packages/streamwall/src/main/ControlWindow.test.ts
+++ b/packages/streamwall/src/main/ControlWindow.test.ts
@@ -20,6 +20,10 @@ class FakeWebContents {
     null
   navHandlers: Record<string, Array<(event: NavEvent) => void>> = {}
 
+  getURL(): string {
+    return APP_PAGE
+  }
+
   on(event: string, listener: (event: NavEvent) => void): this {
     const handlers = this.navHandlers[event] ?? []
     handlers.push(listener)
@@ -78,13 +82,14 @@ vi.mock('electron', () => ({
 }))
 
 // `loadHTML` returns a resolved promise like the real one, so the caller's
-// `.catch` breadcrumb (issue #626) has something to attach to. `isAppPageURL`
-// stands in for the real app-page allowlist, whose answer depends on
-// build-time Vite globals; here the window's own page is the only app URL.
-const APP_PAGE = 'file:///app/renderer/control.html'
+// `.catch` breadcrumb (issue #626) has something to attach to.
+// `rendererPageURL` names the page a window is pinned to; the real one depends
+// on build-time Vite globals.
+const APP_PAGE = 'file:///app/renderer/main_window/src/renderer/control.html'
 vi.mock('./loadHTML', () => ({
   loadHTML: vi.fn(() => Promise.resolve()),
-  isAppPageURL: (url: string) => url === APP_PAGE,
+  rendererPageURL: (name: string) =>
+    `file:///app/renderer/main_window/src/renderer/${name}.html`,
 }))
 
 const createExampleConfig = vi.fn()
@@ -418,14 +423,26 @@ describe('ControlWindow app version', () => {
 // remote page would hand that page the whole bridge while still passing every
 // check (#732).
 describe('ControlWindow navigation hardening', () => {
-  it('cancels a navigation to a remote page and opens it in the OS browser instead', () => {
+  it('cancels a navigation to a remote page', () => {
     const controlWindow = new ControlWindow(configInfo)
     const { webContents } = controlWindow.win as unknown as FakeBrowserWindow
 
     expect(
       webContents.dispatchNavigation('will-navigate', 'https://evil.example/'),
     ).toBe(true)
-    expect(openExternal).toHaveBeenCalledWith('https://evil.example/')
+    expect(openExternal).not.toHaveBeenCalled()
+  })
+
+  it("cancels a navigation to another of the app's own pages", () => {
+    const controlWindow = new ControlWindow(configInfo)
+    const { webContents } = controlWindow.win as unknown as FakeBrowserWindow
+
+    expect(
+      webContents.dispatchNavigation(
+        'will-navigate',
+        'file:///app/renderer/main_window/src/renderer/overlay.html',
+      ),
+    ).toBe(true)
   })
 
   it("lets the window stay on the app's own page", () => {

--- a/packages/streamwall/src/main/ControlWindow.test.ts
+++ b/packages/streamwall/src/main/ControlWindow.test.ts
@@ -19,7 +19,7 @@ class FakeWebContents {
   windowOpenHandler: ((details: { url: string }) => { action: string }) | null =
     null
   navHandlers: Record<string, Array<(event: NavEvent) => void>> = {}
-  url = 'file:///app/control.html'
+  url = APP_PAGE
 
   getURL(): string {
     return this.url
@@ -82,9 +82,15 @@ vi.mock('electron', () => ({
   shell: { openPath, openExternal },
 }))
 
-// Returns a resolved promise like the real loadHTML, so the caller's `.catch`
-// breadcrumb (issue #626) has something to attach to.
-vi.mock('./loadHTML', () => ({ loadHTML: vi.fn(() => Promise.resolve()) }))
+// `loadHTML` returns a resolved promise like the real one, so the caller's
+// `.catch` breadcrumb (issue #626) has something to attach to. `isAppPageURL`
+// stands in for the real app-page allowlist, whose answer depends on
+// build-time Vite globals; here the window's own page is the only app URL.
+const APP_PAGE = 'file:///app/renderer/control.html'
+vi.mock('./loadHTML', () => ({
+  loadHTML: vi.fn(() => Promise.resolve()),
+  isAppPageURL: (url: string) => url === APP_PAGE,
+}))
 
 const createExampleConfig = vi.fn()
 vi.mock('./exampleConfig', () => ({ createExampleConfig }))

--- a/packages/streamwall/src/main/ControlWindow.test.ts
+++ b/packages/streamwall/src/main/ControlWindow.test.ts
@@ -5,8 +5,57 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 // BrowserWindow as a small EventEmitter so `win.on('close', ...)` wiring can
 // be exercised the same way the real window would drive it, without an
 // Electron runtime.
+interface NavEvent {
+  url: string
+  preventDefault(): void
+}
+
+// Stands in for the window's WebContents. `setWindowOpenHandler` and the
+// navigation listeners are recorded rather than mocked away, so the navigation
+// hardening the constructor installs (#732) can be driven from a test.
+class FakeWebContents {
+  send = vi.fn()
+  openDevTools = vi.fn()
+  windowOpenHandler: ((details: { url: string }) => { action: string }) | null =
+    null
+  navHandlers: Record<string, Array<(event: NavEvent) => void>> = {}
+  url = 'file:///app/control.html'
+
+  getURL(): string {
+    return this.url
+  }
+
+  on(event: string, listener: (event: NavEvent) => void): this {
+    const handlers = this.navHandlers[event] ?? []
+    handlers.push(listener)
+    this.navHandlers[event] = handlers
+    return this
+  }
+
+  setWindowOpenHandler(
+    handler: (details: { url: string }) => { action: string },
+  ) {
+    this.windowOpenHandler = handler
+  }
+
+  // Dispatches a navigation event and reports whether a guard cancelled it.
+  dispatchNavigation(event: string, url: string): boolean {
+    let prevented = false
+    const navEvent: NavEvent = {
+      url,
+      preventDefault: () => {
+        prevented = true
+      },
+    }
+    for (const listener of this.navHandlers[event] ?? []) {
+      listener(navEvent)
+    }
+    return prevented
+  }
+}
+
 class FakeBrowserWindow extends EventEmitter {
-  webContents = { send: vi.fn(), openDevTools: vi.fn() }
+  webContents = new FakeWebContents()
   removeMenu = vi.fn()
   options: Record<string, unknown>
 
@@ -23,11 +72,14 @@ const handle = vi.fn((channel: string, handler: IpcHandler) => {
   ipcHandlers.set(channel, handler)
 })
 const openPath = vi.fn()
+// Resolves like the real shell.openExternal so the caller's `.catch`
+// breadcrumb has something to attach to.
+const openExternal = vi.fn(() => Promise.resolve())
 
 vi.mock('electron', () => ({
   BrowserWindow: FakeBrowserWindow,
   ipcMain: { handle },
-  shell: { openPath },
+  shell: { openPath, openExternal },
 }))
 
 // Returns a resolved promise like the real loadHTML, so the caller's `.catch`
@@ -47,6 +99,7 @@ const configInfo = {
 // Every test constructs its own ControlWindow, so the registration history has
 // to start empty rather than accumulating across the file.
 beforeEach(() => {
+  openExternal.mockClear()
   handle.mockClear()
 })
 
@@ -356,6 +409,55 @@ describe('ControlWindow app version', () => {
     expect(await ipcHandlers.get('control:app-version')!({ sender })).toBe(
       '0.9.1',
     )
+  })
+})
+
+// The control window holds the `streamwallControl` bridge, and every `control:*`
+// sender guard compares against this very webContents -- so a navigation to a
+// remote page would hand that page the whole bridge while still passing every
+// check (#732).
+describe('ControlWindow navigation hardening', () => {
+  it('cancels a navigation to a remote page and opens it in the OS browser instead', () => {
+    const controlWindow = new ControlWindow(configInfo)
+    const { webContents } = controlWindow.win as unknown as FakeBrowserWindow
+
+    expect(
+      webContents.dispatchNavigation('will-navigate', 'https://evil.example/'),
+    ).toBe(true)
+    expect(openExternal).toHaveBeenCalledWith('https://evil.example/')
+  })
+
+  it('cancels a redirect escape too, so a 302 cannot do what a click cannot', () => {
+    const controlWindow = new ControlWindow(configInfo)
+    const { webContents } = controlWindow.win as unknown as FakeBrowserWindow
+
+    expect(
+      webContents.dispatchNavigation('will-redirect', 'https://evil.example/'),
+    ).toBe(true)
+  })
+
+  it('denies renderer-opened windows and hands an http(s) link to the OS browser', () => {
+    const controlWindow = new ControlWindow(configInfo)
+    const { webContents } = controlWindow.win as unknown as FakeBrowserWindow
+
+    expect(webContents.windowOpenHandler).not.toBeNull()
+    expect(
+      webContents.windowOpenHandler!({ url: 'https://example.com/stream' }),
+    ).toEqual({ action: 'deny' })
+    expect(openExternal).toHaveBeenCalledWith('https://example.com/stream')
+  })
+
+  it('does not hand a non-http scheme to the OS browser', () => {
+    const controlWindow = new ControlWindow(configInfo)
+    const { webContents } = controlWindow.win as unknown as FakeBrowserWindow
+
+    expect(
+      webContents.windowOpenHandler!({ url: 'file:///etc/passwd' }),
+    ).toEqual({ action: 'deny' })
+    expect(
+      webContents.dispatchNavigation('will-navigate', 'file:///etc/passwd'),
+    ).toBe(true)
+    expect(openExternal).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/streamwall/src/main/ControlWindow.test.ts
+++ b/packages/streamwall/src/main/ControlWindow.test.ts
@@ -19,11 +19,6 @@ class FakeWebContents {
   windowOpenHandler: ((details: { url: string }) => { action: string }) | null =
     null
   navHandlers: Record<string, Array<(event: NavEvent) => void>> = {}
-  url = APP_PAGE
-
-  getURL(): string {
-    return this.url
-  }
 
   on(event: string, listener: (event: NavEvent) => void): this {
     const handlers = this.navHandlers[event] ?? []
@@ -431,6 +426,16 @@ describe('ControlWindow navigation hardening', () => {
       webContents.dispatchNavigation('will-navigate', 'https://evil.example/'),
     ).toBe(true)
     expect(openExternal).toHaveBeenCalledWith('https://evil.example/')
+  })
+
+  it("lets the window stay on the app's own page", () => {
+    const controlWindow = new ControlWindow(configInfo)
+    const { webContents } = controlWindow.win as unknown as FakeBrowserWindow
+
+    expect(webContents.dispatchNavigation('will-navigate', APP_PAGE)).toBe(
+      false,
+    )
+    expect(openExternal).not.toHaveBeenCalled()
   })
 
   it('cancels a redirect escape too, so a 302 cannot do what a click cannot', () => {

--- a/packages/streamwall/src/main/ControlWindow.ts
+++ b/packages/streamwall/src/main/ControlWindow.ts
@@ -6,7 +6,7 @@ import { ControlCommand, StreamwallState } from 'streamwall-shared'
 import { type UpdateStatus } from '../updateStatus'
 import { type ControlCommandResult } from './commandDispatch'
 import { createExampleConfig } from './exampleConfig'
-import { isAppPageURL, loadHTML } from './loadHTML'
+import { loadHTML, rendererPageURL } from './loadHTML'
 import log from './logger'
 import { secureAppWindow } from './navigationSecurity'
 
@@ -64,7 +64,7 @@ export default class ControlWindow extends EventEmitter<ControlWindowEventMap> {
     // carry this webContents -- which holds the `streamwallControl` bridge and
     // satisfies every `control:*` sender guard -- onto remote content (#732).
     secureAppWindow(this.win.webContents, {
-      isAppURL: isAppPageURL,
+      appPageURL: () => rendererPageURL('control'),
       openExternal: (url) => {
         shell.openExternal(url).catch((err) => {
           log.warn('error opening external link', err)

--- a/packages/streamwall/src/main/ControlWindow.ts
+++ b/packages/streamwall/src/main/ControlWindow.ts
@@ -6,7 +6,7 @@ import { ControlCommand, StreamwallState } from 'streamwall-shared'
 import { type UpdateStatus } from '../updateStatus'
 import { type ControlCommandResult } from './commandDispatch'
 import { createExampleConfig } from './exampleConfig'
-import { loadHTML } from './loadHTML'
+import { isAppPageURL, loadHTML } from './loadHTML'
 import log from './logger'
 import { secureAppWindow } from './navigationSecurity'
 
@@ -63,10 +63,13 @@ export default class ControlWindow extends EventEmitter<ControlWindowEventMap> {
     // operator-supplied stream URLs, and a click on one must not be able to
     // carry this webContents -- which holds the `streamwallControl` bridge and
     // satisfies every `control:*` sender guard -- onto remote content (#732).
-    secureAppWindow(this.win.webContents, (url) => {
-      shell.openExternal(url).catch((err) => {
-        log.warn('error opening external link', err)
-      })
+    secureAppWindow(this.win.webContents, {
+      isAppURL: isAppPageURL,
+      openExternal: (url) => {
+        shell.openExternal(url).catch((err) => {
+          log.warn('error opening external link', err)
+        })
+      },
     })
 
     this.win.on('close', (event) => this.emit('close', event))

--- a/packages/streamwall/src/main/ControlWindow.ts
+++ b/packages/streamwall/src/main/ControlWindow.ts
@@ -8,6 +8,7 @@ import { type ControlCommandResult } from './commandDispatch'
 import { createExampleConfig } from './exampleConfig'
 import { loadHTML } from './loadHTML'
 import log from './logger'
+import { secureAppWindow } from './navigationSecurity'
 
 export type ControlCommandHandler = (
   command: ControlCommand,
@@ -57,6 +58,16 @@ export default class ControlWindow extends EventEmitter<ControlWindowEventMap> {
     // Deliberately keeps the window menu (unlike StreamWindow, which stays
     // menu-free for clean capture): on Windows/Linux this is what surfaces
     // the app-level "Open Config Folder" item (#86).
+
+    // Pin the window to the bundled control UI. The sidebar lists
+    // operator-supplied stream URLs, and a click on one must not be able to
+    // carry this webContents -- which holds the `streamwallControl` bridge and
+    // satisfies every `control:*` sender guard -- onto remote content (#732).
+    secureAppWindow(this.win.webContents, (url) => {
+      shell.openExternal(url).catch((err) => {
+        log.warn('error opening external link', err)
+      })
+    })
 
     this.win.on('close', (event) => this.emit('close', event))
 

--- a/packages/streamwall/src/main/ControlWindow.ts
+++ b/packages/streamwall/src/main/ControlWindow.ts
@@ -134,8 +134,10 @@ export default class ControlWindow extends EventEmitter<ControlWindowEventMap> {
 
     this.handleFromControlWindow('control:open-release-notes', () => {
       // Deliberately takes no URL from the renderer: main owns the updater
-      // status, so a compromised renderer cannot turn this into an
-      // open-anything shell.openExternal gadget.
+      // status, so this channel always opens the release notes of the release
+      // the updater actually found. Outward *links* are a separate, deliberate
+      // path -- the navigation guard above forwards them to the OS browser,
+      // restricted to http(s).
       this.updateHandlers?.openReleaseNotes()
     })
   }

--- a/packages/streamwall/src/main/loadHTML.test.ts
+++ b/packages/streamwall/src/main/loadHTML.test.ts
@@ -40,8 +40,10 @@ const dev = () => {
 
 describe('rendererPageURL', () => {
   // The whole point of the export: `secureAppWindow` pins a window to this URL,
-  // so it has to be the URL the window actually ends up on. A drift between the
-  // two would either wedge the window or open a hole.
+  // so it has to name the same page `loadHTML` loads. This pins the two path
+  // derivations together; Electron formats the committed URL itself, and the
+  // guard's tolerance for a spelling difference there comes from its
+  // committed-URL arm rather than from this test.
   it('is the file URL loadHTML loads in a packaged build', async () => {
     packaged()
     const { calls, webContents } = fakeWebContents()

--- a/packages/streamwall/src/main/loadHTML.test.ts
+++ b/packages/streamwall/src/main/loadHTML.test.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import { pathToFileURL } from 'url'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { isAppPageURL } from './loadHTML'
+import { isAppPageURL, loadHTML } from './loadHTML'
 
 // `MAIN_WINDOW_VITE_DEV_SERVER_URL` and `MAIN_WINDOW_VITE_NAME` are injected by
 // the Forge/Vite plugin at build time; under test they are stubbed per case.
@@ -26,6 +26,33 @@ describe('isAppPageURL in a packaged build', () => {
     packaged()
 
     expect(isAppPageURL(appPage)).toBe(true)
+  })
+
+  // Ties the allowlist to the loader: whatever `loadHTML` actually puts in the
+  // window must be an app page, and its parent directory must not be. Without
+  // this, a wrong renderer root in `isAppPageURL` (say one segment too high,
+  // allowlisting everything under `src/`) would leave every other case here
+  // green because they all derive their fixtures from the same expression.
+  it('accepts exactly what loadHTML loads, and not the directory above it', async () => {
+    packaged()
+    let loaded = ''
+    const webContents = {
+      loadFile: (filePath: string) => {
+        loaded = filePath
+        return Promise.resolve()
+      },
+      loadURL: () => Promise.resolve(),
+    }
+
+    await loadHTML(webContents as never, 'control')
+
+    expect(isAppPageURL(pathToFileURL(loaded).href)).toBe(true)
+    // `src/renderer/control.html` -> `src/renderer` -> `src` -> the renderer
+    // root itself, whose parent is outside the bundle.
+    const outside = path.resolve(loaded, '../../../..')
+    expect(isAppPageURL(pathToFileURL(path.join(outside, 'x.html')).href)).toBe(
+      false,
+    )
   })
 
   it('rejects a file URL outside the renderer directory', () => {

--- a/packages/streamwall/src/main/loadHTML.test.ts
+++ b/packages/streamwall/src/main/loadHTML.test.ts
@@ -1,8 +1,7 @@
-import path from 'path'
 import { pathToFileURL } from 'url'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { isAppPageURL, loadHTML } from './loadHTML'
+import { loadHTML, rendererPageURL } from './loadHTML'
 
 // `MAIN_WINDOW_VITE_DEV_SERVER_URL` and `MAIN_WINDOW_VITE_NAME` are injected by
 // the Forge/Vite plugin at build time; under test they are stubbed per case.
@@ -10,125 +9,83 @@ afterEach(() => {
   vi.unstubAllGlobals()
 })
 
-const rendererRoot = path.resolve(__dirname, '../renderer/main_window')
-const appPage = pathToFileURL(
-  path.join(rendererRoot, 'src/renderer/control.html'),
-).href
-
-describe('isAppPageURL in a packaged build', () => {
-  // No dev server URL is the packaged case; pages come off disk.
-  const packaged = () => {
-    vi.stubGlobal('MAIN_WINDOW_VITE_DEV_SERVER_URL', undefined)
-    vi.stubGlobal('MAIN_WINDOW_VITE_NAME', 'main_window')
+// Records what `loadHTML` actually puts in a window.
+function fakeWebContents() {
+  const calls: { loadFile: string[]; loadURL: string[] } = {
+    loadFile: [],
+    loadURL: [],
   }
+  const webContents = {
+    loadFile: (filePath: string) => {
+      calls.loadFile.push(filePath)
+      return Promise.resolve()
+    },
+    loadURL: (url: string) => {
+      calls.loadURL.push(url)
+      return Promise.resolve()
+    },
+  }
+  return { calls, webContents: webContents as never }
+}
 
-  it('accepts a page inside the bundled renderer directory', () => {
+const packaged = () => {
+  vi.stubGlobal('MAIN_WINDOW_VITE_DEV_SERVER_URL', undefined)
+  vi.stubGlobal('MAIN_WINDOW_VITE_NAME', 'main_window')
+}
+
+const dev = () => {
+  vi.stubGlobal('MAIN_WINDOW_VITE_DEV_SERVER_URL', 'http://localhost:5173')
+  vi.stubGlobal('MAIN_WINDOW_VITE_NAME', 'main_window')
+}
+
+describe('rendererPageURL', () => {
+  // The whole point of the export: `secureAppWindow` pins a window to this URL,
+  // so it has to be the URL the window actually ends up on. A drift between the
+  // two would either wedge the window or open a hole.
+  it('is the file URL loadHTML loads in a packaged build', async () => {
     packaged()
+    const { calls, webContents } = fakeWebContents()
 
-    expect(isAppPageURL(appPage)).toBe(true)
-  })
+    await loadHTML(webContents, 'control')
 
-  // Ties the allowlist to the loader: whatever `loadHTML` actually puts in the
-  // window must be an app page, and its parent directory must not be. Without
-  // this, a wrong renderer root in `isAppPageURL` (say one segment too high,
-  // allowlisting everything under `src/`) would leave every other case here
-  // green because they all derive their fixtures from the same expression.
-  it('accepts exactly what loadHTML loads, and not the directory above it', async () => {
-    packaged()
-    let loaded = ''
-    const webContents = {
-      loadFile: (filePath: string) => {
-        loaded = filePath
-        return Promise.resolve()
-      },
-      loadURL: () => Promise.resolve(),
-    }
-
-    await loadHTML(webContents as never, 'control')
-
-    expect(isAppPageURL(pathToFileURL(loaded).href)).toBe(true)
-    // `src/renderer/control.html` -> `src/renderer` -> `src` -> the renderer
-    // root itself, whose parent is outside the bundle.
-    const outside = path.resolve(loaded, '../../../..')
-    expect(isAppPageURL(pathToFileURL(path.join(outside, 'x.html')).href)).toBe(
-      false,
+    expect(calls.loadFile).toHaveLength(1)
+    expect(rendererPageURL('control')).toBe(
+      pathToFileURL(calls.loadFile[0]).href,
     )
   })
 
-  it('rejects a file URL outside the renderer directory', () => {
-    packaged()
+  it('is the dev server URL loadHTML loads in development', async () => {
+    dev()
+    const { calls, webContents } = fakeWebContents()
 
-    expect(isAppPageURL(pathToFileURL('/etc/passwd').href)).toBe(false)
+    await loadHTML(webContents, 'control')
+
+    expect(calls.loadURL).toEqual([rendererPageURL('control')])
   })
 
-  it('rejects a file URL that tries to climb out of the renderer directory', () => {
+  it('names a different URL per page', () => {
     packaged()
 
-    expect(
-      isAppPageURL(`${pathToFileURL(rendererRoot).href}/../../../etc/passwd`),
-    ).toBe(false)
+    expect(rendererPageURL('control')).not.toBe(rendererPageURL('overlay'))
   })
 
-  it('rejects a sibling directory that merely starts with the renderer directory name', () => {
-    // What the trailing separator in the prefix check is for: without it,
-    // `.../main_window_evil/` passes as `.../main_window` + more.
+  it('points at the page itself, not just its directory', () => {
     packaged()
 
-    expect(
-      isAppPageURL(pathToFileURL(`${rendererRoot}_evil/control.html`).href),
-    ).toBe(false)
+    expect(rendererPageURL('control').endsWith('/control.html')).toBe(true)
   })
 
-  it('rejects the renderer directory itself, which is not a page', () => {
+  it('is an absolute file URL in a packaged build', () => {
     packaged()
 
-    expect(isAppPageURL(pathToFileURL(rendererRoot).href)).toBe(false)
+    expect(rendererPageURL('control').startsWith('file:///')).toBe(true)
   })
 
-  it('rejects remote origins', () => {
-    packaged()
-
-    expect(isAppPageURL('https://evil.example/')).toBe(false)
-  })
-
-  it('rejects a string that is not a URL', () => {
-    packaged()
-
-    expect(isAppPageURL('not a url')).toBe(false)
-  })
-
-  it('rejects about:blank, which carries no origin of its own', () => {
-    packaged()
-
-    expect(isAppPageURL('about:blank')).toBe(false)
-  })
-})
-
-describe('isAppPageURL against a dev server', () => {
-  const dev = () => {
-    vi.stubGlobal('MAIN_WINDOW_VITE_DEV_SERVER_URL', 'http://localhost:5173')
-    vi.stubGlobal('MAIN_WINDOW_VITE_NAME', 'main_window')
-  }
-
-  it('accepts any page served from the dev server origin', () => {
+  it('is served from the dev server origin in development', () => {
     dev()
 
-    expect(
-      isAppPageURL('http://localhost:5173/src/renderer/control.html'),
-    ).toBe(true)
-  })
-
-  it('rejects a different port on the same host', () => {
-    dev()
-
-    expect(
-      isAppPageURL('http://localhost:5174/src/renderer/control.html'),
-    ).toBe(false)
-  })
-
-  it('rejects a file URL while the dev server is in use', () => {
-    dev()
-
-    expect(isAppPageURL(appPage)).toBe(false)
+    expect(new URL(rendererPageURL('control')).origin).toBe(
+      'http://localhost:5173',
+    )
   })
 })

--- a/packages/streamwall/src/main/loadHTML.test.ts
+++ b/packages/streamwall/src/main/loadHTML.test.ts
@@ -42,6 +42,22 @@ describe('isAppPageURL in a packaged build', () => {
     ).toBe(false)
   })
 
+  it('rejects a sibling directory that merely starts with the renderer directory name', () => {
+    // What the trailing separator in the prefix check is for: without it,
+    // `.../main_window_evil/` passes as `.../main_window` + more.
+    packaged()
+
+    expect(
+      isAppPageURL(pathToFileURL(`${rendererRoot}_evil/control.html`).href),
+    ).toBe(false)
+  })
+
+  it('rejects the renderer directory itself, which is not a page', () => {
+    packaged()
+
+    expect(isAppPageURL(pathToFileURL(rendererRoot).href)).toBe(false)
+  })
+
   it('rejects remote origins', () => {
     packaged()
 

--- a/packages/streamwall/src/main/loadHTML.test.ts
+++ b/packages/streamwall/src/main/loadHTML.test.ts
@@ -1,0 +1,91 @@
+import path from 'path'
+import { pathToFileURL } from 'url'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { isAppPageURL } from './loadHTML'
+
+// `MAIN_WINDOW_VITE_DEV_SERVER_URL` and `MAIN_WINDOW_VITE_NAME` are injected by
+// the Forge/Vite plugin at build time; under test they are stubbed per case.
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+const rendererRoot = path.resolve(__dirname, '../renderer/main_window')
+const appPage = pathToFileURL(
+  path.join(rendererRoot, 'src/renderer/control.html'),
+).href
+
+describe('isAppPageURL in a packaged build', () => {
+  // No dev server URL is the packaged case; pages come off disk.
+  const packaged = () => {
+    vi.stubGlobal('MAIN_WINDOW_VITE_DEV_SERVER_URL', undefined)
+    vi.stubGlobal('MAIN_WINDOW_VITE_NAME', 'main_window')
+  }
+
+  it('accepts a page inside the bundled renderer directory', () => {
+    packaged()
+
+    expect(isAppPageURL(appPage)).toBe(true)
+  })
+
+  it('rejects a file URL outside the renderer directory', () => {
+    packaged()
+
+    expect(isAppPageURL(pathToFileURL('/etc/passwd').href)).toBe(false)
+  })
+
+  it('rejects a file URL that tries to climb out of the renderer directory', () => {
+    packaged()
+
+    expect(
+      isAppPageURL(`${pathToFileURL(rendererRoot).href}/../../../etc/passwd`),
+    ).toBe(false)
+  })
+
+  it('rejects remote origins', () => {
+    packaged()
+
+    expect(isAppPageURL('https://evil.example/')).toBe(false)
+  })
+
+  it('rejects a string that is not a URL', () => {
+    packaged()
+
+    expect(isAppPageURL('not a url')).toBe(false)
+  })
+
+  it('rejects about:blank, which carries no origin of its own', () => {
+    packaged()
+
+    expect(isAppPageURL('about:blank')).toBe(false)
+  })
+})
+
+describe('isAppPageURL against a dev server', () => {
+  const dev = () => {
+    vi.stubGlobal('MAIN_WINDOW_VITE_DEV_SERVER_URL', 'http://localhost:5173')
+    vi.stubGlobal('MAIN_WINDOW_VITE_NAME', 'main_window')
+  }
+
+  it('accepts any page served from the dev server origin', () => {
+    dev()
+
+    expect(
+      isAppPageURL('http://localhost:5173/src/renderer/control.html'),
+    ).toBe(true)
+  })
+
+  it('rejects a different port on the same host', () => {
+    dev()
+
+    expect(
+      isAppPageURL('http://localhost:5174/src/renderer/control.html'),
+    ).toBe(false)
+  })
+
+  it('rejects a file URL while the dev server is in use', () => {
+    dev()
+
+    expect(isAppPageURL(appPage)).toBe(false)
+  })
+})

--- a/packages/streamwall/src/main/loadHTML.ts
+++ b/packages/streamwall/src/main/loadHTML.ts
@@ -1,7 +1,7 @@
 import { WebContents } from 'electron'
 import path from 'path'
 import querystring from 'querystring'
-import { fileURLToPath } from 'url'
+import { pathToFileURL } from 'url'
 
 /**
  * Origin of the Vite dev server that serves the renderer HTML pages during
@@ -21,44 +21,34 @@ export function devServerOrigin(): string | undefined {
   }
 }
 
+/** The renderer HTML pages the app ships. */
+export type RendererPage = 'background' | 'overlay' | 'playHLS' | 'control'
+
 /** Directory the packaged renderer bundle (HTML pages and assets) lives in. */
 function rendererRoot(): string {
   return path.resolve(__dirname, `../renderer/${MAIN_WINDOW_VITE_NAME}`)
 }
 
+/** Where `loadHTML` reads `name` from in a packaged build. */
+function rendererPagePath(name: RendererPage): string {
+  return path.join(rendererRoot(), `src/renderer/${name}.html`)
+}
+
 /**
- * Whether `url` is one of the app's own renderer pages -- the only navigation
- * target a window rendering Streamwall's own UI may reach (#732).
+ * The exact URL a window ends up on after `loadHTML(webContents, name)` -- the
+ * one navigation target a window rendering that page may reach (#732).
  *
- * In development that is the Vite dev server's origin; in a packaged build it is
- * a `file:` URL inside the bundled renderer directory. The prefix check carries
- * the trailing separator so a sibling directory that merely starts with the same
- * name (`.../main_window_evil/`) is not accepted, and the path is resolved first
- * so the answer does not depend on the URL parser having folded `..` segments
- * away.
+ * A single page rather than the whole bundle: the app's renderer pages do not
+ * all carry the same CSP (the layer and HLS pages allow remote frames and
+ * media), and a window keeps its preload across a same-directory navigation, so
+ * "somewhere under the renderer directory" would be a weaker guarantee than it
+ * looks.
  */
-export function isAppPageURL(url: string): boolean {
-  let parsed: URL
-  try {
-    parsed = new URL(url)
-  } catch {
-    return false
+export function rendererPageURL(name: RendererPage): string {
+  if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
+    return `${MAIN_WINDOW_VITE_DEV_SERVER_URL}/src/renderer/${name}.html`
   }
-
-  const devOrigin = devServerOrigin()
-  if (devOrigin) {
-    return parsed.origin === devOrigin
-  }
-
-  if (parsed.protocol !== 'file:') {
-    return false
-  }
-  try {
-    const root = rendererRoot()
-    return path.resolve(fileURLToPath(parsed)).startsWith(root + path.sep)
-  } catch {
-    return false
-  }
+  return pathToFileURL(rendererPagePath(name)).href
 }
 
 /**
@@ -70,21 +60,15 @@ export function isAppPageURL(url: string): boolean {
  */
 export function loadHTML(
   webContents: WebContents,
-  name: 'background' | 'overlay' | 'playHLS' | 'control',
+  name: RendererPage,
   options?: { query?: Record<string, string> },
 ): Promise<void> {
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
     const queryString = options?.query
       ? '?' + querystring.stringify(options.query)
       : ''
-    return webContents.loadURL(
-      `${MAIN_WINDOW_VITE_DEV_SERVER_URL}/src/renderer/${name}.html` +
-        queryString,
-    )
+    return webContents.loadURL(rendererPageURL(name) + queryString)
   } else {
-    return webContents.loadFile(
-      path.join(rendererRoot(), `src/renderer/${name}.html`),
-      options,
-    )
+    return webContents.loadFile(rendererPagePath(name), options)
   }
 }

--- a/packages/streamwall/src/main/loadHTML.ts
+++ b/packages/streamwall/src/main/loadHTML.ts
@@ -1,6 +1,7 @@
 import { WebContents } from 'electron'
 import path from 'path'
 import querystring from 'querystring'
+import { fileURLToPath } from 'url'
 
 /**
  * Origin of the Vite dev server that serves the renderer HTML pages during
@@ -17,6 +18,44 @@ export function devServerOrigin(): string | undefined {
     return new URL(MAIN_WINDOW_VITE_DEV_SERVER_URL).origin
   } catch {
     return undefined
+  }
+}
+
+/** Directory the packaged renderer bundle (HTML pages and assets) lives in. */
+function rendererRoot(): string {
+  return path.resolve(__dirname, `../renderer/${MAIN_WINDOW_VITE_NAME}`)
+}
+
+/**
+ * Whether `url` is one of the app's own renderer pages -- the only navigation
+ * target a window rendering Streamwall's own UI may reach (#732).
+ *
+ * In development that is the Vite dev server's origin; in a packaged build it is
+ * a `file:` URL inside the bundled renderer directory. The `file:` path is
+ * resolved before the prefix check -- `new URL()` cannot be relied on to fold
+ * `..` segments away -- so a crafted path cannot climb out of that directory.
+ */
+export function isAppPageURL(url: string): boolean {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return false
+  }
+
+  const devOrigin = devServerOrigin()
+  if (devOrigin) {
+    return parsed.origin === devOrigin
+  }
+
+  if (parsed.protocol !== 'file:') {
+    return false
+  }
+  try {
+    const root = rendererRoot()
+    return path.resolve(fileURLToPath(parsed)).startsWith(root + path.sep)
+  } catch {
+    return false
   }
 }
 
@@ -42,10 +81,7 @@ export function loadHTML(
     )
   } else {
     return webContents.loadFile(
-      path.join(
-        __dirname,
-        `../renderer/${MAIN_WINDOW_VITE_NAME}/src/renderer/${name}.html`,
-      ),
+      path.join(rendererRoot(), `src/renderer/${name}.html`),
       options,
     )
   }

--- a/packages/streamwall/src/main/loadHTML.ts
+++ b/packages/streamwall/src/main/loadHTML.ts
@@ -43,6 +43,11 @@ function rendererPagePath(name: RendererPage): string {
  * media), and a window keeps its preload across a same-directory navigation, so
  * "somewhere under the renderer directory" would be a weaker guarantee than it
  * looks.
+ *
+ * Describes a query-less load only. `loadHTML(…, { query })` appends a query
+ * string this does not know about (the HLS page is loaded that way), so
+ * `secureAppWindow` must not be pointed at a page loaded with one -- it would
+ * pin the window to a URL it never commits.
  */
 export function rendererPageURL(name: RendererPage): string {
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {

--- a/packages/streamwall/src/main/loadHTML.ts
+++ b/packages/streamwall/src/main/loadHTML.ts
@@ -31,9 +31,11 @@ function rendererRoot(): string {
  * target a window rendering Streamwall's own UI may reach (#732).
  *
  * In development that is the Vite dev server's origin; in a packaged build it is
- * a `file:` URL inside the bundled renderer directory. The `file:` path is
- * resolved before the prefix check -- `new URL()` cannot be relied on to fold
- * `..` segments away -- so a crafted path cannot climb out of that directory.
+ * a `file:` URL inside the bundled renderer directory. The prefix check carries
+ * the trailing separator so a sibling directory that merely starts with the same
+ * name (`.../main_window_evil/`) is not accepted, and the path is resolved first
+ * so the answer does not depend on the URL parser having folded `..` segments
+ * away.
  */
 export function isAppPageURL(url: string): boolean {
   let parsed: URL

--- a/packages/streamwall/src/main/navigationSecurity.test.ts
+++ b/packages/streamwall/src/main/navigationSecurity.test.ts
@@ -146,12 +146,13 @@ test('secureStreamView allows will-redirect to the same URL', () => {
 // `streamwallControl` bridge, so it must never be allowed to navigate to remote
 // content: the `control:*` sender guards compare against the same webContents
 // and would keep passing afterwards, and control.html's <meta> CSP does not
-// survive a navigation (#732). Unlike a stream view it is allowlisted against
-// the app's own pages rather than pinned to what has committed, so there is no
-// window in which anything goes.
-const APP_ROOT = 'file:///app/renderer/main_window/'
-const APP_PAGE = `${APP_ROOT}src/renderer/control.html`
-const isAppURL = (url: string) => url.startsWith(APP_ROOT)
+// survive a navigation (#732). Unlike a stream view it is pinned to a named
+// page rather than to whatever committed, so there is no window in which
+// anything goes -- and to one page rather than the whole renderer bundle, whose
+// other pages carry weaker CSPs.
+const APP_PAGE = 'file:///app/renderer/main_window/src/renderer/control.html'
+const OTHER_APP_PAGE =
+  'file:///app/renderer/main_window/src/renderer/overlay.html'
 
 // Builds a control-window-style guard set over a fake webContents, returning
 // the double and the injected `openExternal` spy.
@@ -161,7 +162,10 @@ function secureFakeAppWindow(currentURL = APP_PAGE) {
   vi.spyOn(log, 'warn').mockImplementation(() => undefined)
   const wc = new FakeWebContents(currentURL)
   const openExternal = vi.fn()
-  secureAppWindow(asWebContents(wc), { isAppURL, openExternal })
+  secureAppWindow(asWebContents(wc), {
+    appPageURL: () => APP_PAGE,
+    openExternal,
+  })
   return { wc, openExternal }
 }
 
@@ -205,14 +209,16 @@ test('secureAppWindow denies a popup onto the app itself without launching a bro
   assert.equal(openExternal.mock.calls.length, 0)
 })
 
-test('secureAppWindow blocks will-navigate away and opens the target externally', () => {
+test('secureAppWindow cancels a navigation away without launching the browser unattended', () => {
+  // A navigation need not come from a click -- a 302 or a meta refresh reaches
+  // here too -- so it is only ever cancelled, never forwarded outward.
   const { wc, openExternal } = secureFakeAppWindow()
 
   assert.equal(
     wc.dispatchNavigation('will-navigate', 'https://evil.example/'),
     true,
   )
-  assert.deepEqual(openExternal.mock.calls, [['https://evil.example/']])
+  assert.equal(openExternal.mock.calls.length, 0)
 })
 
 test('secureAppWindow blocks a will-redirect escape too, so a 302 cannot do what a click cannot', () => {
@@ -224,7 +230,7 @@ test('secureAppWindow blocks a will-redirect escape too, so a 302 cannot do what
   )
 })
 
-test('secureAppWindow blocks a non-http navigation without handing it to the OS', () => {
+test('secureAppWindow blocks a non-http navigation', () => {
   const { wc, openExternal } = secureFakeAppWindow()
 
   assert.equal(
@@ -234,28 +240,39 @@ test('secureAppWindow blocks a non-http navigation without handing it to the OS'
   assert.equal(openExternal.mock.calls.length, 0)
 })
 
-test("secureAppWindow allows navigation between the app's own pages", () => {
+test('secureAppWindow blocks a navigation to a different page of the same bundle', () => {
+  // The layer and HLS pages carry weaker CSPs than the control page, and this
+  // webContents keeps its preload across such a navigation.
+  const { wc } = secureFakeAppWindow()
+
+  assert.equal(wc.dispatchNavigation('will-navigate', OTHER_APP_PAGE), true)
+})
+
+test('secureAppWindow allows the app page to reload itself', () => {
   const { wc, openExternal } = secureFakeAppWindow()
 
-  assert.equal(
-    wc.dispatchNavigation(
-      'will-navigate',
-      `${APP_ROOT}src/renderer/overlay.html`,
-    ),
-    false,
-  )
+  assert.equal(wc.dispatchNavigation('will-navigate', APP_PAGE), false)
   assert.equal(openExternal.mock.calls.length, 0)
+})
+
+test('secureAppWindow allows a reload spelled the way the window committed it', () => {
+  // Electron may spell the loaded file: URL slightly differently than
+  // `appPageURL` does; the committed URL can only ever be an app page, since
+  // nothing else is allowed to commit.
+  const committed = `${APP_PAGE}?v=1`
+  const { wc } = secureFakeAppWindow(committed)
+
+  assert.equal(wc.dispatchNavigation('will-navigate', committed), false)
 })
 
 test('secureAppWindow blocks a remote navigation even before anything has committed', () => {
   // Unlike a stream view, an app window's page is loaded from disk by the main
   // process: there is no operator-supplied redirect chain to leave room for, so
   // an uncommitted window must not be a hole.
-  const { wc, openExternal } = secureFakeAppWindow('')
+  const { wc } = secureFakeAppWindow('')
 
   assert.equal(
     wc.dispatchNavigation('will-redirect', 'https://evil.example/'),
     true,
   )
-  assert.deepEqual(openExternal.mock.calls, [['https://evil.example/']])
 })

--- a/packages/streamwall/src/main/navigationSecurity.test.ts
+++ b/packages/streamwall/src/main/navigationSecurity.test.ts
@@ -106,6 +106,21 @@ test('secureStreamView allows will-navigate to the same URL (self reload)', () =
   )
 })
 
+test("secureStreamView keeps a stream URL's signed-token query out of the reload log", () => {
+  // Stream and CDN URLs routinely carry a signed token, and the file log
+  // transport persists everything from `info` down.
+  const info = vi.spyOn(log, 'info').mockImplementation(() => undefined)
+  const streamURL = 'https://cdn.example/live.m3u8?token=secret-token'
+  const wc = new FakeWebContents(streamURL)
+  secureStreamView(asWebContents(wc))
+
+  wc.dispatchNavigation('will-navigate', streamURL)
+
+  const logged = info.mock.calls.map((args) => args.join(' ')).join('\n')
+  assert.doesNotMatch(logged, /secret-token/)
+  assert.match(logged, /https:\/\/cdn\.example\/live\.m3u8/)
+})
+
 test('secureStreamView blocks a redirect away once a page has committed (302 escape)', () => {
   const wc = new FakeWebContents('https://example.com/stream')
   secureStreamView(asWebContents(wc))
@@ -203,6 +218,28 @@ test('secureAppWindow keeps credentials out of the log when it denies a link too
   wc.windowOpenHandler!({ url: `${APP_PAGE}#token=secret-fragment` })
 
   assert.doesNotMatch(logged(), /secret-fragment/)
+})
+
+test('secureAppWindow logs nothing but the scheme of an opaque-path URL', () => {
+  // data:, javascript:, mailto: and friends put their whole payload in the
+  // path, so there is no "where it points" to keep.
+  const { wc, logged } = secureFakeAppWindow()
+
+  wc.windowOpenHandler!({ url: 'data:text/html,<h1>secret-payload</h1>' })
+  wc.windowOpenHandler!({ url: 'javascript:alert(document.cookie)' })
+
+  assert.doesNotMatch(logged(), /secret-payload|document\.cookie/)
+  assert.match(logged(), /data:<opaque>/)
+  assert.match(logged(), /javascript:<opaque>/)
+})
+
+test('secureAppWindow logs no userinfo credentials', () => {
+  const { wc, logged } = secureFakeAppWindow()
+
+  wc.windowOpenHandler!({ url: 'https://user:secret-password@example.com/x' })
+
+  assert.doesNotMatch(logged(), /secret-password/)
+  assert.match(logged(), /https:\/\/example\.com\/x/)
 })
 
 test('secureAppWindow keeps credentials out of the log when it blocks a navigation', () => {

--- a/packages/streamwall/src/main/navigationSecurity.test.ts
+++ b/packages/streamwall/src/main/navigationSecurity.test.ts
@@ -123,9 +123,9 @@ test("secureStreamView keeps a stream URL's signed-token query out of the reload
 
   wc.dispatchNavigation('will-navigate', streamURL)
 
-  const logged = info.mock.calls.map((args) => args.join(' ')).join('\n')
-  assert.doesNotMatch(logged, /secret-token/)
-  assert.ok(logged.includes('https://cdn.example/live.m3u8'))
+  assert.deepEqual(info.mock.calls, [
+    ['Allowing page to reload:', 'https://cdn.example/live.m3u8'],
+  ])
 })
 
 test('secureStreamView blocks a redirect away once a page has committed (302 escape)', () => {
@@ -189,7 +189,7 @@ function secureFakeAppWindow(currentURL = APP_PAGE) {
     openExternal,
   })
   const logged = () => info.mock.calls.map((args) => args.join(' ')).join('\n')
-  return { wc, openExternal, logged }
+  return { wc, openExternal, logged, info }
 }
 
 test('secureAppWindow hands an http(s) popup to the OS browser and denies the in-app window', () => {
@@ -208,15 +208,15 @@ test('secureAppWindow hands an http(s) popup to the OS browser and denies the in
 test('secureAppWindow records the external open, without the credentials a link may carry', () => {
   // The file log transport persists everything from `info` down, and the
   // control UI renders links whose secret lives in the fragment (invite links).
-  const { wc, logged } = secureFakeAppWindow()
+  const { wc, info } = secureFakeAppWindow()
 
   wc.windowOpenHandler!({
     url: 'https://example.com/invite?key=secret-query#token=secret-fragment',
   })
 
-  assert.match(logged(), /Opening link in the OS browser/)
-  assert.ok(logged().includes('https://example.com/invite'))
-  assert.doesNotMatch(logged(), /secret-query|secret-fragment/)
+  assert.deepEqual(info.mock.calls, [
+    ['Opening link in the OS browser:', 'https://example.com/invite'],
+  ])
 })
 
 test('secureAppWindow keeps credentials out of the log when it denies a link too', () => {
@@ -241,12 +241,13 @@ test('secureAppWindow logs nothing but the scheme of an opaque-path URL', () => 
 })
 
 test('secureAppWindow logs no userinfo credentials', () => {
-  const { wc, logged } = secureFakeAppWindow()
+  const { wc, info } = secureFakeAppWindow()
 
   wc.windowOpenHandler!({ url: 'https://user:secret-password@example.com/x' })
 
-  assert.doesNotMatch(logged(), /secret-password/)
-  assert.ok(logged().includes('https://example.com/x'))
+  assert.deepEqual(info.mock.calls, [
+    ['Opening link in the OS browser:', 'https://example.com/x'],
+  ])
 })
 
 test('secureAppWindow keeps credentials out of the log when it blocks a navigation', () => {

--- a/packages/streamwall/src/main/navigationSecurity.test.ts
+++ b/packages/streamwall/src/main/navigationSecurity.test.ts
@@ -155,18 +155,19 @@ const OTHER_APP_PAGE =
   'file:///app/renderer/main_window/src/renderer/overlay.html'
 
 // Builds a control-window-style guard set over a fake webContents, returning
-// the double and the injected `openExternal` spy.
+// the double, the injected `openExternal` spy, and the guard's log output.
 function secureFakeAppWindow(currentURL = APP_PAGE) {
-  // Silence the guard's breadcrumbs so test output stays clean.
-  vi.spyOn(log, 'info').mockImplementation(() => undefined)
-  vi.spyOn(log, 'warn').mockImplementation(() => undefined)
+  // Captured rather than printed, so the breadcrumbs can be asserted on without
+  // spamming test output.
+  const info = vi.spyOn(log, 'info').mockImplementation(() => undefined)
   const wc = new FakeWebContents(currentURL)
   const openExternal = vi.fn()
   secureAppWindow(asWebContents(wc), {
     appPageURL: () => APP_PAGE,
     openExternal,
   })
-  return { wc, openExternal }
+  const logged = () => info.mock.calls.map((args) => args.join(' ')).join('\n')
+  return { wc, openExternal, logged }
 }
 
 test('secureAppWindow hands an http(s) popup to the OS browser and denies the in-app window', () => {
@@ -180,6 +181,37 @@ test('secureAppWindow hands an http(s) popup to the OS browser and denies the in
     },
   )
   assert.deepEqual(openExternal.mock.calls, [['https://example.com/stream']])
+})
+
+test('secureAppWindow records the external open, without the credentials a link may carry', () => {
+  // The file log transport persists everything from `info` down, and the
+  // control UI renders links whose secret lives in the fragment (invite links).
+  const { wc, logged } = secureFakeAppWindow()
+
+  wc.windowOpenHandler!({
+    url: 'https://example.com/invite?key=secret-query#token=secret-fragment',
+  })
+
+  assert.match(logged(), /Opening link in the OS browser/)
+  assert.match(logged(), /https:\/\/example\.com\/invite/)
+  assert.doesNotMatch(logged(), /secret-query|secret-fragment/)
+})
+
+test('secureAppWindow keeps credentials out of the log when it denies a link too', () => {
+  const { wc, logged } = secureFakeAppWindow()
+
+  wc.windowOpenHandler!({ url: `${APP_PAGE}#token=secret-fragment` })
+
+  assert.doesNotMatch(logged(), /secret-fragment/)
+})
+
+test('secureAppWindow keeps credentials out of the log when it blocks a navigation', () => {
+  const { wc, logged } = secureFakeAppWindow()
+
+  wc.dispatchNavigation('will-navigate', 'https://evil.example/#token=secret')
+
+  assert.match(logged(), /Blocking navigation away from the app page/)
+  assert.doesNotMatch(logged(), /secret/)
 })
 
 test('secureAppWindow denies a non-http popup without handing it to the OS', () => {

--- a/packages/streamwall/src/main/navigationSecurity.test.ts
+++ b/packages/streamwall/src/main/navigationSecurity.test.ts
@@ -156,6 +156,9 @@ const isAppURL = (url: string) => url.startsWith(APP_ROOT)
 // Builds a control-window-style guard set over a fake webContents, returning
 // the double and the injected `openExternal` spy.
 function secureFakeAppWindow(currentURL = APP_PAGE) {
+  // Silence the guard's breadcrumbs so test output stays clean.
+  vi.spyOn(log, 'info').mockImplementation(() => undefined)
+  vi.spyOn(log, 'warn').mockImplementation(() => undefined)
   const wc = new FakeWebContents(currentURL)
   const openExternal = vi.fn()
   secureAppWindow(asWebContents(wc), { isAppURL, openExternal })

--- a/packages/streamwall/src/main/navigationSecurity.test.ts
+++ b/packages/streamwall/src/main/navigationSecurity.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { test, vi } from 'vitest'
+import { afterEach, test, vi } from 'vitest'
 
 import type { WebContents } from 'electron'
 
@@ -63,6 +63,13 @@ class FakeWebContents {
 }
 
 const asWebContents = (fake: FakeWebContents) => fake as unknown as WebContents
+
+// `vi.spyOn` hands back the existing spy when a property is already spied, so
+// without this every test that silences the logger would share one accumulating
+// mock and read the previous tests' output back as its own.
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 test('denyWindowOpen installs a handler that denies every popup', () => {
   const wc = new FakeWebContents('https://example.com/stream')

--- a/packages/streamwall/src/main/navigationSecurity.test.ts
+++ b/packages/streamwall/src/main/navigationSecurity.test.ts
@@ -4,7 +4,11 @@ import { test, vi } from 'vitest'
 import type { WebContents } from 'electron'
 
 import log from './logger'
-import { denyWindowOpen, secureStreamView } from './navigationSecurity'
+import {
+  denyWindowOpen,
+  secureAppWindow,
+  secureStreamView,
+} from './navigationSecurity'
 
 interface NavEvent {
   url: string
@@ -136,4 +140,109 @@ test('secureStreamView allows will-redirect to the same URL', () => {
     wc.dispatchNavigation('will-redirect', 'https://example.com/stream'),
     false,
   )
+})
+
+// The control window renders the app's own bundled UI and holds the
+// `streamwallControl` bridge, so it must never be allowed to navigate to remote
+// content: the `control:*` sender guards compare against the same webContents
+// and would keep passing afterwards, and control.html's <meta> CSP does not
+// survive a navigation (#732).
+const APP_PAGE = 'file:///app/renderer/control.html'
+
+test('secureAppWindow hands an http(s) popup to the OS browser and denies the in-app window', () => {
+  const wc = new FakeWebContents(APP_PAGE)
+  const openExternal = vi.fn()
+  secureAppWindow(asWebContents(wc), openExternal)
+
+  assert.ok(wc.windowOpenHandler, 'a window-open handler must be registered')
+  assert.deepEqual(
+    wc.windowOpenHandler({ url: 'https://example.com/stream' }),
+    {
+      action: 'deny',
+    },
+  )
+  assert.deepEqual(openExternal.mock.calls, [['https://example.com/stream']])
+})
+
+test('secureAppWindow denies a non-http popup without handing it to the OS', () => {
+  const wc = new FakeWebContents(APP_PAGE)
+  const openExternal = vi.fn()
+  secureAppWindow(asWebContents(wc), openExternal)
+
+  assert.deepEqual(wc.windowOpenHandler!({ url: 'file:///etc/passwd' }), {
+    action: 'deny',
+  })
+  assert.equal(openExternal.mock.calls.length, 0)
+})
+
+test('secureAppWindow denies a popup whose URL does not parse', () => {
+  const wc = new FakeWebContents(APP_PAGE)
+  const openExternal = vi.fn()
+  secureAppWindow(asWebContents(wc), openExternal)
+
+  assert.deepEqual(wc.windowOpenHandler!({ url: 'not a url' }), {
+    action: 'deny',
+  })
+  assert.equal(openExternal.mock.calls.length, 0)
+})
+
+test('secureAppWindow blocks will-navigate away and opens the target externally', () => {
+  const wc = new FakeWebContents(APP_PAGE)
+  const openExternal = vi.fn()
+  secureAppWindow(asWebContents(wc), openExternal)
+
+  assert.equal(
+    wc.dispatchNavigation('will-navigate', 'https://evil.example/'),
+    true,
+  )
+  assert.deepEqual(openExternal.mock.calls, [['https://evil.example/']])
+})
+
+test('secureAppWindow blocks a will-redirect escape once the app page has committed', () => {
+  const wc = new FakeWebContents(APP_PAGE)
+  const openExternal = vi.fn()
+  secureAppWindow(asWebContents(wc), openExternal)
+
+  assert.equal(
+    wc.dispatchNavigation('will-redirect', 'https://evil.example/'),
+    true,
+  )
+})
+
+test('secureAppWindow blocks a non-http navigation without handing it to the OS', () => {
+  const wc = new FakeWebContents(APP_PAGE)
+  const openExternal = vi.fn()
+  secureAppWindow(asWebContents(wc), openExternal)
+
+  assert.equal(
+    wc.dispatchNavigation('will-navigate', 'file:///etc/passwd'),
+    true,
+  )
+  assert.equal(openExternal.mock.calls.length, 0)
+})
+
+test('secureAppWindow allows the app page to reload itself', () => {
+  // Silence the informational reload log so test output stays clean.
+  vi.spyOn(log, 'info').mockImplementation(() => undefined)
+  const wc = new FakeWebContents(APP_PAGE)
+  const openExternal = vi.fn()
+  secureAppWindow(asWebContents(wc), openExternal)
+
+  assert.equal(wc.dispatchNavigation('will-navigate', APP_PAGE), false)
+  assert.equal(openExternal.mock.calls.length, 0)
+})
+
+test('secureAppWindow allows the initial load to resolve before anything has committed', () => {
+  const wc = new FakeWebContents('')
+  const openExternal = vi.fn()
+  secureAppWindow(asWebContents(wc), openExternal)
+
+  assert.equal(
+    wc.dispatchNavigation(
+      'will-redirect',
+      'http://localhost:5173/control.html',
+    ),
+    false,
+  )
+  assert.equal(openExternal.mock.calls.length, 0)
 })

--- a/packages/streamwall/src/main/navigationSecurity.test.ts
+++ b/packages/streamwall/src/main/navigationSecurity.test.ts
@@ -125,7 +125,7 @@ test("secureStreamView keeps a stream URL's signed-token query out of the reload
 
   const logged = info.mock.calls.map((args) => args.join(' ')).join('\n')
   assert.doesNotMatch(logged, /secret-token/)
-  assert.match(logged, /https:\/\/cdn\.example\/live\.m3u8/)
+  assert.ok(logged.includes('https://cdn.example/live.m3u8'))
 })
 
 test('secureStreamView blocks a redirect away once a page has committed (302 escape)', () => {
@@ -215,7 +215,7 @@ test('secureAppWindow records the external open, without the credentials a link 
   })
 
   assert.match(logged(), /Opening link in the OS browser/)
-  assert.match(logged(), /https:\/\/example\.com\/invite/)
+  assert.ok(logged().includes('https://example.com/invite'))
   assert.doesNotMatch(logged(), /secret-query|secret-fragment/)
 })
 
@@ -246,7 +246,7 @@ test('secureAppWindow logs no userinfo credentials', () => {
   wc.windowOpenHandler!({ url: 'https://user:secret-password@example.com/x' })
 
   assert.doesNotMatch(logged(), /secret-password/)
-  assert.match(logged(), /https:\/\/example\.com\/x/)
+  assert.ok(logged().includes('https://example.com/x'))
 })
 
 test('secureAppWindow keeps credentials out of the log when it blocks a navigation', () => {

--- a/packages/streamwall/src/main/navigationSecurity.test.ts
+++ b/packages/streamwall/src/main/navigationSecurity.test.ts
@@ -146,13 +146,24 @@ test('secureStreamView allows will-redirect to the same URL', () => {
 // `streamwallControl` bridge, so it must never be allowed to navigate to remote
 // content: the `control:*` sender guards compare against the same webContents
 // and would keep passing afterwards, and control.html's <meta> CSP does not
-// survive a navigation (#732).
-const APP_PAGE = 'file:///app/renderer/control.html'
+// survive a navigation (#732). Unlike a stream view it is allowlisted against
+// the app's own pages rather than pinned to what has committed, so there is no
+// window in which anything goes.
+const APP_ROOT = 'file:///app/renderer/main_window/'
+const APP_PAGE = `${APP_ROOT}src/renderer/control.html`
+const isAppURL = (url: string) => url.startsWith(APP_ROOT)
+
+// Builds a control-window-style guard set over a fake webContents, returning
+// the double and the injected `openExternal` spy.
+function secureFakeAppWindow(currentURL = APP_PAGE) {
+  const wc = new FakeWebContents(currentURL)
+  const openExternal = vi.fn()
+  secureAppWindow(asWebContents(wc), { isAppURL, openExternal })
+  return { wc, openExternal }
+}
 
 test('secureAppWindow hands an http(s) popup to the OS browser and denies the in-app window', () => {
-  const wc = new FakeWebContents(APP_PAGE)
-  const openExternal = vi.fn()
-  secureAppWindow(asWebContents(wc), openExternal)
+  const { wc, openExternal } = secureFakeAppWindow()
 
   assert.ok(wc.windowOpenHandler, 'a window-open handler must be registered')
   assert.deepEqual(
@@ -165,9 +176,7 @@ test('secureAppWindow hands an http(s) popup to the OS browser and denies the in
 })
 
 test('secureAppWindow denies a non-http popup without handing it to the OS', () => {
-  const wc = new FakeWebContents(APP_PAGE)
-  const openExternal = vi.fn()
-  secureAppWindow(asWebContents(wc), openExternal)
+  const { wc, openExternal } = secureFakeAppWindow()
 
   assert.deepEqual(wc.windowOpenHandler!({ url: 'file:///etc/passwd' }), {
     action: 'deny',
@@ -176,9 +185,7 @@ test('secureAppWindow denies a non-http popup without handing it to the OS', () 
 })
 
 test('secureAppWindow denies a popup whose URL does not parse', () => {
-  const wc = new FakeWebContents(APP_PAGE)
-  const openExternal = vi.fn()
-  secureAppWindow(asWebContents(wc), openExternal)
+  const { wc, openExternal } = secureFakeAppWindow()
 
   assert.deepEqual(wc.windowOpenHandler!({ url: 'not a url' }), {
     action: 'deny',
@@ -186,10 +193,17 @@ test('secureAppWindow denies a popup whose URL does not parse', () => {
   assert.equal(openExternal.mock.calls.length, 0)
 })
 
+test('secureAppWindow denies a popup onto the app itself without launching a browser copy of the UI', () => {
+  const { wc, openExternal } = secureFakeAppWindow()
+
+  assert.deepEqual(wc.windowOpenHandler!({ url: APP_PAGE }), {
+    action: 'deny',
+  })
+  assert.equal(openExternal.mock.calls.length, 0)
+})
+
 test('secureAppWindow blocks will-navigate away and opens the target externally', () => {
-  const wc = new FakeWebContents(APP_PAGE)
-  const openExternal = vi.fn()
-  secureAppWindow(asWebContents(wc), openExternal)
+  const { wc, openExternal } = secureFakeAppWindow()
 
   assert.equal(
     wc.dispatchNavigation('will-navigate', 'https://evil.example/'),
@@ -198,10 +212,8 @@ test('secureAppWindow blocks will-navigate away and opens the target externally'
   assert.deepEqual(openExternal.mock.calls, [['https://evil.example/']])
 })
 
-test('secureAppWindow blocks a will-redirect escape once the app page has committed', () => {
-  const wc = new FakeWebContents(APP_PAGE)
-  const openExternal = vi.fn()
-  secureAppWindow(asWebContents(wc), openExternal)
+test('secureAppWindow blocks a will-redirect escape too, so a 302 cannot do what a click cannot', () => {
+  const { wc } = secureFakeAppWindow()
 
   assert.equal(
     wc.dispatchNavigation('will-redirect', 'https://evil.example/'),
@@ -210,9 +222,7 @@ test('secureAppWindow blocks a will-redirect escape once the app page has commit
 })
 
 test('secureAppWindow blocks a non-http navigation without handing it to the OS', () => {
-  const wc = new FakeWebContents(APP_PAGE)
-  const openExternal = vi.fn()
-  secureAppWindow(asWebContents(wc), openExternal)
+  const { wc, openExternal } = secureFakeAppWindow()
 
   assert.equal(
     wc.dispatchNavigation('will-navigate', 'file:///etc/passwd'),
@@ -221,28 +231,28 @@ test('secureAppWindow blocks a non-http navigation without handing it to the OS'
   assert.equal(openExternal.mock.calls.length, 0)
 })
 
-test('secureAppWindow allows the app page to reload itself', () => {
-  // Silence the informational reload log so test output stays clean.
-  vi.spyOn(log, 'info').mockImplementation(() => undefined)
-  const wc = new FakeWebContents(APP_PAGE)
-  const openExternal = vi.fn()
-  secureAppWindow(asWebContents(wc), openExternal)
-
-  assert.equal(wc.dispatchNavigation('will-navigate', APP_PAGE), false)
-  assert.equal(openExternal.mock.calls.length, 0)
-})
-
-test('secureAppWindow allows the initial load to resolve before anything has committed', () => {
-  const wc = new FakeWebContents('')
-  const openExternal = vi.fn()
-  secureAppWindow(asWebContents(wc), openExternal)
+test("secureAppWindow allows navigation between the app's own pages", () => {
+  const { wc, openExternal } = secureFakeAppWindow()
 
   assert.equal(
     wc.dispatchNavigation(
-      'will-redirect',
-      'http://localhost:5173/control.html',
+      'will-navigate',
+      `${APP_ROOT}src/renderer/overlay.html`,
     ),
     false,
   )
   assert.equal(openExternal.mock.calls.length, 0)
+})
+
+test('secureAppWindow blocks a remote navigation even before anything has committed', () => {
+  // Unlike a stream view, an app window's page is loaded from disk by the main
+  // process: there is no operator-supplied redirect chain to leave room for, so
+  // an uncommitted window must not be a hole.
+  const { wc, openExternal } = secureFakeAppWindow('')
+
+  assert.equal(
+    wc.dispatchNavigation('will-redirect', 'https://evil.example/'),
+    true,
+  )
+  assert.deepEqual(openExternal.mock.calls, [['https://evil.example/']])
 })

--- a/packages/streamwall/src/main/navigationSecurity.ts
+++ b/packages/streamwall/src/main/navigationSecurity.ts
@@ -21,13 +21,13 @@ export function denyWindowOpen(webContents: WebContents): void {
 function preventNavigationAway(
   webContents: WebContents,
   event: NavigationEvent,
-): boolean {
+): void {
   const currentURL = webContents.getURL()
 
   // Allow the page to reload itself (navigating to the URL it is already on).
   if (event.url === currentURL) {
     log.info('Allowing page to reload:', event.url)
-    return false
+    return
   }
 
   // Allow the initial load to resolve through server redirects. Until the view
@@ -35,11 +35,10 @@ function preventNavigationAway(
   // (http->https, CDN, shortlinks) fire `will-redirect` even though the load was
   // started from the main process, and must not be blocked.
   if (currentURL === '') {
-    return false
+    return
   }
 
   event.preventDefault()
-  return true
 }
 
 // The only schemes we are willing to hand to the OS browser. Anything else
@@ -62,9 +61,8 @@ function isExternallyOpenable(url: string): boolean {
 export function secureStreamView(webContents: WebContents): void {
   denyWindowOpen(webContents)
 
-  const guard = (event: NavigationEvent) => {
+  const guard = (event: NavigationEvent) =>
     preventNavigationAway(webContents, event)
-  }
   webContents.on('will-navigate', guard)
   webContents.on('will-redirect', guard)
 }
@@ -79,29 +77,45 @@ export function secureStreamView(webContents: WebContents): void {
  * every sender check. control.html's `<meta>` CSP is a property of the local
  * document and does not survive such a navigation either (#732).
  *
- * `openExternal` is injected rather than imported so the guards stay testable
- * without a running Electron app; callers pass `shell.openExternal`.
+ * Unlike `secureStreamView`, this allowlists the app's own pages outright
+ * instead of pinning to whatever has committed: the page is loaded from disk (or
+ * the dev server) by the main process, so there is no legitimate redirect chain
+ * to leave room for, and no window in which nothing has committed yet.
+ *
+ * `isAppURL` and `openExternal` are injected rather than imported so the guards
+ * stay testable without a running Electron app; callers pass `isAppPageURL` and
+ * `shell.openExternal`.
  */
 export function secureAppWindow(
   webContents: WebContents,
-  openExternal: (url: string) => void,
+  {
+    isAppURL,
+    openExternal,
+  }: {
+    isAppURL: (url: string) => boolean
+    openExternal: (url: string) => void
+  },
 ): void {
-  webContents.setWindowOpenHandler(({ url }) => {
-    if (isExternallyOpenable(url)) {
+  // Hands an outward link to the OS browser, where the page gets none of the
+  // app's privileges. An app page reached this way is dropped instead: opening
+  // a second copy of the control UI in a browser is not what a click meant.
+  const openAway = (url: string) => {
+    if (!isAppURL(url) && isExternallyOpenable(url)) {
       openExternal(url)
     }
+  }
+
+  webContents.setWindowOpenHandler(({ url }) => {
+    openAway(url)
     return { action: 'deny' as const }
   })
 
   const guard = (event: NavigationEvent) => {
-    if (!preventNavigationAway(webContents, event)) {
+    if (isAppURL(event.url)) {
       return
     }
-    // The click was a deliberate "take me to this stream"; honour the intent in
-    // the OS browser, where the page gets none of the app's privileges.
-    if (isExternallyOpenable(event.url)) {
-      openExternal(event.url)
-    }
+    event.preventDefault()
+    openAway(event.url)
   }
   webContents.on('will-navigate', guard)
   webContents.on('will-redirect', guard)

--- a/packages/streamwall/src/main/navigationSecurity.ts
+++ b/packages/streamwall/src/main/navigationSecurity.ts
@@ -77,53 +77,53 @@ export function secureStreamView(webContents: WebContents): void {
  * every sender check. control.html's `<meta>` CSP is a property of the local
  * document and does not survive such a navigation either (#732).
  *
- * Unlike `secureStreamView`, this allowlists the app's own pages outright
- * instead of pinning to whatever has committed: the page is loaded from disk (or
- * the dev server) by the main process, so there is no legitimate redirect chain
- * to leave room for, and no window in which nothing has committed yet.
+ * Unlike `secureStreamView`, which pins a view to whatever it has committed,
+ * this names the allowed page up front: the page is loaded from disk (or the dev
+ * server) by the main process, so there is no operator-supplied redirect chain
+ * to leave room for and no window in which nothing has committed yet. The
+ * committed URL is accepted as well, so a self-reload survives even if Electron
+ * spells the loaded `file:` URL slightly differently than `appPageURL` does --
+ * that URL can only ever be an app page, since nothing else is allowed to
+ * commit.
  *
- * `isAppURL` and `openExternal` are injected rather than imported so the guards
- * stay testable without a running Electron app; callers pass `isAppPageURL` and
- * `shell.openExternal`.
+ * `appPageURL` and `openExternal` are injected rather than imported so the
+ * guards stay testable without a running Electron app; callers pass
+ * `rendererPageURL(...)` and `shell.openExternal`.
  */
 export function secureAppWindow(
   webContents: WebContents,
   {
-    isAppURL,
+    appPageURL,
     openExternal,
   }: {
-    isAppURL: (url: string) => boolean
+    appPageURL: () => string
     openExternal: (url: string) => void
   },
 ): void {
-  // Hands an outward link to the OS browser, where the page gets none of the
-  // app's privileges. An app page reached this way is dropped instead: opening
-  // a second copy of the control UI in a browser is not what a click meant.
-  const openAway = (url: string) => {
-    if (isAppURL(url)) {
-      return
-    }
-    if (!isExternallyOpenable(url)) {
-      // Leaves a breadcrumb: a link that neither navigates nor opens anywhere
-      // is otherwise a silent dead click.
-      log.warn('Dropping link with a non-externally-openable scheme:', url)
-      return
-    }
-    openExternal(url)
-  }
-
   webContents.setWindowOpenHandler(({ url }) => {
-    openAway(url)
+    // A renderer-opened window is an explicit "take me there" gesture, so it is
+    // honoured in the OS browser, where the page gets none of the app's
+    // privileges. Anything the OS browser has no business launching -- and the
+    // app's own page, which would just be a second copy of the UI -- is dropped
+    // with a breadcrumb rather than silently swallowed.
+    if (url !== appPageURL() && isExternallyOpenable(url)) {
+      openExternal(url)
+    } else {
+      log.warn('Denied window open without handing it to the OS browser:', url)
+    }
     return { action: 'deny' as const }
   })
 
+  // A navigation is only ever cancelled, never redirected outward: unlike a
+  // window open it need not come from a click at all (a 302, a `<meta
+  // http-equiv="refresh">`, a dropped URL), and those must not be able to launch
+  // the operator's browser at a control-server-supplied address unattended.
   const guard = (event: NavigationEvent) => {
-    if (isAppURL(event.url)) {
+    if (event.url === appPageURL() || event.url === webContents.getURL()) {
       return
     }
-    log.info('Blocking navigation away from an app page:', event.url)
+    log.info('Blocking navigation away from the app page:', event.url)
     event.preventDefault()
-    openAway(event.url)
   }
   webContents.on('will-navigate', guard)
   webContents.on('will-redirect', guard)

--- a/packages/streamwall/src/main/navigationSecurity.ts
+++ b/packages/streamwall/src/main/navigationSecurity.ts
@@ -21,13 +21,13 @@ export function denyWindowOpen(webContents: WebContents): void {
 function preventNavigationAway(
   webContents: WebContents,
   event: NavigationEvent,
-): void {
+): boolean {
   const currentURL = webContents.getURL()
 
   // Allow the page to reload itself (navigating to the URL it is already on).
   if (event.url === currentURL) {
     log.info('Allowing page to reload:', event.url)
-    return
+    return false
   }
 
   // Allow the initial load to resolve through server redirects. Until the view
@@ -35,10 +35,26 @@ function preventNavigationAway(
   // (http->https, CDN, shortlinks) fire `will-redirect` even though the load was
   // started from the main process, and must not be blocked.
   if (currentURL === '') {
-    return
+    return false
   }
 
   event.preventDefault()
+  return true
+}
+
+// The only schemes we are willing to hand to the OS browser. Anything else
+// (file:, javascript:, a custom protocol registered by another installed app)
+// is dropped rather than launched: the URL originates from operator- or
+// control-server-supplied stream data, so `shell.openExternal` on it would be a
+// launch-anything gadget.
+const EXTERNALLY_OPENABLE_PROTOCOLS = new Set(['http:', 'https:'])
+
+function isExternallyOpenable(url: string): boolean {
+  try {
+    return EXTERNALLY_OPENABLE_PROTOCOLS.has(new URL(url).protocol)
+  } catch {
+    return false
+  }
 }
 
 // Lock a stream view's web contents down: deny popups and block both navigation
@@ -46,8 +62,47 @@ function preventNavigationAway(
 export function secureStreamView(webContents: WebContents): void {
   denyWindowOpen(webContents)
 
-  const guard = (event: NavigationEvent) =>
+  const guard = (event: NavigationEvent) => {
     preventNavigationAway(webContents, event)
+  }
+  webContents.on('will-navigate', guard)
+  webContents.on('will-redirect', guard)
+}
+
+/**
+ * Lock a window that renders Streamwall's own bundled UI (currently the control
+ * window) to that UI, and route outward links to the OS browser instead.
+ *
+ * The control window holds the `streamwallControl` bridge, and every `control:*`
+ * IPC guard compares `ev.sender` against this very webContents — so a navigation
+ * to remote content would hand that page the full bridge while still passing
+ * every sender check. control.html's `<meta>` CSP is a property of the local
+ * document and does not survive such a navigation either (#732).
+ *
+ * `openExternal` is injected rather than imported so the guards stay testable
+ * without a running Electron app; callers pass `shell.openExternal`.
+ */
+export function secureAppWindow(
+  webContents: WebContents,
+  openExternal: (url: string) => void,
+): void {
+  webContents.setWindowOpenHandler(({ url }) => {
+    if (isExternallyOpenable(url)) {
+      openExternal(url)
+    }
+    return { action: 'deny' as const }
+  })
+
+  const guard = (event: NavigationEvent) => {
+    if (!preventNavigationAway(webContents, event)) {
+      return
+    }
+    // The click was a deliberate "take me to this stream"; honour the intent in
+    // the OS browser, where the page gets none of the app's privileges.
+    if (isExternallyOpenable(event.url)) {
+      openExternal(event.url)
+    }
+  }
   webContents.on('will-navigate', guard)
   webContents.on('will-redirect', guard)
 }

--- a/packages/streamwall/src/main/navigationSecurity.ts
+++ b/packages/streamwall/src/main/navigationSecurity.ts
@@ -56,6 +56,19 @@ function isExternallyOpenable(url: string): boolean {
   }
 }
 
+// Where a link points, without what it carries. The URLs reaching these guards
+// are renderer-supplied and can hold credentials -- an invite link keeps its
+// token in the fragment -- while `initLogger` persists everything from `info`
+// down to the user data log file, so the query and fragment must never reach it.
+function redactURL(url: string): string {
+  try {
+    const { protocol, host, pathname } = new URL(url)
+    return `${protocol}//${host}${pathname}`
+  } catch {
+    return '<unparseable URL>'
+  }
+}
+
 // Lock a stream view's web contents down: deny popups and block both navigation
 // and redirect escapes away from the intended URL, while permitting self-reloads.
 export function secureStreamView(webContents: WebContents): void {
@@ -110,10 +123,13 @@ export function secureAppWindow(
       // Logged because this is the one thing here that reaches outside the app:
       // an operator wondering why their browser just opened something can
       // correlate it.
-      log.info('Opening link in the OS browser:', url)
+      log.info('Opening link in the OS browser:', redactURL(url))
       openExternal(url)
     } else {
-      log.info('Denied window open without handing it to the OS browser:', url)
+      log.info(
+        'Denied window open without handing it to the OS browser:',
+        redactURL(url),
+      )
     }
     return { action: 'deny' as const }
   })
@@ -126,7 +142,10 @@ export function secureAppWindow(
     if (event.url === appPageURL() || event.url === webContents.getURL()) {
       return
     }
-    log.info('Blocking navigation away from the app page:', event.url)
+    log.info(
+      'Blocking navigation away from the app page:',
+      redactURL(event.url),
+    )
     event.preventDefault()
   }
   webContents.on('will-navigate', guard)

--- a/packages/streamwall/src/main/navigationSecurity.ts
+++ b/packages/streamwall/src/main/navigationSecurity.ts
@@ -26,7 +26,7 @@ function preventNavigationAway(
 
   // Allow the page to reload itself (navigating to the URL it is already on).
   if (event.url === currentURL) {
-    log.info('Allowing page to reload:', event.url)
+    log.info('Allowing page to reload:', redactURL(event.url))
     return
   }
 
@@ -61,12 +61,23 @@ function isExternallyOpenable(url: string): boolean {
 // token in the fragment -- while `initLogger` persists everything from `info`
 // down to the user data log file, so the query and fragment must never reach it.
 function redactURL(url: string): string {
+  let parsed: URL
   try {
-    const { protocol, host, pathname } = new URL(url)
-    return `${protocol}//${host}${pathname}`
+    parsed = new URL(url)
   } catch {
     return '<unparseable URL>'
   }
+  const { protocol, host, pathname } = parsed
+  if (host) {
+    // Drops any `user:password@` userinfo along with the query and fragment.
+    return `${protocol}//${host}${pathname}`
+  }
+  if (protocol === 'file:') {
+    return `${protocol}//${pathname}`
+  }
+  // An opaque-path scheme (data:, javascript:, mailto:, about:) carries its
+  // whole payload in the path, so only the scheme is safe to write down.
+  return `${protocol}<opaque>`
 }
 
 // Lock a stream view's web contents down: deny popups and block both navigation

--- a/packages/streamwall/src/main/navigationSecurity.ts
+++ b/packages/streamwall/src/main/navigationSecurity.ts
@@ -100,9 +100,16 @@ export function secureAppWindow(
   // app's privileges. An app page reached this way is dropped instead: opening
   // a second copy of the control UI in a browser is not what a click meant.
   const openAway = (url: string) => {
-    if (!isAppURL(url) && isExternallyOpenable(url)) {
-      openExternal(url)
+    if (isAppURL(url)) {
+      return
     }
+    if (!isExternallyOpenable(url)) {
+      // Leaves a breadcrumb: a link that neither navigates nor opens anywhere
+      // is otherwise a silent dead click.
+      log.warn('Dropping link with a non-externally-openable scheme:', url)
+      return
+    }
+    openExternal(url)
   }
 
   webContents.setWindowOpenHandler(({ url }) => {
@@ -114,6 +121,7 @@ export function secureAppWindow(
     if (isAppURL(event.url)) {
       return
     }
+    log.info('Blocking navigation away from an app page:', event.url)
     event.preventDefault()
     openAway(event.url)
   }

--- a/packages/streamwall/src/main/navigationSecurity.ts
+++ b/packages/streamwall/src/main/navigationSecurity.ts
@@ -107,9 +107,13 @@ export function secureAppWindow(
     // app's own page, which would just be a second copy of the UI -- is dropped
     // with a breadcrumb rather than silently swallowed.
     if (url !== appPageURL() && isExternallyOpenable(url)) {
+      // Logged because this is the one thing here that reaches outside the app:
+      // an operator wondering why their browser just opened something can
+      // correlate it.
+      log.info('Opening link in the OS browser:', url)
       openExternal(url)
     } else {
-      log.warn('Denied window open without handing it to the OS browser:', url)
+      log.info('Denied window open without handing it to the OS browser:', url)
     }
     return { action: 'deny' as const }
   })


### PR DESCRIPTION
## Problem

The Control Window was created with only a `preload` and never passed through the app's navigation hardening. The control UI lists operator-supplied stream URLs as links, so a click could navigate the window itself to a remote origin — and every `control:*` IPC guard compares `ev.sender !== this.win.webContents`, which is still true afterwards. The attacker's page would then hold the whole `streamwallControl` bridge and pass every sender check: `invokeCommand({type:'browse', …})`, `invokeCommand({type:'dev-tools', …})`, `installUpdate()`, `openConfigFolder()`. `browse` and `dev-tools` are exactly the commands the uplink allowlist exists to keep away from a compromised control server, so this was a full bypass of that trust boundary. `control.html`'s `<meta>` CSP is a property of the local document and does not survive the navigation either.

## Solution

`secureAppWindow()` joins `secureStreamView()` in `navigationSecurity.ts`, for windows that render Streamwall's own bundled UI:

- **Pinned to one page, not the bundle.** `rendererPageURL('control')` names the exact URL `loadHTML` puts in the window, and the `will-navigate` / `will-redirect` guard allows only that URL — plus whatever the window has already committed, so a self-reload survives even if Electron spells the `file:` URL slightly differently. Only an app page can ever commit, so that second arm cannot widen the guard. Scoping to a single page matters: the layer and HLS pages carry weaker CSPs (`frame-src`/`media-src` open to remote), and a window keeps its preload across a same-directory navigation.
- **No committed-URL escape hatch.** Unlike a stream view, an app window's page is loaded from disk (or the dev server) by the main process, so there is no operator-supplied redirect chain to leave room for — a window that has committed nothing is not a hole.
- **Window-open denied, links honoured outward.** `setWindowOpenHandler` always denies the in-app window and hands http(s) targets to `shell.openExternal`, where the page gets none of the app's privileges. Any other scheme is dropped rather than launched, so a control-server-supplied `link` cannot become a launch-anything gadget.
- **Navigations are only cancelled, never forwarded.** A navigation need not come from a click — a 302, a `<meta http-equiv="refresh">`, a dropped URL — so it must not be able to open the operator's browser unattended. Only the window-open path, which does correspond to an explicit gesture, opens externally.
- **Breadcrumbs, redacted.** Blocking, denying and opening are logged, with URLs reduced to scheme + host + path (scheme only for opaque-path schemes like `data:`/`javascript:`). The file log transport persists everything from `info` down and the UI renders links whose secret lives in the fragment (invite links), so the raw URL must never reach it. The same redaction now covers `secureStreamView`'s reload breadcrumb, which was logging signed-token stream URLs verbatim.

In the UI, both sidebar stream links now carry `target="_blank" rel="noopener noreferrer"`, which routes them through that window-open handler inside Electron and keeps them from replacing the browser-hosted control UI.

## Architecture decisions

- `appPageURL` and `openExternal` are injected rather than imported from `electron`, matching how the module already stays runnable without an Electron runtime (its test file mocks no electron).
- `rendererPageURL()` lives in `loadHTML.ts` beside the loader it must agree with, and a test pins the two together.
- The `streamwallControl` preload bridge is deliberately unchanged: this closes the way remote content reaches it, not the bridge itself.

## Testing

- `navigationSecurity.test.ts`: the window-open handler (http(s) forwarded, non-http(s)/unparseable/app-own dropped), navigation and redirect cancellation, same-bundle-different-page cancellation, self-reload and committed-URL reload allowed, uncommitted window still guarded, and the log redaction for query, fragment, userinfo and opaque-path URLs.
- `ControlWindow.test.ts`: the guards are actually installed on the window's webContents, and behave as above end to end.
- `loadHTML.test.ts` (new): `rendererPageURL` names the page `loadHTML` loads, in both the packaged and dev-server cases.
- `Sidebar.test.tsx`, `ServerUpdateBanner.test.tsx`: the anchors carry `target`/`rel`.
- Quality gate green locally: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (2163 tests).

## Risks / breaking changes

No public API change. Behaviour changes are confined to the control window: it can no longer navigate anywhere but its own page, and sidebar links open in the OS browser instead of in-app. `loadHTML`'s packaged path was refactored through a shared `rendererPagePath()` and resolves to the identical file.

## Bundled fixes

- `ServerUpdateBanner`'s release link, whose URL likewise comes from the control server, gained the same `rel="noopener noreferrer"`. Scheme-validating that URL at the schema boundary is #773.

## Pre-PR review

Nine rounds with independent reviewers that had none of the implementation context, ending in `NO FINDINGS`. Every finding was accepted and fixed; none were dismissed. The substantive ones:

1. The guard inherited the stream view's "nothing has committed yet" allowance, which an app window has no use for and which would have left a control window whose initial load never commits wide open. Replaced with an app-page allowlist.
2. The allowlist accepted any page in the renderer bundle; narrowed to the single page the window loads, since the bundle's pages carry different CSPs and the preload survives a same-directory navigation.
3. A cancelled navigation was being forwarded to `shell.openExternal`, so a 302 or meta refresh could launch the operator's browser unattended. Now only window-open forwards.
4. The new log breadcrumbs wrote raw URLs to the persisted log; an invite link's token lives in its fragment and reaches the window-open handler on a middle-click. Redacted — and the redaction initially still leaked opaque-path payloads (`data:`, `javascript:`) and did not cover `secureStreamView`'s pre-existing reload log.
5. Test-validity fixes: a traversal test that the URL parser had already neutralised, a renderer-root pin that could not detect a wrong root, and a `log.info` spy shared across the whole file because `vi.spyOn` returns the existing spy.

## Follow-ups

- #773 — validate the control server's `releaseUrl` as an http(s) URL at the schema boundary.
- #776 — apply the same guards to the overlay and background layer views.

Closes #732
