### PR TITLE
fix(control-server): raise test-timing margins found while investigating #804

### DIFF
--- a/packages/streamwall-control-server/package.json
+++ b/packages/streamwall-control-server/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "tsx ./src/index.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "test": "node --import tsx --test --test-force-exit --test-timeout=60000 \"src/**/*.test.ts\""
+    "test": "node --import tsx --test --test-force-exit --test-timeout=120000 \"src/**/*.test.ts\""
   },
   "repository": "github:NilsR0711/streamwall",
   "author": "Nils Reeh <info@nilsreeh.de>",

--- a/packages/streamwall-control-server/src/gracefulShutdown.test.ts
+++ b/packages/streamwall-control-server/src/gracefulShutdown.test.ts
@@ -343,12 +343,20 @@ test(
     // The credential banner is the last thing the boot prints, so seeing it
     // means the server is up and the signal lands on a running process. Matched
     // against everything received so far, since a pipe splits where it likes.
+    //
+    // The wait is bounded well under the file's 120000ms `--test-timeout`
+    // (#804/#537): a real child process spawn plus a scrypt-hashed token boot
+    // measurably needs more than 30s of wall clock on a machine running many
+    // `node --test` files (each its own process) concurrently, and letting the
+    // *outer* per-test timeout win that race instead of this one turns a
+    // readable "never finished booting" failure into an unattributed
+    // `testTimeoutFailure` that reports no failing subtest at all.
     await new Promise<void>((resolve, reject) => {
       const fail = (reason: string) =>
         reject(new Error(`${reason}\nstdout: ${stdout}\nstderr: ${stderr}`))
       const timer = setTimeout(
         () => fail('the server never finished booting'),
-        30000,
+        45000,
       )
       child.on('error', (err) =>
         fail(`the server could not be spawned: ${err}`),

--- a/packages/streamwall-control-server/src/scryptRateLimit.test.ts
+++ b/packages/streamwall-control-server/src/scryptRateLimit.test.ts
@@ -321,7 +321,7 @@ describe('scrypt-bearing routes', () => {
     // entry would expire and the reconnect after an uplink flap would derive.
     const { app, auth, port } = await bootServerWithUplink({
       clientPing: { intervalMs: 20, timeoutMs: 2000 },
-      verifiedTokenTtlMs: 400,
+      verifiedTokenTtlMs: 2000,
     })
 
     const invite = await auth.createToken({
@@ -347,9 +347,15 @@ describe('scrypt-bearing routes', () => {
     await once(ws, 'open')
     await messageCollector(ws)(500)
 
-    // Several TTLs later: without the refresh the entry is long gone, and the
-    // margin over the 20ms cadence leaves room for a loaded runner.
-    await delay(1200)
+    // Several TTLs later: without the refresh the entry is long gone. The TTL
+    // is 100x the 20ms ping cadence (raised from 20x in #804): a 400ms TTL
+    // measurably flaked under `node --test`'s default concurrency, where an
+    // OS-scheduler stall of a few hundred ms on this file's own process is
+    // enough to skip every ping in the window and let a "warm" entry expire
+    // for real — a legitimate race in the test, not in the cache (see
+    // verifiedTokenCache.test.ts for the deterministic, fake-clock coverage of
+    // the sliding-expiry logic itself).
+    await delay(5000)
     const derivations = countDerivations(auth)
     const res = await app.inject({
       method: 'GET',

--- a/test/workspace-metadata.test.mjs
+++ b/test/workspace-metadata.test.mjs
@@ -92,6 +92,15 @@ test('every workspace that packages with electron-forge typechecks first', () =>
 // `# fail 0` with a non-zero exit, which reads as an unexplained flake. The
 // floor keeps the timeout a hang detector rather than a per-file budget.
 // Issue #492.
+//
+// The same class recurred as #804 against `gracefulShutdown.test.ts`, which
+// spawns a real child process and waits for it to finish booting: under
+// `node --test`'s default per-file-process concurrency plus several other
+// `node --test` invocations running at once (parallel worktrees), the file's
+// cumulative wall-clock cost pushed past the 60s value this floor used to
+// equal. `streamwall-control-server` now configures 120000ms — comfortably
+// above this floor, which stays at the original value so it keeps acting as a
+// minimum rather than tracking every package's current setting.
 const NODE_TEST_TIMEOUT_FLOOR_MS = 60_000
 
 test('node:test workspaces leave room for whole-file runtime in --test-timeout', () => {


### PR DESCRIPTION
## Summary

`streamwall-control-server`'s `node --test` runner occasionally exits non-zero while reporting zero failing subtests — the same signature as the closed #492 (a "cancelled" file, not a failing assertion, which node:test reports as `# fail 0` / `# cancelled 1`). Investigating it directly reproduced the exact signature, plus a second, distinct assertion-level flake, both under artificial heavy CPU load (many `yes > /dev/null &` processes plus 3-4 parallel `npm -w packages/streamwall-control-server test` invocations at once on a 12-core machine — comparable to several parallel worktree sessions running the suite at the same time).

## Findings and fixes

1. **`src/gracefulShutdown.test.ts` — the actual #804 signature.** Its last test spawns the entry point as a real child process and waits (previously up to 30000ms) for it to finish booting before sending a real SIGTERM. `node --test` applies `--test-timeout` to the *implicit file-level test* wrapping the whole file (the root cause #492/PR #537 already documented), so under enough load for that boot wait to eat a large fraction of the package's 60000ms `--test-timeout`, the file's cumulative runtime (that wait plus its ~11 other tests) can exceed the budget before this test's own timeout ever fires — producing a cancelled file with 0 reported failures. Reproduced this exactly: `gracefulShutdown.test.ts` timed out at 60021ms with `failureType: 'testTimeoutFailure'`.

   Fix: raise `streamwall-control-server`'s `--test-timeout` from 60000ms to 120000ms, and the boot-wait's own timeout from 30000ms to 45000ms (comfortably under the new file budget, so a genuine boot failure still reports a readable message instead of an opaque file-level timeout).

2. **`src/scryptRateLimit.test.ts` — a related but distinct flake.** "an open client socket keeps its session verification warm" relies on a real `setInterval` ping (20ms cadence) refreshing a 400ms sliding-TTL cache entry. Under the same load, an OS-scheduler stall of a few hundred ms on this file's own process is enough to skip every ping in that window and let the entry genuinely expire, so the test correctly observes a re-derivation and fails its assertion (`derivations.calls` 1 instead of 0) — a real race in the test's real-clock margin, not in the cache logic itself (`verifiedTokenCache.ts` already has deterministic, fake-clock coverage of the sliding-expiry behavior in `verifiedTokenCache.test.ts`, unaffected by this change).

   Fix: raise the TTL to 2000ms (100x the ping cadence, up from 20x) and the wait before asserting to 5000ms.

3. **`test/workspace-metadata.test.mjs`** gained a comment near `NODE_TEST_TIMEOUT_FLOOR_MS` referencing #804, explaining why `streamwall-control-server` now configures above the (unchanged) 60000ms floor.

Note: while reproducing, a third, separate bug surfaced in `messageCollector` (`testHelpers.ts`) — it threw a SyntaxError on a binary WebSocket frame arriving before the expected JSON one. That is a different symptom (a real thrown exception, reported as an actual failure, not the "0 failures" signature) from a different root cause, and it was already found and fixed independently on `main` by #807 (closes #805) before this branch was cut from an up-to-date `origin/main`. Nothing here duplicates or touches that.

## Testing performed

This is an inherently probabilistic OS-scheduling race, so it cannot be pinned down with a deterministic unit test. Verification was empirical, matching the precedent set by #537 for #492:

- Before the fix: reproduced the exact `# fail 0` / `# cancelled 1` file-timeout signature, and separately the `scryptRateLimit.test.ts` assertion failure, several times across ~90 runs of `npm -w packages/streamwall-control-server test` under artificial heavy load.
- After the fix: 64 consecutive runs under the same artificial heavy load (4 parallel full-suite invocations plus unrelated busy processes oversubscribing a 12-core machine), 0 failures and 0 cancellations.
- Full quality gate green: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm run test` (root, all 6 workspaces + repository invariants, 2348 tests).
- `npm -w packages/streamwall-control-server test` alone: 248/248 passing under normal (unloaded) conditions.

No production code is touched — every change is to test timing constants and a comment.

## Risks / breaking changes

Low. Widening timeouts only makes the suite more tolerant of slow machines; it does not change what is asserted. A genuinely hung test still fails, just after a longer wait (120s instead of 60s for `gracefulShutdown.test.ts`, matching the same trade-off #537 already made for #492).

## Pre-PR review

One independent review round (fresh subagent, no session context) against the pushed diff: **NO FINDINGS**.

## Follow-ups

None opened. The one adjacent issue found during investigation (the `messageCollector` binary-frame bug) was already reported and fixed independently as #805/#807 before this PR was opened.

Closes #804

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests (or this PR explains why none apply) — no new automated tests; see "Testing performed" for why this class of bug cannot be pinned down deterministically, and what verification was done instead
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments