### PR TITLE
fix(streamwall): pin the wall's chrome layers to their own pages

### DIFF
--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -119,6 +119,15 @@ vi.mock('./loadHTML', () => ({
   // breadcrumb (issue #626) has something to attach to.
   loadHTML: vi.fn(() => Promise.resolve()),
   devServerOrigin: vi.fn((): string | undefined => undefined),
+  rendererPageURL: (name: string) =>
+    `file:///app/renderer/main_window/src/renderer/${name}.html`,
+}))
+
+// The navigation guards reach into a real Electron webContents; record which
+// views they are installed on and with what.
+vi.mock('./navigationSecurity', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./navigationSecurity')>()),
+  secureAppWindow: vi.fn(),
 }))
 
 // `hardenSession` reaches into a real Electron session; the partition allocator
@@ -129,7 +138,9 @@ vi.mock('./partitions', async (importOriginal) => ({
 }))
 
 const { default: StreamWindow } = await import('./StreamWindow')
-const { devServerOrigin, loadHTML } = await import('./loadHTML')
+const { devServerOrigin, loadHTML, rendererPageURL } =
+  await import('./loadHTML')
+const { secureAppWindow } = await import('./navigationSecurity')
 const { hardenSession } = await import('./partitions')
 
 function makeConfig(
@@ -1533,6 +1544,7 @@ describe('StreamWindow constructor', () => {
     electronStub.resetIpc()
     vi.mocked(loadHTML).mockClear()
     vi.mocked(hardenSession).mockClear()
+    vi.mocked(secureAppWindow).mockClear()
     vi.mocked(devServerOrigin).mockReturnValue(undefined)
   })
 
@@ -1649,6 +1661,32 @@ describe('StreamWindow constructor', () => {
     expect(
       vi.mocked(hardenSession).mock.calls.map(([, options]) => options),
     ).toEqual([{ allowedOrigins: [] }, { allowedOrigins: [] }])
+  })
+
+  // The layers render the app's own page and hold the `streamwallLayer` bridge,
+  // so they need the same navigation lockdown the control window got in #732 --
+  // but with no outward path: nobody is sitting at the wall to receive a browser
+  // tab, and their content is operator-supplied (#776).
+  it('pins each layer to its own page and denies renderer-opened windows', () => {
+    const sw = new StreamWindow(makeConfig())
+
+    const guarded = vi.mocked(secureAppWindow).mock.calls
+    expect(guarded).toHaveLength(2)
+    expect(guarded[0][0]).toBe(sw.backgroundView.webContents)
+    expect(guarded[1][0]).toBe(sw.overlayView.webContents)
+    expect(guarded.map(([, options]) => options.appPageURL())).toEqual([
+      rendererPageURL('background'),
+      rendererPageURL('overlay'),
+    ])
+  })
+
+  it("gives the layers no way to open a link in the operator's browser", () => {
+    new StreamWindow(makeConfig())
+
+    for (const [, options] of vi.mocked(secureAppWindow).mock.calls) {
+      expect(options.openExternal).toBeUndefined()
+    }
+    expect(vi.mocked(secureAppWindow)).toHaveBeenCalledTimes(2)
   })
 
   it('starts with empty view bookkeeping', () => {

--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -1680,13 +1680,18 @@ describe('StreamWindow constructor', () => {
     ])
   })
 
-  it("gives the layers no way to open a link in the operator's browser", () => {
+  it("gives the layers no way to open a link in the operator's browser, but lets their iframes redirect", () => {
     new StreamWindow(makeConfig())
 
-    for (const [, options] of vi.mocked(secureAppWindow).mock.calls) {
-      expect(options.openExternal).toBeUndefined()
-    }
-    expect(vi.mocked(secureAppWindow)).toHaveBeenCalledTimes(2)
+    expect(
+      vi.mocked(secureAppWindow).mock.calls.map(([, options]) => ({
+        openExternal: options.openExternal,
+        allowSubframeNavigation: options.allowSubframeNavigation,
+      })),
+    ).toEqual([
+      { openExternal: null, allowSubframeNavigation: true },
+      { openExternal: null, allowSubframeNavigation: true },
+    ])
   })
 
   it('starts with empty view bookkeeping', () => {

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -24,9 +24,9 @@ import {
   ViewState,
 } from 'streamwall-shared'
 import { createActor, EventFrom, SnapshotFrom } from 'xstate'
-import { devServerOrigin, loadHTML } from './loadHTML'
+import { devServerOrigin, loadHTML, rendererPageURL } from './loadHTML'
 import log from './logger'
-import { secureStreamView } from './navigationSecurity'
+import { secureAppWindow, secureStreamView } from './navigationSecurity'
 import {
   allocateLayerPartition,
   allocateViewPartition,
@@ -195,6 +195,12 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
    * with the SSRF request guard and permission denial. Left in Electron's
    * default session it would reach the network with neither, and would share
    * cookies and cache on disk with the control window (#733).
+   *
+   * It is pinned to its own page for the same reason the control window is
+   * (#732/#776): the layer holds the `streamwallLayer` bridge, whose `layer:*`
+   * IPC guards compare `ev.sender` against this very webContents and would keep
+   * passing after a navigation. Unlike the control window it gets no
+   * `openExternal`: nobody is sitting at the wall to receive a browser tab.
    */
   private createLayerView(
     page: 'background' | 'overlay',
@@ -206,6 +212,9 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
         ...webPreferences,
         partition: allocateLayerPartition(),
       },
+    })
+    secureAppWindow(layerView.webContents, {
+      appPageURL: () => rendererPageURL(page),
     })
     hardenSession(layerView.webContents.session, {
       // In development the layer page and its assets are served from the Vite

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -215,6 +215,8 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
     })
     secureAppWindow(layerView.webContents, {
       appPageURL: () => rendererPageURL(page),
+      openExternal: null,
+      allowSubframeNavigation: true,
     })
     hardenSession(layerView.webContents.session, {
       // In development the layer page and its assets are served from the Vite

--- a/packages/streamwall/src/main/navigationSecurity.test.ts
+++ b/packages/streamwall/src/main/navigationSecurity.test.ts
@@ -12,6 +12,7 @@ import {
 
 interface NavEvent {
   url: string
+  isMainFrame?: boolean
   preventDefault(): void
 }
 
@@ -47,10 +48,15 @@ class FakeWebContents {
 
   // Dispatch a navigation event to the registered listeners and report whether
   // any of them called preventDefault().
-  dispatchNavigation(event: string, url: string): boolean {
+  dispatchNavigation(
+    event: string,
+    url: string,
+    isMainFrame?: boolean,
+  ): boolean {
     let prevented = false
     const navEvent: NavEvent = {
       url,
+      isMainFrame,
       preventDefault: () => {
         prevented = true
       },
@@ -350,6 +356,75 @@ test('secureAppWindow blocks a remote navigation even before anything has commit
 
   assert.equal(
     wc.dispatchNavigation('will-redirect', 'https://evil.example/'),
+    true,
+  )
+})
+
+// The wall's chrome layers are app pages too, but nobody is sitting at the wall
+// to receive a browser tab, and their content is operator- (or control-server-)
+// supplied -- so they get the guard with no outward path at all (#776).
+function secureFakeLayer(currentURL = APP_PAGE) {
+  vi.spyOn(log, 'info').mockImplementation(() => undefined)
+  const wc = new FakeWebContents(currentURL)
+  secureAppWindow(asWebContents(wc), { appPageURL: () => APP_PAGE })
+  return { wc }
+}
+
+test('secureAppWindow without an openExternal denies every popup and launches nothing', () => {
+  const { wc } = secureFakeLayer()
+
+  assert.ok(wc.windowOpenHandler, 'a window-open handler must be registered')
+  for (const url of [
+    'https://example.com/stream',
+    'file:///etc/passwd',
+    APP_PAGE,
+  ]) {
+    assert.deepEqual(wc.windowOpenHandler({ url }), { action: 'deny' })
+  }
+})
+
+test('secureAppWindow without an openExternal still blocks navigation away', () => {
+  const { wc } = secureFakeLayer()
+
+  assert.equal(
+    wc.dispatchNavigation('will-navigate', 'https://evil.example/', true),
+    true,
+  )
+})
+
+test('secureAppWindow lets a subframe resolve its own redirects', () => {
+  // `will-redirect` fires for sub-frames as well, and the chrome layers exist to
+  // host third-party iframes whose own 302s (shortlinks, http->https, CDNs) must
+  // resolve. Those requests are governed at the network layer by the session's
+  // SSRF guard instead (#733).
+  const { wc } = secureFakeLayer()
+
+  assert.equal(
+    wc.dispatchNavigation(
+      'will-redirect',
+      'https://cdn.example/overlay',
+      false,
+    ),
+    false,
+  )
+})
+
+test('secureAppWindow still blocks a main-frame redirect', () => {
+  const { wc } = secureFakeLayer()
+
+  assert.equal(
+    wc.dispatchNavigation('will-redirect', 'https://evil.example/', true),
+    true,
+  )
+})
+
+test('secureAppWindow guards an event that reports no frame at all', () => {
+  // Older Electron event shapes carry no `isMainFrame`; an unknown frame must
+  // fail closed rather than skip the guard.
+  const { wc } = secureFakeLayer()
+
+  assert.equal(
+    wc.dispatchNavigation('will-navigate', 'https://evil.example/'),
     true,
   )
 })

--- a/packages/streamwall/src/main/navigationSecurity.test.ts
+++ b/packages/streamwall/src/main/navigationSecurity.test.ts
@@ -366,11 +366,15 @@ test('secureAppWindow blocks a remote navigation even before anything has commit
 function secureFakeLayer(currentURL = APP_PAGE) {
   vi.spyOn(log, 'info').mockImplementation(() => undefined)
   const wc = new FakeWebContents(currentURL)
-  secureAppWindow(asWebContents(wc), { appPageURL: () => APP_PAGE })
+  secureAppWindow(asWebContents(wc), {
+    appPageURL: () => APP_PAGE,
+    openExternal: null,
+    allowSubframeNavigation: true,
+  })
   return { wc }
 }
 
-test('secureAppWindow without an openExternal denies every popup and launches nothing', () => {
+test('secureAppWindow with a null openExternal denies every popup and launches nothing', () => {
   const { wc } = secureFakeLayer()
 
   assert.ok(wc.windowOpenHandler, 'a window-open handler must be registered')
@@ -383,16 +387,7 @@ test('secureAppWindow without an openExternal denies every popup and launches no
   }
 })
 
-test('secureAppWindow without an openExternal still blocks navigation away', () => {
-  const { wc } = secureFakeLayer()
-
-  assert.equal(
-    wc.dispatchNavigation('will-navigate', 'https://evil.example/', true),
-    true,
-  )
-})
-
-test('secureAppWindow lets a subframe resolve its own redirects', () => {
+test('secureAppWindow lets a subframe resolve its own redirects where the caller opts in', () => {
   // `will-redirect` fires for sub-frames as well, and the chrome layers exist to
   // host third-party iframes whose own 302s (shortlinks, http->https, CDNs) must
   // resolve. Those requests are governed at the network layer by the session's
@@ -414,6 +409,18 @@ test('secureAppWindow still blocks a main-frame redirect', () => {
 
   assert.equal(
     wc.dispatchNavigation('will-redirect', 'https://evil.example/', true),
+    true,
+  )
+})
+
+test('secureAppWindow blocks a subframe redirect where the caller has not opted in', () => {
+  // The control window renders no iframe, and relaxing it would leave
+  // control.html's <meta> CSP as the only thing between a future embed and
+  // remote content.
+  const { wc } = secureFakeAppWindow()
+
+  assert.equal(
+    wc.dispatchNavigation('will-redirect', 'https://evil.example/', false),
     true,
   )
 })

--- a/packages/streamwall/src/main/navigationSecurity.ts
+++ b/packages/streamwall/src/main/navigationSecurity.ts
@@ -7,7 +7,7 @@ import log from './logger'
 interface NavigationEvent {
   readonly url: string
   // `will-redirect` fires for sub-frames as well as the main frame. Optional
-  // because `secureStreamView`'s guard predates the field and does not read it.
+  // because `secureStreamView`'s guard does not read it (see #794).
   readonly isMainFrame?: boolean
   preventDefault(): void
 }
@@ -113,10 +113,20 @@ export function secureStreamView(webContents: WebContents): void {
  * that URL can only ever be an app page, since nothing else is allowed to
  * commit.
  *
- * `openExternal` is optional: the control window hands an outward link to the
- * OS browser because an operator is sitting in front of it, while the wall's
- * chrome layers -- which nobody is sitting at, and whose content is
- * operator-supplied -- omit it and get no outward path at all (#776).
+ * `openExternal` is stated rather than defaulted: the control window hands an
+ * outward link to the OS browser because an operator is sitting in front of it,
+ * while the wall's chrome layers -- which nobody is sitting at, and whose
+ * content is operator-supplied -- pass `null` and get no outward path at all
+ * (#776). Nullable rather than optional so a new caller cannot lose the outward
+ * path by forgetting the field.
+ *
+ * `allowSubframeNavigation` is likewise opt-in. `will-redirect` fires for
+ * sub-frames as well as the main frame, and the chrome layers exist to host
+ * third-party iframes whose own 302s (shortlinks, http->https, CDNs) have to
+ * resolve -- those requests are governed at the network layer by the session's
+ * SSRF guard instead (#733). The control window does not opt in: it renders no
+ * iframe today, and relaxing it would leave `control.html`'s `<meta>` CSP as
+ * the only thing standing between a future embed and remote content.
  *
  * `appPageURL` and `openExternal` are injected rather than imported so the
  * guards stay testable without a running Electron app; callers pass
@@ -127,9 +137,11 @@ export function secureAppWindow(
   {
     appPageURL,
     openExternal,
+    allowSubframeNavigation = false,
   }: {
     appPageURL: () => string
-    openExternal?: (url: string) => void
+    openExternal: ((url: string) => void) | null
+    allowSubframeNavigation?: boolean
   },
 ): void {
   webContents.setWindowOpenHandler(({ url }) => {
@@ -158,13 +170,10 @@ export function secureAppWindow(
   // http-equiv="refresh">`, a dropped URL), and those must not be able to launch
   // the operator's browser at a control-server-supplied address unattended.
   const guard = (event: NavigationEvent) => {
-    // A sub-frame navigating itself is not this window leaving its page: the
-    // chrome layers exist to host third-party iframes, whose own 302s
-    // (shortlinks, http->https, CDNs) have to resolve. Those requests are
-    // governed at the network layer by the session's SSRF guard instead. An
-    // event that reports no frame at all is treated as the main frame, so an
-    // unknown shape fails closed.
-    if (event.isMainFrame === false) {
+    // Where the caller hosts third-party iframes, a sub-frame navigating itself
+    // is not this window leaving its page. An event that reports no frame at
+    // all is treated as the main frame, so an unknown event shape fails closed.
+    if (allowSubframeNavigation && event.isMainFrame === false) {
       return
     }
     if (event.url === appPageURL() || event.url === webContents.getURL()) {

--- a/packages/streamwall/src/main/navigationSecurity.ts
+++ b/packages/streamwall/src/main/navigationSecurity.ts
@@ -6,6 +6,9 @@ import log from './logger'
 // exercised without a running Electron app.
 interface NavigationEvent {
   readonly url: string
+  // `will-redirect` fires for sub-frames as well as the main frame. Optional
+  // because `secureStreamView`'s guard predates the field and does not read it.
+  readonly isMainFrame?: boolean
   preventDefault(): void
 }
 
@@ -110,6 +113,11 @@ export function secureStreamView(webContents: WebContents): void {
  * that URL can only ever be an app page, since nothing else is allowed to
  * commit.
  *
+ * `openExternal` is optional: the control window hands an outward link to the
+ * OS browser because an operator is sitting in front of it, while the wall's
+ * chrome layers -- which nobody is sitting at, and whose content is
+ * operator-supplied -- omit it and get no outward path at all (#776).
+ *
  * `appPageURL` and `openExternal` are injected rather than imported so the
  * guards stay testable without a running Electron app; callers pass
  * `rendererPageURL(...)` and `shell.openExternal`.
@@ -121,7 +129,7 @@ export function secureAppWindow(
     openExternal,
   }: {
     appPageURL: () => string
-    openExternal: (url: string) => void
+    openExternal?: (url: string) => void
   },
 ): void {
   webContents.setWindowOpenHandler(({ url }) => {
@@ -130,7 +138,7 @@ export function secureAppWindow(
     // privileges. Anything the OS browser has no business launching -- and the
     // app's own page, which would just be a second copy of the UI -- is dropped
     // with a breadcrumb rather than silently swallowed.
-    if (url !== appPageURL() && isExternallyOpenable(url)) {
+    if (openExternal && url !== appPageURL() && isExternallyOpenable(url)) {
       // Logged because this is the one thing here that reaches outside the app:
       // an operator wondering why their browser just opened something can
       // correlate it.
@@ -150,6 +158,15 @@ export function secureAppWindow(
   // http-equiv="refresh">`, a dropped URL), and those must not be able to launch
   // the operator's browser at a control-server-supplied address unattended.
   const guard = (event: NavigationEvent) => {
+    // A sub-frame navigating itself is not this window leaving its page: the
+    // chrome layers exist to host third-party iframes, whose own 302s
+    // (shortlinks, http->https, CDNs) have to resolve. Those requests are
+    // governed at the network layer by the session's SSRF guard instead. An
+    // event that reports no frame at all is treated as the main frame, so an
+    // unknown shape fails closed.
+    if (event.isMainFrame === false) {
+      return
+    }
     if (event.url === appPageURL() || event.url === webContents.getURL()) {
       return
     }

--- a/packages/streamwall/src/main/navigationSecurity.ts
+++ b/packages/streamwall/src/main/navigationSecurity.ts
@@ -95,8 +95,9 @@ export function secureStreamView(webContents: WebContents): void {
 }
 
 /**
- * Lock a window that renders Streamwall's own bundled UI (currently the control
- * window) to that UI, and route outward links to the OS browser instead.
+ * Lock a window that renders one of Streamwall's own bundled pages -- the
+ * control window and the wall's two chrome layers -- to that page, and, where
+ * the caller supplies a way to, route outward links to the OS browser instead.
  *
  * The control window holds the `streamwallControl` bridge, and every `control:*`
  * IPC guard compares `ev.sender` against this very webContents — so a navigation
@@ -130,7 +131,7 @@ export function secureStreamView(webContents: WebContents): void {
  *
  * `appPageURL` and `openExternal` are injected rather than imported so the
  * guards stay testable without a running Electron app; callers pass
- * `rendererPageURL(...)` and `shell.openExternal`.
+ * `rendererPageURL(...)` and either `shell.openExternal` or `null`.
  */
 export function secureAppWindow(
   webContents: WebContents,


### PR DESCRIPTION
## Problem

The wall's background and overlay layers were the last app-page `webContents` outside the navigation hardening #732 built. They render Streamwall's own bundled pages and carry the `streamwallLayer` preload bridge, but `createLayerView()` installed no `setWindowOpenHandler` and no `will-navigate`/`will-redirect` guard — while the `layer:*` IPC handlers compare `ev.sender` against those very webContents, so they would keep passing after a navigation away.

No live trigger today (the layer pages render no operator-supplied anchor, and their embeds are sandboxed iframes), but it left two of the app's three app-page renderers unguarded.

## Solution

Both layers now go through `secureAppWindow`, pinned to their own renderer page (`rendererPageURL('background')` / `('overlay')`), with two deliberate differences from the control window:

- **No outward path.** `openExternal` became nullable-but-required and the layers pass `null`, so every renderer-opened window is denied rather than handed to `shell.openExternal`. Nobody is sitting at the wall to receive a browser tab, and the content there is operator- or control-server-supplied. Nullable rather than optional so a future caller cannot lose the outward path by forgetting the field.
- **Sub-frame navigations are left alone**, via an opt-in `allowSubframeNavigation` that only the layers pass. `will-redirect` fires for sub-frames as well as the main frame, and the layers exist to host third-party iframes whose own 302s (shortlinks, http→https, CDNs) have to resolve; those requests are governed at the network layer by the session SSRF guard added in #733. An event carrying no frame information at all is treated as the main frame, so an unknown event shape fails closed.

The issue asked whether `will-frame-navigate` was warranted here. It is not: registering it would cancel exactly the iframe navigations these layers exist to display, and the network-layer guard already covers that surface.

The opt-in is per call site rather than blanket: relaxing sub-frames for the control window too would have left `control.html`'s `<meta>` CSP as the only thing between a future embed and remote content — the very mechanism `secureAppWindow` exists because it does not survive a navigation.

## Testing

- `navigationSecurity.test.ts`: a `null` `openExternal` denies every popup and launches nothing; a sub-frame redirect resolves where the caller opts in and is blocked where it does not; main-frame redirects and frame-unknown events still block.
- `StreamWindow.test.ts`: both layers are passed to `secureAppWindow`, each pinned to its own page, both with `openExternal: null` and `allowSubframeNavigation: true`.
- Quality gate green locally: `npm run format`, `npm run lint`, `npm run typecheck` plus `tsc -p packages/streamwall`, `npm run test` (2262 tests).

## Risks / breaking changes

This constrains navigation for two always-present renderers, so the surface was traced: main-process-initiated loads emit no `will-navigate`, a self-reload matches the committed URL, a Vite full reload targets the same query-less URL `rendererPageURL` returns, and the layer iframes are `sandbox="allow-scripts"` — no `allow-popups`, no `allow-top-navigation` — so the sub-frame relaxation cannot be leveraged into a top-frame escape or a popup. `will-navigate` is main-frame-only in this Electron, so the opt-in only ever relaxes `will-redirect`.

## Pre-PR review

Three rounds with independent reviewers that had none of the implementation context, ending in `NO FINDINGS`. All findings accepted; none dismissed. One reviewer mutation-tested six mutations of the production code and confirmed each is killed by exactly one new test. The substantive findings were: the sub-frame skip initially relaxed the shared helper for the control window too (made opt-in); `openExternal` was initially optional, removing the compiler's forcing function (made nullable-but-required); one new test that no plausible mutation could fail (dropped, replaced with the control window's un-relaxed sub-frame case); and a stale doc summary.

## Follow-ups

- #794 — investigate whether `secureStreamView` wrongly cancels sub-frame redirects in stream views. It has the same sub-frame behaviour and is deliberately untouched here: stream views are a different content class, and whether real embeds are affected wants checking against a real stream rather than fixing blind.

Closes #776
