### PR TITLE
refactor(streamwall): share the dev-server allowance between hardened sessions

### DIFF
--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -118,7 +118,7 @@ vi.mock('./loadHTML', () => ({
   // Returns a resolved promise like the real loadHTML, so the caller's `.catch`
   // breadcrumb (issue #626) has something to attach to.
   loadHTML: vi.fn(() => Promise.resolve()),
-  devServerOrigin: vi.fn((): string | undefined => undefined),
+  devServerAllowedOrigins: vi.fn((): string[] => []),
   rendererPageURL: (name: string) =>
     `file:///app/renderer/main_window/src/renderer/${name}.html`,
 }))
@@ -139,7 +139,7 @@ vi.mock('./partitions', async (importOriginal) => ({
 
 const { default: StreamWindow, MAX_PENDING_BLOCKED_URLS } =
   await import('./StreamWindow')
-const { devServerOrigin, loadHTML, rendererPageURL } =
+const { devServerAllowedOrigins, loadHTML, rendererPageURL } =
   await import('./loadHTML')
 const { secureAppWindow } = await import('./navigationSecurity')
 const { hardenSession } = await import('./partitions')
@@ -1546,7 +1546,7 @@ describe('StreamWindow constructor', () => {
     vi.mocked(loadHTML).mockClear()
     vi.mocked(hardenSession).mockClear()
     vi.mocked(secureAppWindow).mockClear()
-    vi.mocked(devServerOrigin).mockReturnValue(undefined)
+    vi.mocked(devServerAllowedOrigins).mockReturnValue([])
   })
 
   function contentViewOf(win: InstanceType<typeof StreamWindow>['win']) {
@@ -1642,7 +1642,9 @@ describe('StreamWindow constructor', () => {
   it('allows the dev server origin so the layer pages themselves still load', () => {
     // In development the layer HTML and its assets come from the Vite dev
     // server on loopback, which the SSRF guard would otherwise cancel.
-    vi.mocked(devServerOrigin).mockReturnValue('http://localhost:5173')
+    vi.mocked(devServerAllowedOrigins).mockReturnValue([
+      'http://localhost:5173',
+    ])
 
     new StreamWindow(makeConfig())
 

--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -92,6 +92,9 @@ vi.mock('electron', () => {
       close: vi.fn(),
       openDevTools: vi.fn(),
       isDestroyed: vi.fn(() => false),
+      // `secureStreamView` installs these on every raw view.
+      setWindowOpenHandler: vi.fn(),
+      getURL: vi.fn(() => ''),
       session: {},
     }
     setBackgroundColor = vi.fn()
@@ -1806,6 +1809,28 @@ describe('StreamWindow constructor', () => {
 
       expect(sw.overlayView.webContents.send).not.toHaveBeenCalled()
     })
+  })
+
+  // The stream views' sessions need the same dev-server allowance the layers
+  // do -- the HLS renderer page is served from it too -- and losing it only
+  // shows up when someone runs the dev server (#791).
+  it("hardens a stream view's session with the dev server allowance", () => {
+    vi.mocked(devServerAllowedOrigins).mockReturnValue([
+      'http://localhost:5173',
+    ])
+    const sw = new StreamWindow(makeConfig())
+    vi.mocked(hardenSession).mockClear()
+
+    const { view } = (
+      sw as unknown as {
+        createRawView(): { view: { webContents: { session: unknown } } }
+      }
+    ).createRawView()
+
+    const [[session, options], ...rest] = vi.mocked(hardenSession).mock.calls
+    expect(rest).toEqual([])
+    expect(session).toBe(view.webContents.session)
+    expect(options?.allowedOrigins).toEqual(['http://localhost:5173'])
   })
 
   it('starts with empty view bookkeeping', () => {

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -24,7 +24,7 @@ import {
   ViewState,
 } from 'streamwall-shared'
 import { createActor, EventFrom, SnapshotFrom } from 'xstate'
-import { devServerOrigin, loadHTML, rendererPageURL } from './loadHTML'
+import { devServerAllowedOrigins, loadHTML, rendererPageURL } from './loadHTML'
 import log from './logger'
 import { secureAppWindow, secureStreamView } from './navigationSecurity'
 import {
@@ -235,10 +235,7 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
       allowSubframeNavigation: true,
     })
     hardenSession(layerView.webContents.session, {
-      // In development the layer page and its assets are served from the Vite
-      // dev server on loopback; allow that origin so the SSRF request guard
-      // does not cancel the layer's own load.
-      allowedOrigins: [devServerOrigin()].filter((o) => o !== undefined),
+      allowedOrigins: devServerAllowedOrigins(),
       // Unlike a stream view, a layer has no `did-fail-load` surface -- and a
       // cancelled load inside one of its iframes would not reach one anyway --
       // so a blocked URL would just go blank (#790).
@@ -492,10 +489,7 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
       },
     })
     hardenSession(view.webContents.session, {
-      // In development the HLS renderer page and its assets are served from the
-      // Vite dev server on loopback; allow that origin so the SSRF request guard
-      // does not cancel them.
-      allowedOrigins: [devServerOrigin()].filter((o) => o !== undefined),
+      allowedOrigins: devServerAllowedOrigins(),
     })
     view.setBackgroundColor(backgroundColor)
 

--- a/packages/streamwall/src/main/loadHTML.test.ts
+++ b/packages/streamwall/src/main/loadHTML.test.ts
@@ -1,7 +1,7 @@
 import { pathToFileURL } from 'url'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { loadHTML, rendererPageURL } from './loadHTML'
+import { devServerAllowedOrigins, loadHTML, rendererPageURL } from './loadHTML'
 
 // `MAIN_WINDOW_VITE_DEV_SERVER_URL` and `MAIN_WINDOW_VITE_NAME` are injected by
 // the Forge/Vite plugin at build time; under test they are stubbed per case.
@@ -89,5 +89,29 @@ describe('rendererPageURL', () => {
     expect(new URL(rendererPageURL('control')).origin).toBe(
       'http://localhost:5173',
     )
+  })
+})
+
+// Every session that may load one of the app's own renderer pages needs this
+// allowance, and getting it wrong only shows up when someone runs the dev
+// server -- so the two call sites share one definition (#791).
+describe('devServerAllowedOrigins', () => {
+  it('allows the dev server origin in development', () => {
+    dev()
+
+    expect(devServerAllowedOrigins()).toEqual(['http://localhost:5173'])
+  })
+
+  it('allows nothing in a packaged build, where there is no dev server', () => {
+    packaged()
+
+    expect(devServerAllowedOrigins()).toEqual([])
+  })
+
+  it('allows nothing when the dev server URL does not parse', () => {
+    vi.stubGlobal('MAIN_WINDOW_VITE_DEV_SERVER_URL', 'not a url')
+    vi.stubGlobal('MAIN_WINDOW_VITE_NAME', 'main_window')
+
+    expect(devServerAllowedOrigins()).toEqual([])
   })
 })

--- a/packages/streamwall/src/main/loadHTML.ts
+++ b/packages/streamwall/src/main/loadHTML.ts
@@ -21,6 +21,21 @@ export function devServerOrigin(): string | undefined {
   }
 }
 
+/**
+ * The origins a session must be allowed to reach on top of the public internet,
+ * for any session that may load one of the app's own renderer pages.
+ *
+ * In development those pages and their assets are served from the Vite dev
+ * server on loopback, which the SSRF request guard would otherwise cancel --
+ * along with the guard's own HMR socket. Empty in a packaged build, where the
+ * pages come off disk. Shared by every such call site because getting it wrong
+ * only shows up when someone runs the dev server (#791).
+ */
+export function devServerAllowedOrigins(): string[] {
+  const origin = devServerOrigin()
+  return origin === undefined ? [] : [origin]
+}
+
 /** The renderer HTML pages the app ships. */
 export type RendererPage = 'background' | 'overlay' | 'playHLS' | 'control'
 

--- a/packages/streamwall/src/main/loadHTML.ts
+++ b/packages/streamwall/src/main/loadHTML.ts
@@ -10,7 +10,7 @@ import { pathToFileURL } from 'url'
  * guard must allow this origin explicitly or it would cancel the HLS renderer
  * page and its bundled assets while developing.
  */
-export function devServerOrigin(): string | undefined {
+function devServerOrigin(): string | undefined {
   if (!MAIN_WINDOW_VITE_DEV_SERVER_URL) {
     return undefined
   }
@@ -27,9 +27,11 @@ export function devServerOrigin(): string | undefined {
  *
  * In development those pages and their assets are served from the Vite dev
  * server on loopback, which the SSRF request guard would otherwise cancel --
- * along with the guard's own HMR socket. Empty in a packaged build, where the
- * pages come off disk. Shared by every such call site because getting it wrong
- * only shows up when someone runs the dev server (#791).
+ * along with the dev server's own ws: HMR socket, covered by the same entry
+ * because the guard matches on host rather than full origin. Empty in a
+ * packaged build, where the pages come off disk. Shared by every such call site
+ * because getting it wrong only shows up when someone runs the dev server
+ * (#791).
  */
 export function devServerAllowedOrigins(): string[] {
   const origin = devServerOrigin()


### PR DESCRIPTION
## Problem

`allowedOrigins: [devServerOrigin()].filter((o) => o !== undefined)`, together with the comment explaining it, was duplicated verbatim in `createLayerView()` and `createRawView()`. Two copies is where a third gets copied from, and this is exactly the detail a new session-hardening call site would forget — with the failure mode being "the app's own page does not load", which nobody hits until they run the dev server.

## Solution

`devServerAllowedOrigins()` states it once, next to the `devServerOrigin()` it wraps, and both call sites use it. `devServerOrigin` is no longer exported, so the raw origin cannot be reached for and the filter reconstructed.

`hardenSession`'s explicit `allowedOrigins` option stays. The issue offered a `hardenAppSession(session)` wrapper that fills the origin in itself; that would be wrong for a third of the call sites — the browse window deliberately passes none, because it loads operator-supplied URLs and never one of the app's own pages, so handing it the loopback allowance would weaken its SSRF protection. `createLayerView` also passes an `onBlocked` reporter through, which a no-argument wrapper could not carry.

## Testing

- `loadHTML.test.ts`: the helper allows the dev server origin in development, nothing in a packaged build, and nothing when the dev server URL does not parse — matching the inlined expression's behaviour exactly.
- `StreamWindow.test.ts`: a new case pins `createRawView`'s hardening call, which had no test at all. Removing its `allowedOrigins` previously left the whole suite green, and this refactor deletes the comment that was the only thing marking the line as load-bearing — precisely the regression this issue is about. The stream-view stub gained the `setWindowOpenHandler` that `secureStreamView` installs, so `createRawView` can run under test.
- Quality gate green locally: `npm run format`, `npm run lint`, `npm run typecheck` plus `tsc -p packages/streamwall`, `npm run test` (2310 tests).

## Risks / breaking changes

None. Behaviour-preserving: all three call sites receive the same `allowedOrigins` as before in both dev and packaged builds, and a malformed dev-server URL still yields an empty list.

## Pre-PR review

Two rounds with independent reviewers that had none of the implementation context, ending in `NO FINDINGS`; both mutation-tested the new coverage. The first round's findings — the untested `createRawView` call, a comment that attributed the HMR socket to the guard rather than the dev server, and the now-unused `devServerOrigin` export — were all accepted and fixed.

Closes #791
