### PR TITLE
fix(shared): validate releaseUrl as an http(s) URL at the schema boundary

### DIFF
--- a/packages/streamwall-control-ui/src/ServerUpdateBanner.test.tsx
+++ b/packages/streamwall-control-ui/src/ServerUpdateBanner.test.tsx
@@ -100,6 +100,26 @@ describe('ServerUpdateBanner', () => {
     expect(link.getAttribute('rel')).toBe('noopener noreferrer')
   })
 
+  // `releaseUrl` is narrowed to a valid http(s) URL (or `null`) at the schema
+  // boundary (issue #773), but the banner applies its own check too rather
+  // than trusting that every caller went through `serverStatusSchema` first.
+  test('omits the release link for a non-http(s) releaseUrl', () => {
+    const el = renderBanner({
+      ...AVAILABLE_STATUS,
+      releaseUrl: 'javascript:alert(1)',
+    })
+    const banner = el.querySelector('.server-update-banner')
+    expect(banner?.textContent).toContain('1.0.0')
+    expect(banner?.querySelector('a')).toBeNull()
+  })
+
+  test('still shows the notice without a link when releaseUrl is null', () => {
+    const el = renderBanner({ ...AVAILABLE_STATUS, releaseUrl: null })
+    const banner = el.querySelector('.server-update-banner')
+    expect(banner?.textContent).toContain('1.0.0')
+    expect(banner?.querySelector('a')).toBeNull()
+  })
+
   test('renders English copy', () => {
     const el = renderBanner(AVAILABLE_STATUS)
     const text = el.querySelector('.server-update-banner')?.textContent

--- a/packages/streamwall-control-ui/src/ServerUpdateBanner.tsx
+++ b/packages/streamwall-control-ui/src/ServerUpdateBanner.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'preact/hooks'
-import { type ServerStatus } from 'streamwall-shared'
+import { isHttpUrl, type ServerStatus } from 'streamwall-shared'
 import { styled } from 'styled-components'
 
 const StyledServerUpdateBanner = styled.div`
@@ -86,7 +86,7 @@ export function ServerUpdateBanner({
             A Streamwall update is available: {status.latestVersion} (you're on{' '}
             {status.version}).
           </span>
-          {status.releaseUrl && (
+          {status.releaseUrl && isHttpUrl(status.releaseUrl) && (
             <a
               href={status.releaseUrl}
               target="_blank"

--- a/packages/streamwall-shared/src/schemas.test.ts
+++ b/packages/streamwall-shared/src/schemas.test.ts
@@ -1054,4 +1054,51 @@ describe('serverStatusSchema', () => {
       expect(result.data).toEqual(VALID_STATUS)
     }
   })
+
+  test('accepts an http (non-secure) releaseUrl', () => {
+    const result = serverStatusSchema.safeParse({
+      ...VALID_STATUS,
+      releaseUrl: 'http://example.com/releases/v0.11.0',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.releaseUrl).toBe('http://example.com/releases/v0.11.0')
+    }
+  })
+
+  test.each([
+    ['a javascript: URL', 'javascript:alert(1)'],
+    ['a data: URL', 'data:text/html,<script>alert(1)</script>'],
+    ['a relative path', '/releases/v0.11.0'],
+    ['a bare protocol-relative garbage string', 'not a url'],
+    ['an ftp: URL', 'ftp://example.com/release.zip'],
+    ['an overlong URL', `https://example.com/${'a'.repeat(MAX_URL_LENGTH)}`],
+  ])(
+    'narrows releaseUrl to null instead of rejecting the whole status for %s',
+    (_description, badReleaseUrl) => {
+      const result = serverStatusSchema.safeParse({
+        ...VALID_STATUS,
+        releaseUrl: badReleaseUrl,
+      })
+      // A mixed-version deployment might send a server-controlled value that
+      // isn't a valid http(s) URL; dropping just this field (rather than
+      // failing the entire status) keeps the rest of the update-status UI
+      // (version, updateAvailable) working (issue #773).
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.releaseUrl).toBeNull()
+      }
+    },
+  )
+
+  test('keeps releaseUrl null when the server has not sent one', () => {
+    const result = serverStatusSchema.safeParse({
+      ...VALID_STATUS,
+      releaseUrl: null,
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.releaseUrl).toBeNull()
+    }
+  })
 })

--- a/packages/streamwall-shared/src/schemas.ts
+++ b/packages/streamwall-shared/src/schemas.ts
@@ -99,6 +99,39 @@ export const MAX_URL_LENGTH = 2048
 const urlSchema = z.string().max(MAX_URL_LENGTH)
 const nonEmptyUrlSchema = z.string().min(1).max(MAX_URL_LENGTH)
 
