### PR TITLE
fix(streamwall): let stream-view sub-frames resolve their own redirects

### DIFF
--- a/packages/streamwall/src/main/navigationSecurity.test.ts
+++ b/packages/streamwall/src/main/navigationSecurity.test.ts
@@ -54,13 +54,16 @@ class FakeWebContents {
     isMainFrame?: boolean,
   ): boolean {
     let prevented = false
-    const navEvent: NavEvent = {
-      url,
-      isMainFrame,
-      preventDefault: () => {
-        prevented = true
-      },
+    const preventDefault = () => {
+      prevented = true
     }
+    // Omitted rather than set to `undefined`, so a caller that passes no frame
+    // information reproduces an event shape that carries no `isMainFrame` key
+    // at all -- the case every guard has to fail closed on.
+    const navEvent: NavEvent =
+      isMainFrame === undefined
+        ? { url, preventDefault }
+        : { url, isMainFrame, preventDefault }
     for (const listener of this.navHandlers[event] ?? []) {
       listener(navEvent)
     }
@@ -135,6 +138,9 @@ test("secureStreamView keeps a stream URL's signed-token query out of the reload
 })
 
 test('secureStreamView blocks a redirect away once a page has committed (302 escape)', () => {
+  // Dispatched without any frame information, so this pins the fail-closed
+  // path too: an event shape that reports no frame is guarded as a main-frame
+  // navigation rather than skipped.
   const wc = new FakeWebContents('https://example.com/stream')
   secureStreamView(asWebContents(wc))
 
@@ -155,6 +161,35 @@ test('secureStreamView allows a redirect while the initial load is still resolvi
   assert.equal(
     wc.dispatchNavigation('will-redirect', 'https://cdn.example/live'),
     false,
+  )
+})
+
+test('secureStreamView lets a sub-frame resolve its own redirect', () => {
+  // `will-redirect` fires for sub-frames as well as the main frame, and a
+  // stream view exists to host embedded players whose iframes redirect
+  // (CDN handoffs, consent frames, shortlinks). Comparing such a redirect
+  // against `getURL()` -- always the *main* frame's URL -- could only ever
+  // cancel it, leaving a blank embed and no `did-fail-load` to report (#794).
+  // Those requests stay governed at the network layer by the session's SSRF
+  // guard (`installRequestSSRFGuard`).
+  const wc = new FakeWebContents('https://example.com/stream')
+  secureStreamView(asWebContents(wc))
+
+  assert.equal(
+    wc.dispatchNavigation('will-redirect', 'https://cdn.example/ad', false),
+    false,
+  )
+})
+
+test('secureStreamView still blocks a main-frame redirect away', () => {
+  // The negative control for the case above: the same event, reported as the
+  // main frame, is still the view being taken off its page.
+  const wc = new FakeWebContents('https://example.com/stream')
+  secureStreamView(asWebContents(wc))
+
+  assert.equal(
+    wc.dispatchNavigation('will-redirect', 'https://evil.example/', true),
+    true,
   )
 })
 

--- a/packages/streamwall/src/main/navigationSecurity.ts
+++ b/packages/streamwall/src/main/navigationSecurity.ts
@@ -6,8 +6,10 @@ import log from './logger'
 // exercised without a running Electron app.
 interface NavigationEvent {
   readonly url: string
-  // `will-redirect` fires for sub-frames as well as the main frame. Optional
-  // because `secureStreamView`'s guard does not read it (see #794).
+  // `will-redirect` fires for sub-frames as well as the main frame (Electron's
+  // navigation throttle gates only `will-navigate` on the main frame). Optional
+  // so an event shape that carries no frame at all still type-checks; every
+  // guard below treats that case as the main frame and so fails closed.
   readonly isMainFrame?: boolean
   preventDefault(): void
 }
@@ -25,6 +27,21 @@ function preventNavigationAway(
   webContents: WebContents,
   event: NavigationEvent,
 ): void {
+  // A sub-frame navigating itself is not the view leaving its page, and this
+  // check has nothing to compare it against: `getURL()` is always the *main*
+  // frame's URL, so a sub-frame's redirect target can never equal it and would
+  // always be cancelled. Stream views host operator-supplied embeds -- video
+  // players, CDN handoffs, consent frames, shortlinks -- whose iframes redirect
+  // routinely, and the cancellation would surface as a blank embed with no
+  // main-frame `did-fail-load` to report it (#794). Sub-frame requests stay
+  // governed at the network layer by the session's SSRF guard
+  // (`installRequestSSRFGuard` in partitions.ts), which re-checks every hop.
+  // An event that reports no frame at all is treated as the main frame, so an
+  // unknown event shape fails closed.
+  if (event.isMainFrame === false) {
+    return
+  }
+
   const currentURL = webContents.getURL()
 
   // Allow the page to reload itself (navigating to the URL it is already on).
@@ -84,7 +101,8 @@ function redactURL(url: string): string {
 }
 
 // Lock a stream view's web contents down: deny popups and block both navigation
-// and redirect escapes away from the intended URL, while permitting self-reloads.
+// and redirect escapes away from the intended URL, while permitting self-reloads
+// and leaving embedded sub-frames to resolve their own redirects.
 export function secureStreamView(webContents: WebContents): void {
   denyWindowOpen(webContents)
 


### PR DESCRIPTION
## Summary

`secureStreamView` cancelled every sub-frame redirect inside a committed stream view.

The investigation the issue asked for came out positive, from Electron's own semantics:

- Electron's navigation throttle (`shell/browser/electron_navigation_throttle.cc`) gates `will-navigate` on `handle->IsInMainFrame()`, but emits `will-redirect` for **every** frame — no main-frame check. The pinned typings agree: `will-navigate` is documented as "start navigation on the main frame", while `WebContentsWillRedirectEventParams` carries an `isMainFrame` flag with no such restriction.
- `preventNavigationAway` compared the event URL against `webContents.getURL()`, which is always the *main frame's* URL. A sub-frame's redirect target can never equal it, so once a page had committed (`currentURL !== ''`) every sub-frame 302 was `preventDefault()`ed.

Stream views exist to host operator-supplied embeds — video players, CDN handoffs, consent frames, shortlinks — i.e. exactly the content whose iframes redirect. Such a cancellation would show up as a blank embed with no main-frame `did-fail-load` to report it.

The guard now returns early for `event.isMainFrame === false`, matching the opt-in `secureAppWindow` gained in #776. The skip is unconditional here rather than opt-in because `secureStreamView` has exactly one caller (`StreamWindow.createRawView()`), and that caller is the iframe-hosting case.

## Security

- Main-frame behaviour is untouched: navigations and redirects away are still cancelled, self-reloads still allowed, and the uncommitted-view allowance for the initial load's own redirect chain is unchanged.
- The comparison is `=== false`, not `!== true`, so an event that carries no frame information at all is still guarded as a main frame — it fails closed.
- No protection is lost for sub-frames: every stream view's session is hardened by `hardenSession` → `installRequestSSRFGuard` (`StreamWindow.ts:491`, before `secureStreamView` at `:498`), which re-checks every request hop against the non-public-address policy. A sub-frame's *initial* load was never gated by this navigation guard either.

## How was this tested?

`npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (2337 tests, green) at the repo root.

New unit coverage in `navigationSecurity.test.ts`:

- a sub-frame redirect (`isMainFrame: false`) resolves — this test fails on `main`, and is the reproduction of the reported bug;
- the same redirect reported as the main frame is still blocked (negative control);
- the existing "302 escape" case now explicitly documents that it dispatches an event with **no** frame information and must still be blocked. `FakeWebContents.dispatchNavigation` was adjusted to omit the `isMainFrame` key entirely in that case instead of setting it to `undefined`, so the fail-closed path is exercised against a genuinely key-less event shape. That is a no-op for every existing assertion (both shapes compare `!== false`).

No live Electron run was performed — no GUI environment is available here — so the "load a real redirecting embed" bullet was answered from Electron's throttle source and typings plus the unit-level reproduction above.

## Pre-PR review

Three rounds with an independent reviewer that had none of the implementing session's context.

- Round 1 — two minor findings, both accepted: (a) the new "reports no frame at all" test duplicated an existing case and the test double never produced a truly key-less event → the double now omits the key and the duplicate test was dropped in favour of documenting the existing case; (b) the commit body asserted the real-world impact as observed fact although no live embed was loaded → wording softened to the conditional and the substitution documented here.
- Round 2 — one minor finding, accepted: the two "still blocks a main-frame …" tests were redundant (the guard treats `true` and an absent key identically) → the `will-navigate` one was dropped, the `will-redirect` one kept as the negative control beside the new sub-frame test.
- Round 3 — `NO FINDINGS`.

No findings were dismissed.

Closes #794

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests (or this PR explains why none apply)
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments
