### PR TITLE
fix(streamwall): resolve per-package vitest config for single-file runs

### DIFF
--- a/packages/streamwall-shared/vitest.config.ts
+++ b/packages/streamwall-shared/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+// This package needs no special resolve/environment config of its own, but a
+// vitest.config.ts still has to exist here: Vitest's config search walks
+// *up* from cwd, so without a config of its own `npm run test -w
+// streamwall-shared` (cwd = this directory) would otherwise walk up to the
+// repo-root `vitest.config.ts` and run every workspace's `test.projects`
+// instead of just this package's tests (issue #796).
+export default defineConfig({})

--- a/test/renderer-single-file.test.mjs
+++ b/test/renderer-single-file.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { dirname } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)))
+
+// #796: a `packages/streamwall/src/renderer` component test crashed
+// (`TypeError: Cannot add property __, object is not extensible` - a frozen
+// React element hitting Preact's reconciler) whenever it was run on its own
+// with a repo-root-relative path, because Vitest's config search starts at
+// `process.cwd()` and walks *up*, never down: with no config at the repo
+// root, `packages/streamwall/vitest.config.ts` - and the `react` ->
+// `preact/compat` alias it sets up - was never even considered. The fix is
+// the root `vitest.config.ts`'s `test.projects` list, which lets that lookup
+// still find the right package config no matter where vitest started
+// searching from.
+//
+// This spawns the real CLI rather than asserting on `vitest.config.ts`'s
+// shape, because the bug was about which config Vitest actually resolves for
+// a given cwd/path combination, not about what the config file contains.
+test('a renderer component test passes when run standalone from the repo root', () => {
+  const result = spawnSync(
+    'npx',
+    ['vitest', 'run', 'packages/streamwall/src/renderer/OverlayRoot.test.tsx'],
+    {
+      cwd: rootDir,
+      encoding: 'utf8',
+      // npx is only reachable as the `npx.cmd` shim on Windows, which Node
+      // refuses to spawn without a shell since the CVE-2024-27980 fix (#586).
+      shell: process.platform === 'win32',
+    },
+  )
+
+  assert.equal(
+    result.status,
+    0,
+    `expected the standalone run to pass; vitest exited ${result.status}\n` +
+      `${result.stdout}\n${result.stderr}`,
+  )
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,51 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+// No workspace at this level has its own tests; this file exists solely so
+// that `vitest` run from the repo root (or given a full `packages/<name>/...`
+// path, as an IDE test runner or a copy-pasted file path does) still resolves
+// each file's own package config.
+//
+// Vitest's config search starts at `process.cwd()` and walks *up* the
+// directory tree, never down into subdirectories, so
+// `npx vitest run packages/streamwall/src/renderer/Foo.test.tsx` run from the
+// repo root picked up no config at all: none exists here (until this file),
+// and `packages/streamwall/vitest.config.ts` was never even considered. Every
+// package-specific `resolve.alias` (`react` -> `preact/compat`, the
+// `electron-log/main` redirect) and `deps.inline` entry was silently dropped,
+// so the file resolved the real `react` package instead of `preact/compat`
+// and crashed Preact's reconciler (`Cannot add property __, object is not
+// extensible`) - the exact class of bug `packages/streamwall/vitest.config.ts`
+// documents at length for `react-icons`/`styled-components`, just triggered by
+// cwd instead of module load order (issue #796).
+//
+// `npm run test -w <workspace>` (what `scripts/run-tests.mjs` and each
+// workspace's own `npm test` use) sets cwd to the workspace directory, so
+// those already found their own package's config directly and never needed
+// this file - every vitest workspace that has one keeps it, so that lookup
+// still finds the nearer, package-specific config first and never reaches
+// this one. `streamwall-shared` had no config of its own, which without a
+// stub file here would let ITS `npm run test -w streamwall-shared` walk
+// straight up to this root config and run every project's tests instead of
+// just its own; `packages/streamwall-shared/vitest.config.ts` exists purely
+// to stay closer than this file.
+//
+// `test.projects` makes every listed workspace's config apply to its own
+// files regardless of the cwd vitest was invoked from - it does not run their
+// suites here, it only lets this root config delegate resolution to them.
+// The entries are absolute: this file can be discovered from any cwd via the
+// upward search above, and relative project paths resolve against that cwd,
+// not against this file's own directory - a nested cwd would otherwise turn
+// `packages/streamwall` into a path under itself.
+const dirname = fileURLToPath(new URL('.', import.meta.url))
+
+export default defineConfig({
+  test: {
+    projects: [
+      `${dirname}packages/streamwall`,
+      `${dirname}packages/streamwall-shared`,
+      `${dirname}packages/streamwall-control-client`,
+      `${dirname}packages/streamwall-control-ui`,
+    ],
+  },
+})


### PR DESCRIPTION
## Problem

Every Preact component test under `packages/streamwall/src/renderer` failed when run on its own with a repo-root-relative path (e.g. `npx vitest run packages/streamwall/src/renderer/OverlayRoot.test.tsx`), while passing when the whole package ran (`npm run test -w packages/streamwall`) or with `--root packages/streamwall` explicitly set:

```
TypeError: Cannot add property __, object is not extensible
    at newParentVNode node_modules/preact/src/diff/children.js:229
```

## Root cause

Vitest's config search starts at `process.cwd()` and walks **up** the directory tree — it never walks down into subdirectories. With no `vitest.config.ts` at the repo root, invoking vitest from the repo root with a `packages/streamwall/...` path never even considered `packages/streamwall/vitest.config.ts`, so none of its settings applied — most importantly the `react` -> `preact/compat` alias, `mainFields`, and `deps.inline` that exist precisely so `react-icons`/`styled-components` resolve `preact/compat` instead of the real `react` package. Without them, the real `react` package resolved, producing a frozen React element that crashed Preact's reconciler.

`npm run test -w <workspace>` (used by `scripts/run-tests.mjs` and each workspace's own `npm test`) sets `cwd` to the workspace directory, so it always found the package's own config directly and never hit this bug.

## Fix

- Added a root `vitest.config.ts` with `test.projects` listing every vitest-based workspace (`streamwall`, `streamwall-shared`, `streamwall-control-client`, `streamwall-control-ui`), using absolute paths so the list resolves correctly no matter which `cwd` vitest started its upward config search from. This lets a single-file run from the repo root — or from any nested `cwd` with no closer config of its own — still resolve to the right package's settings.
- Added `packages/streamwall-shared/vitest.config.ts` (empty `defineConfig({})`). That package had no config of its own, so without this stub its own `npm run test -w streamwall-shared` would now walk up past its own directory and hit the new root config, running every project's tests instead of just its own. The stub keeps a closer config in place so that lookup stops there, as it always did.
- `streamwall-control-server` (plain `node:test`, not vitest) and `streamwall-control-e2e` (Playwright, its own separate `test:e2e` script) are untouched and unaffected — neither goes through Vitest's config resolution.

## Testing performed

- Reproduced the failure on `main`, confirmed the fix resolves it: every renderer test file in `packages/streamwall/src/renderer` now passes individually, run from both the repo root and from inside `packages/streamwall`.
- `npm run test -w packages/streamwall` (1079 tests), `-w packages/streamwall-shared` (380 tests), `-w packages/streamwall-control-ui` (399 tests), `-w packages/streamwall-control-client` (38 tests), `-w packages/streamwall-control-server` (238 tests, unaffected) all still pass individually.
- Full `npm run test` from the repo root: 2336 tests across 6 suites, all green.
- `npm run lint`, `npm run format:check`, `npm run typecheck`: clean.
- Added `test/renderer-single-file.test.mjs`, a `node:test` regression test that spawns the real `vitest` CLI from the repo root for one renderer test file and asserts it exits 0. Verified it fails without the fix (removed the two new config files, confirmed the regression test fails for the right reason) and passes with it.

## Pre-PR review

One independent review round (fresh subagent, no context from this session) — result: `NO FINDINGS`. It independently reproduced the pre-fix failure, verified the regression test is real (fails without the fix), and re-ran the full quality gate plus every workspace's own test script.

Closes #796