### PR TITLE
fix(streamwall): harden the session behind the wall's chrome layers

### DIFF
--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -1617,12 +1617,13 @@ describe('StreamWindow constructor', () => {
     }
     expect(partitions[0]).not.toBe(partitions[1])
 
-    expect(
-      vi.mocked(hardenSession).mock.calls.map(([session]) => session),
-    ).toEqual([
-      sw.backgroundView.webContents.session,
-      sw.overlayView.webContents.session,
-    ])
+    // Compared by identity: the Electron stub gives every view a bare `{}` as
+    // its session, which any structural comparison would match against any
+    // other view's.
+    const hardened = vi.mocked(hardenSession).mock.calls
+    expect(hardened).toHaveLength(2)
+    expect(hardened[0][0]).toBe(sw.backgroundView.webContents.session)
+    expect(hardened[1][0]).toBe(sw.overlayView.webContents.session)
   })
 
   it('allows the dev server origin so the layer pages themselves still load', () => {
@@ -1632,17 +1633,22 @@ describe('StreamWindow constructor', () => {
 
     new StreamWindow(makeConfig())
 
-    for (const [, options] of vi.mocked(hardenSession).mock.calls) {
-      expect(options?.allowedOrigins).toEqual(['http://localhost:5173'])
-    }
+    // Asserted on the call list rather than by iterating it: an empty list
+    // would let a `for` loop pass without hardening anything at all.
+    expect(
+      vi.mocked(hardenSession).mock.calls.map(([, options]) => options),
+    ).toEqual([
+      { allowedOrigins: ['http://localhost:5173'] },
+      { allowedOrigins: ['http://localhost:5173'] },
+    ])
   })
 
   it('passes no allowed origins in a packaged build, where there is no dev server', () => {
     new StreamWindow(makeConfig())
 
-    for (const [, options] of vi.mocked(hardenSession).mock.calls) {
-      expect(options?.allowedOrigins).toEqual([])
-    }
+    expect(
+      vi.mocked(hardenSession).mock.calls.map(([, options]) => options),
+    ).toEqual([{ allowedOrigins: [] }, { allowedOrigins: [] }])
   })
 
   it('starts with empty view bookkeeping', () => {

--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -118,11 +118,19 @@ vi.mock('./loadHTML', () => ({
   // Returns a resolved promise like the real loadHTML, so the caller's `.catch`
   // breadcrumb (issue #626) has something to attach to.
   loadHTML: vi.fn(() => Promise.resolve()),
-  devServerOrigin: () => undefined,
+  devServerOrigin: vi.fn((): string | undefined => undefined),
+}))
+
+// `hardenSession` reaches into a real Electron session; the partition allocator
+// beside it is a pure string generator worth keeping.
+vi.mock('./partitions', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./partitions')>()),
+  hardenSession: vi.fn(),
 }))
 
 const { default: StreamWindow } = await import('./StreamWindow')
-const { loadHTML } = await import('./loadHTML')
+const { devServerOrigin, loadHTML } = await import('./loadHTML')
+const { hardenSession } = await import('./partitions')
 
 function makeConfig(
   overrides: Partial<StreamWindowConfig> = {},
@@ -1524,6 +1532,8 @@ describe('StreamWindow constructor', () => {
     electronStub.webContentsViews.length = 0
     electronStub.resetIpc()
     vi.mocked(loadHTML).mockClear()
+    vi.mocked(hardenSession).mockClear()
+    vi.mocked(devServerOrigin).mockReturnValue(undefined)
   })
 
   function contentViewOf(win: InstanceType<typeof StreamWindow>['win']) {
@@ -1581,6 +1591,57 @@ describe('StreamWindow constructor', () => {
         width: 1280,
         height: 720,
       })
+    }
+  })
+
+  // The chrome layers embed operator- (and control-server-) supplied overlay
+  // and background URLs in iframes. Without a partition of their own they ran
+  // in Electron's default, on-disk session -- the one the control window uses,
+  // and the one `hardenSession` is never called on, so those iframes reached
+  // the network with neither the SSRF request guard nor permission denial
+  // (#733).
+  it('isolates each layer in its own ephemeral, hardened session', () => {
+    const sw = new StreamWindow(makeConfig())
+
+    const partitionOf = (view: unknown) =>
+      (view as { options: { webPreferences: Electron.WebPreferences } }).options
+        .webPreferences.partition
+    const partitions = [
+      partitionOf(sw.backgroundView),
+      partitionOf(sw.overlayView),
+    ]
+    for (const partition of partitions) {
+      expect(partition).toBeDefined()
+      expect(partition!.startsWith('layer-')).toBe(true)
+      expect(partition!.startsWith('persist:')).toBe(false)
+    }
+    expect(partitions[0]).not.toBe(partitions[1])
+
+    expect(
+      vi.mocked(hardenSession).mock.calls.map(([session]) => session),
+    ).toEqual([
+      sw.backgroundView.webContents.session,
+      sw.overlayView.webContents.session,
+    ])
+  })
+
+  it('allows the dev server origin so the layer pages themselves still load', () => {
+    // In development the layer HTML and its assets come from the Vite dev
+    // server on loopback, which the SSRF guard would otherwise cancel.
+    vi.mocked(devServerOrigin).mockReturnValue('http://localhost:5173')
+
+    new StreamWindow(makeConfig())
+
+    for (const [, options] of vi.mocked(hardenSession).mock.calls) {
+      expect(options?.allowedOrigins).toEqual(['http://localhost:5173'])
+    }
+  })
+
+  it('passes no allowed origins in a packaged build, where there is no dev server', () => {
+    new StreamWindow(makeConfig())
+
+    for (const [, options] of vi.mocked(hardenSession).mock.calls) {
+      expect(options?.allowedOrigins).toEqual([])
     }
   })
 

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -27,7 +27,11 @@ import { createActor, EventFrom, SnapshotFrom } from 'xstate'
 import { devServerOrigin, loadHTML } from './loadHTML'
 import log from './logger'
 import { secureStreamView } from './navigationSecurity'
-import { allocateViewPartition, hardenSession } from './partitions'
+import {
+  allocateLayerPartition,
+  allocateViewPartition,
+  hardenSession,
+} from './partitions'
 import { planViewLayout, type ViewCandidate } from './viewLayoutPlan'
 import viewStateMachine, {
   DEFAULT_RETRY_CONFIG,
@@ -184,13 +188,31 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
    * Creates one of the two transparent full-window chrome layers (the
    * background and the overlay), sizes it to the configured wall dimensions
    * and loads its HTML entry point.
+   *
+   * The layer renders the app's own page, but that page embeds
+   * operator-supplied overlay/background URLs in iframes -- so it gets the same
+   * treatment as a stream view: its own unique ephemeral partition, hardened
+   * with the SSRF request guard and permission denial. Left in Electron's
+   * default session it would reach the network with neither, and would share
+   * cookies and cache on disk with the control window (#733).
    */
   private createLayerView(
     page: 'background' | 'overlay',
     webPreferences: Electron.WebPreferences,
   ): WebContentsView {
     const { width, height } = this.config
-    const layerView = new WebContentsView({ webPreferences })
+    const layerView = new WebContentsView({
+      webPreferences: {
+        ...webPreferences,
+        partition: allocateLayerPartition(),
+      },
+    })
+    hardenSession(layerView.webContents.session, {
+      // In development the layer page and its assets are served from the Vite
+      // dev server on loopback; allow that origin so the SSRF request guard
+      // does not cancel the layer's own load.
+      allowedOrigins: [devServerOrigin()].filter((o) => o !== undefined),
+    })
     layerView.setBackgroundColor('#0000')
     this.win.contentView.addChildView(layerView)
     layerView.setBounds({

--- a/packages/streamwall/src/main/partitions.test.ts
+++ b/packages/streamwall/src/main/partitions.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { test } from 'vitest'
 import {
+  allocateLayerPartition,
   allocateViewPartition,
   BROWSE_PARTITION,
   createPartitionAllocator,
@@ -108,6 +109,32 @@ test('BROWSE_PARTITION is ephemeral and isolated from stream views', () => {
     !BROWSE_PARTITION.startsWith('view-'),
     'browse partition must not collide with the stream-view namespace',
   )
+})
+
+test('allocateLayerPartition returns a unique ephemeral partition on every call', () => {
+  // The chrome layers embed operator-supplied overlay/background URLs in
+  // iframes, so they need the same isolation a stream view gets rather than the
+  // app's shared, on-disk default session (#733).
+  const seen = new Set<string>()
+  for (let i = 0; i < 100; i++) {
+    const partition = allocateLayerPartition()
+    assert.ok(partition.startsWith('layer-'), 'layer partitions are prefixed')
+    assert.ok(
+      !partition.startsWith('persist:'),
+      'layer partitions are ephemeral',
+    )
+    assert.ok(!seen.has(partition), `partition ${partition} must be unique`)
+    seen.add(partition)
+  }
+})
+
+test('layer partitions do not collide with the stream-view or browse namespaces', () => {
+  const partition = allocateLayerPartition()
+  assert.ok(
+    !partition.startsWith('view-'),
+    'a layer must not land in a stream view session',
+  )
+  assert.notEqual(partition, BROWSE_PARTITION)
 })
 
 test('hardenSession registers a permission request handler', () => {

--- a/packages/streamwall/src/main/partitions.ts
+++ b/packages/streamwall/src/main/partitions.ts
@@ -9,8 +9,11 @@
  * and is discarded when its last web context goes away.
  *
  * To prevent cross-site data bleed and persistent tracking, every stream view
- * gets its own unique, ephemeral partition and the browse window gets a separate
- * ephemeral partition of its own.
+ * gets its own unique, ephemeral partition, each chrome layer (which embeds
+ * operator-supplied overlay/background URLs in iframes) gets one too, and the
+ * browse window gets a separate ephemeral partition of its own. Nothing that
+ * renders third-party content is left in Electron's default session, which is
+ * persisted to disk and shared with the control window.
  *
  * @see https://www.electronjs.org/docs/latest/api/session
  */
@@ -20,6 +23,7 @@ import { createSessionHostResolver, findRequestBlockReason } from '../util'
 import log from './logger'
 
 const VIEW_PARTITION_PREFIX = 'view-'
+const LAYER_PARTITION_PREFIX = 'layer-'
 
 /**
  * Dedicated ephemeral partition for the operator's browse window. It is
@@ -46,6 +50,18 @@ export function createPartitionAllocator(prefix: string): () => string {
  */
 export const allocateViewPartition = createPartitionAllocator(
   VIEW_PARTITION_PREFIX,
+)
+
+/**
+ * App-wide allocator for the wall's chrome-layer partitions (the background and
+ * overlay layers). They render the app's own page, but that page embeds
+ * operator-supplied URLs in iframes, so each layer needs a hardened session of
+ * its own rather than the app's default one -- which is persisted to disk,
+ * shared with the control window, and never passed through
+ * {@link hardenSession} (#733).
+ */
+export const allocateLayerPartition = createPartitionAllocator(
+  LAYER_PARTITION_PREFIX,
 )
 
 // Minimal structural view of the request-filtering surface a session exposes,


### PR DESCRIPTION
## Problem

`createLayerView()` built the wall's background and overlay layers with no `partition:`, so both ran in Electron's default session — the one that is persisted to disk, shared with the Control Window, and never passed through `hardenSession()`.

Those layers are not passive chrome: they embed operator-supplied URLs in iframes (`OverlayRoot.tsx` and `background.tsx` render `src={s.link}`), and `update-custom-stream` is on the uplink allowlist, so a compromised or MITM'd control server can point one at `http://169.254.169.254/latest/meta-data/…` or a LAN address. Without `installRequestSSRFGuard` on that session those requests went out unchecked — and kept going out, since the iframe's own scripts issue further requests long after any up-front URL check would have run. The same session also had no `setPermissionRequestHandler`, so Electron's approve-everything default applied, and untrusted third-party content wrote cookies and cache to disk beside the Control Window's.

## Solution

Each layer now gets what a stream view already gets: its own unique ephemeral partition from a `layer-` allocator beside the existing `view-` one, hardened with `hardenSession()` — the SSRF request guard plus permission-request denial. The Vite dev server origin is allowed exactly as `createRawView()` does it, so the layer's own page and its HMR socket still load in development.

A partition per layer rather than one shared `layer` partition: the background and overlay embed independently operator-controlled documents, and a shared partition would let a background iframe and an overlay iframe from the same host share an HTTP cache.

## Testing

- `partitions.test.ts`: `allocateLayerPartition` yields unique, ephemeral, `layer-`-prefixed names that collide with neither the `view-` namespace nor `BROWSE_PARTITION`.
- `StreamWindow.test.ts`: each layer is constructed with its own ephemeral `layer-` partition, and `hardenSession` is called with each layer's own session — asserted by reference and against the whole call list, so a reverted fix (which calls it zero times) cannot pass vacuously. Separate cases pin the dev-server allowance and its absence in a packaged build, since that allowance is the one property preventing a dev-mode regression.
- Quality gate green locally: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (2241 tests).

## Risks / breaking changes

This changes which Electron session two always-present renderers run in, so the regression surface was traced explicitly:

- **Packaged build**: `findRequestBlockReason` governs only http(s)/ws(s), so the layer's `file:` page and every bundled asset pass untouched.
- **Development**: `allowedOrigins` matches on host, so the dev server's page, its module/CSS/font subrequests and its `ws://` HMR socket all take the allow fast-path.
- **Nothing depended on the shared default session**: no `session.defaultSession`, `webRequest`, `protocol.register*` or `setUserAgent` use anywhere in the package; preload paths, `webContents.id` routing, the `layer:load` / `devtools-overlay` handlers and `openDevTools` are per-`webContents` or process-global, not per-session.
- **Permission denial is inert here**: `LAYER_FRAME_SANDBOX` is `allow-scripts` only, so layer frames already run in an opaque origin with no storage, and `allow="autoplay"` is not a permission request.

One behaviour change is worth calling out: a layer URL the guard now blocks fails to a blank layer with only a `log.warn`, because `createLayerView` has no `did-fail-load` surface and a cancelled *iframe* load would not reach one anyway. That is strictly better than the previous behaviour (it loaded), but the operator deserves to be told — #790.

## Pre-PR review

Two rounds with independent reviewers that had none of the implementation context, ending in `NO FINDINGS`. All findings were accepted; none dismissed. The substantive ones were both test-validity problems: the `allowedOrigins` assertions iterated the mock's call list, so the empty list a reverted fix produces passed them vacuously; and the session assertion compared structurally, which the Electron stub's bare `{}` sessions satisfy for any pair of views.

Scope was deliberately held to the partition and `hardenSession` half of the issue's suggested fix. The reviewers agreed with both deferrals: `setPermissionCheckHandler` changes the stream-view and browse-window sessions too and needs its own verification pass, and `ensureValidURL` on `s.link` is a separate change whose real value is operator-visible feedback.

## Follow-ups

- #789 — deny synchronous permission checks in `hardenSession`, not just permission requests.
- #790 — tell the operator when an overlay or background URL is rejected instead of failing blank.
- #791 — deduplicate the `hardenSession` dev-server allowance across its call sites.

Closes #733
