### PR TITLE
fix(streamwall): answer no to synchronous permission checks too

### DIFF
--- a/packages/streamwall/src/main/partitions.test.ts
+++ b/packages/streamwall/src/main/partitions.test.ts
@@ -364,6 +364,10 @@ test('hardenSession registers a permission check handler', () => {
 })
 
 test('hardened session answers no to every permission check', () => {
+  // Electron's `setPermissionCheckHandler` union, which is not the request
+  // handler's: `hid`, `serial`, `usb` and `deprecated-sync-clipboard-read` are
+  // check-only, while `display-capture`, `keyboardLock`, `speaker-selection`
+  // and `window-management` are request-only.
   const session = fakeSession()
   hardenSession(session)
   for (const permission of [
@@ -374,6 +378,9 @@ test('hardened session answers no to every permission check', () => {
     'midi',
     'midiSysex',
     'clipboard-read',
+    'clipboard-sanitized-write',
+    'deprecated-sync-clipboard-read',
+    'fileSystem',
     'fullscreen',
     'openExternal',
     'serial',
@@ -382,7 +389,6 @@ test('hardened session answers no to every permission check', () => {
     'idle-detection',
     'storage-access',
     'top-level-storage-access',
-    'speaker-selection',
     'pointerLock',
   ]) {
     assert.equal(

--- a/packages/streamwall/src/main/partitions.test.ts
+++ b/packages/streamwall/src/main/partitions.test.ts
@@ -20,12 +20,24 @@ type PermissionHandler = (
   callback: (granted: boolean) => void,
 ) => void
 
+// Electron's synchronous counterpart: it returns the answer rather than
+// calling back, and is consulted for checks that raise no prompt.
+type PermissionCheckHandler = (
+  webContents: unknown,
+  permission: string,
+  requestingOrigin: string,
+) => boolean
+
 function fakeSession() {
   let handler: PermissionHandler | null = null
+  let checkHandler: PermissionCheckHandler | null = null
   let requestListener: RequestListener | null = null
   return {
     setPermissionRequestHandler(next: PermissionHandler | null) {
       handler = next
+    },
+    setPermissionCheckHandler(next: PermissionCheckHandler | null) {
+      checkHandler = next
     },
     webRequest: {
       onBeforeRequest(listener: RequestListener) {
@@ -37,6 +49,13 @@ function fakeSession() {
     resolveHost: async (): Promise<{
       endpoints: { address: string; family: 'ipv4' | 'ipv6' }[]
     }> => ({ endpoints: [{ address: '93.184.216.34', family: 'ipv4' }] }),
+    check(permission: string): boolean {
+      assert.ok(checkHandler, 'a permission check handler must be registered')
+      return checkHandler({}, permission, 'https://example.com')
+    },
+    hasCheckHandler(): boolean {
+      return checkHandler !== null
+    },
     request(permission: string): boolean {
       assert.ok(handler, 'a permission request handler must be registered')
       let granted: boolean | undefined
@@ -330,4 +349,46 @@ test('hardenSession passes the blocked-request reporter through', async () => {
   await session.requestURL('http://169.254.169.254/latest/meta-data/')
 
   assert.deepEqual(blocked, ['http://169.254.169.254/latest/meta-data/'])
+})
+
+// The request handler covers the prompt path; Chromium consults the check
+// handler on its own for `navigator.permissions.query`, device enumeration and
+// other capability probes that never raise a prompt (#789).
+test('hardenSession registers a permission check handler', () => {
+  const session = fakeSession()
+  hardenSession(session)
+  assert.ok(
+    session.hasCheckHandler(),
+    'hardenSession must register a permission check handler',
+  )
+})
+
+test('hardened session answers no to every permission check', () => {
+  const session = fakeSession()
+  hardenSession(session)
+  for (const permission of [
+    'media',
+    'mediaKeySystem',
+    'geolocation',
+    'notifications',
+    'midi',
+    'midiSysex',
+    'clipboard-read',
+    'fullscreen',
+    'openExternal',
+    'serial',
+    'hid',
+    'usb',
+    'idle-detection',
+    'storage-access',
+    'top-level-storage-access',
+    'speaker-selection',
+    'pointerLock',
+  ]) {
+    assert.equal(
+      session.check(permission),
+      false,
+      `permission check "${permission}" must be denied`,
+    )
+  }
 })

--- a/packages/streamwall/src/main/partitions.ts
+++ b/packages/streamwall/src/main/partitions.ts
@@ -185,12 +185,17 @@ export function installRequestSSRFGuard(
  * prompt path; Chromium consults the check handler on its own for
  * `navigator.permissions.query`, device enumeration and other capability probes
  * that never raise a prompt, and grants them by default when no handler is set.
- * They govern the same permission names, so answering no to both says one thing
- * consistently rather than leaving content able to learn what it would be
- * refused (#789).
+ * The two permission names overlap on everything Streamwall's content can
+ * reach, `mediaKeySystem` (EME) included, so answering no to both says one
+ * thing consistently rather than leaving content able to learn what it would be
+ * refused. The check-only names (`hid`, `serial`, `usb`,
+ * `deprecated-sync-clipboard-read`) have no request-path equivalent: the first
+ * three additionally need a `select-*-device` listener, which the app never
+ * registers, and the last was simply default-granted before (#789).
  *
- * All three handlers are per-session in Electron, so this must be called for
- * each isolated partition rather than once for a shared one.
+ * The two permission handlers and the request listener are all per-session in
+ * Electron, so this must be called for each isolated partition rather than once
+ * for a shared one.
  */
 export function hardenSession(
   session: Pick<

--- a/packages/streamwall/src/main/partitions.ts
+++ b/packages/streamwall/src/main/partitions.ts
@@ -176,20 +176,33 @@ export function installRequestSSRFGuard(
 
 /**
  * Applies baseline hardening to a session: denies every permission request
- * (camera, microphone, geolocation, notifications, etc.) from web content and
- * installs the network-layer SSRF guard so redirects and sub-resources are
- * revalidated against the same non-public-address policy.
+ * (camera, microphone, geolocation, notifications, etc.) from web content, and
+ * answers no to every synchronous permission *check* as well, and installs the
+ * network-layer SSRF guard so redirects and sub-resources are revalidated
+ * against the same non-public-address policy.
  *
- * Both handlers are per-session in Electron, so this must be called for each
- * isolated partition rather than once for a shared one.
+ * The two permission handlers cover different paths. The request handler is the
+ * prompt path; Chromium consults the check handler on its own for
+ * `navigator.permissions.query`, device enumeration and other capability probes
+ * that never raise a prompt, and grants them by default when no handler is set.
+ * They govern the same permission names, so answering no to both says one thing
+ * consistently rather than leaving content able to learn what it would be
+ * refused (#789).
+ *
+ * All three handlers are per-session in Electron, so this must be called for
+ * each isolated partition rather than once for a shared one.
  */
 export function hardenSession(
-  session: Pick<Session, 'setPermissionRequestHandler'> &
+  session: Pick<
+    Session,
+    'setPermissionRequestHandler' | 'setPermissionCheckHandler'
+  > &
     RequestFilteringSession,
   options: RequestGuardOptions = {},
 ): void {
   session.setPermissionRequestHandler((_webContents, _permission, callback) => {
     callback(false)
   })
+  session.setPermissionCheckHandler(() => false)
   installRequestSSRFGuard(session, options)
 }


### PR DESCRIPTION
## Problem

`hardenSession()` denied every permission *request* — the prompt path — but left the *check* path to Electron's default, which grants everything. Chromium consults the check handler on its own for `navigator.permissions.query`, device enumeration and other capability probes that raise no prompt, so untrusted content in a hardened session could still learn what that session would say about a capability.

## Solution

`hardenSession()` now also installs `setPermissionCheckHandler(() => false)`, so every hardened partition gets it at once: stream views, the wall's chrome layers, and the browse window. The Control Window is not hardened — it runs the app's own UI in the default session — so it is unaffected.

## Risks / breaking changes

Deliberately assessed rather than assumed, because this touches every session that loads third-party content:

- **DRM is unchanged.** `mediaKeySystem` (EME) appears in *both* handlers' permission unions, so a page that checks and then requests was already refused at the request. Nothing that plays today is newly denied through that path.
- **The unions are not identical**, and the difference is harmless in both directions. Check-only: `hid`, `serial`, `usb`, `deprecated-sync-clipboard-read`. WebHID, WebSerial and WebUSB additionally require a `select-*-device` listener, which the app never registers, so those APIs were already dead-ended; the clipboard one was simply default-granted before, and denying it is a strengthening. Request-only names (`display-capture`, `keyboardLock`, `speaker-selection`, `window-management`) are untouched by this change.
- **Playback itself is not permission-gated.** Ordinary HLS/Twitch/YouTube stream views carry no EME.

One residual risk cannot be settled from the code: whether any desktop EME path consults *only* the check handler, without a following request. If one does, DRM content in a hardened session would newly fail where it previously fell through to Electron's default grant. The narrowest manual check is to open the **browse window** on a Widevine site and confirm it behaves as before; a real stream playing with audio in a wall cell is a cheap second check. Both are recorded here rather than blocking, because no ordinary Streamwall stream is in that category.

## Testing

- `partitions.test.ts`: `hardenSession` registers a permission check handler, and it answers no for every name in Electron's check-handler union. The list is the check handler's, not the request handler's, with the difference between them noted in the test.
- Mutation-verified by the reviewer: flipping the handler to `() => true` fails one case, deleting it fails two.
- Quality gate green locally: `npm run format`, `npm run lint`, `npm run typecheck` plus `tsc -p packages/streamwall`, `npm run test` (2335 tests).

## Pre-PR review

Two rounds with independent reviewers that had none of the implementation context, ending in `NO FINDINGS`. All findings were accepted; none dismissed. The first round checked the claim this change rests on against Electron's own typings and found it half-true — the two unions overlap on `mediaKeySystem` but are not identical — so the doc comment and the test's permission list were corrected rather than left leaning on a false equivalence. It also confirmed the widened `Pick<Session, …>` breaks no caller or test double.

Closes #789
