### PR TITLE
fix(streamwall): register the media preload's IPC handlers before view-init

### DIFF
--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -627,8 +627,10 @@ const viewStateMachine = setup({
             // fetching. A resume that lands before the renderer registered
             // its handlers is simply dropped, but then the `view-init` reply
             // (which carries `paused: desiredPaused`) has not been sent yet
-            // either, so the fresh view starts unpaused anyway -- except for
-            // the sub-tick window tracked in #756.
+            // either, so the fresh view starts unpaused anyway. The preload
+            // subscribes to 'resume' before it awaits that round trip, so
+            // there is no window left in which the reply has been answered
+            // but the handler is still missing (issue #756).
             RESUME: {
               actions: [assign({ desiredPaused: false }), 'sendViewResume'],
             },

--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -1131,6 +1131,16 @@ describe('RotationController', () => {
   afterEach(() => {
     vi.restoreAllMocks()
     vi.resetModules()
+    // These tests import the module for its exported class only, but that
+    // import still runs main(), which now subscribes to its four operator
+    // channels before awaiting the (never-resolving) view-init. Without this
+    // clearing, a later describe's registeredHandler() -- which takes the
+    // first matching ipcRenderer.on call -- would bind to a handler closed
+    // over this dead module instance.
+    invoke.mockClear()
+    send.mockClear()
+    on.mockClear()
+    exposeInMainWorld.mockClear()
   })
 
   async function makeController() {

--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -1676,6 +1676,15 @@ describe('mediaPreload IPC handlers registered before view-init (issue #756)', (
     expect(registeredChannels()).toEqual(
       expect.arrayContaining(['pause', 'resume', 'options', 'volume']),
     )
+    // Pinned by call order rather than by "they exist once the import
+    // settled": the request must go out only after every channel is
+    // listening, so no suspension point can ever be introduced between the
+    // two and silently reopen the window.
+    const requestedAt = invoke.mock.invocationCallOrder[0]
+    for (const channel of ['pause', 'resume', 'options', 'volume']) {
+      const index = on.mock.calls.findIndex(([ch]) => ch === channel)
+      expect(on.mock.invocationCallOrder[index]).toBeLessThan(requestedAt)
+    }
   })
 
   it('honors a pause delivered before view-init resolved', async () => {

--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -1777,5 +1777,8 @@ describe('mediaPreload IPC handlers registered before view-init (issue #756)', (
 
     expect(viewLoadedCalls()).toHaveLength(1)
     expect(video.className).toBe('__rot0__')
+    // Not just "the view still loads": before the guard, dereferencing the
+    // null threw out of main() and put the tile into an error state.
+    expect(send).not.toHaveBeenCalledWith('view-error', expect.anything())
   })
 })

--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -1742,4 +1742,18 @@ describe('mediaPreload IPC handlers registered before view-init (issue #756)', (
     expect(video.volume).toBe(0.5)
     expect(video.className).toBe('__rot270__')
   })
+
+  it('acquires media when view-init reports no display options yet', async () => {
+    // The view actor's `context.options` starts out null and only becomes an
+    // object once it has seen an OPTIONS event, so the payload legitimately
+    // carries null. Dereferencing it must not abort main() before the
+    // acquisition it now precedes.
+    const video = playableVideo()
+    const settleViewInit = await loadWithPendingViewInit()
+
+    await settleViewInit({ options: null })
+
+    expect(viewLoadedCalls()).toHaveLength(1)
+    expect(video.className).toBe('__rot0__')
+  })
 })

--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -1718,6 +1718,18 @@ describe('mediaPreload IPC handlers registered before view-init (issue #756)', (
     expect(video.volume).toBe(0.25)
   })
 
+  it('keeps an early volume of 0, which a truthiness check would discard', async () => {
+    // The defaulting has to be nullish (`??=`), not `||=`: a muted view is a
+    // legitimate operator choice and must not fall back to the payload.
+    const video = playableVideo()
+    const settleViewInit = await loadWithPendingViewInit()
+
+    registeredHandler('volume')(null, 0)
+    await settleViewInit({ volume: 1 })
+
+    expect(video.volume).toBe(0)
+  })
+
   it('does not let the view-init payload clobber options delivered before it resolved', async () => {
     const video = playableVideo()
     const settleViewInit = await loadWithPendingViewInit()

--- a/packages/streamwall/src/preload/mediaPreload.test.ts
+++ b/packages/streamwall/src/preload/mediaPreload.test.ts
@@ -1584,3 +1584,162 @@ describe('mediaPreload paused acquisition announces the park to the page world (
     expect(video.paused).toBe(false)
   })
 })
+
+describe('mediaPreload IPC handlers registered before view-init (issue #756)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.resetModules()
+    invoke.mockClear()
+    send.mockClear()
+    on.mockClear()
+    exposeInMainWorld.mockClear()
+    document.body.innerHTML = ''
+  })
+
+  function registeredChannels(): string[] {
+    return on.mock.calls.map(([channel]) => channel as string)
+  }
+
+  function registeredHandler(
+    channel: string,
+  ): (ev: unknown, ...args: unknown[]) => void {
+    const call = on.mock.calls.find(([ch]) => ch === channel)
+    if (!call) {
+      throw new Error(`no ipcRenderer.on('${channel}', ...) handler registered`)
+    }
+    return call[1] as (ev: unknown, ...args: unknown[]) => void
+  }
+
+  function viewLoadedCalls() {
+    return send.mock.calls.filter(([channel]) => channel === 'view-loaded')
+  }
+
+  // happy-dom's HTMLVideoElement never implements videoWidth, so give it a
+  // truthy value to skip findMedia's "wait for playing" branch.
+  function playableVideo(): HTMLVideoElement {
+    const video = document.createElement('video')
+    ;(video as unknown as { videoWidth: number }).videoWidth = 100
+    document.body.appendChild(video)
+    return video
+  }
+
+  // Imports the preload with the 'view-init' round trip still in flight, so a
+  // test can deliver IPC in exactly the window this issue is about: after the
+  // main process answered 'view-init' and dispatched to the view actor, but
+  // before the renderer resumed past its own `await`.
+  async function loadWithPendingViewInit(): Promise<
+    (init?: Record<string, unknown>) => Promise<void>
+  > {
+    let resolveInit!: (payload: Record<string, unknown>) => void
+    invoke.mockImplementationOnce(
+      () =>
+        new Promise<Record<string, unknown>>((resolve) => {
+          resolveInit = resolve
+        }),
+    )
+
+    await import('./mediaPreload')
+
+    return async (init: Record<string, unknown> = {}) => {
+      resolveInit({
+        content: { kind: 'video', link: 'https://example.com/stream' },
+        options: {},
+        volume: 1,
+        ...init,
+      })
+      document.dispatchEvent(new Event('DOMContentLoaded'))
+      process.emit('loaded' as never)
+      await vi.advanceTimersByTimeAsync(0)
+    }
+  }
+
+  it('registers the operator IPC handlers before awaiting the view-init round trip', async () => {
+    await loadWithPendingViewInit()
+
+    // Electron drops messages for channels that have no listener yet, so
+    // every channel the main process may send right after answering
+    // 'view-init' has to be listening already.
+    expect(registeredChannels()).toEqual(
+      expect.arrayContaining(['pause', 'resume', 'options', 'volume']),
+    )
+  })
+
+  it('honors a pause delivered before view-init resolved', async () => {
+    const video = playableVideo()
+    const settleViewInit = await loadWithPendingViewInit()
+
+    registeredHandler('pause')(null)
+    await settleViewInit({ paused: false })
+
+    expect(viewLoadedCalls()).toHaveLength(1)
+    expect(video.paused).toBe(true)
+  })
+
+  it('does not let the view-init payload clobber a resume delivered before it resolved', async () => {
+    const video = playableVideo()
+    const settleViewInit = await loadWithPendingViewInit()
+
+    registeredHandler('resume')(null)
+    await settleViewInit({ paused: true })
+
+    expect(viewLoadedCalls()).toHaveLength(1)
+    expect(video.paused).toBe(false)
+  })
+
+  it('announces an early pause to the page world at acquisition time too', async () => {
+    const video = playableVideo()
+    const settleViewInit = await loadWithPendingViewInit()
+    const events: string[] = []
+    document.addEventListener('streamwall:media-pause', (ev) =>
+      events.push(ev.type),
+    )
+
+    registeredHandler('pause')(null)
+    await settleViewInit({ paused: false })
+
+    // Once from the handler itself (no media existed yet) and once from the
+    // acquisition re-asserting the park on the element it just found, so a
+    // freshly created hls.js instance also learns to stop loading (#667).
+    expect(events).toEqual(['streamwall:media-pause', 'streamwall:media-pause'])
+    expect(video.paused).toBe(true)
+  })
+
+  it('does not let the view-init payload clobber a volume delivered before it resolved', async () => {
+    const video = playableVideo()
+    const settleViewInit = await loadWithPendingViewInit()
+
+    registeredHandler('volume')(null, 0.25)
+    await settleViewInit({ volume: 1 })
+
+    expect(video.volume).toBe(0.25)
+  })
+
+  it('does not let the view-init payload clobber options delivered before it resolved', async () => {
+    const video = playableVideo()
+    const settleViewInit = await loadWithPendingViewInit()
+
+    registeredHandler('options')(null, { rotation: 90 })
+    await settleViewInit({ options: { rotation: 180 } })
+
+    expect(video.className).toBe('__rot90__')
+  })
+
+  it('still applies the view-init payload when no message arrived early', async () => {
+    const video = playableVideo()
+    const settleViewInit = await loadWithPendingViewInit()
+
+    await settleViewInit({
+      paused: true,
+      volume: 0.5,
+      options: { rotation: 270 },
+    })
+
+    expect(video.paused).toBe(true)
+    expect(video.volume).toBe(0.5)
+    expect(video.className).toBe('__rot270__')
+  })
+})

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -580,7 +580,8 @@ export type StreamwallMediaGlobal = typeof mediaApi
 contextBridge.exposeInMainWorld('streamwallMedia', mediaApi)
 
 async function main() {
-  const viewInit = ipcRenderer.invoke('view-init')
+  // Subscribed here rather than next to the 'view-init' request below, since
+  // 'loaded' can only be emitted once this synchronous prologue returns.
   const pageReady = new Promise((resolve) => process.once('loaded', resolve))
 
   // Operator-set state, all of it tracked across re-acquisitions (which build
@@ -670,6 +671,13 @@ async function main() {
       console.warn('error resuming media playback', err)
     })
   })
