### PR TITLE
fix(control-server): shut down gracefully on SIGTERM/SIGINT

### DIFF
--- a/packages/streamwall-control-server/src/bootstrap.ts
+++ b/packages/streamwall-control-server/src/bootstrap.ts
@@ -1,3 +1,4 @@
+import process from 'node:process'
 import { inviteLink } from 'streamwall-shared'
 import type { Auth } from './auth.ts'
 import { resolveListenPort } from './config.ts'
@@ -129,6 +130,85 @@ export function logBootstrap({
   console.log('🔑 Admin invite:', adminInviteLink)
 }
 
+/** The slice of `process` the shutdown wiring uses, so specs can inject one. */
+export interface ProcessLike {
+  on(signal: 'SIGTERM' | 'SIGINT', listener: () => void): unknown
+  exit(code?: number): void
+}
+
+/** The slice of a Fastify instance the shutdown wiring uses. */
+interface ClosableApp {
+  log: {
+    info(fields: object, msg?: string): void
+    warn(fields: object, msg?: string): void
+    error(fields: object, msg?: string): void
+  }
+  close(): Promise<void>
+}
+
+/**
+ * How long a shutdown may take before the process exits anyway. A container
+ * runtime escalates to SIGKILL after ~10s of its own, so hanging any longer
+ * only trades a logged force-exit for an unlogged kill.
+ */
+export const DEFAULT_FORCE_EXIT_MS = 10_000
+
+/**
+ * Terminates the server on `SIGTERM`/`SIGINT` instead of letting the runtime
+ * kill it outright: `app.close()` runs the `onClose` hooks (update-checker
+ * teardown, storage flush) and sends WebSocket peers a close frame rather than
+ * a TCP reset (issue #751).
+ *
+ * The shutdown runs at most once, so the second signal an impatient operator
+ * sends cannot re-enter it, and a close that gets stuck still exits by way of
+ * the force-exit timer.
+ */
+export function registerShutdownHandlers({
+  app,
+  process: proc,
+  forceExitAfterMs = DEFAULT_FORCE_EXIT_MS,
+}: {
+  app: ClosableApp
+  process: ProcessLike
+  forceExitAfterMs?: number
+}): void {
+  let shuttingDown = false
+
+  const shutdown = (signal: 'SIGTERM' | 'SIGINT') => {
+    if (shuttingDown) {
+      app.log.warn({ signal }, 'Shutdown already in progress, ignoring signal')
+      return
+    }
+    shuttingDown = true
+    app.log.info({ signal }, 'Shutting down')
+
+    const forceExit = setTimeout(() => {
+      app.log.error({ signal, forceExitAfterMs }, 'Shutdown timed out, exiting')
+      proc.exit(1)
+    }, forceExitAfterMs)
+    // Unref'd so a shutdown that finishes early is never held open by the
+    // timer it no longer needs.
+    forceExit.unref()
+
+    void app.close().then(
+      () => {
+        clearTimeout(forceExit)
+        app.log.info({ signal }, 'Shutdown complete')
+        proc.exit(0)
+      },
+      (err: unknown) => {
+        clearTimeout(forceExit)
+        app.log.error({ err, signal }, 'Shutdown failed')
+        proc.exit(1)
+      },
+    )
+  }
+
+  for (const signal of ['SIGTERM', 'SIGINT'] as const) {
+    proc.on(signal, () => shutdown(signal))
+  }
+}
+
 export default async function runServer({
   port: overridePort,
   hostname: overrideHostname,
@@ -138,9 +218,12 @@ export default async function runServer({
   logLevel,
   logStream,
   updateChecker: injectedUpdateChecker,
+  process: proc = process,
 }: AppOptions & {
   hostname?: string
   port?: string
+  /** Test-only override for the signal source and exit path. */
+  process?: ProcessLike
   /** Test-only override so specs can exercise the real listen() path without touching disk. */
   db?: StorageDB
   /** Overrides the level from `LOG_LEVEL` (used by tests to silence or widen output). */
@@ -179,9 +262,23 @@ export default async function runServer({
   // throws FST_ERR_INSTANCE_ALREADY_LISTENING otherwise (issue #442).
   app.addHook('onClose', async () => {
     updateChecker.stop()
+    // Auth persistence is fire-and-forget (`auth.on('state')` in `initApp`) and
+    // storage writes are serialized, so one more write drains whatever is
+    // still queued instead of letting a shutdown truncate it. A storage that
+    // is already failing must not turn an orderly shutdown into a crash — it
+    // is reported the same way the fire-and-forget writes are.
+    try {
+      await db.write()
+    } catch (err) {
+      app.log.error({ err }, 'Failed to flush storage during shutdown')
+    }
   })
 
   await app.listen({ port, host: hostname })
+
+  // Registered only once the server is actually up: before that, a failed
+  // boot exits on its own and there is nothing to shut down.
+  registerShutdownHandlers({ app, process: proc })
 
   // Fire-and-forget: a slow or unreachable GitHub must never delay serving.
   void updateChecker.start()

--- a/packages/streamwall-control-server/src/bootstrap.ts
+++ b/packages/streamwall-control-server/src/bootstrap.ts
@@ -147,11 +147,11 @@ interface ClosableApp {
 }
 
 /**
- * How long a shutdown may take before the process exits anyway. A container
- * runtime escalates to SIGKILL after ~10s of its own, so hanging any longer
- * only trades a logged force-exit for an unlogged kill.
+ * How long a shutdown may take before the process exits anyway. Kept just
+ * under Docker's default ten-second stop grace period, so a wedged shutdown
+ * still exits with a logged reason instead of being SIGKILLed unannounced.
  */
-export const DEFAULT_FORCE_EXIT_MS = 10_000
+export const DEFAULT_FORCE_EXIT_MS = 8_000
 
 /**
  * Terminates the server on `SIGTERM`/`SIGINT` instead of letting the runtime
@@ -178,7 +178,7 @@ export function registerShutdownHandlers({
   process: ProcessLike
   forceExitAfterMs?: number
   beforeClose?: () => Promise<unknown>
-}): void {
+}): { isShuttingDown: () => boolean } {
   let shuttingDown = false
 
   const shutdown = (signal: 'SIGTERM' | 'SIGINT') => {
@@ -237,6 +237,10 @@ export function registerShutdownHandlers({
   for (const signal of ['SIGTERM', 'SIGINT'] as const) {
     proc.on(signal, () => shutdown(signal))
   }
+
+  // Lets the caller skip work it would otherwise start on top of a teardown
+  // that is already running.
+  return { isShuttingDown: () => shuttingDown }
 }
 
 export default async function runServer({
@@ -270,7 +274,7 @@ export default async function runServer({
   // The startup diagnostics below run *after* `initApp` purely so they can go
   // through `app.log`: they belong in the structured stream like every other
   // server diagnostic, and the logger only exists once Fastify does (#493).
-  const { app, db, auth, updateChecker } = await initApp({
+  const { app, db, auth, updateChecker, reportCaughtError } = await initApp({
     baseURL,
     clientStaticPath,
     db: injectedDb,
@@ -307,6 +311,7 @@ export default async function runServer({
       await db.write()
     } catch (err) {
       app.log.error({ err }, 'Failed to flush storage during shutdown')
+      reportCaughtError(err)
     }
   })
 
@@ -320,12 +325,21 @@ export default async function runServer({
     await app.listen({ port, host: hostname })
   })()
 
-  registerShutdownHandlers({ app, process: proc, beforeClose: () => boot })
+  const { isShuttingDown } = registerShutdownHandlers({
+    app,
+    process: proc,
+    beforeClose: () => boot,
+  })
 
   await boot
 
   // Fire-and-forget: a slow or unreachable GitHub must never delay serving.
-  void updateChecker.start()
+  // Skipped when a signal already arrived during the boot: the checker's first
+  // request would then go out as part of shutting down, and it would arm a
+  // poll interval after `onClose` had already stopped it.
+  if (!isShuttingDown()) {
+    void updateChecker.start()
+  }
 
   return { server: app.server }
 }

--- a/packages/streamwall-control-server/src/bootstrap.ts
+++ b/packages/streamwall-control-server/src/bootstrap.ts
@@ -198,12 +198,15 @@ export function registerShutdownHandlers({
       proc.exit(1)
     }, forceExitAfterMs)
 
+    let bootError: unknown = null
     const closed = (async () => {
       if (beforeClose) {
         try {
           await beforeClose()
-        } catch {
-          // A boot that failed has nothing left to protect; close anyway.
+        } catch (err) {
+          // A boot that failed has nothing left to protect, so the teardown
+          // still runs — but the process must not report a clean stop for it.
+          bootError = err
         }
       }
       await app.close()
@@ -212,6 +215,14 @@ export function registerShutdownHandlers({
     void closed.then(
       () => {
         clearTimeout(forceExit)
+        if (bootError !== null) {
+          app.log.error(
+            { err: bootError, signal },
+            'Shutdown complete, but the boot had failed',
+          )
+          proc.exit(1)
+          return
+        }
         app.log.info({ signal }, 'Shutdown complete')
         proc.exit(0)
       },
@@ -278,11 +289,20 @@ export default async function runServer({
   // throws FST_ERR_INSTANCE_ALREADY_LISTENING otherwise (issue #442).
   app.addHook('onClose', async () => {
     updateChecker.stop()
-    // Auth persistence is fire-and-forget (`auth.on('state')` in `initApp`) and
-    // storage writes are serialized, so one more write drains whatever is
-    // still queued instead of letting a shutdown truncate it. A storage that
-    // is already failing must not turn an orderly shutdown into a crash — it
-    // is reported the same way the fire-and-forget writes are.
+  })
+
+  // Auth persistence is fire-and-forget (`auth.on('state')` in `initApp`) and
+  // storage writes are serialized, so one more write drains whatever is still
+  // queued instead of letting a shutdown truncate it.
+  //
+  // It runs in `preClose`, before connections are drained, rather than in
+  // `onClose` after them: a peer whose TCP path is already dead can hold the
+  // drain open for the WebSocket close timeout, and the force-exit timer would
+  // then fire before a flush placed behind it ever ran — losing exactly the
+  // write this exists to save. A storage that is already failing must not turn
+  // an orderly shutdown into a crash, so it is reported the same way the
+  // fire-and-forget writes are.
+  app.addHook('preClose', async () => {
     try {
       await db.write()
     } catch (err) {

--- a/packages/streamwall-control-server/src/bootstrap.ts
+++ b/packages/streamwall-control-server/src/bootstrap.ts
@@ -182,13 +182,14 @@ export function registerShutdownHandlers({
     shuttingDown = true
     app.log.info({ signal }, 'Shutting down')
 
+    // Deliberately not unref'd: a wedged `close()` can leave nothing but
+    // pending promises behind, and an unref'd timer would let the process
+    // slip out with code 0 instead of reporting the timeout. Both settle
+    // paths clear it, so it can never hold an orderly shutdown open.
     const forceExit = setTimeout(() => {
       app.log.error({ signal, forceExitAfterMs }, 'Shutdown timed out, exiting')
       proc.exit(1)
     }, forceExitAfterMs)
-    // Unref'd so a shutdown that finishes early is never held open by the
-    // timer it no longer needs.
-    forceExit.unref()
 
     void app.close().then(
       () => {
@@ -255,9 +256,6 @@ export default async function runServer({
   )
   app.log.debug({ hostname, port }, 'Initializing web server')
 
-  const bootstrap = await initialInviteCodes({ db, auth, baseURL })
-  logBootstrap(bootstrap)
-
   // Hooks must be registered before the instance starts listening -- Fastify 5
   // throws FST_ERR_INSTANCE_ALREADY_LISTENING otherwise (issue #442).
   app.addHook('onClose', async () => {
@@ -274,11 +272,16 @@ export default async function runServer({
     }
   })
 
-  await app.listen({ port, host: hostname })
-
-  // Registered only once the server is actually up: before that, a failed
-  // boot exits on its own and there is nothing to shut down.
+  // Armed before the boot finishes rather than after `listen`, so a stop
+  // signal arriving during a slow start — minting the uplink token is a scrypt
+  // derivation plus two storage writes — is handled too. Closing an instance
+  // that never listened simply runs the hooks above.
   registerShutdownHandlers({ app, process: proc })
+
+  const bootstrap = await initialInviteCodes({ db, auth, baseURL })
+  logBootstrap(bootstrap)
+
+  await app.listen({ port, host: hostname })
 
   // Fire-and-forget: a slow or unreachable GitHub must never delay serving.
   void updateChecker.start()

--- a/packages/streamwall-control-server/src/bootstrap.ts
+++ b/packages/streamwall-control-server/src/bootstrap.ts
@@ -162,15 +162,22 @@ export const DEFAULT_FORCE_EXIT_MS = 10_000
  * The shutdown runs at most once, so the second signal an impatient operator
  * sends cannot re-enter it, and a close that gets stuck still exits by way of
  * the force-exit timer.
+ *
+ * `beforeClose` lets the caller finish work the instance knows nothing about
+ * (the boot, which is still minting and persisting tokens) before the teardown
+ * runs; a rejection there is ignored, since a failed boot must not keep the
+ * process alive. The force-exit timer bounds that wait too.
  */
 export function registerShutdownHandlers({
   app,
   process: proc,
   forceExitAfterMs = DEFAULT_FORCE_EXIT_MS,
+  beforeClose,
 }: {
   app: ClosableApp
   process: ProcessLike
   forceExitAfterMs?: number
+  beforeClose?: () => Promise<unknown>
 }): void {
   let shuttingDown = false
 
@@ -191,7 +198,18 @@ export function registerShutdownHandlers({
       proc.exit(1)
     }, forceExitAfterMs)
 
-    void app.close().then(
+    const closed = (async () => {
+      if (beforeClose) {
+        try {
+          await beforeClose()
+        } catch {
+          // A boot that failed has nothing left to protect; close anyway.
+        }
+      }
+      await app.close()
+    })()
+
+    void closed.then(
       () => {
         clearTimeout(forceExit)
         app.log.info({ signal }, 'Shutdown complete')
@@ -272,16 +290,19 @@ export default async function runServer({
     }
   })
 
-  // Armed before the boot finishes rather than after `listen`, so a stop
-  // signal arriving during a slow start — minting the uplink token is a scrypt
-  // derivation plus two storage writes — is handled too. Closing an instance
-  // that never listened simply runs the hooks above.
-  registerShutdownHandlers({ app, process: proc })
+  // The rest of the boot runs as one awaitable unit so the shutdown handlers
+  // can be armed before it starts: a stop signal arriving during a slow start
+  // — minting the uplink token is a scrypt derivation plus two storage writes
+  // — then waits for those writes to land instead of exiting on top of them.
+  const boot = (async () => {
+    const bootstrap = await initialInviteCodes({ db, auth, baseURL })
+    logBootstrap(bootstrap)
+    await app.listen({ port, host: hostname })
+  })()
 
-  const bootstrap = await initialInviteCodes({ db, auth, baseURL })
-  logBootstrap(bootstrap)
+  registerShutdownHandlers({ app, process: proc, beforeClose: () => boot })
 
-  await app.listen({ port, host: hostname })
+  await boot
 
   // Fire-and-forget: a slow or unreachable GitHub must never delay serving.
   void updateChecker.start()

--- a/packages/streamwall-control-server/src/bootstrap.ts
+++ b/packages/streamwall-control-server/src/bootstrap.ts
@@ -178,7 +178,10 @@ export function registerShutdownHandlers({
   process: ProcessLike
   forceExitAfterMs?: number
   beforeClose?: () => Promise<unknown>
-}): { isShuttingDown: () => boolean } {
+}): {
+  isShuttingDown: () => boolean
+  shutdown: (signal: 'SIGTERM' | 'SIGINT') => void
+} {
   let shuttingDown = false
 
   const shutdown = (signal: 'SIGTERM' | 'SIGINT') => {
@@ -238,9 +241,10 @@ export function registerShutdownHandlers({
     proc.on(signal, () => shutdown(signal))
   }
 
-  // Lets the caller skip work it would otherwise start on top of a teardown
-  // that is already running.
-  return { isShuttingDown: () => shuttingDown }
+  // `isShuttingDown` lets the caller skip work it would otherwise start on top
+  // of a teardown that is already running; `shutdown` lets it replay a signal
+  // that arrived before the app existed.
+  return { isShuttingDown: () => shuttingDown, shutdown }
 }
 
 export default async function runServer({
@@ -270,6 +274,18 @@ export default async function runServer({
   const url = new URL(baseURL)
   const hostname = overrideHostname ?? url.hostname
   const port = resolveListenPort(baseURL, overridePort)
+
+  // As PID 1 in a container the kernel drops a signal for which no handler is
+  // installed, so a `docker stop` during `initApp` — which creates the storage
+  // directory and may write the default storage.json — would be ignored
+  // outright until the grace period expires. Catch it here and replay it into
+  // the real handler as soon as there is an app to shut down.
+  let signalDuringInit: 'SIGTERM' | 'SIGINT' | null = null
+  for (const signal of ['SIGTERM', 'SIGINT'] as const) {
+    proc.on(signal, () => {
+      signalDuringInit ??= signal
+    })
+  }
 
   // The startup diagnostics below run *after* `initApp` purely so they can go
   // through `app.log`: they belong in the structured stream like every other
@@ -325,13 +341,27 @@ export default async function runServer({
     await app.listen({ port, host: hostname })
   })()
 
-  const { isShuttingDown } = registerShutdownHandlers({
+  const { isShuttingDown, shutdown } = registerShutdownHandlers({
     app,
     process: proc,
     beforeClose: () => boot,
   })
 
-  await boot
+  if (signalDuringInit !== null) {
+    shutdown(signalDuringInit)
+  }
+
+  try {
+    await boot
+  } catch (err) {
+    // While shutting down, the teardown owns the outcome: rethrowing here
+    // would surface as an unhandled rejection and kill the process in the
+    // middle of the storage flush the shutdown is running.
+    if (!isShuttingDown()) {
+      throw err
+    }
+    return { server: app.server }
+  }
 
   // Fire-and-forget: a slow or unreachable GitHub must never delay serving.
   // Skipped when a signal already arrived during the boot: the checker's first

--- a/packages/streamwall-control-server/src/bootstrap.ts
+++ b/packages/streamwall-control-server/src/bootstrap.ts
@@ -280,10 +280,21 @@ export default async function runServer({
   // directory and may write the default storage.json — would be ignored
   // outright until the grace period expires. Catch it here and replay it into
   // the real handler as soon as there is an app to shut down.
+  //
+  // Installing a listener also suppresses the default disposition everywhere
+  // else, so this one arms a deadline of its own: a `mkdir` or first write
+  // wedged on an unresponsive volume must not leave the process unkillable,
+  // and a second signal in that window gives up immediately — nothing has been
+  // built yet that could be flushed.
   let signalDuringInit: 'SIGTERM' | 'SIGINT' | null = null
   for (const signal of ['SIGTERM', 'SIGINT'] as const) {
     proc.on(signal, () => {
-      signalDuringInit ??= signal
+      if (signalDuringInit !== null) {
+        proc.exit(1)
+        return
+      }
+      signalDuringInit = signal
+      setTimeout(() => proc.exit(1), DEFAULT_FORCE_EXIT_MS)
     })
   }
 

--- a/packages/streamwall-control-server/src/bootstrap.ts
+++ b/packages/streamwall-control-server/src/bootstrap.ts
@@ -133,6 +133,7 @@ export function logBootstrap({
 /** The slice of `process` the shutdown wiring uses, so specs can inject one. */
 export interface ProcessLike {
   on(signal: 'SIGTERM' | 'SIGINT', listener: () => void): unknown
+  off(signal: 'SIGTERM' | 'SIGINT', listener: () => void): unknown
   exit(code?: number): void
 }
 
@@ -166,18 +167,22 @@ export const DEFAULT_FORCE_EXIT_MS = 8_000
  * `beforeClose` lets the caller finish work the instance knows nothing about
  * (the boot, which is still minting and persisting tokens) before the teardown
  * runs; a rejection there is ignored, since a failed boot must not keep the
- * process alive. The force-exit timer bounds that wait too.
+ * process alive. `flush` then persists whatever that work left queued, ahead of
+ * draining connections and — unlike a Fastify hook — genuinely awaited. The
+ * force-exit timer bounds both waits.
  */
 export function registerShutdownHandlers({
   app,
   process: proc,
   forceExitAfterMs = DEFAULT_FORCE_EXIT_MS,
   beforeClose,
+  flush,
 }: {
   app: ClosableApp
   process: ProcessLike
   forceExitAfterMs?: number
   beforeClose?: () => Promise<unknown>
+  flush?: () => Promise<void>
 }): {
   isShuttingDown: () => boolean
   shutdown: (signal: 'SIGTERM' | 'SIGINT') => void
@@ -211,6 +216,9 @@ export function registerShutdownHandlers({
           // still runs — but the process must not report a clean stop for it.
           bootError = err
         }
+      }
+      if (flush) {
+        await flush()
       }
       await app.close()
     })()
@@ -287,16 +295,19 @@ export default async function runServer({
   // and a second signal in that window gives up immediately — nothing has been
   // built yet that could be flushed.
   let signalDuringInit: 'SIGTERM' | 'SIGINT' | null = null
-  for (const signal of ['SIGTERM', 'SIGINT'] as const) {
-    proc.on(signal, () => {
+  let initDeadline: ReturnType<typeof setTimeout> | undefined
+  const initListeners = (['SIGTERM', 'SIGINT'] as const).map((signal) => {
+    const listener = () => {
       if (signalDuringInit !== null) {
         proc.exit(1)
         return
       }
       signalDuringInit = signal
-      setTimeout(() => proc.exit(1), DEFAULT_FORCE_EXIT_MS)
-    })
-  }
+      initDeadline = setTimeout(() => proc.exit(1), DEFAULT_FORCE_EXIT_MS)
+    }
+    proc.on(signal, listener)
+    return { signal, listener }
+  })
 
   // The startup diagnostics below run *after* `initApp` purely so they can go
   // through `app.log`: they belong in the structured stream like every other
@@ -326,21 +337,22 @@ export default async function runServer({
   // storage writes are serialized, so one more write drains whatever is still
   // queued instead of letting a shutdown truncate it.
   //
-  // It runs in `preClose`, before connections are drained, rather than in
-  // `onClose` after them: a peer whose TCP path is already dead can hold the
-  // drain open for the WebSocket close timeout, and the force-exit timer would
-  // then fire before a flush placed behind it ever ran — losing exactly the
-  // write this exists to save. A storage that is already failing must not turn
-  // an orderly shutdown into a crash, so it is reported the same way the
-  // fire-and-forget writes are.
-  app.addHook('preClose', async () => {
+  // It is driven from the shutdown path rather than from a Fastify hook: an
+  // `onClose` hook runs only after connections have drained, which a peer with
+  // a dead TCP path can stall past the force-exit budget, and a `preClose` hook
+  // is not reliably awaited — `@fastify/websocket`'s own `preClose` calls its
+  // `done` twice, letting `app.close()` resolve while a later hook is still
+  // running. A storage that is already failing must not turn an orderly
+  // shutdown into a crash, so it is reported the way the fire-and-forget writes
+  // are.
+  const flushStorage = async () => {
     try {
       await db.write()
     } catch (err) {
       app.log.error({ err }, 'Failed to flush storage during shutdown')
       reportCaughtError(err)
     }
-  })
+  }
 
   // The rest of the boot runs as one awaitable unit so the shutdown handlers
   // can be armed before it starts: a stop signal arriving during a slow start
@@ -356,7 +368,16 @@ export default async function runServer({
     app,
     process: proc,
     beforeClose: () => boot,
+    flush: flushStorage,
   })
+
+  // Every signal now goes through the single idempotent handler above; leaving
+  // the init-window listeners in place would let a second one hard-exit on top
+  // of the teardown they were only ever meant to bridge to.
+  for (const { signal, listener } of initListeners) {
+    proc.off(signal, listener)
+  }
+  clearTimeout(initDeadline)
 
   if (signalDuringInit !== null) {
     shutdown(signalDuringInit)

--- a/packages/streamwall-control-server/src/gracefulShutdown.test.ts
+++ b/packages/streamwall-control-server/src/gracefulShutdown.test.ts
@@ -17,7 +17,17 @@ function fakeApp(close: () => Promise<void>, logs: LogCapture) {
   const record =
     (level: string) =>
     (fields: object, msg?: string): void => {
-      logs.stream.write(JSON.stringify({ level, ...fields, msg }))
+      // Errors are flattened the way pino's standard serializer does, so a
+      // spec can assert on what an operator would actually read.
+      const { err, ...rest } = fields as { err?: unknown }
+      logs.stream.write(
+        JSON.stringify({
+          level,
+          ...rest,
+          ...(err instanceof Error && { err: { message: err.message } }),
+          msg,
+        }),
+      )
     }
   let closeCalls = 0
   return {
@@ -98,6 +108,24 @@ describe('registerShutdownHandlers', () => {
     proc.emit('SIGTERM')
     await logs.waitForMessage('Shutdown timed out')
 
+    assert.deepEqual(exitCodes, [1])
+  })
+
+  test('still tears down when the boot fails, but never reports it as clean', async () => {
+    const logs = captureLogs()
+    const { proc, exitCodes } = fakeProcess()
+    const { app, calls } = fakeApp(() => Promise.resolve(), logs)
+
+    registerShutdownHandlers({
+      app,
+      process: proc,
+      beforeClose: () => Promise.reject(new Error('listen: EADDRINUSE')),
+    })
+    proc.emit('SIGTERM')
+    const entry = await logs.waitForMessage('the boot had failed')
+
+    assert.equal(calls(), 1, 'a failed boot must still be torn down')
+    assert.match(JSON.stringify(entry.err), /EADDRINUSE/)
     assert.deepEqual(exitCodes, [1])
   })
 

--- a/packages/streamwall-control-server/src/gracefulShutdown.test.ts
+++ b/packages/streamwall-control-server/src/gracefulShutdown.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
 import { once } from 'node:events'
-import { mkdtempSync, readFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import process from 'node:process'
@@ -178,6 +178,32 @@ describe('runServer shutdown wiring', () => {
     assert.deepEqual(exitCodes, [0])
   })
 
+  test('a signal arriving during init is replayed once the app exists', async () => {
+    // `runServer` runs synchronously up to `await initApp`, so a signal emitted
+    // right after the call lands in the window where there is no app to close
+    // yet. It must not be dropped: as PID 1 the kernel discards a signal only
+    // while no handler is installed, and this one is.
+    const logs = captureLogs()
+    const { proc, exitCodes } = fakeProcess()
+    const starting = runServer({
+      baseURL: 'http://127.0.0.1:0',
+      clientStaticPath: import.meta.dirname,
+      db: inMemoryDb(),
+      logLevel: 'trace',
+      logStream: logs.stream,
+      updateChecker: fakeUpdateChecker(),
+      process: proc,
+    })
+    proc.emit('SIGTERM')
+
+    const { server } = await starting
+    after(() => server.close())
+    await logs.waitForMessage('Shutdown complete', 15000)
+
+    assert.equal(server.listening, false)
+    assert.deepEqual(exitCodes, [0])
+  })
+
   test('a signal during the boot waits for the boot to finish writing', async () => {
     // Minting the uplink token is a scrypt derivation plus persisted writes,
     // so a container stop can easily land inside the boot. Exiting on top of
@@ -264,9 +290,11 @@ test('a real SIGTERM to the entry point exits 0 and leaves storage intact', asyn
   // the entry point as a child and signals it the way a container stop does.
   const dataDir = mkdtempSync(path.join(tmpdir(), 'sw-shutdown-'))
   const dbPath = path.join(dataDir, 'storage.json')
+  // Launched exactly the way the image's CMD does — `node <entry>`, on Node's
+  // own type stripping — so this covers the same invocation a container stops.
   const child = spawn(
     process.execPath,
-    ['--import', 'tsx', path.join(import.meta.dirname, 'index.ts')],
+    [path.join(import.meta.dirname, 'index.ts')],
     {
       env: {
         ...process.env,
@@ -279,27 +307,43 @@ test('a real SIGTERM to the entry point exits 0 and leaves storage intact', asyn
       stdio: ['ignore', 'pipe', 'pipe'],
     },
   )
-  after(() => child.kill('SIGKILL'))
+  after(() => {
+    child.kill('SIGKILL')
+    rmSync(dataDir, { recursive: true, force: true })
+  })
+
+  // Both streams are drained: an unread pipe blocks the child once it fills,
+  // and stderr is what says why a boot died.
+  let stdout = ''
+  let stderr = ''
+  child.stdout.on('data', (chunk: Buffer) => (stdout += chunk.toString()))
+  child.stderr.on('data', (chunk: Buffer) => (stderr += chunk.toString()))
 
   // The credential banner is the last thing the boot prints, so seeing it
-  // means the server is up and the signal lands on a running process.
+  // means the server is up and the signal lands on a running process. Matched
+  // against everything received so far, since a pipe splits where it likes.
   await new Promise<void>((resolve, reject) => {
+    const fail = (reason: string) =>
+      reject(new Error(`${reason}\nstdout: ${stdout}\nstderr: ${stderr}`))
     const timer = setTimeout(
-      () => reject(new Error('the server never finished booting')),
+      () => fail('the server never finished booting'),
       30000,
     )
-    child.stdout.on('data', (chunk: Buffer) => {
-      if (chunk.toString().includes('Admin invite')) {
+    child.on('error', (err) => fail(`the server could not be spawned: ${err}`))
+    child.on('exit', (code) => fail(`the server exited early with ${code}`))
+    child.stdout.on('data', () => {
+      if (stdout.includes('Admin invite')) {
         clearTimeout(timer)
         resolve()
       }
     })
   })
 
+  child.removeAllListeners('exit')
   child.kill('SIGTERM')
   const [code] = (await once(child, 'exit')) as [number | null, string | null]
 
-  assert.equal(code, 0, 'a stop signal must produce a clean exit')
+  assert.equal(code, 0, `a stop signal must produce a clean exit\n${stderr}`)
   assert.doesNotThrow(
     () => JSON.parse(readFileSync(dbPath, 'utf8')),
     'the storage file must survive the shutdown intact',

--- a/packages/streamwall-control-server/src/gracefulShutdown.test.ts
+++ b/packages/streamwall-control-server/src/gracefulShutdown.test.ts
@@ -1,41 +1,16 @@
 import assert from 'node:assert/strict'
-import { EventEmitter } from 'node:events'
 import { after, describe, test } from 'node:test'
 import { setTimeout as delay } from 'node:timers/promises'
 
-import runServer, {
-  registerShutdownHandlers,
-  type ProcessLike,
-} from './bootstrap.ts'
+import runServer, { registerShutdownHandlers } from './bootstrap.ts'
 import type { StorageDB } from './storage.ts'
 import {
   captureLogs,
+  fakeProcess,
   fakeUpdateChecker,
   inMemoryDb,
   type LogCapture,
 } from './testHelpers.ts'
-
-/**
- * A stand-in for `process`: signals are emitted by the spec and `exit` is
- * recorded instead of tearing the test runner down.
- */
-function fakeProcess() {
-  const emitter = new EventEmitter()
-  const exitCodes: (number | undefined)[] = []
-  const proc: ProcessLike & { emit(signal: string): void } = {
-    on(signal, listener) {
-      emitter.on(signal, listener)
-      return proc
-    },
-    exit(code) {
-      exitCodes.push(code)
-    },
-    emit(signal: string) {
-      emitter.emit(signal)
-    },
-  }
-  return { proc, exitCodes }
-}
 
 /** The slice of a Fastify instance the shutdown wiring actually uses. */
 function fakeApp(close: () => Promise<void>, logs: LogCapture) {
@@ -164,6 +139,51 @@ describe('runServer shutdown wiring', () => {
       server.listening,
       false,
       'the server must have stopped listening',
+    )
+    assert.deepEqual(exitCodes, [0])
+  })
+
+  test('a signal during the boot waits for the boot to finish writing', async () => {
+    // Minting the uplink token is a scrypt derivation plus persisted writes,
+    // so a container stop can easily land inside the boot. Exiting on top of
+    // those writes is exactly the truncated storage.json #751 is about.
+    const db = inMemoryDb() as StorageDB
+    const { proc, exitCodes } = fakeProcess()
+    const events: string[] = []
+    const realUpdate = db.update.bind(db)
+    let signalled = false
+    db.update = async (fn) => {
+      if (!signalled) {
+        signalled = true
+        // The boot's very first write is in flight: stop the server now.
+        proc.emit('SIGTERM')
+      }
+      events.push('write:start')
+      await delay(20)
+      await realUpdate(fn)
+      events.push('write:done')
+    }
+    proc.exit = (code) => {
+      events.push(`exit:${code}`)
+      exitCodes.push(code)
+    }
+
+    const logs = captureLogs()
+    const { server } = await runServer({
+      baseURL: 'http://127.0.0.1:0',
+      clientStaticPath: import.meta.dirname,
+      db,
+      logLevel: 'trace',
+      logStream: logs.stream,
+      updateChecker: fakeUpdateChecker(),
+      process: proc,
+    })
+    after(() => server.close())
+    await logs.waitForMessage('Shutdown complete', 10000)
+
+    assert.ok(
+      events.indexOf('write:done') < events.indexOf('exit:0'),
+      `the boot's writes must land before the process exits, got ${events.join(', ')}`,
     )
     assert.deepEqual(exitCodes, [0])
   })

--- a/packages/streamwall-control-server/src/gracefulShutdown.test.ts
+++ b/packages/streamwall-control-server/src/gracefulShutdown.test.ts
@@ -1,4 +1,10 @@
 import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { once } from 'node:events'
+import { mkdtempSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
 import { after, describe, test } from 'node:test'
 import { setTimeout as delay } from 'node:timers/promises'
 
@@ -9,6 +15,7 @@ import {
   fakeProcess,
   fakeUpdateChecker,
   inMemoryDb,
+  makeStaticDir,
   type LogCapture,
 } from './testHelpers.ts'
 
@@ -248,4 +255,53 @@ describe('runServer shutdown wiring', () => {
       'shutdown must flush storage rather than leave a fire-and-forget write in flight',
     )
   })
+})
+
+test('a real SIGTERM to the entry point exits 0 and leaves storage intact', async () => {
+  // The specs above inject a fake process, which is what keeps the handlers off
+  // the test runner — but that also means nothing exercises the default
+  // binding to the real `process`, or the real `process.exit`. This one boots
+  // the entry point as a child and signals it the way a container stop does.
+  const dataDir = mkdtempSync(path.join(tmpdir(), 'sw-shutdown-'))
+  const dbPath = path.join(dataDir, 'storage.json')
+  const child = spawn(
+    process.execPath,
+    ['--import', 'tsx', path.join(import.meta.dirname, 'index.ts')],
+    {
+      env: {
+        ...process.env,
+        DB_PATH: dbPath,
+        LOG_LEVEL: 'info',
+        STREAMWALL_CONTROL_URL: 'http://127.0.0.1:0',
+        STREAMWALL_CONTROL_STATIC: makeStaticDir(),
+        STREAMWALL_UPDATE_CHECK: 'false',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  )
+  after(() => child.kill('SIGKILL'))
+
+  // The credential banner is the last thing the boot prints, so seeing it
+  // means the server is up and the signal lands on a running process.
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error('the server never finished booting')),
+      30000,
+    )
+    child.stdout.on('data', (chunk: Buffer) => {
+      if (chunk.toString().includes('Admin invite')) {
+        clearTimeout(timer)
+        resolve()
+      }
+    })
+  })
+
+  child.kill('SIGTERM')
+  const [code] = (await once(child, 'exit')) as [number | null, string | null]
+
+  assert.equal(code, 0, 'a stop signal must produce a clean exit')
+  assert.doesNotThrow(
+    () => JSON.parse(readFileSync(dbPath, 'utf8')),
+    'the storage file must survive the shutdown intact',
+  )
 })

--- a/packages/streamwall-control-server/src/gracefulShutdown.test.ts
+++ b/packages/streamwall-control-server/src/gracefulShutdown.test.ts
@@ -1,0 +1,207 @@
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { after, describe, test } from 'node:test'
+import { setTimeout as delay } from 'node:timers/promises'
+
+import runServer, {
+  registerShutdownHandlers,
+  type ProcessLike,
+} from './bootstrap.ts'
+import type { StorageDB } from './storage.ts'
+import {
+  captureLogs,
+  fakeUpdateChecker,
+  inMemoryDb,
+  type LogCapture,
+} from './testHelpers.ts'
+
+/**
+ * A stand-in for `process`: signals are emitted by the spec and `exit` is
+ * recorded instead of tearing the test runner down.
+ */
+function fakeProcess() {
+  const emitter = new EventEmitter()
+  const exitCodes: (number | undefined)[] = []
+  const proc: ProcessLike & { emit(signal: string): void } = {
+    on(signal, listener) {
+      emitter.on(signal, listener)
+      return proc
+    },
+    exit(code) {
+      exitCodes.push(code)
+    },
+    emit(signal: string) {
+      emitter.emit(signal)
+    },
+  }
+  return { proc, exitCodes, listenerCount: () => emitter.eventNames().length }
+}
+
+/** The slice of a Fastify instance the shutdown wiring actually uses. */
+function fakeApp(close: () => Promise<void>, logs: LogCapture) {
+  const record =
+    (level: string) =>
+    (fields: unknown, msg?: string): void => {
+      const entry =
+        typeof fields === 'string'
+          ? { level, msg: fields }
+          : { level, ...(fields as object), msg }
+      logs.stream.write(JSON.stringify(entry))
+    }
+  let closeCalls = 0
+  return {
+    app: {
+      log: {
+        info: record('info'),
+        warn: record('warn'),
+        error: record('error'),
+      },
+      close: () => {
+        closeCalls += 1
+        return close()
+      },
+    },
+    calls: () => closeCalls,
+  }
+}
+
+describe('registerShutdownHandlers', () => {
+  test('closes the app and exits 0 on SIGTERM', async () => {
+    const logs = captureLogs()
+    const { proc, exitCodes } = fakeProcess()
+    const { app, calls } = fakeApp(() => Promise.resolve(), logs)
+
+    registerShutdownHandlers({ app, process: proc })
+    proc.emit('SIGTERM')
+    await logs.waitForMessage('Shutdown complete')
+
+    assert.equal(calls(), 1, 'the app must be closed exactly once')
+    assert.deepEqual(exitCodes, [0])
+  })
+
+  test('closes the app and exits 0 on SIGINT', async () => {
+    const logs = captureLogs()
+    const { proc, exitCodes } = fakeProcess()
+    const { app, calls } = fakeApp(() => Promise.resolve(), logs)
+
+    registerShutdownHandlers({ app, process: proc })
+    proc.emit('SIGINT')
+    await logs.waitForMessage('Shutdown complete')
+
+    assert.equal(calls(), 1)
+    assert.deepEqual(exitCodes, [0])
+  })
+
+  test('a second signal never starts a second shutdown', async () => {
+    const logs = captureLogs()
+    const { proc, exitCodes } = fakeProcess()
+    let release = () => {}
+    const closing = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const { app, calls } = fakeApp(() => closing, logs)
+
+    registerShutdownHandlers({ app, process: proc })
+    proc.emit('SIGTERM')
+    proc.emit('SIGINT')
+    await logs.waitForMessage('Shutdown already in progress')
+    release()
+    await logs.waitForMessage('Shutdown complete')
+
+    assert.equal(
+      calls(),
+      1,
+      'close() must not be re-entered by a second signal',
+    )
+    assert.deepEqual(exitCodes, [0], 'the process must be exited exactly once')
+  })
+
+  test('exits non-zero when the shutdown exceeds its budget', async () => {
+    const logs = captureLogs()
+    const { proc, exitCodes } = fakeProcess()
+    // A close that never settles: without the fallback the process would hang
+    // until the supervisor escalates to SIGKILL.
+    const { app } = fakeApp(() => new Promise<void>(() => {}), logs)
+
+    registerShutdownHandlers({ app, process: proc, forceExitAfterMs: 20 })
+    proc.emit('SIGTERM')
+    await logs.waitForMessage('Shutdown timed out')
+
+    assert.deepEqual(exitCodes, [1])
+  })
+
+  test('exits non-zero when closing fails, and reports the error', async () => {
+    const logs = captureLogs()
+    const { proc, exitCodes } = fakeProcess()
+    const { app } = fakeApp(
+      () => Promise.reject(new Error('close blew up')),
+      logs,
+    )
+
+    registerShutdownHandlers({ app, process: proc })
+    proc.emit('SIGTERM')
+    await logs.waitForMessage('Shutdown failed')
+    assert.deepEqual(exitCodes, [1])
+  })
+})
+
+describe('runServer shutdown wiring', () => {
+  test('a SIGTERM stops the listening server and exits 0', async () => {
+    const logs = captureLogs()
+    const { proc, exitCodes } = fakeProcess()
+    const { server } = await runServer({
+      baseURL: 'http://127.0.0.1:0',
+      clientStaticPath: import.meta.dirname,
+      db: inMemoryDb(),
+      logLevel: 'trace',
+      logStream: logs.stream,
+      updateChecker: fakeUpdateChecker(),
+      process: proc,
+    })
+    after(() => server.close())
+    assert.ok(server.listening)
+
+    proc.emit('SIGTERM')
+    await logs.waitForMessage('Shutdown complete', 10000)
+
+    assert.equal(
+      server.listening,
+      false,
+      'the server must have stopped listening',
+    )
+    assert.deepEqual(exitCodes, [0])
+  })
+
+  test('closing flushes storage, so a queued auth write cannot be lost', async () => {
+    const db = inMemoryDb() as StorageDB
+    let writes = 0
+    const realWrite = db.write.bind(db)
+    db.write = async () => {
+      writes += 1
+      await delay(5)
+      return realWrite()
+    }
+
+    const logs = captureLogs()
+    const { proc } = fakeProcess()
+    const { server } = await runServer({
+      baseURL: 'http://127.0.0.1:0',
+      clientStaticPath: import.meta.dirname,
+      db,
+      logLevel: 'trace',
+      logStream: logs.stream,
+      updateChecker: fakeUpdateChecker(),
+      process: proc,
+    })
+    after(() => server.close())
+
+    const before = writes
+    proc.emit('SIGTERM')
+    await logs.waitForMessage('Shutdown complete', 10000)
+
+    assert.ok(
+      writes > before,
+      'shutdown must flush storage rather than leave a fire-and-forget write in flight',
+    )
+  })
+})

--- a/packages/streamwall-control-server/src/gracefulShutdown.test.ts
+++ b/packages/streamwall-control-server/src/gracefulShutdown.test.ts
@@ -249,18 +249,31 @@ describe('runServer shutdown wiring', () => {
     assert.deepEqual(exitCodes, [0])
   })
 
-  test('closing flushes storage, so a queued auth write cannot be lost', async () => {
+  test('the storage flush completes before the process exits', async () => {
+    // Starting the flush is not enough: auth persistence is fire-and-forget, so
+    // a shutdown that exits while the write is still in flight truncates
+    // exactly the state it was supposed to save.
     const db = inMemoryDb() as StorageDB
-    let writes = 0
+    const { proc, exitCodes } = fakeProcess()
+    const events: string[] = []
     const realWrite = db.write.bind(db)
+    let booted = false
     db.write = async () => {
-      writes += 1
-      await delay(5)
+      if (booted) {
+        events.push('flush:start')
+        await delay(50)
+        await realWrite()
+        events.push('flush:done')
+        return
+      }
       return realWrite()
+    }
+    proc.exit = (code) => {
+      events.push(`exit:${code}`)
+      exitCodes.push(code)
     }
 
     const logs = captureLogs()
-    const { proc } = fakeProcess()
     const { server } = await runServer({
       baseURL: 'http://127.0.0.1:0',
       clientStaticPath: import.meta.dirname,
@@ -271,81 +284,92 @@ describe('runServer shutdown wiring', () => {
       process: proc,
     })
     after(() => server.close())
+    booted = true
 
-    const before = writes
     proc.emit('SIGTERM')
     await logs.waitForMessage('Shutdown complete', 10000)
 
-    assert.ok(
-      writes > before,
-      'shutdown must flush storage rather than leave a fire-and-forget write in flight',
+    assert.deepEqual(
+      events,
+      ['flush:start', 'flush:done', 'exit:0'],
+      'the flush must have landed before the process exited',
     )
   })
 })
 
-test('a real SIGTERM to the entry point exits 0 and leaves storage intact', async () => {
-  // The specs above inject a fake process, which is what keeps the handlers off
-  // the test runner — but that also means nothing exercises the default
-  // binding to the real `process`, or the real `process.exit`. This one boots
-  // the entry point as a child and signals it the way a container stop does.
-  const dataDir = mkdtempSync(path.join(tmpdir(), 'sw-shutdown-'))
-  const dbPath = path.join(dataDir, 'storage.json')
-  // Launched exactly the way the image's CMD does — `node <entry>`, on Node's
-  // own type stripping — so this covers the same invocation a container stops.
-  const child = spawn(
-    process.execPath,
-    [path.join(import.meta.dirname, 'index.ts')],
-    {
-      env: {
-        ...process.env,
-        DB_PATH: dbPath,
-        LOG_LEVEL: 'info',
-        STREAMWALL_CONTROL_URL: 'http://127.0.0.1:0',
-        STREAMWALL_CONTROL_STATIC: makeStaticDir(),
-        STREAMWALL_UPDATE_CHECK: 'false',
+test(
+  'a real SIGTERM to the entry point exits 0 and leaves storage intact',
+  {
+    // Windows has no POSIX signals: `kill('SIGTERM')` there is an unconditional
+    // TerminateProcess, so there is no graceful path to observe.
+    skip: process.platform === 'win32' ? 'POSIX signals only' : false,
+  },
+  async () => {
+    // The specs above inject a fake process, which is what keeps the handlers off
+    // the test runner — but that also means nothing exercises the default
+    // binding to the real `process`, or the real `process.exit`. This one boots
+    // the entry point as a child and signals it the way a container stop does.
+    const dataDir = mkdtempSync(path.join(tmpdir(), 'sw-shutdown-'))
+    const dbPath = path.join(dataDir, 'storage.json')
+    // Launched exactly the way the image's CMD does — `node <entry>`, on Node's
+    // own type stripping — so this covers the same invocation a container stops.
+    const child = spawn(
+      process.execPath,
+      [path.join(import.meta.dirname, 'index.ts')],
+      {
+        env: {
+          ...process.env,
+          DB_PATH: dbPath,
+          LOG_LEVEL: 'info',
+          STREAMWALL_CONTROL_URL: 'http://127.0.0.1:0',
+          STREAMWALL_CONTROL_STATIC: makeStaticDir(),
+          STREAMWALL_UPDATE_CHECK: 'false',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
       },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    },
-  )
-  after(() => {
-    child.kill('SIGKILL')
-    rmSync(dataDir, { recursive: true, force: true })
-  })
-
-  // Both streams are drained: an unread pipe blocks the child once it fills,
-  // and stderr is what says why a boot died.
-  let stdout = ''
-  let stderr = ''
-  child.stdout.on('data', (chunk: Buffer) => (stdout += chunk.toString()))
-  child.stderr.on('data', (chunk: Buffer) => (stderr += chunk.toString()))
-
-  // The credential banner is the last thing the boot prints, so seeing it
-  // means the server is up and the signal lands on a running process. Matched
-  // against everything received so far, since a pipe splits where it likes.
-  await new Promise<void>((resolve, reject) => {
-    const fail = (reason: string) =>
-      reject(new Error(`${reason}\nstdout: ${stdout}\nstderr: ${stderr}`))
-    const timer = setTimeout(
-      () => fail('the server never finished booting'),
-      30000,
     )
-    child.on('error', (err) => fail(`the server could not be spawned: ${err}`))
-    child.on('exit', (code) => fail(`the server exited early with ${code}`))
-    child.stdout.on('data', () => {
-      if (stdout.includes('Admin invite')) {
-        clearTimeout(timer)
-        resolve()
-      }
+    after(() => {
+      child.kill('SIGKILL')
+      rmSync(dataDir, { recursive: true, force: true })
     })
-  })
 
-  child.removeAllListeners('exit')
-  child.kill('SIGTERM')
-  const [code] = (await once(child, 'exit')) as [number | null, string | null]
+    // Both streams are drained: an unread pipe blocks the child once it fills,
+    // and stderr is what says why a boot died.
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk: Buffer) => (stdout += chunk.toString()))
+    child.stderr.on('data', (chunk: Buffer) => (stderr += chunk.toString()))
 
-  assert.equal(code, 0, `a stop signal must produce a clean exit\n${stderr}`)
-  assert.doesNotThrow(
-    () => JSON.parse(readFileSync(dbPath, 'utf8')),
-    'the storage file must survive the shutdown intact',
-  )
-})
+    // The credential banner is the last thing the boot prints, so seeing it
+    // means the server is up and the signal lands on a running process. Matched
+    // against everything received so far, since a pipe splits where it likes.
+    await new Promise<void>((resolve, reject) => {
+      const fail = (reason: string) =>
+        reject(new Error(`${reason}\nstdout: ${stdout}\nstderr: ${stderr}`))
+      const timer = setTimeout(
+        () => fail('the server never finished booting'),
+        30000,
+      )
+      child.on('error', (err) =>
+        fail(`the server could not be spawned: ${err}`),
+      )
+      child.on('exit', (code) => fail(`the server exited early with ${code}`))
+      child.stdout.on('data', () => {
+        if (stdout.includes('Admin invite')) {
+          clearTimeout(timer)
+          resolve()
+        }
+      })
+    })
+
+    child.removeAllListeners('exit')
+    child.kill('SIGTERM')
+    const [code] = (await once(child, 'exit')) as [number | null, string | null]
+
+    assert.equal(code, 0, `a stop signal must produce a clean exit\n${stderr}`)
+    assert.doesNotThrow(
+      () => JSON.parse(readFileSync(dbPath, 'utf8')),
+      'the storage file must survive the shutdown intact',
+    )
+  },
+)

--- a/packages/streamwall-control-server/src/gracefulShutdown.test.ts
+++ b/packages/streamwall-control-server/src/gracefulShutdown.test.ts
@@ -34,19 +34,15 @@ function fakeProcess() {
       emitter.emit(signal)
     },
   }
-  return { proc, exitCodes, listenerCount: () => emitter.eventNames().length }
+  return { proc, exitCodes }
 }
 
 /** The slice of a Fastify instance the shutdown wiring actually uses. */
 function fakeApp(close: () => Promise<void>, logs: LogCapture) {
   const record =
     (level: string) =>
-    (fields: unknown, msg?: string): void => {
-      const entry =
-        typeof fields === 'string'
-          ? { level, msg: fields }
-          : { level, ...(fields as object), msg }
-      logs.stream.write(JSON.stringify(entry))
+    (fields: object, msg?: string): void => {
+      logs.stream.write(JSON.stringify({ level, ...fields, msg }))
     }
   let closeCalls = 0
   return {

--- a/packages/streamwall-control-server/src/index.test.ts
+++ b/packages/streamwall-control-server/src/index.test.ts
@@ -7,28 +7,9 @@ import runServer, {
   resolveListenPort,
   SESSION_COOKIE_NAME,
 } from './index.ts'
-import { captureLogs, inMemoryDb } from './testHelpers.ts'
-import type { UpdateChecker, UpdateStatus } from './updateCheck.ts'
+import { captureLogs, fakeUpdateChecker, inMemoryDb } from './testHelpers.ts'
 
 const ONE_YEAR_IN_SECONDS = 365 * 24 * 60 * 60
-
-/** Stub `UpdateChecker` so specs never reach GitHub. */
-function fakeUpdateChecker(): UpdateChecker {
-  const status: UpdateStatus = {
-    version: 'test',
-    latestVersion: null,
-    updateAvailable: false,
-    releaseUrl: null,
-    lastCheckedAt: null,
-    checkEnabled: false,
-  }
-  return {
-    getStatus: () => status,
-    checkNow: async () => status,
-    start: async () => {},
-    stop: () => {},
-  }
-}
 
 /**
  * Build an isolated control-server app backed by in-memory storage, mint a

--- a/packages/streamwall-control-server/src/index.test.ts
+++ b/packages/streamwall-control-server/src/index.test.ts
@@ -7,7 +7,12 @@ import runServer, {
   resolveListenPort,
   SESSION_COOKIE_NAME,
 } from './index.ts'
-import { captureLogs, fakeUpdateChecker, inMemoryDb } from './testHelpers.ts'
+import {
+  captureLogs,
+  fakeProcess,
+  fakeUpdateChecker,
+  inMemoryDb,
+} from './testHelpers.ts'
 
 const ONE_YEAR_IN_SECONDS = 365 * 24 * 60 * 60
 
@@ -124,6 +129,7 @@ describe('runServer', () => {
       clientStaticPath: import.meta.dirname,
       db: inMemoryDb(),
       updateChecker: fakeUpdateChecker(),
+      process: fakeProcess().proc,
     })
     after(() => {
       server.close()
@@ -155,6 +161,7 @@ describe('runServer', () => {
         logLevel: 'trace',
         logStream: logs.stream,
         updateChecker: fakeUpdateChecker(),
+        process: fakeProcess().proc,
       }))
     } finally {
       console.log = originalLog

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -262,7 +262,7 @@ export async function initApp({
     ctx.currentStreamwallConn?.clientState.update({ auth: auth.getState() })
   })
 
-  return { app, db, auth, updateChecker }
+  return { app, db, auth, updateChecker, reportCaughtError }
 }
 
 // `runServer` and the bootstrap helpers live in `./bootstrap.ts`; re-exported

--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -280,5 +280,11 @@ if (isMainModule) {
     clientStaticPath:
       process.env.STREAMWALL_CONTROL_STATIC ??
       path.join(import.meta.dirname, '../../streamwall-control-client/dist'),
+  }).catch((err: unknown) => {
+    // A boot that never got as far as a logger has nothing but `console` left,
+    // and reporting it here keeps a failed start on the same exit-code
+    // convention as a failed shutdown instead of an unhandled rejection.
+    console.error('streamwall-control-server failed to start:', err)
+    process.exit(1)
   })
 }

--- a/packages/streamwall-control-server/src/testEnvHygiene.test.ts
+++ b/packages/streamwall-control-server/src/testEnvHygiene.test.ts
@@ -89,16 +89,13 @@ test('no spec writes process.env through a computed key', () => {
  * instead of interrupting the run, and every boot leaks two listeners.
  */
 test('every spec that boots runServer injects a fake process', () => {
+  // Checked per file rather than per call site: matching a call's own extent
+  // means brace-counting, and a spec that boots the server without an injected
+  // process alongside one that does is not a distinction worth the parser.
   const offenders = testFiles()
     .filter((file) => {
       const source = readFileSync(file, 'utf8')
-      return [...source.matchAll(/\brunServer\(\{/g)].some((match) => {
-        const call = source.slice(
-          match.index,
-          source.indexOf('})', match.index),
-        )
-        return !/\bprocess:/.test(call)
-      })
+      return /\brunServer\(/.test(source) && !/\bprocess:/.test(source)
     })
     .map((file) => path.relative(SRC_DIR, file))
 

--- a/packages/streamwall-control-server/src/testEnvHygiene.test.ts
+++ b/packages/streamwall-control-server/src/testEnvHygiene.test.ts
@@ -81,3 +81,30 @@ test('no spec writes process.env through a computed key', () => {
     'setEnvForTest() takes a variable name as a key, so a bracketed write is never needed',
   )
 })
+
+/**
+ * `runServer` arms the SIGTERM/SIGINT handlers on the `process` it is given,
+ * which defaults to the real one. A spec that lets it default installs handlers
+ * on the test runner itself: a Ctrl-C would then shut that app down and exit 0
+ * instead of interrupting the run, and every boot leaks two listeners.
+ */
+test('every spec that boots runServer injects a fake process', () => {
+  const offenders = testFiles()
+    .filter((file) => {
+      const source = readFileSync(file, 'utf8')
+      return [...source.matchAll(/\brunServer\(\{/g)].some((match) => {
+        const call = source.slice(
+          match.index,
+          source.indexOf('})', match.index),
+        )
+        return !/\bprocess:/.test(call)
+      })
+    })
+    .map((file) => path.relative(SRC_DIR, file))
+
+  assert.deepEqual(
+    offenders,
+    [],
+    'pass `process: fakeProcess().proc` so the handlers never land on the test runner',
+  )
+})

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -1,5 +1,5 @@
 import { Low, Memory } from 'lowdb'
-import { once } from 'node:events'
+import { EventEmitter, once } from 'node:events'
 import { mkdtempSync, writeFileSync } from 'node:fs'
 import type { AddressInfo } from 'node:net'
 import { tmpdir } from 'node:os'
@@ -18,6 +18,7 @@ import type {
 } from 'streamwall-shared'
 import WebSocket from 'ws'
 import type { ScryptParams } from './auth.ts'
+import type { ProcessLike } from './bootstrap.ts'
 import type { HeartbeatConfig, RateLimitConfig } from './config.ts'
 import { type AppOptions, initApp } from './index.ts'
 import type { LogLevel } from './logger.ts'
@@ -37,6 +38,29 @@ export function makeStaticDir(): string {
     '<!doctype html><title>streamwall test</title>',
   )
   return dir
+}
+
+/**
+ * A stand-in for `process`: the spec emits the signals, and `exit` is recorded
+ * instead of tearing the test runner down. Every spec that boots `runServer`
+ * needs one, or the real signal handlers end up on the runner's own process.
+ */
+export function fakeProcess() {
+  const emitter = new EventEmitter()
+  const exitCodes: (number | undefined)[] = []
+  const proc: ProcessLike & { emit(signal: string): void } = {
+    on(signal, listener) {
+      emitter.on(signal, listener)
+      return proc
+    },
+    exit(code) {
+      exitCodes.push(code)
+    },
+    emit(signal: string) {
+      emitter.emit(signal)
+    },
+  }
+  return { proc, exitCodes }
 }
 
 /** Stub `UpdateChecker` so specs never reach GitHub. */

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -24,7 +24,7 @@ import type { LogLevel } from './logger.ts'
 import type { SentryCaptureClient } from './sentry.ts'
 import type { DocUpdateLimits } from './stateDocGuard.ts'
 import type { StorageDB, StoredData } from './storage.ts'
-import type { UpdateChecker } from './updateCheck.ts'
+import type { UpdateChecker, UpdateStatus } from './updateCheck.ts'
 
 /**
  * Creates a throwaway directory containing a minimal index.html so that
@@ -37,6 +37,24 @@ export function makeStaticDir(): string {
     '<!doctype html><title>streamwall test</title>',
   )
   return dir
+}
+
+/** Stub `UpdateChecker` so specs never reach GitHub. */
+export function fakeUpdateChecker(): UpdateChecker {
+  const status: UpdateStatus = {
+    version: 'test',
+    latestVersion: null,
+    updateAvailable: false,
+    releaseUrl: null,
+    lastCheckedAt: null,
+    checkEnabled: false,
+  }
+  return {
+    getStatus: () => status,
+    checkNow: async () => status,
+    start: async () => {},
+    stop: () => {},
+  }
 }
 
 /** An isolated in-memory storage backend, so tests never touch the disk. */

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -53,6 +53,10 @@ export function fakeProcess() {
       emitter.on(signal, listener)
       return proc
     },
+    off(signal, listener) {
+      emitter.off(signal, listener)
+      return proc
+    },
     exit(code) {
       exitCodes.push(code)
     },

--- a/packages/streamwall-control-server/src/updateCheck.test.ts
+++ b/packages/streamwall-control-server/src/updateCheck.test.ts
@@ -232,6 +232,39 @@ describe('createUpdateChecker', () => {
     assert.equal(timers.length, 0)
   })
 
+  test('a stop() during the first check never arms the interval', async () => {
+    // `start()` awaits a real network round trip before scheduling, so a
+    // shutdown can land inside it. Arming afterwards would leave a poll
+    // running on a server that has already been torn down (issue #751).
+    const timers: unknown[] = []
+    let releaseFetch = () => {}
+    const fetching = new Promise<void>((resolve) => {
+      releaseFetch = resolve
+    })
+    const checker = createUpdateChecker({
+      log: recordingLogger().log,
+      currentVersion: '0.9.1',
+      fetchImpl: async () => {
+        await fetching
+        return jsonResponse({ tag_name: 'v0.9.1', html_url: 'https://x.test' })
+      },
+      setIntervalImpl: () => {
+        timers.push({})
+        return timers.length
+      },
+      clearIntervalImpl: () => {
+        timers.pop()
+      },
+    })
+
+    const started = checker.start()
+    checker.stop()
+    releaseFetch()
+    await started
+
+    assert.deepEqual(timers, [], 'no interval may survive the stop')
+  })
+
   test('start() is idempotent (no duplicate intervals)', async () => {
     const timers: unknown[] = []
     const checker = createUpdateChecker({

--- a/packages/streamwall-control-server/src/updateCheck.ts
+++ b/packages/streamwall-control-server/src/updateCheck.ts
@@ -121,6 +121,7 @@ export function createUpdateChecker({
   let lastCheckedAt: string | null = null
   let announcedVersion: string | null = null
   let timer: unknown = null
+  let stopped = false
 
   const getStatus = (): UpdateStatus => ({
     version: currentVersion,
@@ -175,12 +176,20 @@ export function createUpdateChecker({
       if (!enabled || timer !== null) {
         return
       }
+      stopped = false
       await checkNow()
+      // The first check is a network round trip, so a `stop()` can land while
+      // it is still in flight — arming the interval afterwards would leave a
+      // poll running on a server that has already been torn down.
+      if (stopped) {
+        return
+      }
       timer = setIntervalImpl(() => {
         void checkNow()
       }, intervalMs)
     },
     stop() {
+      stopped = true
       if (timer !== null) {
         clearIntervalImpl(timer)
         timer = null

--- a/test/release-docker.test.mjs
+++ b/test/release-docker.test.mjs
@@ -254,14 +254,18 @@ test('the compose stack can pull the published image', () => {
 // would go back to killing the container outright after its grace period.
 test('the container runs node directly, so a stop signal reaches it', () => {
   const dockerfile = readText(`packages/${IMAGE_REPOSITORY}/Dockerfile`)
-  const cmd = dockerfile.match(/^CMD\s+(.*)$/m)
+  // Every stage's CMD, not just the first: this is a multi-stage build, and a
+  // shell-form CMD anywhere would be easy to miss.
+  const commands = [...dockerfile.matchAll(/^CMD\s+(.*)$/gm)]
 
-  assert.ok(cmd, 'the Dockerfile must declare a CMD')
-  assert.match(
-    cmd[1],
-    /^\[/,
-    'CMD must use the exec form so no shell intercepts SIGTERM',
-  )
+  assert.ok(commands.length > 0, 'the Dockerfile must declare a CMD')
+  for (const [, value] of commands) {
+    assert.match(
+      value,
+      /^\[/,
+      'CMD must use the exec form so no shell intercepts SIGTERM',
+    )
+  }
   assert.ok(
     !/^ENTRYPOINT\s+(?!\[)/m.test(dockerfile),
     'an ENTRYPOINT, if any, must use the exec form for the same reason',

--- a/test/release-docker.test.mjs
+++ b/test/release-docker.test.mjs
@@ -248,6 +248,26 @@ test('the compose stack can pull the published image', () => {
   )
 })
 
+// The server shuts down gracefully on SIGTERM (#751), which only helps if the
+// signal reaches node at all: the shell form of CMD wraps the process in
+// `/bin/sh -c`, which becomes PID 1 and swallows the signal, so `docker stop`
+// would go back to killing the container outright after its grace period.
+test('the container runs node directly, so a stop signal reaches it', () => {
+  const dockerfile = readText(`packages/${IMAGE_REPOSITORY}/Dockerfile`)
+  const cmd = dockerfile.match(/^CMD\s+(.*)$/m)
+
+  assert.ok(cmd, 'the Dockerfile must declare a CMD')
+  assert.match(
+    cmd[1],
+    /^\[/,
+    'CMD must use the exec form so no shell intercepts SIGTERM',
+  )
+  assert.ok(
+    !/^ENTRYPOINT\s+(?!\[)/m.test(dockerfile),
+    'an ENTRYPOINT, if any, must use the exec form for the same reason',
+  )
+})
+
 test('self-hosting documents pulling and pinning the image', () => {
   const doc = readText('docs/self-hosting.md')
 


### PR DESCRIPTION
## Problem

Nothing ever called `app.close()` in production. `runServer()` started listening and returned, so a container stop killed the process outright: WebSocket peers got a TCP reset instead of a close frame, the `onClose` hooks never ran, and an in-flight `storage.json` write could be truncated.

## Solution

`registerShutdownHandlers` closes the app on `SIGTERM`/`SIGINT`:

- **Exactly once.** A second signal is logged and ignored rather than re-entering the teardown, so a supervisor that signals twice cannot abort the graceful path it asked for.
- **Bounded.** A force-exit timer (8s, deliberately inside Docker's ten-second stop grace period, and deliberately not `unref`'d) exits 1 with a logged reason instead of letting a wedged close end in an unexplained SIGKILL.
- **Conventional exit codes.** 0 for a clean stop; 1 when the close fails, when the budget runs out, or when the boot had failed.
- **Ordered around the boot.** The handlers are armed before the boot finishes, and the shutdown awaits it: a stop signal landing while the uplink token is being minted and persisted now waits for those writes instead of exiting on top of them.
- **Ordered around the storage flush.** Auth persistence is fire-and-forget and storage writes are serialized, so the shutdown performs one final `db.write()` — awaited in the shutdown path itself, ahead of `app.close()`.
- **Bridged over the init window.** As PID 1 the kernel discards a signal for which no handler exists, so a `docker stop` during `initApp` (which creates the storage directory) was ignored outright. A pair of listeners captures it, arms a deadline of its own so a wedged volume cannot make the process unkillable, and replays the signal into the real handler as soon as there is an app to close; they are detached and their deadline cleared the moment the real handlers take over.

Bundled, because the same teardown surfaced them:

- `updateChecker.start()` awaits a GitHub round trip before arming its interval, so a `stop()` landing inside that window left a poll running on a torn-down server. `stop()` now marks the checker stopped and `start()` re-checks before scheduling. The checker is also not started at all when a signal already arrived during the boot.
- The process entry point now catches a failed boot, so it exits 1 through the same convention instead of as an unhandled rejection.
- `initApp` returns `reportCaughtError`, so a failed shutdown flush reaches Sentry like the fire-and-forget writes it drains.

## Testing

`src/gracefulShutdown.test.ts` covers the handler directly with an injected process (both signals, idempotency, a rejecting close, a close that exceeds its budget, a failed boot) and through `runServer` (a signal after boot, during the boot, and during init; the flush completing before the exit). One spec spawns the entry point the way the image's `CMD` does — `node <entry>.ts` on Node's own type stripping — sends a real `SIGTERM` and asserts exit code 0 with an intact `storage.json`; it is skipped on Windows, which has no POSIX signals.

`test/release-docker.test.mjs` pins every `CMD` in the Dockerfile to the exec form: the graceful path is worth nothing if a shell sits between the container and node. `src/testEnvHygiene.test.ts` pins that specs booting `runServer` inject a fake process, so the handlers never land on the test runner. `src/updateCheck.test.ts` covers the new `stop()`-during-`start()` guard.

Full quality gate green locally: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (2166 tests).

## Risks

The shutdown path is new behaviour by definition. The teardown is bounded by the force-exit timer in every branch, and a failing storage is reported rather than turned into a crash, so the worst case stays "exits 1 with a logged reason".

## Pre-PR review

Six rounds with independent reviewers, each with a freshly generated diff and no context from the implementation. What they caught, in order:

1. `unref()` on the force-exit timer let a wedged close slip out with code 0; dead code in the test doubles; the Docker invariant only checked the first `CMD`.
2. Arming the handlers before the boot made a mid-boot signal exit *while* the boot was still writing — fixed with the awaited `beforeClose` seam; specs that booted `runServer` were installing real signal handlers on the test runner.
3. The flush sat in an `onClose` hook, i.e. behind the connection drain a half-dead WebSocket peer can stall past the budget; a failed boot exited 0.
4. The update checker's start/stop race; the force-exit budget equalled Docker's grace period instead of landing inside it; the flush failure never reached Sentry; the `runServer` test-injection rule was unenforced.
5. The init-window listeners suppressed the default signal disposition without a deadline of their own; the init path and the update-checker guard had no coverage; the child-process spec was fragile.
6. **The decisive one:** `@fastify/websocket`'s own `preClose` hook calls its `done` twice, so Fastify stops awaiting the remaining `preClose` hooks — `app.close()` resolved while the storage flush was still in flight and the process exited on top of it. The flush moved out of the hook and into the shutdown path, and its spec now asserts ordering (`flush:done` before `exit:0`) rather than merely that a write started. Also: the init-window listeners were never detached, so a second signal hard-exited mid-shutdown; and the child-process spec would have failed on the Windows CI leg.

Round seven returned `NO FINDINGS`.

Nothing was dismissed except three scope calls, all re-verified: a second signal does not force an immediate exit (it would defeat the graceful path a supervisor's retry asks for), the force-exit timer stays `ref`'d, and asserting WebSocket close-frame semantics belongs to @fastify/websocket rather than here.

Closes #751
