### PR TITLE
test(control-server): make the warm-session TTL spec clock-independent

### DIFF
--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -28,6 +28,7 @@ import {
 } from './context.ts'
 import { registerInviteRoutes } from './inviteExchange/invite.ts'
 import { getLoggerOptions, type LogLevel } from './logger.ts'
+import type { Clock } from './rateLimiter.ts'
 import {
   captureException,
   initSentry,
@@ -75,6 +76,7 @@ export async function initApp({
   updateChecker: injectedUpdateChecker,
   uplinkPing: injectedUplinkPing,
   verifiedTokenTtlMs,
+  verifiedTokenClock,
 }: AppOptions & {
   db?: StorageDB
   /**
@@ -124,6 +126,12 @@ export async function initApp({
    * spec can exercise expiry without waiting a minute for it.
    */
   verifiedTokenTtlMs?: number
+  /**
+   * Test-only override for the clock the verified-token cache reads its TTL
+   * from, so a spec can step across many TTLs deterministically (e.g. with
+   * `node:test`'s mock timers) instead of waiting on the wall clock.
+   */
+  verifiedTokenClock?: Clock
 }) {
   const expectedOrigin = new URL(baseURL).origin
   const isSecure = baseURL.startsWith('https')
@@ -250,6 +258,7 @@ export async function initApp({
   const verifiedTokens = createVerifiedTokenCache({
     auth,
     ...(verifiedTokenTtlMs !== undefined && { ttlMs: verifiedTokenTtlMs }),
+    ...(verifiedTokenClock !== undefined && { clock: verifiedTokenClock }),
   })
 
   registerUplinkRoute(app, ctx, {

--- a/packages/streamwall-control-server/src/scryptRateLimit.test.ts
+++ b/packages/streamwall-control-server/src/scryptRateLimit.test.ts
@@ -1,7 +1,6 @@
 import assert from 'node:assert/strict'
 import { once } from 'node:events'
 import { after, describe, test } from 'node:test'
-import { setTimeout as delay } from 'node:timers/promises'
 import WebSocket from 'ws'
 
 import { SESSION_COOKIE_NAME } from './index.ts'
@@ -316,12 +315,25 @@ describe('scrypt-bearing routes', () => {
     )
   })
 
-  test('an open client socket keeps its session verification warm', async () => {
+  test('an open client socket keeps its session verification warm', async (t) => {
     // A connected browser makes no further requests, so without a refresh its
     // entry would expire and the reconnect after an uplink flap would derive.
+    // The refresh itself (`ws/client.ts`'s `keepVerified` interval) is a plain
+    // `setInterval` reading an injectable clock, not something tied to real
+    // network pings — so the sliding-expiry race this spec is about (#811,
+    // previously "fixed" by widening margins in #804/#808) can be driven
+    // deterministically: a fake clock the cache reads its TTL from, and
+    // `node:test`'s mock timers to fire the refresh interval on demand. No
+    // real time elapses, so no OS-scheduler stall can skip a beat.
+    const pingIntervalMs = 20
+    const ttlMs = 400
+    let now = 0
+    const clock = { now: () => now }
+
     const { app, auth, port } = await bootServerWithUplink({
-      clientPing: { intervalMs: 20, timeoutMs: 2000 },
-      verifiedTokenTtlMs: 2000,
+      clientPing: { intervalMs: pingIntervalMs, timeoutMs: 2000 },
+      verifiedTokenTtlMs: ttlMs,
+      verifiedTokenClock: clock,
     })
 
     const invite = await auth.createToken({
@@ -340,6 +352,11 @@ describe('scrypt-bearing routes', () => {
       Array.isArray(rawCookie) ? rawCookie[0] : String(rawCookie)
     ).split(';')[0]
 
+    // Mocking `setInterval` before the socket connects means the `keepVerified`
+    // interval it creates on connect is already the mocked one; `t.mock`
+    // restores the real timers automatically once this test finishes.
+    t.mock.timers.enable({ apis: ['setInterval'] })
+
     const ws = new WebSocket(`ws://127.0.0.1:${port}/client/ws`, {
       headers: { Cookie: cookie, Origin: TEST_BASE_URL },
     })
@@ -347,15 +364,16 @@ describe('scrypt-bearing routes', () => {
     await once(ws, 'open')
     await messageCollector(ws)(500)
 
-    // Several TTLs later: without the refresh the entry is long gone. The TTL
-    // is 100x the 20ms ping cadence (raised from 20x in #804): a 400ms TTL
-    // measurably flaked under `node --test`'s default concurrency, where an
-    // OS-scheduler stall of a few hundred ms on this file's own process is
-    // enough to skip every ping in the window and let a "warm" entry expire
-    // for real — a legitimate race in the test, not in the cache (see
-    // verifiedTokenCache.test.ts for the deterministic, fake-clock coverage of
-    // the sliding-expiry logic itself).
-    await delay(5000)
+    // Step across ten TTLs, one refresh cycle at a time: each step advances
+    // the fake clock by half a TTL and then fires the pending refresh
+    // interval once, exactly mirroring what keeps a real long-lived socket's
+    // entry alive — deterministically, without a single real millisecond
+    // passing.
+    for (let i = 0; i < 10; i++) {
+      now += ttlMs / 2
+      t.mock.timers.tick(pingIntervalMs)
+    }
+
     const derivations = countDerivations(auth)
     const res = await app.inject({
       method: 'GET',

--- a/packages/streamwall-control-server/src/testHelpers.ts
+++ b/packages/streamwall-control-server/src/testHelpers.ts
@@ -22,6 +22,7 @@ import type { ProcessLike } from './bootstrap.ts'
 import type { HeartbeatConfig, RateLimitConfig } from './config.ts'
 import { type AppOptions, initApp } from './index.ts'
 import type { LogLevel } from './logger.ts'
+import type { Clock } from './rateLimiter.ts'
 import type { SentryCaptureClient } from './sentry.ts'
 import type { DocUpdateLimits } from './stateDocGuard.ts'
 import type { StorageDB, StoredData } from './storage.ts'
@@ -295,6 +296,7 @@ export type TestAppOverrides = Partial<AppOptions> & {
   sentryClient?: SentryCaptureClient
   updateChecker?: UpdateChecker
   verifiedTokenTtlMs?: number
+  verifiedTokenClock?: Clock
 }
 
 /**


### PR DESCRIPTION
## Problem

`an open client socket keeps its session verification warm` in `packages/streamwall-control-server/src/scryptRateLimit.test.ts` asserted a sliding TTL by sleeping past it on the real wall clock (`delay(1200)`, later widened to `delay(5000)` by #808). On a loaded runner an OS-scheduler stall could skip every refresh tick in that window and fail the assertion for reasons unrelated to the branch under test — two separate reviewers of #809 hit it on an otherwise unrelated checkout.

## Solution

Removed the wall-clock dependency instead of widening the margin again:

- Added an optional `verifiedTokenClock` parameter (type `Clock` from `rateLimiter.ts`) threaded through `initApp` (`index.ts`) into `createVerifiedTokenCache(...)`, mirroring the existing test-only `verifiedTokenTtlMs` option.
- Exposed the same override through `TestAppOverrides` in `testHelpers.ts`.
- Rewrote the flaky test to supply a hand-cranked fake clock and drive the `keepVerified` refresh interval in `ws/client.ts` with node:test's `t.mock.timers` (`enable({ apis: ['setInterval'] })` + `tick(...)`), stepping across ten TTLs deterministically with no real time elapsing and no interval tick left to chance.

This matches the issue's top-preference suggested fix ("drive the refresh deterministically" / fake the clock), not another margin widening.

## Testing performed

- `npm run format`, `npm run lint`, `npm run typecheck` (full workspace) — clean.
- `npm run test` (full workspace, 2397 tests) — all passing.
- The target file run 20 consecutive times in isolation (`node --import tsx --test --test-force-exit --test-timeout=120000 src/scryptRateLimit.test.ts`) — 12/12 tests passing every run, ~500ms each (down from the previous 5s+ delay), no flakes observed.

## Risks / breaking changes

None. Test-only change plus one optional test-only constructor parameter (`verifiedTokenClock`) that defaults to the existing `systemClock` and is not reachable from any production configuration path.

## Pre-PR review

One independent review round (fresh subagent, no session context) — result: **NO FINDINGS**. It additionally verified, on its own, that reverting the `keepVerified` refresh in `ws/client.ts`, or breaking the sliding-expiry renewal in `verifiedTokenCache.ts`, makes the rewritten test fail — confirming it is still a genuine regression test for the production behavior, not a tautology against the fake clock.

Closes #811