+
+  // Requested only now that every channel is listening. Keeping the request
+  // below the registrations makes the ordering structural instead of relying
+  // on there being no suspension point in between: the main process answers
+  // 'view-init' and dispatches VIEW_INIT to the view actor in one go, so a
+  // PAUSE/RESUME can follow immediately.
+  const viewInit = ipcRenderer.invoke('view-init')
 
   const [
     {

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -611,7 +611,14 @@ async function main() {
   // message received at any point can act on whichever one is current.
   let currentMedia: HTMLMediaElement | undefined
 
-  function updateOptions(options: ContentDisplayOptions) {
+  // The view actor's `context.options` is null until it has seen an OPTIONS
+  // event, and the view-init reply forwards it verbatim, so a null payload is
+  // a normal state rather than an error -- and one that must not throw now
+  // that this runs before the acquisition rather than after it.
+  function updateOptions(options: ContentDisplayOptions | null) {
+    if (!options) {
+      return
+    }
     hasReceivedOptions = true
     latestRotation = options.rotation
     if (rotationController) {
@@ -681,7 +688,7 @@ async function main() {
   desiredPaused ??= initialPaused ?? false
   latestVolume ??= initialVolume ?? 1
   if (!hasReceivedOptions) {
-    updateOptions(initialOptions)
+    updateOptions(initialOptions ?? null)
   }
 
   async function acquireMedia(elementTimeout: number) {

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -583,6 +583,89 @@ async function main() {
   const viewInit = ipcRenderer.invoke('view-init')
   const pageReady = new Promise((resolve) => process.once('loaded', resolve))
 
+  const snapshotController = new SnapshotController()
+
+  // Operator-set state, all of it tracked across re-acquisitions (which build
+  // a fresh RotationController/VolumeController and unconditionally start
+  // playback) so the operator's latest intent survives an internal stall
+  // recovery (issues #620/#621).
+  //
+  // Each starts out `undefined` and is only defaulted from the view-init
+  // payload below if no IPC message has set it in the meantime: the handlers
+  // are registered before the round trip is awaited (see below), so a message
+  // that arrives while it is still in flight must not be clobbered by the
+  // payload it raced (issue #756).
+  let rotationController: RotationController | undefined
+  let volumeController: VolumeController | undefined
+  let latestVolume: number | undefined
+  let latestRotation: number | undefined
+  let hasReceivedOptions = false
+  // Whether the operator asked this view's playback to stay paused (a parked
+  // view, issue #374). Defaulted from the view-init payload so a fresh view
+  // for an already-paused cell -- in particular a background preload for a
+  // parked cell -- never starts playing before the post-swap 'pause' IPC
+  // arrives (issue #658).
+  let desiredPaused: boolean | undefined
+  // The most recently acquired media element (reassigned across a re-
+  // acquisition, e.g. the 'emptied' handler below), so a PAUSE/RESUME
+  // message received at any point can act on whichever one is current.
+  let currentMedia: HTMLMediaElement | undefined
+
+  function updateOptions(options: ContentDisplayOptions) {
+    hasReceivedOptions = true
+    latestRotation = options.rotation
+    if (rotationController) {
+      rotationController.setCustom(options.rotation)
+    }
+  }
+
+  function updateVolume(volume: number) {
+    latestVolume = volume
+    volumeController?.setVolume(volume)
+  }
+
+  // Every operator channel is subscribed before the 'view-init' round trip is
+  // awaited: Electron drops messages for channels that have no listener yet,
+  // and the main process answers 'view-init' and dispatches VIEW_INIT to the
+  // view actor at the same moment -- so a PAUSE/RESUME processed right after
+  // that would be sent into a renderer still parked on its own `await` and be
+  // lost for good (issue #756, the renderer-side half of #738).
+  ipcRenderer.on('options', (ev, options) => updateOptions(options))
+  ipcRenderer.on('volume', (ev, volume) => updateVolume(volume))
+
+  // Stops/resumes the acquired media element's own playback -- used to pause
+  // a parked (hidden) view instead of keeping it fully live while it's
+  // hidden behind a fullscreen expansion (issue #374). No-ops when no media
+  // has been acquired yet (e.g. a 'web' kind view, or one still loading).
+  ipcRenderer.on('pause', () => {
+    // Announced unconditionally, before the media guard below: the bundled
+    // HLS player page keeps its hls.js instance in a closure this preload
+    // cannot reach, and it should stop fetching segments whether or not a
+    // <video> has been acquired here yet (issue #384).
+    document.dispatchEvent(new CustomEvent(MEDIA_PAUSE_EVENT))
+    desiredPaused = true
+    if (!currentMedia) {
+      return
+    }
+    // lockdownMediaTags() permanently shadows the element's own `pause`
+    // method with a no-op (to stop sites like Facebook from auto-pausing),
+    // so call the native implementation directly instead of
+    // `currentMedia.pause()`, which would silently do nothing.
+    HTMLMediaElement.prototype.pause.call(currentMedia)
+  })
+  ipcRenderer.on('resume', () => {
+    document.dispatchEvent(new CustomEvent(MEDIA_RESUME_EVENT))
+    desiredPaused = false
+    // Live streams are typically not seekable on-demand video, so resuming
+    // after a pause may briefly re-buffer or land slightly behind the live
+    // edge -- both cheaper than a full reload and expected to self-correct
+    // as playback continues. A play() rejection (e.g. autoplay policy) is
+    // otherwise invisible, so log it as a breadcrumb (issue #392).
+    currentMedia?.play().catch((err) => {
+      console.warn('error resuming media playback', err)
+    })
+  })
+
   const [
     {
       content,
@@ -592,28 +675,15 @@ async function main() {
     },
   ] = await Promise.all([viewInit, pageReady])
 
-  const snapshotController = new SnapshotController()
+  // Fill in whatever no early message already decided. Applied before the
+  // acquisition starts below so the first VolumeController/RotationController
+  // is built from the effective values rather than racing them.
+  desiredPaused ??= initialPaused ?? false
+  latestVolume ??= initialVolume ?? 1
+  if (!hasReceivedOptions) {
+    updateOptions(initialOptions)
+  }
 
-  let rotationController: RotationController | undefined
-  let volumeController: VolumeController | undefined
-  let latestVolume = initialVolume ?? 1
-  // The most recent operator-set rotation, mirroring `latestVolume`: a
-  // re-acquisition constructs a fresh RotationController (which starts at
-  // 0°), and no 'options' message is re-sent for the internal stall
-  // recovery, so the tracked value is re-applied below (issue #620).
-  let latestRotation: number | undefined = initialOptions?.rotation
-  // Whether the operator asked this view's playback to stay paused (a parked
-  // view, issue #374). Initialized from the view-init payload so a fresh view
-  // for an already-paused cell -- in particular a background preload for a
-  // parked cell -- never starts playing before the post-swap 'pause' IPC
-  // arrives (issue #658). Tracked so a re-acquisition -- whose findMedia()
-  // unconditionally starts playback -- can re-assert the pause instead of
-  // silently resuming a hidden view (issue #621).
-  let desiredPaused = initialPaused ?? false
-  // The most recently acquired media element (reassigned across a re-
-  // acquisition, e.g. the 'emptied' handler below), so a PAUSE/RESUME
-  // message received at any point can act on whichever one is current.
-  let currentMedia: HTMLMediaElement | undefined
   async function acquireMedia(elementTimeout: number) {
     let snapshotInterval: number | undefined
 
@@ -709,54 +779,6 @@ async function main() {
     webFrame.insertCSS(NO_SCROLL_STYLE, { cssOrigin: 'user' })
     ipcRenderer.send('view-loaded')
   }
-
-  function updateOptions(options: ContentDisplayOptions) {
-    latestRotation = options.rotation
-    if (rotationController) {
-      rotationController.setCustom(options.rotation)
-    }
-  }
-  ipcRenderer.on('options', (ev, options) => updateOptions(options))
-  updateOptions(initialOptions)
-
-  function updateVolume(volume: number) {
-    latestVolume = volume
-    volumeController?.setVolume(volume)
-  }
-  ipcRenderer.on('volume', (ev, volume) => updateVolume(volume))
-
-  // Stops/resumes the acquired media element's own playback -- used to pause
-  // a parked (hidden) view instead of keeping it fully live while it's
-  // hidden behind a fullscreen expansion (issue #374). No-ops when no media
-  // has been acquired yet (e.g. a 'web' kind view, or one still loading).
-  ipcRenderer.on('pause', () => {
-    // Announced unconditionally, before the media guard below: the bundled
-    // HLS player page keeps its hls.js instance in a closure this preload
-    // cannot reach, and it should stop fetching segments whether or not a
-    // <video> has been acquired here yet (issue #384).
-    document.dispatchEvent(new CustomEvent(MEDIA_PAUSE_EVENT))
-    desiredPaused = true
-    if (!currentMedia) {
-      return
-    }
-    // lockdownMediaTags() permanently shadows the element's own `pause`
-    // method with a no-op (to stop sites like Facebook from auto-pausing),
-    // so call the native implementation directly instead of
-    // `currentMedia.pause()`, which would silently do nothing.
-    HTMLMediaElement.prototype.pause.call(currentMedia)
-  })
-  ipcRenderer.on('resume', () => {
-    document.dispatchEvent(new CustomEvent(MEDIA_RESUME_EVENT))
-    desiredPaused = false
-    // Live streams are typically not seekable on-demand video, so resuming
-    // after a pause may briefly re-buffer or land slightly behind the live
-    // edge -- both cheaper than a full reload and expected to self-correct
-    // as playback continues. A play() rejection (e.g. autoplay policy) is
-    // otherwise invisible, so log it as a breadcrumb (issue #392).
-    currentMedia?.play().catch((err) => {
-      console.warn('error resuming media playback', err)
-    })
-  })
 }
 
 main().catch((error) => {

--- a/packages/streamwall/src/preload/mediaPreload.ts
+++ b/packages/streamwall/src/preload/mediaPreload.ts
@@ -583,8 +583,6 @@ async function main() {
   const viewInit = ipcRenderer.invoke('view-init')
   const pageReady = new Promise((resolve) => process.once('loaded', resolve))
 
-  const snapshotController = new SnapshotController()
-
   // Operator-set state, all of it tracked across re-acquisitions (which build
   // a fresh RotationController/VolumeController and unconditionally start
   // playback) so the operator's latest intent survives an internal stall
@@ -681,6 +679,8 @@ async function main() {
       paused: initialPaused,
     },
   ] = await Promise.all([viewInit, pageReady])
+
+  const snapshotController = new SnapshotController()
 
   // Fill in whatever no early message already decided. Applied before the
   // acquisition starts below so the first VolumeController/RotationController


### PR DESCRIPTION
Closes #756

## Problem

`packages/streamwall/src/preload/mediaPreload.ts` subscribed to `pause`, `resume`, `options` and `volume` only after `await Promise.all([viewInit, pageReady])` in `main()`. Electron drops IPC for channels that have no listener yet, so anything the main process sent between answering `view-init` and the renderer resuming past that await was silently lost. The main process answers `view-init` and dispatches `VIEW_INIT` to the view actor in one go, so a `PAUSE`/`RESUME` processed right afterwards lands in exactly that window — and `pageReady` (`process.once("loaded")`) can delay the continuation further. The view then keeps the playback state it was initialised with: the renderer-side half of #738.

## Solution

- All four handlers are registered synchronously at the top of `main()`, and `ipcRenderer.invoke("view-init")` is now issued *after* them, so the ordering is structural rather than dependent on there being no suspension point in between.
- The operator-set state (`desiredPaused`, `latestVolume`, `latestRotation`) starts out `undefined` and is only defaulted from the view-init payload if no message already set it (`??=`, plus a `hasReceivedOptions` sentinel because `rotation` is legitimately `undefined`). An early `resume` — or an early volume of `0` — is therefore never clobbered by the payload it raced.
- The effective values are applied before the first acquisition starts, so the initial `VolumeController`/`RotationController` are built from them instead of racing them.
- `updateOptions` now tolerates a `null` payload. The view actor’s `context.options` is `ContentDisplayOptions | null` and the reply forwards it verbatim; previously that throw landed after the acquisition had been launched (a spurious `view-error` on an otherwise loaded view), but with the reordering it would have aborted `main()` before the view ever loaded.
- The `RESUME`-in-`loading` comment in `viewStateMachine.ts` no longer points at this now-closed window as an open gap.

Existing lockdown semantics are untouched: both pause sites still go through `HTMLMediaElement.prototype.pause.call(...)`, since `lockdownMediaTags()` permanently shadows the element’s own `pause` with a no-op.

## Testing

`npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (2198 tests) all green.

Nine new cases in `mediaPreload.test.ts` drive IPC through a deferred `view-init` promise — the exact window the issue describes. Eight of them fail against `main`. They cover: handler registration pinned by invocation order against the request; an early `pause` surviving a `paused: false` payload; an early `resume` surviving a `paused: true` payload; the park being announced to the page world at acquisition too; early `volume` and `options` not being clobbered (including a `0` case that a truthiness check would discard); the payload still applying when nothing arrived early; and a `null` options payload loading without a `view-error`.

## Risks

Low and contained to the preload. The reordering does not change what any handler does, only when it is attached; `web`-kind views and the re-acquisition paths for #620/#621/#658/#667 are unaffected and still covered.

## Pre-PR review

Six rounds with an independent reviewer that had none of the implementing context; the sixth returned no findings. Fixed along the way:

1. A null `options` payload aborting `main()` before the acquisition (own commit + regression test).
2. `SnapshotController` construction needlessly hoisted above the await — moved back.
3. Missing early-`volume`-of-0 case, which a `||=` regression would have slipped past.
4. A stale "window tracked in #756" claim in the `viewStateMachine` comment.
5. The `RotationController` describe leaking `ipcRenderer.on` registrations into later describes, now that importing the module registers handlers immediately — a latent cross-test binding to a dead module instance.
6. The null-options guard not asserting the absence of the spurious `view-error`.
7. `invoke("view-init")` sitting above the registrations, making the ordering incidental; moved below and pinned by `invocationCallOrder`.

No findings were dismissed.

## Follow-ups

- #785 — the per-describe duplication of the `registeredHandler` / `viewLoadedCalls` / `playableVideo` helpers in `mediaPreload.test.ts`. It predates this branch and a file-wide test refactor does not belong in this diff.