### PR TITLE
feat(control-ui): key blocked-URL dismissals by the wall's clear generation

### DIFF
--- a/packages/streamwall-control-client/src/dev.tsx
+++ b/packages/streamwall-control-client/src/dev.tsx
@@ -170,6 +170,7 @@ const demoState: StreamwallState = {
   favorites: ['https://twitch.tv/woke'],
   dataSourceHealth: [],
   blockedLayerURLs: [],
+  blockedLayerURLsGeneration: 0,
 }
 
 function useMockConnection(): StreamwallConnection {

--- a/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.test.tsx
+++ b/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.test.tsx
@@ -89,6 +89,7 @@ const minimalState: StreamwallState = {
   favorites: [],
   dataSourceHealth: [],
   blockedLayerURLs: [],
+  blockedLayerURLsGeneration: 0,
 }
 
 function stateMessage(state: StreamwallState = minimalState) {

--- a/packages/streamwall-control-e2e/tests/harness.ts
+++ b/packages/streamwall-control-e2e/tests/harness.ts
@@ -91,6 +91,7 @@ const E2E_STATE: StreamwallState = {
   favorites: [],
   dataSourceHealth: [],
   blockedLayerURLs: [],
+  blockedLayerURLsGeneration: 0,
 }
 
 /** Options for {@link startHarness}, exposed to specs via `test.use(...)`. */

--- a/packages/streamwall-control-server/src/auth.test.ts
+++ b/packages/streamwall-control-server/src/auth.test.ts
@@ -405,6 +405,7 @@ function makeState(): StreamwallState {
     favorites: ['https://example.com/stream'],
     dataSourceHealth: [],
     blockedLayerURLs: ['http://192.168.1.5/overlay'],
+    blockedLayerURLsGeneration: 2,
   }
 }
 
@@ -418,6 +419,26 @@ for (const role of ['admin', 'operator', 'local'] satisfies StreamwallRole[]) {
     const view = new StateWrapper(state).view(role)
 
     assert.deepEqual(view.blockedLayerURLs, state.blockedLayerURLs)
+  })
+}
+
+// Issue #810: the generation says nothing about any address, and a client
+// that is later told about the list has to be able to tell which clear the
+// list it sees belongs to.
+for (const role of [
+  'admin',
+  'operator',
+  'local',
+  'monitor',
+] satisfies StreamwallRole[]) {
+  test(`StateWrapper.view("${role}") carries the blocked layer URL generation`, () => {
+    const state = makeState()
+    const view = new StateWrapper(state).view(role)
+
+    assert.equal(
+      view.blockedLayerURLsGeneration,
+      state.blockedLayerURLsGeneration,
+    )
   })
 }
 