+/**
+ * True for a value that is a syntactically valid, bounded `http:`/`https:`
+ * URL - the only schemes a `target="_blank"` anchor should ever be allowed
+ * to carry (issue #773). Exported so the control UI can apply the same
+ * check at render time, independent of the schema layer.
+ */
+export function isHttpUrl(value: string): boolean {
+  if (value.length > MAX_URL_LENGTH) {
+    return false
+  }
+  try {
+    const { protocol } = new URL(value)
+    return protocol === 'http:' || protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Narrows a nullable, server-controlled URL field to `null` whenever it
+ * isn't a valid `http(s)` URL, instead of failing the whole containing
+ * object. `releaseUrl` (issue #773) is rendered straight into an `<a href>`
+ * by the control UI; a compromised or misconfigured server could otherwise
+ * put an arbitrary scheme there (`javascript:`, `data:`, a custom protocol
+ * registered by another installed app). Narrowing rather than rejecting
+ * keeps the rest of a status/state payload usable in a mixed-version
+ * deployment where an older or buggy server sends a malformed value here.
+ */
+const nullableHttpUrlSchema = z
+  .string()
+  .nullable()
+  .transform((value) => (value != null && isHttpUrl(value) ? value : null))
+
 /** Optional descriptive fields shared by every stream-data shape. */
 const streamMetaFields = {
   label: z.string().optional(),
@@ -499,7 +532,12 @@ export const serverStatusSchema = z.object({
   /** Latest release seen by the most recent successful check, if any. */
   latestVersion: z.string().nullable(),
   updateAvailable: z.boolean(),
-  releaseUrl: z.string().nullable(),
+  /**
+   * Narrowed to `null` on anything other than a valid `http(s)` URL rather
+   * than rejecting the whole status (issue #773) - see
+   * {@link nullableHttpUrlSchema}.
+   */
+  releaseUrl: nullableHttpUrlSchema,
   /** ISO timestamp of the last *successful* check. */
   lastCheckedAt: z.string().nullable(),
   checkEnabled: z.boolean(),


### PR DESCRIPTION
## Problem
`releaseUrl` in the server update status was typed as a bare nullable string and rendered straight into an `href` in the control UI. The value comes from the control server, so a compromised or misconfigured server could put an arbitrary scheme there (`javascript:`, `data:`, a custom protocol registered by another installed app). The existing hardening (the Electron window-open handler forwarding only `http:`/`https:` to `shell.openExternal`, and the browser control UI's `default-src 'self'` CSP) is defence in depth around a value that was never itself validated.

## Technical solution
- `packages/streamwall-shared/src/schemas.ts`: added an exported `isHttpUrl(value)` helper (bounded by the existing `MAX_URL_LENGTH`, parses with `URL` and checks for `http:`/`https:`) and a `nullableHttpUrlSchema` built on it. `serverStatusSchema.releaseUrl` now uses this schema.
- `packages/streamwall-control-ui/src/ServerUpdateBanner.tsx`: only renders the "Release notes" anchor when `status.releaseUrl` is both present and `isHttpUrl(...)`.

## Architecture decision
Per the issue's own suggestion, a non-http(s) `releaseUrl` is narrowed to `null` rather than failing the whole `serverStatusSchema` parse. This is deliberate: in a mixed-version deployment, an older or buggy server sending a malformed `releaseUrl` shouldn't blank out the rest of the update-status UI (version, `updateAvailable`) — only the release link disappears.

`isHttpUrl` is exported (rather than kept private) so the control UI can apply the identical check again at render time, independent of whether the caller already went through `serverStatusSchema.safeParse` — this is not required by the current type (the schema already narrows before the value reaches the component) but is cheap, harmless belt-and-suspenders on a server-controlled value that ends up in an `href`.

## Testing performed
- `packages/streamwall-shared/src/schemas.test.ts`: new cases for `serverStatusSchema` covering an `http:` (non-secure) URL, narrowing to `null` for `javascript:`, `data:`, a relative path, garbage, an `ftp:` URL, and an overlong URL, plus the already-`null` case.
- `packages/streamwall-control-ui/src/ServerUpdateBanner.test.tsx`: new cases asserting the release link is omitted for a `javascript:` `releaseUrl` and for a `null` one, while the rest of the notice still renders.
- Full quality gate green: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (2265 tests, all packages).

## Risks / breaking changes
None expected. `ServerStatus.releaseUrl`'s TypeScript type is unchanged (`string | null`); only the runtime values that can reach it are now constrained. `packages/streamwall-control-server` is untouched — it already just forwards whatever it parsed from the GitHub releases API, unvalidated, and this change validates it on the consumer side.

## Pre-PR review
One independent review round (fresh subagent, no session context) against the full diff and issue text: `NO FINDINGS`.

Closes #773