--- a/packages/streamwall-control-server/src/auth.ts
+++ b/packages/streamwall-control-server/src/auth.ts
@@ -115,6 +115,7 @@ export class StateWrapper extends EventEmitter {
       favorites,
       dataSourceHealth,
       blockedLayerURLs,
+      blockedLayerURLsGeneration,
     } = this._value
 
     const state: StreamwallState = {
@@ -136,6 +137,11 @@ export class StateWrapper extends EventEmitter {
       blockedLayerURLs: roleCan(role, 'update-custom-stream')
         ? blockedLayerURLs
         : [],
+      // Passed to every role, unlike the list itself: it is a count of the
+      // operator's own layer-link edits and names no address, and the client
+      // that is told about the list needs it to know which clear that list
+      // belongs to (issue #810).
+      blockedLayerURLsGeneration,
     }
     if (role === 'admin') {
       state.auth = auth

--- a/packages/streamwall-control-ui/src/BlockedLayerURLNotice.test.tsx
+++ b/packages/streamwall-control-ui/src/BlockedLayerURLNotice.test.tsx
@@ -14,16 +14,19 @@ afterEach(() => {
   }
 })
 
-function renderNotice(urls: readonly string[]): HTMLDivElement {
+function renderNotice(urls: readonly string[], generation = 0): HTMLDivElement {
   container = document.createElement('div')
   document.body.appendChild(container)
-  rerender(urls)
+  rerender(urls, generation)
   return container
 }
 
-function rerender(urls: readonly string[]): void {
+function rerender(urls: readonly string[], generation = 0): void {
   act(() => {
-    render(<BlockedLayerURLNotice urls={urls} />, container!)
+    render(
+      <BlockedLayerURLNotice urls={urls} generation={generation} />,
+      container!,
+    )
   })
 }
 
@@ -135,6 +138,49 @@ describe('BlockedLayerURLNotice', () => {
     })
 
     rerender(['http://192.168.1.5/overlay', 'http://10.0.0.9/bg'])
+
+    expect(shownURLs(el)).toEqual(['http://10.0.0.9/bg'])
+  })
+
+  // Issue #810: a client disconnected across the operator's edit reconnects to
+  // a snapshot that already names the same address again, so it never observes
+  // the empty list. The generation the desktop bumped on that clear is what
+  // tells it the dismissal was made against a list that no longer stands.
+  test('names an address again after a clear it never saw', () => {
+    const el = renderNotice(['http://192.168.1.5/overlay'], 3)
+    act(() => {
+      dismissButton(el)!.click()
+    })
+    expect(shownURLs(el)).toEqual([])
+
+    rerender(['http://192.168.1.5/overlay'], 4)
+
+    expect(shownURLs(el)).toEqual(['http://192.168.1.5/overlay'])
+  })
+
+  // The point of keying by generation rather than dropping dismissals on every
+  // reconnect: a dismissal the operator made still holds for the list it was
+  // made against, however often that list is re-broadcast.
+  test('keeps a dismissal while the generation stands', () => {
+    const el = renderNotice(['http://192.168.1.5/overlay'], 3)
+    act(() => {
+      dismissButton(el)!.click()
+    })
+
+    rerender(['http://192.168.1.5/overlay'], 3)
+
+    expect(shownURLs(el)).toEqual([])
+  })
+
+  // A desktop older than #810 sends no generation and the control UI defaults
+  // it to a constant, which must not read as a clear on every state update.
+  test('keeps a dismissal across updates from a desktop with no generation', () => {
+    const el = renderNotice(['http://192.168.1.5/overlay'], 0)
+    act(() => {
+      dismissButton(el)!.click()
+    })
+
+    rerender(['http://192.168.1.5/overlay', 'http://10.0.0.9/bg'], 0)
 
     expect(shownURLs(el)).toEqual(['http://10.0.0.9/bg'])
   })

--- a/packages/streamwall-control-ui/src/BlockedLayerURLNotice.tsx
+++ b/packages/streamwall-control-ui/src/BlockedLayerURLNotice.tsx
@@ -23,20 +23,38 @@ import { styled } from 'styled-components'
  * Dismissal is per address and forgotten once the desktop stops reporting that
  * address, so a later refusal of a different URL, or of the same one after a
  * clear this client saw, is announced again rather than swallowed by an
- * earlier dismissal. A clear this client did not see -- it was disconnected
- * across the operator's edit and reconnected to a snapshot already naming the
- * same address again -- is indistinguishable from the address never having
- * gone away, and stays dismissed. Telling the two apart would need the
- * desktop to carry a clear generation in the state, which is more machinery
- * than a dismissed notice is worth.
+ * earlier dismissal.
+ *
+ * A clear this client did not see -- it was disconnected across the operator's
+ * edit and reconnected to a snapshot already naming the same address again --
+ * is indistinguishable from the address never having gone away by membership
+ * alone, which used to leave the new refusal silently suppressed for the life
+ * of the page (issue #810). Dismissals are therefore keyed by the clear
+ * generation the desktop broadcasts: one made against an older list never
+ * applies to a newer one, while a dismissal against the list still standing
+ * survives any number of reconnects.
  *
  * The live region itself stays mounted while nothing is refused and only its
  * contents are swapped: `aria-live` announcements are only reliable for
  * changes inside a region that already exists in the accessibility tree
  * (WCAG 4.1.3, issue #463).
  */
-export function BlockedLayerURLNotice({ urls }: { urls: readonly string[] }) {
-  const [dismissed, setDismissed] = useState<readonly string[]>([])
+export function BlockedLayerURLNotice({
+  urls,
+  generation,
+}: {
+  urls: readonly string[]
+  /**
+   * How often the desktop has cleared its list (issue #810). Dismissals are
+   * scoped to the value they were made under, so a clear this client was
+   * disconnected across still takes them down.
+   */
+  generation: number
+}) {
+  const [dismissed, setDismissed] = useState<{
+    generation: number
+    urls: readonly string[]
+  }>({ generation, urls: [] })
 
   // A dismissal for an address the desktop no longer reports is forgotten, so
   // the same address being refused again -- after the operator's edit cleared
@@ -45,16 +63,28 @@ export function BlockedLayerURLNotice({ urls }: { urls: readonly string[] }) {
   // flash of the address the operator dismissed.
   useLayoutEffect(() => {
     setDismissed((previous) => {
-      const next = previous.filter((url) => urls.includes(url))
-      return next.length === previous.length ? previous : next
+      // A clear the desktop reports takes every dismissal with it, whether or
+      // not this client saw the list go empty in between (issue #810).
+      if (previous.generation !== generation) {
+        return { generation, urls: [] }
+      }
+      const next = previous.urls.filter((url) => urls.includes(url))
+      return next.length === previous.urls.length
+        ? previous
+        : { generation, urls: next }
     })
-  }, [urls])
+  }, [urls, generation])
 
-  const visible = urls.filter((url) => !dismissed.includes(url))
+  // Read through the generation rather than trusting the state alone: the
+  // effect above only runs after this render, and a dismissal from an older
+  // list must not suppress anything even for that one pass.
+  const activeDismissals =
+    dismissed.generation === generation ? dismissed.urls : []
+  const visible = urls.filter((url) => !activeDismissals.includes(url))
 
   const handleDismiss = useCallback(() => {
-    setDismissed(urls)
-  }, [urls])
+    setDismissed({ generation, urls })
+  }, [urls, generation])
 
   return (
     <StyledBlockedLayerURLNotice role="status" aria-live="polite">

--- a/packages/streamwall-control-ui/src/CustomStreamInput.test.tsx
+++ b/packages/streamwall-control-ui/src/CustomStreamInput.test.tsx
@@ -72,6 +72,7 @@ function makeConnection(customStreams: StreamData[]): StreamwallConnection {
     favorites: [],
     dataSourceHealth: [],
     blockedLayerURLs: [],
+    blockedLayerURLsGeneration: 0,
   }
 }
 

--- a/packages/streamwall-control-ui/src/StreamList.test.tsx
+++ b/packages/streamwall-control-ui/src/StreamList.test.tsx
@@ -81,6 +81,7 @@ function makeConnection(
     favorites,
     dataSourceHealth: [],
     blockedLayerURLs: [],
+    blockedLayerURLsGeneration: 0,
   }
 }
 

--- a/packages/streamwall-control-ui/src/components/ControlSidebar.tsx
+++ b/packages/streamwall-control-ui/src/components/ControlSidebar.tsx
@@ -43,6 +43,7 @@ export function ControlSidebar({
   onChangeCustomStream,
   onDeleteCustomStream,
   blockedLayerURLs,
+  blockedLayerURLsGeneration,
   authState,
   newInvite,
   onCreateInvite,
@@ -63,6 +64,7 @@ export function ControlSidebar({
   onChangeCustomStream: (url: string, customStream: LocalStreamData) => void
   onDeleteCustomStream: (url: string) => void
   blockedLayerURLs: string[]
+  blockedLayerURLsGeneration: number
   authState: StreamwallState['auth'] | undefined
   newInvite: Invite | undefined
   onCreateInvite: (args: { name: string; role: InvitableRole }) => void
@@ -151,7 +153,10 @@ export function ControlSidebar({
                 same thing to whoever stands in front of it, which is nobody in
                 a control-server deployment (issue #797).
               */}
-              <BlockedLayerURLNotice urls={blockedLayerURLs} />
+              <BlockedLayerURLNotice
+                urls={blockedLayerURLs}
+                generation={blockedLayerURLsGeneration}
+              />
               <div>
                 {/*
                   Keyed by `link` (each custom stream's stable id) rather

--- a/packages/streamwall-control-ui/src/connectionStatus.test.tsx
+++ b/packages/streamwall-control-ui/src/connectionStatus.test.tsx
@@ -74,6 +74,7 @@ function renderControlUI(isConnected: boolean): HTMLDivElement {
     favorites: [],
     dataSourceHealth: [],
     blockedLayerURLs: [],
+    blockedLayerURLsGeneration: 0,
   }
 
   act(() => {

--- a/packages/streamwall-control-ui/src/disconnectRendering.test.tsx
+++ b/packages/streamwall-control-ui/src/disconnectRendering.test.tsx
@@ -76,6 +76,7 @@ function renderControlUI(
     favorites: [],
     dataSourceHealth: [],
     blockedLayerURLs: [],
+    blockedLayerURLsGeneration: 0,
     ...connectionOverrides,
   }
 

--- a/packages/streamwall-control-ui/src/gridDragMoveRoleGating.test.tsx
+++ b/packages/streamwall-control-ui/src/gridDragMoveRoleGating.test.tsx
@@ -128,6 +128,7 @@ function renderControlUI(role: StreamwallRole | null): {
     favorites: [],
     dataSourceHealth: [],
     blockedLayerURLs: [],
+    blockedLayerURLsGeneration: 0,
   }
 
   act(() => {

--- a/packages/streamwall-control-ui/src/gridTestHooks.test.tsx
+++ b/packages/streamwall-control-ui/src/gridTestHooks.test.tsx
@@ -80,6 +80,7 @@ function renderControlUI(isConnected: boolean): HTMLDivElement {
     favorites: [],
     dataSourceHealth: [],
     blockedLayerURLs: [],
+    blockedLayerURLsGeneration: 0,
   }
 
   act(() => {

--- a/packages/streamwall-control-ui/src/index.tsx
+++ b/packages/streamwall-control-ui/src/index.tsx
@@ -71,6 +71,7 @@ export function ControlUI({
     favorites,
     dataSourceHealth,
     blockedLayerURLs,
+    blockedLayerURLsGeneration,
   } = connection
   const {
     cols,
@@ -266,6 +267,7 @@ export function ControlUI({
         onChangeCustomStream={handleChangeCustomStream}
         onDeleteCustomStream={handleDeleteCustomStream}
         blockedLayerURLs={blockedLayerURLs}
+        blockedLayerURLsGeneration={blockedLayerURLsGeneration}
         authState={authState}
         newInvite={newInvite}
         onCreateInvite={handleCreateInvite}

--- a/packages/streamwall-control-ui/src/responsiveLayout.test.tsx
+++ b/packages/streamwall-control-ui/src/responsiveLayout.test.tsx
@@ -72,6 +72,7 @@ function renderControlUI(): HTMLDivElement {
     favorites: [],
     dataSourceHealth: [],
     blockedLayerURLs: [],
+    blockedLayerURLsGeneration: 0,
   }
 
   act(() => {

--- a/packages/streamwall-control-ui/src/serverStatusGating.test.tsx
+++ b/packages/streamwall-control-ui/src/serverStatusGating.test.tsx
@@ -79,6 +79,7 @@ async function renderControlUI(role: StreamwallRole): Promise<HTMLDivElement> {
     favorites: [],
     dataSourceHealth: [],
     blockedLayerURLs: [],
+    blockedLayerURLsGeneration: 0,
   }
 
   await act(async () => {

--- a/packages/streamwall-control-ui/src/streamwallState.test.tsx
+++ b/packages/streamwall-control-ui/src/streamwallState.test.tsx
@@ -87,6 +87,7 @@ function makeState(views: ViewState[]): StreamwallState {
     favorites: [],
     dataSourceHealth: [],
     blockedLayerURLs: [],
+    blockedLayerURLsGeneration: 0,
   }
 }
 
@@ -201,6 +202,25 @@ describe('useStreamwallState', () => {
     delete (state as Partial<StreamwallState>).blockedLayerURLs
 
     expect(runHook(state).blockedLayerURLs).toEqual([])
+  })
+
+  // Issue #810: the notice keys its dismissals by this value, so it has to
+  // reach the sidebar as the desktop sent it.
+  test('carries the blocked layer URL generation through', () => {
+    const state = makeState([])
+    state.blockedLayerURLsGeneration = 4
+
+    expect(runHook(state).blockedLayerURLsGeneration).toBe(4)
+  })
+
+  // Same version skew as the list: a server older than #810 sends no
+  // generation, and a constant default keeps every dismissal valid rather
+  // than dropping them on every update.
+  test('defaults the blocked layer URL generation when a server omits it', () => {
+    const state = makeState([])
+    delete (state as Partial<StreamwallState>).blockedLayerURLsGeneration
+
+    expect(runHook(state).blockedLayerURLsGeneration).toBe(0)
   })
 
   test('keeps the view-id and cell-index axes apart', () => {

--- a/packages/streamwall-control-ui/src/streamwallState.tsx
+++ b/packages/streamwall-control-ui/src/streamwallState.tsx
@@ -69,6 +69,11 @@ export interface StreamwallConnection {
   dataSourceHealth: DataSourceHealth[]
   /** Layer URLs the wall's sessions refused to fetch (issue #797). */
   blockedLayerURLs: string[]
+  /**
+   * How often the wall cleared that list on an operator's layer-link edit
+   * (issue #810) -- what the notice keys its dismissals by.
+   */
+  blockedLayerURLsGeneration: number
 }
 
 export function useStreamwallState(state: StreamwallState | undefined) {
@@ -88,6 +93,7 @@ export function useStreamwallState(state: StreamwallState | undefined) {
         favorites: [],
         dataSourceHealth: [],
         blockedLayerURLs: [],
+        blockedLayerURLsGeneration: 0,
       }
     }
 
@@ -107,6 +113,10 @@ export function useStreamwallState(state: StreamwallState | undefined) {
       // passing through `streamwallStateSchema` (which would have defaulted
       // it), so an undefined value would reach the sidebar as a crash.
       blockedLayerURLs = [],
+      // Defaulted for the same reason and in the same way as the list above:
+      // a constant, so that a server predating #810 costs its clients the
+      // reconnect fix rather than every dismissal they make (issue #810).
+      blockedLayerURLsGeneration = 0,
     } = state
     const stateIdxMap = new Map<CellIdx, ViewInfo>()
     const views: ViewInfo[] = []
@@ -164,6 +174,7 @@ export function useStreamwallState(state: StreamwallState | undefined) {
       favorites,
       dataSourceHealth,
       blockedLayerURLs,
+      blockedLayerURLsGeneration,
     }
   }, [state])
 }

--- a/packages/streamwall-control-ui/src/swapHotkeyRoleGating.test.tsx
+++ b/packages/streamwall-control-ui/src/swapHotkeyRoleGating.test.tsx
@@ -128,6 +128,7 @@ function renderControlUI(role: StreamwallRole | null): HTMLDivElement {
     favorites: [],
     dataSourceHealth: [],
     blockedLayerURLs: [],
+    blockedLayerURLsGeneration: 0,
   }
 
   act(() => {

--- a/packages/streamwall-control-ui/src/testHelpers.tsx
+++ b/packages/streamwall-control-ui/src/testHelpers.tsx
@@ -121,6 +121,7 @@ export function makeConnection(
     favorites: [],
     dataSourceHealth: [],
     blockedLayerURLs: [],
+    blockedLayerURLsGeneration: 0,
     ...overrides,
   }
 }

--- a/packages/streamwall-control-ui/src/useCollabConnection.test.tsx
+++ b/packages/streamwall-control-ui/src/useCollabConnection.test.tsx
@@ -31,6 +31,7 @@ const minimalState: StreamwallState = {
   favorites: [],
   dataSourceHealth: [],
   blockedLayerURLs: [],
+  blockedLayerURLsGeneration: 0,
 }
 
 /**

--- a/packages/streamwall-shared/src/schemas.test.ts
+++ b/packages/streamwall-shared/src/schemas.test.ts
@@ -40,6 +40,7 @@ const VALID_STATE = {
   favorites: [],
   dataSourceHealth: [],
   blockedLayerURLs: [],
+  blockedLayerURLsGeneration: 0,
 }
 
 describe('streamDataInputSchema', () => {
@@ -938,6 +939,45 @@ describe('streamwallStateSchema', () => {
     const result = streamwallStateSchema.safeParse(withoutBlocked)
     expect(result.success).toBe(true)
     expect(result.data?.blockedLayerURLs).toEqual([])
+  })
+
+  // Issue #810: the counter is what tells a control client that the list it is
+  // looking at is not the one its dismissals were made against, so it has to
+  // survive the trip as an exact value -- which for JSON means a safe integer.
+  test('accepts a blocked layer URL generation', () => {
+    const bumped = { ...VALID_STATE, blockedLayerURLsGeneration: 7 }
+    expect(streamwallStateSchema.safeParse(bumped).success).toBe(true)
+  })
+
+  test('rejects a negative blocked layer URL generation', () => {
+    const negative = { ...VALID_STATE, blockedLayerURLsGeneration: -1 }
+    expect(streamwallStateSchema.safeParse(negative).success).toBe(false)
+  })
+
+  test('rejects a fractional blocked layer URL generation', () => {
+    const fractional = { ...VALID_STATE, blockedLayerURLsGeneration: 1.5 }
+    expect(streamwallStateSchema.safeParse(fractional).success).toBe(false)
+  })
+
+  test('rejects a blocked layer URL generation past the safe integer range', () => {
+    const unsafe = {
+      ...VALID_STATE,
+      blockedLayerURLsGeneration: Number.MAX_SAFE_INTEGER + 2,
+    }
+    expect(streamwallStateSchema.safeParse(unsafe).success).toBe(false)
+  })
+
+  // Same version skew as the list itself: a desktop older than #810 sends no
+  // generation, and defaulting it costs that desktop the reconnect fix rather
+  // than its whole state broadcast.
+  test('defaults the blocked layer URL generation when a desktop omits it', () => {
+    const {
+      blockedLayerURLsGeneration: _blockedLayerURLsGeneration,
+      ...withoutGeneration
+    } = VALID_STATE
+    const result = streamwallStateSchema.safeParse(withoutGeneration)
+    expect(result.success).toBe(true)
+    expect(result.data?.blockedLayerURLsGeneration).toBe(0)
   })
 
   test('rejects a state missing the required streams field', () => {

--- a/packages/streamwall-shared/src/schemas.ts
+++ b/packages/streamwall-shared/src/schemas.ts
@@ -512,6 +512,31 @@ const blockedLayerURLsSchema = z
   // than costing it one notice.
   .default([])
 
+/**
+ * Counts the clears the desktop applied to {@link blockedLayerURLsSchema}
+ * (issue #810).
+ *
+ * A control client that was disconnected across the operator's edit never
+ * observes the empty list: it reconnects to a snapshot that can already name
+ * the same address again, which membership alone cannot tell apart from the
+ * address never having gone away. The counter is the marker that says a clear
+ * happened, so a dismissal made under an older value never applies to a
+ * newer one.
+ *
+ * `int()` is the bound: it holds the value inside the safe integer range, so
+ * the equality the control UI compares by survives the JSON round trip
+ * exactly. The desktop bumps it once per operator edit, which does not come
+ * within reach of that range.
+ */
+const blockedLayerURLsGenerationSchema = z
+  .number()
+  .int()
+  .nonnegative()
+  // Same version skew as the list itself: a desktop older than #810 sends no
+  // such field, and taking its whole state broadcast down would cost far more
+  // than the one dismissal edge this counter fixes.
+  .default(0)
+
 const dataSourceHealthSchema = z.object({
   id: z.string(),
   type: z.enum(['json-url', 'toml-file']),
@@ -548,6 +573,7 @@ export const streamwallStateSchema = z.object({
   favorites: z.array(z.string()),
   dataSourceHealth: z.array(dataSourceHealthSchema),
   blockedLayerURLs: blockedLayerURLsSchema,
+  blockedLayerURLsGeneration: blockedLayerURLsGenerationSchema,
 })
 
 /**

--- a/packages/streamwall-shared/src/stateDiff.test.ts
+++ b/packages/streamwall-shared/src/stateDiff.test.ts
@@ -54,6 +54,7 @@ function makeState(overrides: Partial<StreamwallState> = {}): StreamwallState {
     favorites: [],
     dataSourceHealth: [],
     blockedLayerURLs: [],
+    blockedLayerURLsGeneration: 0,
     ...overrides,
   }
 }

--- a/packages/streamwall-shared/src/types.ts
+++ b/packages/streamwall-shared/src/types.ts
@@ -167,6 +167,17 @@ export interface StreamwallState {
    * `MAX_BLOCKED_LAYER_URL_LENGTH`.
    */
   blockedLayerURLs: string[]
+  /**
+   * How often the wall has cleared `blockedLayerURLs` because the operator
+   * edited a layer link (issue #810).
+   *
+   * A control client that was disconnected across such a clear reconnects to a
+   * snapshot that can already name the same address again, and cannot tell
+   * that apart from the address never having gone away. Dismissals in the
+   * control UI are keyed by this value, so one made against an older list
+   * never suppresses a newer refusal.
+   */
+  blockedLayerURLsGeneration: number
 }
 
 type MessageMeta = {

--- a/packages/streamwall/src/main/blockedLayerURLs.test.ts
+++ b/packages/streamwall/src/main/blockedLayerURLs.test.ts
@@ -164,6 +164,76 @@ describe('BlockedLayerURLTracker', () => {
       ).toBeNull()
     })
 
+    // Issue #810: a control client that was disconnected across the clear
+    // reconnects to a snapshot that can name the same address again, which
+    // membership alone cannot tell apart from the address never having gone
+    // away. The generation is the marker that says a clear happened.
+    it('starts at generation zero', () => {
+      expect(new BlockedLayerURLTracker().generation).toBe(0)
+    })
+
+    it('bumps the generation when an edit clears the list', () => {
+      const tracker = new BlockedLayerURLTracker()
+      tracker.syncLayerLinks(layers('https://example.com/o'))
+      tracker.report('http://192.168.1.5/a')
+
+      tracker.syncLayerLinks(layers('https://example.com/fixed'))
+
+      expect(tracker.generation).toBe(1)
+    })
+
+    it('bumps the generation once per clear', () => {
+      const tracker = new BlockedLayerURLTracker()
+      tracker.syncLayerLinks(layers('https://example.com/o'))
+      tracker.report('http://192.168.1.5/a')
+      tracker.syncLayerLinks(layers('https://example.com/second'))
+      tracker.report('http://192.168.1.5/a')
+      tracker.syncLayerLinks(layers('https://example.com/third'))
+
+      expect(tracker.generation).toBe(2)
+    })
+
+    it('leaves the generation alone while the layer links stand still', () => {
+      const tracker = new BlockedLayerURLTracker()
+      tracker.syncLayerLinks(layers('https://example.com/o'))
+      tracker.report('http://192.168.1.5/a')
+
+      tracker.syncLayerLinks(layers('https://example.com/o'))
+
+      expect(tracker.generation).toBe(0)
+    })
+
+    it('leaves the generation alone when it learns the links for the first time', () => {
+      const tracker = new BlockedLayerURLTracker()
+      tracker.report('http://192.168.1.5/a')
+
+      tracker.syncLayerLinks(layers('https://example.com/o'))
+
+      expect(tracker.generation).toBe(0)
+    })
+
+    // Nothing was cleared, so no dismissal can be pointing at a list that no
+    // longer stands: a dismissal only ever names an address the desktop was
+    // reporting, and an empty list was reporting none.
+    it('leaves the generation alone when an edit clears an empty list', () => {
+      const tracker = new BlockedLayerURLTracker()
+      tracker.syncLayerLinks(layers('https://example.com/o'))
+
+      tracker.syncLayerLinks(layers('https://example.com/other'))
+
+      expect(tracker.generation).toBe(0)
+    })
+
+    it('leaves the generation alone while collecting reports', () => {
+      const tracker = new BlockedLayerURLTracker()
+      tracker.syncLayerLinks(layers('https://example.com/o'))
+
+      tracker.report('http://192.168.1.5/a')
+      tracker.report('http://192.168.1.5/b')
+
+      expect(tracker.generation).toBe(0)
+    })
+
     it('re-collects reports after an edit cleared them', () => {
       const tracker = new BlockedLayerURLTracker()
       tracker.syncLayerLinks(layers('https://example.com/o'))

--- a/packages/streamwall/src/main/blockedLayerURLs.ts
+++ b/packages/streamwall/src/main/blockedLayerURLs.ts
@@ -33,6 +33,20 @@ function truncate(url: string): string {
 export class BlockedLayerURLTracker {
   private urls: string[] = []
   private linksKey: string | undefined
+  private clearCount = 0
+
+  /**
+   * How often the list has been cleared, broadcast alongside it (issue #810).
+   *
+   * A control client that was disconnected across a clear reconnects to a
+   * snapshot that can already name the same address again, and membership
+   * alone cannot tell that apart from the address never having gone away. The
+   * control UI keys its dismissals by this value, so one made against an
+   * older list never suppresses a newer refusal.
+   */
+  get generation(): number {
+    return this.clearCount
+  }
 
   /** Records one refused URL. */
   report(url: string): string[] | null {
@@ -58,6 +72,11 @@ export class BlockedLayerURLTracker {
    *
    * Learning the links for the first time is not an edit: the reports the
    * guard makes during startup arrive before any state does.
+   *
+   * An edit that finds the list already empty leaves {@link generation} alone
+   * as well: nothing was cleared, and no dismissal can be pointing at a list
+   * that no longer stands, because a dismissal only ever names an address the
+   * desktop was reporting.
    */
   syncLayerLinks(streams: readonly StreamData[]): string[] | null {
     const previous = this.linksKey
@@ -69,6 +88,7 @@ export class BlockedLayerURLTracker {
       return null
     }
     this.urls = []
+    this.clearCount += 1
     return [...this.urls]
   }
 }

--- a/packages/streamwall/src/main/bootstrap.test.ts
+++ b/packages/streamwall/src/main/bootstrap.test.ts
@@ -688,7 +688,39 @@ describe('createBlockedLayerURLReporter', () => {
     )
     const after = syncBlockedLayerURLs(before)
 
-    expect(after).toEqual({ ...before, blockedLayerURLs: [] })
+    expect(after).toEqual({
+      ...before,
+      blockedLayerURLs: [],
+      blockedLayerURLsGeneration: 1,
+    })
+  })
+
+  // Issue #810: a control client that was disconnected across the clear only
+  // ever sees the snapshot after it, so the state has to carry the fact that
+  // a clear happened rather than leaving it to be inferred from the list.
+  it('marks the clear with a bumped generation in the broadcast state', () => {
+    const { report, syncBlockedLayerURLs } = setup()
+    syncBlockedLayerURLs(stateWith([overlay('https://example.com/o')]))
+    report('http://192.168.1.5/overlay')
+
+    const next = syncBlockedLayerURLs(
+      stateWith(
+        [overlay('https://example.com/fixed')],
+        ['http://192.168.1.5/overlay'],
+      ),
+    )
+
+    expect(next.blockedLayerURLsGeneration).toBe(1)
+  })
+
+  it('starts the broadcast state at generation zero', () => {
+    expect(
+      createInitialClientState({
+        config: { width: 0, height: 0, x: 0, y: 0, cols: 2, rows: 2 },
+        layoutPresets: [],
+        favorites: [],
+      }).blockedLayerURLsGeneration,
+    ).toBe(0)
   })
 })
 

--- a/packages/streamwall/src/main/bootstrap.ts
+++ b/packages/streamwall/src/main/bootstrap.ts
@@ -117,6 +117,7 @@ export function createInitialClientState(
     favorites: deps.favorites,
     dataSourceHealth: [],
     blockedLayerURLs: [],
+    blockedLayerURLsGeneration: 0,
   }
 }
 
@@ -527,7 +528,16 @@ export function createBlockedLayerURLReporter(
   })
   return (state) => {
     const cleared = tracker.syncLayerLinks(state.streams)
-    return cleared ? { ...state, blockedLayerURLs: cleared } : state
+    return cleared
+      ? {
+          ...state,
+          blockedLayerURLs: cleared,
+          // Broadcast with the cleared list, so a control client that was
+          // disconnected across this clear can still tell that its dismissals
+          // were made against a list that no longer stands (issue #810).
+          blockedLayerURLsGeneration: tracker.generation,
+        }
+      : state
   }
 }
 


### PR DESCRIPTION
## Summary

`BlockedLayerURLNotice` (#797) dropped a dismissal once the desktop stopped reporting that address. That only works for a client that observed the intermediate state: a control client disconnected across the operator's layer-link edit reconnects to a snapshot that can already name the same address again, which membership alone cannot tell apart from the address never having gone away. The new refusal then stayed suppressed for the life of that page, silently and permanently.

The desktop already knows when it cleared, so it now says so in the state.

- `BlockedLayerURLTracker` counts its clears and exposes the count as `generation`; `createBlockedLayerURLReporter` broadcasts it alongside the cleared list.
- `StreamwallState.blockedLayerURLsGeneration` (shared type + `streamwallStateSchema`) carries it across the uplink.
- `BlockedLayerURLNotice` keys its `dismissed` list by that value: a dismissal made against an older list never suppresses a newer refusal, while a dismissal against the list still standing survives any number of reconnects.

Closes #810

## Architecture decisions

- **Counter on the tracker, not a new return shape.** `report`/`syncLayerLinks` keep returning `string[] | null`; the generation is a getter the reporter reads when it folds the clear into the state. Keeps the existing call sites and their tests untouched.
- **An edit that clears an already empty list does not bump.** Nothing was cleared, and a dismissal only ever names an address the desktop was reporting, so no dismissal can be pointing at a list that no longer stands. It also preserves the existing "no state re-broadcast unless something changed" property.
- **Bound is `z.number().int().nonnegative()`.** Zod 4's `int()` enforces the safe-integer range, which is exactly what the value needs: the control UI compares it for equality, so it has to survive the JSON round trip exactly. One bump per operator edit never comes within reach of that range.
- **`.default(0)` for version skew**, mirroring `blockedLayerURLs`: a desktop or control server predating this change costs its clients the reconnect fix rather than its whole state broadcast. The control UI defaults it the same way when destructuring a snapshot that never passed through the schema.
- **The control server passes the generation to every role**, including the roles the list itself is withheld from: it counts the operator's own layer-link edits and names no address.
- **Render reads through the generation** (`dismissed.generation === generation ? … : []`) rather than trusting the stored dismissals alone, so a stale dismissal cannot suppress anything even for the single render pass before the layout effect resets it.

## How was this tested?

`npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (2420 tests) — all green. New tests on all three layers:

- **Schema** (`streamwall-shared/src/schemas.test.ts`): accepts a generation, rejects negative / fractional / past-safe-integer values, defaults to 0 when a desktop omits it.
- **Tracker** (`streamwall/src/main/blockedLayerURLs.test.ts`): starts at 0, bumps once per clear, stays put while the links stand still, on first learning the links, on an edit that clears an empty list, and while collecting reports. `bootstrap.test.ts` covers the bumped generation reaching the broadcast state and the initial state starting at 0.
- **UI** (`streamwall-control-ui/src/BlockedLayerURLNotice.test.tsx`): the reconnect-across-clear scenario from the issue (dismiss at generation 3, next snapshot names the same address at generation 4 → announced again), a dismissal held while the generation stands, and a dismissal held across updates from a desktop that sends no generation. `streamwallState.test.tsx` covers the value being carried through and defaulted.
- **Control server** (`streamwall-control-server/src/auth.test.ts`): `StateWrapper.view()` carries the generation for every role, including `monitor`, whose view still withholds the list itself.

The remaining changed files are one-line additions of the new required field to existing `StreamwallState` / `StreamwallConnection` literals.

## Risks / breaking changes

None. The field is defaulted at every boundary, so a desktop, control server, or client on either side of this change interoperates; the only thing an old peer loses is the reconnect fix. Existing dismissal behaviour for a connected client is unchanged. The `viewStateValueSchema` drift guard and all `blockedLayerURLs` bounds are untouched.

## Pre-PR review

One round with an independent reviewer that had none of the implementing session's context: **NO FINDINGS**. Nothing dismissed.

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests (or this PR explains why none apply)
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments
