### PR TITLE
fix(streamwall): type-check the package's own test files

### DIFF
--- a/packages/streamwall/forge.config.test.ts
+++ b/packages/streamwall/forge.config.test.ts
@@ -1,4 +1,7 @@
-import type { ForgeConfig } from '@electron-forge/shared-types'
+import type {
+  ForgeConfig,
+  ResolvedForgeConfig,
+} from '@electron-forge/shared-types'
 import { describe, expect, it, vi } from 'vitest'
 
 const runTypecheck = vi.fn()
@@ -11,7 +14,7 @@ const createPackagingTmpdir = vi.fn(
 const removePackagingTmpdir = vi.fn()
 const unregisterFallbackCleanup = vi.fn()
 const registerPackagingTmpdirFallbackCleanup = vi.fn(
-  () => unregisterFallbackCleanup,
+  (_dir: string) => unregisterFallbackCleanup,
 )
 vi.mock('./forge.tmpdir', () => ({
   createPackagingTmpdir: () => createPackagingTmpdir(),
@@ -22,13 +25,18 @@ vi.mock('./forge.tmpdir', () => ({
 
 const { default: config }: { default: ForgeConfig } =
   await import('./forge.config')
+// The hooks' real signature takes forge's fully-resolved config (it adds
+// fields like `pluginInterface` that only forge's own config loader fills
+// in), but these tests exercise the hook directly with the config module's
+// raw export - forge always resolves it first in the real packaging run.
+const resolvedConfig = config as unknown as ResolvedForgeConfig
 
 // `package`, `make` and `publish` all funnel through forge's package step, so
 // a single `prePackage` hook covers every path that produces a distributable
 // (#472). `start` deliberately stays fast and unchecked.
 describe('forge prePackage hook', () => {
   it('typechecks before packaging the app', async () => {
-    await config.hooks?.prePackage?.(config, '', '')
+    await config.hooks?.prePackage?.(resolvedConfig, '', '')
 
     expect(runTypecheck).toHaveBeenCalledTimes(1)
   })
@@ -38,9 +46,9 @@ describe('forge prePackage hook', () => {
       throw new Error('typecheck failed')
     })
 
-    await expect(config.hooks?.prePackage?.(config, '', '')).rejects.toThrow(
-      /typecheck failed/,
-    )
+    await expect(
+      config.hooks?.prePackage?.(resolvedConfig, '', ''),
+    ).rejects.toThrow(/typecheck failed/)
   })
 
   // #749: loading this config (e.g. for `electron-forge start`, or for the
@@ -53,9 +61,9 @@ describe('forge prePackage hook', () => {
       throw new Error('typecheck failed')
     })
 
-    await expect(config.hooks?.prePackage?.(config, '', '')).rejects.toThrow(
-      /typecheck failed/,
-    )
+    await expect(
+      config.hooks?.prePackage?.(resolvedConfig, '', ''),
+    ).rejects.toThrow(/typecheck failed/)
 
     expect(createPackagingTmpdir).not.toHaveBeenCalled()
   })
@@ -69,10 +77,10 @@ describe('forge packaging temp directory', () => {
   it('stages the app in a directory of its own once prePackage runs', async () => {
     createPackagingTmpdir.mockClear()
 
-    await config.hooks?.prePackage?.(config, '', '')
+    await config.hooks?.prePackage?.(resolvedConfig, '', '')
 
     expect(createPackagingTmpdir).toHaveBeenCalledTimes(1)
-    expect(config.packagerConfig.tmpdir).toBe(
+    expect(config.packagerConfig!.tmpdir).toBe(
       await createPackagingTmpdir.mock.results[0]?.value,
     )
   })
@@ -84,20 +92,20 @@ describe('forge packaging temp directory', () => {
   it('registers a process-exit fallback cleanup once a directory is staged', async () => {
     registerPackagingTmpdirFallbackCleanup.mockClear()
 
-    await config.hooks?.prePackage?.(config, '', '')
+    await config.hooks?.prePackage?.(resolvedConfig, '', '')
 
     expect(registerPackagingTmpdirFallbackCleanup).toHaveBeenCalledWith(
-      config.packagerConfig.tmpdir,
+      config.packagerConfig!.tmpdir,
     )
   })
 
   it('removes that directory and stands down the fallback once packaging is done', async () => {
-    await config.hooks?.prePackage?.(config, '', '')
-    const tmpdir = config.packagerConfig.tmpdir
+    await config.hooks?.prePackage?.(resolvedConfig, '', '')
+    const tmpdir = config.packagerConfig!.tmpdir
     unregisterFallbackCleanup.mockClear()
     removePackagingTmpdir.mockClear()
 
-    await config.hooks?.postPackage?.(config, {
+    await config.hooks?.postPackage?.(resolvedConfig, {
       platform: 'darwin',
       arch: 'arm64',
       outputPaths: [],
@@ -113,17 +121,17 @@ describe('forge packaging temp directory', () => {
   // cycle's directory.
   it('stages and removes a fresh directory on each successive prePackage/postPackage cycle', async () => {
     removePackagingTmpdir.mockClear()
-    await config.hooks?.prePackage?.(config, '', '')
-    const firstTmpdir = config.packagerConfig.tmpdir
-    await config.hooks?.postPackage?.(config, {
+    await config.hooks?.prePackage?.(resolvedConfig, '', '')
+    const firstTmpdir = config.packagerConfig!.tmpdir
+    await config.hooks?.postPackage?.(resolvedConfig, {
       platform: 'darwin',
       arch: 'arm64',
       outputPaths: [],
     })
 
-    await config.hooks?.prePackage?.(config, '', '')
-    const secondTmpdir = config.packagerConfig.tmpdir
-    await config.hooks?.postPackage?.(config, {
+    await config.hooks?.prePackage?.(resolvedConfig, '', '')
+    const secondTmpdir = config.packagerConfig!.tmpdir
+    await config.hooks?.postPackage?.(resolvedConfig, {
       platform: 'linux',
       arch: 'x64',
       outputPaths: [],
@@ -146,11 +154,14 @@ describe('forge packaging temp directory', () => {
     const { default: freshConfig }: { default: ForgeConfig } =
       await import('./forge.config')
 
-    await freshConfig.hooks?.postPackage?.(freshConfig, {
-      platform: 'darwin',
-      arch: 'arm64',
-      outputPaths: [],
-    })
+    await freshConfig.hooks?.postPackage?.(
+      freshConfig as unknown as ResolvedForgeConfig,
+      {
+        platform: 'darwin',
+        arch: 'arm64',
+        outputPaths: [],
+      },
+    )
 
     expect(removePackagingTmpdir).not.toHaveBeenCalled()
   })

--- a/packages/streamwall/forge.typecheck.test.ts
+++ b/packages/streamwall/forge.typecheck.test.ts
@@ -1,6 +1,6 @@
 import type { SpawnSyncReturns } from 'node:child_process'
 import { describe, expect, it, vi } from 'vitest'
-import { runTypecheck } from './forge.typecheck'
+import { runTypecheck, type SpawnSync } from './forge.typecheck'
 
 function spawnResult(
   overrides: Partial<SpawnSyncReturns<Buffer>> = {},
@@ -18,7 +18,7 @@ function spawnResult(
 
 describe('runTypecheck', () => {
   it('runs the package `typecheck` script', () => {
-    const spawn = vi.fn(() => spawnResult())
+    const spawn = vi.fn<SpawnSync>(() => spawnResult())
 
     runTypecheck(spawn, 'linux')
 
@@ -33,7 +33,7 @@ describe('runTypecheck', () => {
   // `shell` the hook dies with ENOENT (bare `npm`) or EINVAL (`npm.cmd`) and
   // takes the whole packaging run down (#586).
   it('spawns through a shell on Windows', () => {
-    const spawn = vi.fn(() => spawnResult())
+    const spawn = vi.fn<SpawnSync>(() => spawnResult())
 
     runTypecheck(spawn, 'win32')
 
@@ -44,7 +44,7 @@ describe('runTypecheck', () => {
   })
 
   it('does not need a shell elsewhere', () => {
-    const spawn = vi.fn(() => spawnResult())
+    const spawn = vi.fn<SpawnSync>(() => spawnResult())
 
     runTypecheck(spawn, 'linux')
 
@@ -53,7 +53,7 @@ describe('runTypecheck', () => {
   })
 
   it('runs in the package directory so it does not typecheck the caller workspace', () => {
-    const spawn = vi.fn(() => spawnResult())
+    const spawn = vi.fn<SpawnSync>(() => spawnResult())
 
     runTypecheck(spawn)
 
@@ -62,7 +62,7 @@ describe('runTypecheck', () => {
   })
 
   it('streams tsc output to the terminal instead of swallowing it', () => {
-    const spawn = vi.fn(() => spawnResult())
+    const spawn = vi.fn<SpawnSync>(() => spawnResult())
 
     runTypecheck(spawn)
 
@@ -71,19 +71,21 @@ describe('runTypecheck', () => {
   })
 
   it('throws when the typecheck reports errors, aborting the packaging run', () => {
-    const spawn = vi.fn(() => spawnResult({ status: 2 }))
+    const spawn = vi.fn<SpawnSync>(() => spawnResult({ status: 2 }))
 
     expect(() => runTypecheck(spawn)).toThrow(/typecheck failed/i)
   })
 
   it('throws when the typecheck is killed by a signal', () => {
-    const spawn = vi.fn(() => spawnResult({ status: null, signal: 'SIGKILL' }))
+    const spawn = vi.fn<SpawnSync>(() =>
+      spawnResult({ status: null, signal: 'SIGKILL' }),
+    )
 
     expect(() => runTypecheck(spawn)).toThrow(/SIGKILL/)
   })
 
   it('throws when npm cannot be spawned at all', () => {
-    const spawn = vi.fn(() =>
+    const spawn = vi.fn<SpawnSync>(() =>
       spawnResult({ status: null, error: new Error('spawn npm ENOENT') }),
     )
 

--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -1,6 +1,8 @@
 import {
   asCellIdx,
+  asViewId,
   fullscreenViewContentMap,
+  type StreamList,
   type StreamWindowConfig,
   type ViewContent,
   type ViewContentMap,
@@ -19,12 +21,16 @@ const electronStub = vi.hoisted(() => {
   // crash (issue #629) and verify `dispose()` releases the channels again.
   const registeredHandlers = new Set<string>()
   const registeredListeners = new Map<string, Set<(...args: never[]) => void>>()
-  const handle = vi.fn((channel: string) => {
-    if (registeredHandlers.has(channel)) {
-      throw new Error(`Attempted to register a second handler for '${channel}'`)
-    }
-    registeredHandlers.add(channel)
-  })
+  const handle = vi.fn(
+    (channel: string, _listener: (...args: never[]) => unknown) => {
+      if (registeredHandlers.has(channel)) {
+        throw new Error(
+          `Attempted to register a second handler for '${channel}'`,
+        )
+      }
+      registeredHandlers.add(channel)
+    },
+  )
   const removeHandler = vi.fn((channel: string) => {
     registeredHandlers.delete(channel)
   })
@@ -217,6 +223,17 @@ describe('StreamWindow.setGridSize', () => {
 })
 
 /**
+ * A minimal stand-in for a `StreamList`: `setViews`/`onState` only ever read
+ * the `byURL` lookup (never the array itself), so building a real
+ * `StreamData[]` with a `byURL` property attached would just add unused
+ * fixture noise. The values behind each URL only need whichever
+ * `StreamDataContent` fields the test under exercise actually reads.
+ */
+function makeStreams(entries: [string, unknown][] = []): StreamList {
+  return { byURL: new Map(entries) } as unknown as StreamList
+}
+
+/**
  * A minimal stand-in for a ViewActor: enough of the `getSnapshot()`/`send()`
  * surface for setViewVolume/sendViewEvent/findViewById to operate on,
  * without a real XState actor or Electron WebContentsView.
@@ -232,9 +249,11 @@ describe('StreamWindow.setViewVolume', () => {
   it('sends SET_VOLUME to the view with the given stable id', () => {
     const sw = makeStreamWindow(makeConfig())
     const send = vi.fn()
-    sw.views = new Map([[1, makeFakeViewActor({ spaces: [0] }, send)]])
+    sw.views = new Map([
+      [asViewId(1), makeFakeViewActor({ spaces: [0] }, send)],
+    ])
 
-    sw.setViewVolume(1, 0.5)
+    sw.setViewVolume(asViewId(1), 0.5)
 
     expect(send).toHaveBeenCalledWith({ type: 'SET_VOLUME', volume: 0.5 })
   })
@@ -242,9 +261,11 @@ describe('StreamWindow.setViewVolume', () => {
   it('does nothing when no view has the given id', () => {
     const sw = makeStreamWindow(makeConfig())
     const send = vi.fn()
-    sw.views = new Map([[1, makeFakeViewActor({ spaces: [0] }, send)]])
+    sw.views = new Map([
+      [asViewId(1), makeFakeViewActor({ spaces: [0] }, send)],
+    ])
 
-    sw.setViewVolume(5, 0.5)
+    sw.setViewVolume(asViewId(5), 0.5)
 
     expect(send).not.toHaveBeenCalled()
   })
@@ -257,11 +278,11 @@ describe('StreamWindow.setViewVolume', () => {
     const movedSend = vi.fn()
     const otherSend = vi.fn()
     sw.views = new Map([
-      [42, makeFakeViewActor({ spaces: [7] }, movedSend)],
-      [9, makeFakeViewActor({ spaces: [0] }, otherSend)],
+      [asViewId(42), makeFakeViewActor({ spaces: [7] }, movedSend)],
+      [asViewId(9), makeFakeViewActor({ spaces: [0] }, otherSend)],
     ])
 
-    sw.setViewVolume(42, 0.25)
+    sw.setViewVolume(asViewId(42), 0.25)
 
     expect(movedSend).toHaveBeenCalledWith({ type: 'SET_VOLUME', volume: 0.25 })
     expect(otherSend).not.toHaveBeenCalled()
@@ -283,11 +304,11 @@ describe('StreamWindow.setListeningView', () => {
     const selected = vi.fn()
     const other = vi.fn()
     sw.views = new Map([
-      [42, displayingActor(selected)],
-      [9, displayingActor(other)],
+      [asViewId(42), displayingActor(selected)],
+      [asViewId(9), displayingActor(other)],
     ])
 
-    sw.setListeningView(42)
+    sw.setListeningView(asViewId(42))
 
     expect(selected).toHaveBeenCalledWith({ type: 'UNMUTE' })
     expect(other).toHaveBeenCalledWith({ type: 'MUTE' })
@@ -298,8 +319,8 @@ describe('StreamWindow.setListeningView', () => {
     const a = vi.fn()
     const b = vi.fn()
     sw.views = new Map([
-      [1, displayingActor(a)],
-      [2, displayingActor(b)],
+      [asViewId(1), displayingActor(a)],
+      [asViewId(2), displayingActor(b)],
     ])
 
     sw.setListeningView(null)
@@ -312,17 +333,17 @@ describe('StreamWindow.setListeningView', () => {
 describe('StreamWindow.getViewAnchorIdx', () => {
   it('returns the top-left cell of the view with the given id', () => {
     const sw = makeStreamWindow(makeConfig())
-    sw.views = new Map([[42, makeFakeViewActor({ spaces: [7, 8] })]])
+    sw.views = new Map([[asViewId(42), makeFakeViewActor({ spaces: [7, 8] })]])
 
-    expect(sw.getViewAnchorIdx(42)).toBe(7)
+    expect(sw.getViewAnchorIdx(asViewId(42))).toBe(7)
   })
 
   it('returns null for an unknown id or a view without a placement', () => {
     const sw = makeStreamWindow(makeConfig())
-    sw.views = new Map([[42, makeFakeViewActor(null)]])
+    sw.views = new Map([[asViewId(42), makeFakeViewActor(null)]])
 
-    expect(sw.getViewAnchorIdx(42)).toBeNull()
-    expect(sw.getViewAnchorIdx(999)).toBeNull()
+    expect(sw.getViewAnchorIdx(asViewId(42))).toBeNull()
+    expect(sw.getViewAnchorIdx(asViewId(999))).toBeNull()
   })
 })
 
@@ -331,7 +352,7 @@ describe('StreamWindow.emitState', () => {
     const sw = makeStreamWindow(makeConfig())
     sw.views = new Map([
       [
-        1,
+        asViewId(1),
         makeFakeViewActorWithSnapshot({
           value: 'empty',
           context: {
@@ -490,7 +511,7 @@ describe('StreamWindow.setViews', () => {
     const viewContentMap: ViewContentMap = new Map([
       ['0', { url: 'https://example.com/missing', kind: 'video' }],
     ])
-    const streams = { byURL: new Map() }
+    const streams = makeStreams()
 
     sw.setViews(viewContentMap, streams)
 
@@ -513,7 +534,7 @@ describe('StreamWindow.setViews', () => {
     const viewContentMap: ViewContentMap = new Map([
       ['0', { url: 'https://example.com/missing', kind: 'video' }],
     ])
-    const streams = { byURL: new Map() }
+    const streams = makeStreams()
 
     sw.setViews(viewContentMap, streams)
 
@@ -537,7 +558,7 @@ describe('StreamWindow.setViews', () => {
       spaces: [0],
       running: true,
     })
-    sw.views = new Map([[1, orphan.actor]])
+    sw.views = new Map([[asViewId(1), orphan.actor]])
     sw.createView = vi.fn()
 
     const emitted: number[][] = []
@@ -553,7 +574,7 @@ describe('StreamWindow.setViews', () => {
 
     // The single box is dropped, leaving the actor unused: it is stopped, and
     // that stop emits state while `setViews` is still mid-flight.
-    sw.setViews(new Map(), { byURL: new Map() })
+    sw.setViews(new Map(), makeStreams())
 
     expect(orphan.stop).toHaveBeenCalled()
     // The intermediate emit must still describe the pre-teardown layout.
@@ -606,7 +627,7 @@ describe('StreamWindow.displayPlannedViews', () => {
 
     const newViews = planExecutorOf(sw).displayPlannedViews(
       [{ box, view: tracked.actor }],
-      { byURL: new Map() },
+      makeStreams(),
       new Set(),
       unusedViews,
     )
@@ -726,14 +747,14 @@ describe('StreamWindow.setViews reusing an actor across a genuine content change
       spaces: [0],
       running: true,
     })
-    sw.views = new Map([[1, actor]])
+    sw.views = new Map([[asViewId(1), actor]])
     sw.createView = vi.fn()
 
     // Space 0 now requests streamB instead of the streamA the actor there is
     // currently displaying -- a genuine content change, e.g. a playlist
     // advance or a drag-to-place reassignment.
     const viewContentMap: ViewContentMap = new Map([['0', streamB]])
-    const streams = { byURL: new Map([[streamB.url, {}]]) }
+    const streams = makeStreams([[streamB.url, {}]])
 
     sw.setViews(viewContentMap, streams)
 
@@ -742,7 +763,7 @@ describe('StreamWindow.setViews reusing an actor across a genuine content change
     expect(send).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'DISPLAY', content: streamB }),
     )
-    expect(sw.views.get(1)).toBe(actor)
+    expect(sw.views.get(asViewId(1))).toBe(actor)
   })
 
   it('does not reuse a still-loading actor across a content change, since the state machine has no handler that would apply it', () => {
@@ -765,7 +786,7 @@ describe('StreamWindow.setViews reusing an actor across a genuine content change
       spaces: [0],
       running: false,
     })
-    sw.views = new Map([[1, actor]])
+    sw.views = new Map([[asViewId(1), actor]])
     const { actor: newActor, send: newSend } = makeReuseTestActor({
       id: 2,
       content: null,
@@ -775,7 +796,7 @@ describe('StreamWindow.setViews reusing an actor across a genuine content change
     sw.createView = vi.fn(() => newActor)
 
     const viewContentMap: ViewContentMap = new Map([['0', streamB]])
-    const streams = { byURL: new Map([[streamB.url, {}]]) }
+    const streams = makeStreams([[streamB.url, {}]])
 
     sw.setViews(viewContentMap, streams)
 
@@ -830,8 +851,8 @@ describe('StreamWindow.setViews reusing an actor across a genuine content change
       running: true,
     })
     sw.views = new Map([
-      [1, spaceOnly.actor],
-      [2, moved.actor],
+      [asViewId(1), spaceOnly.actor],
+      [asViewId(2), moved.actor],
     ])
     const { actor: newActor, send: newSend } = makeReuseTestActor({
       id: 3,
@@ -846,13 +867,11 @@ describe('StreamWindow.setViews reusing an actor across a genuine content change
       ['1', streamE], // unrelated new content -> no existing actor fits
       ['2', streamB], // same content as `moved`, elsewhere -> should reuse moved
     ])
-    const streams = {
-      byURL: new Map([
-        [streamB.url, {}],
-        [streamC.url, {}],
-        [streamE.url, {}],
-      ]),
-    }
+    const streams = makeStreams([
+      [streamB.url, {}],
+      [streamC.url, {}],
+      [streamE.url, {}],
+    ])
 
     sw.setViews(viewContentMap, streams)
 
@@ -902,23 +921,21 @@ describe('StreamWindow.setViews matcher precedence', () => {
     // `elsewhere` is registered first, so only the space-overlap tie-break in
     // the first matcher can make `inPlace` win.
     sw.views = new Map([
-      [2, elsewhere.actor],
-      [1, inPlace.actor],
+      [asViewId(2), elsewhere.actor],
+      [asViewId(1), inPlace.actor],
     ])
     sw.createView = vi.fn()
 
-    sw.setViews(new Map([['0', streamA]]), {
-      byURL: new Map([[streamA.url, {}]]),
-    })
+    sw.setViews(new Map([['0', streamA]]), makeStreams([[streamA.url, {}]]))
 
     expect(sw.createView).not.toHaveBeenCalled()
     expect(inPlace.send).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'DISPLAY', content: streamA }),
     )
-    expect(sw.views.get(1)).toBe(inPlace.actor)
+    expect(sw.views.get(asViewId(1))).toBe(inPlace.actor)
     // The redundant copy is torn down rather than left dangling.
     expect(elsewhere.stop).toHaveBeenCalled()
-    expect(sw.views.has(2)).toBe(false)
+    expect(sw.views.has(asViewId(2))).toBe(false)
   })
 
   it('reuses a still-loading view that already has the requested content instead of creating a new one', () => {
@@ -933,19 +950,17 @@ describe('StreamWindow.setViews matcher precedence', () => {
       spaces: [0],
       running: false,
     })
-    sw.views = new Map([[1, loading.actor]])
+    sw.views = new Map([[asViewId(1), loading.actor]])
     sw.createView = vi.fn()
 
-    sw.setViews(new Map([['0', streamA]]), {
-      byURL: new Map([[streamA.url, {}]]),
-    })
+    sw.setViews(new Map([['0', streamA]]), makeStreams([[streamA.url, {}]]))
 
     expect(sw.createView).not.toHaveBeenCalled()
     expect(loading.stop).not.toHaveBeenCalled()
     expect(loading.send).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'DISPLAY', content: streamA }),
     )
-    expect(sw.views.get(1)).toBe(loading.actor)
+    expect(sw.views.get(asViewId(1))).toBe(loading.actor)
   })
 
   it('prefers a live view over an equally-matching parked one', () => {
@@ -966,15 +981,13 @@ describe('StreamWindow.setViews matcher precedence', () => {
       spaces: [0],
       running: true,
     })
-    sw.views = new Map([[1, live.actor]])
-    sw.parkedViews = new Map([[2, parked.actor]])
+    sw.views = new Map([[asViewId(1), live.actor]])
+    sw.parkedViews = new Map([[asViewId(2), parked.actor]])
     sw.createView = vi.fn()
 
-    sw.setViews(new Map([['0', streamA]]), {
-      byURL: new Map([[streamA.url, {}]]),
-    })
+    sw.setViews(new Map([['0', streamA]]), makeStreams([[streamA.url, {}]]))
 
-    expect(sw.views.get(1)).toBe(live.actor)
+    expect(sw.views.get(asViewId(1))).toBe(live.actor)
     expect(live.stop).not.toHaveBeenCalled()
     expect(parked.stop).toHaveBeenCalled()
     // The parking bookkeeping is reset by every setViews call.
@@ -993,10 +1006,10 @@ describe('StreamWindow.setViews matcher precedence', () => {
       spaces: [0],
       running: true,
     })
-    sw.views = new Map([[1, orphan.actor]])
+    sw.views = new Map([[asViewId(1), orphan.actor]])
     sw.createView = vi.fn()
 
-    sw.setViews(new Map(), { byURL: new Map() })
+    sw.setViews(new Map(), makeStreams())
 
     expect(orphan.stop).toHaveBeenCalled()
     expect(orphan.disposeView).toHaveBeenCalledTimes(1)
@@ -1034,15 +1047,16 @@ describe('StreamWindow.setViews expanding a view to fill the wall (issue #362)',
       running: true,
     })
     sw.views = new Map([
-      [1, expanding.actor],
-      [2, other.actor],
+      [asViewId(1), expanding.actor],
+      [asViewId(2), other.actor],
     ])
     sw.createView = vi.fn()
 
     // The fullscreen override fills every cell with streamB.
-    sw.setViews(fullscreenViewContentMap(2, 2, streamB), {
-      byURL: new Map([[streamB.url, {}]]),
-    })
+    sw.setViews(
+      fullscreenViewContentMap(2, 2, streamB),
+      makeStreams([[streamB.url, {}]]),
+    )
 
     // No new view is created: the already-running streamB actor is reused and
     // repositioned to span the whole wall.
@@ -1058,7 +1072,7 @@ describe('StreamWindow.setViews expanding a view to fill the wall (issue #362)',
     // expanded view).
     expect(other.stop).toHaveBeenCalled()
     expect(sw.views.size).toBe(1)
-    expect(sw.views.get(1)).toBe(expanding.actor)
+    expect(sw.views.get(asViewId(1))).toBe(expanding.actor)
   })
 })
 
@@ -1090,14 +1104,14 @@ describe('StreamWindow.setViews parking unused views during a fullscreen expansi
       running: true,
     })
     sw.views = new Map([
-      [1, expanding.actor],
-      [2, other.actor],
+      [asViewId(1), expanding.actor],
+      [asViewId(2), other.actor],
     ])
     sw.createView = vi.fn()
 
     sw.setViews(
       fullscreenViewContentMap(2, 2, streamB),
-      { byURL: new Map([[streamB.url, {}]]) },
+      makeStreams([[streamB.url, {}]]),
       { parkUnused: true },
     )
 
@@ -1111,7 +1125,7 @@ describe('StreamWindow.setViews parking unused views during a fullscreen expansi
     // It no longer appears in the emitted view states (only the expanded
     // view is visible, matching the pre-#369 behavior)...
     expect(sw.views.size).toBe(1)
-    expect(sw.views.get(1)).toBe(expanding.actor)
+    expect(sw.views.get(asViewId(1))).toBe(expanding.actor)
     // ...but StreamWindow retains it internally so a later collapse can
     // reuse it instead of recreating it from scratch.
     expect(
@@ -1148,15 +1162,15 @@ describe('StreamWindow.setViews parking unused views during a fullscreen expansi
       running: true,
     })
     sw.views = new Map([
-      [1, expanding.actor],
-      [2, other.actor],
+      [asViewId(1), expanding.actor],
+      [asViewId(2), other.actor],
     ])
     sw.createView = vi.fn()
 
     // Expand: `other` is parked instead of disposed.
     sw.setViews(
       fullscreenViewContentMap(2, 2, streamB),
-      { byURL: new Map([[streamB.url, {}]]) },
+      makeStreams([[streamB.url, {}]]),
       { parkUnused: true },
     )
 
@@ -1165,12 +1179,13 @@ describe('StreamWindow.setViews parking unused views during a fullscreen expansi
       ['0', streamA],
       ['1', streamB],
     ])
-    sw.setViews(viewContentMap, {
-      byURL: new Map([
+    sw.setViews(
+      viewContentMap,
+      makeStreams([
         [streamA.url, {}],
         [streamB.url, {}],
       ]),
-    })
+    )
 
     // The parked actor is reused for its original space instead of a new
     // view being created for it (which would show a reload/black flash).
@@ -1179,7 +1194,7 @@ describe('StreamWindow.setViews parking unused views during a fullscreen expansi
       expect.objectContaining({ type: 'DISPLAY', content: streamA }),
     )
     expect(sw.views.size).toBe(2)
-    expect(sw.views.get(2)).toBe(other.actor)
+    expect(sw.views.get(asViewId(2))).toBe(other.actor)
   })
 
   it('still tears down a view left unused after collapse (its cell was cleared while expanded)', () => {
@@ -1209,21 +1224,21 @@ describe('StreamWindow.setViews parking unused views during a fullscreen expansi
       running: true,
     })
     sw.views = new Map([
-      [1, expanding.actor],
-      [2, other.actor],
+      [asViewId(1), expanding.actor],
+      [asViewId(2), other.actor],
     ])
     sw.createView = vi.fn()
 
     sw.setViews(
       fullscreenViewContentMap(2, 2, streamB),
-      { byURL: new Map([[streamB.url, {}]]) },
+      makeStreams([[streamB.url, {}]]),
       { parkUnused: true },
     )
 
     // Collapse, but the cell `other` used to occupy was cleared while
     // expanded: the normal layout no longer has any box for streamA.
     const viewContentMap: ViewContentMap = new Map([['1', streamB]])
-    sw.setViews(viewContentMap, { byURL: new Map([[streamB.url, {}]]) })
+    sw.setViews(viewContentMap, makeStreams([[streamB.url, {}]]))
 
     // The parked actor is genuinely no longer needed, so it is torn down
     // instead of being parked forever.
@@ -1260,14 +1275,14 @@ describe('StreamWindow parking pauses playback when pauseParkedViews is enabled 
       running: true,
     })
     sw.views = new Map([
-      [1, expanding.actor],
-      [2, other.actor],
+      [asViewId(1), expanding.actor],
+      [asViewId(2), other.actor],
     ])
     sw.createView = vi.fn()
 
     sw.setViews(
       fullscreenViewContentMap(2, 2, streamB),
-      { byURL: new Map([[streamB.url, {}]]) },
+      makeStreams([[streamB.url, {}]]),
       { parkUnused: true },
     )
 
@@ -1295,14 +1310,14 @@ describe('StreamWindow parking pauses playback when pauseParkedViews is enabled 
       running: true,
     })
     sw.views = new Map([
-      [1, expanding.actor],
-      [2, other.actor],
+      [asViewId(1), expanding.actor],
+      [asViewId(2), other.actor],
     ])
     sw.createView = vi.fn()
 
     sw.setViews(
       fullscreenViewContentMap(2, 2, streamB),
-      { byURL: new Map([[streamB.url, {}]]) },
+      makeStreams([[streamB.url, {}]]),
       { parkUnused: true },
     )
 
@@ -1331,15 +1346,15 @@ describe('StreamWindow parking pauses playback when pauseParkedViews is enabled 
       running: true,
     })
     sw.views = new Map([
-      [1, expanding.actor],
-      [2, other.actor],
+      [asViewId(1), expanding.actor],
+      [asViewId(2), other.actor],
     ])
     sw.createView = vi.fn()
 
     // Expand: `other` is parked and paused.
     sw.setViews(
       fullscreenViewContentMap(2, 2, streamB),
-      { byURL: new Map([[streamB.url, {}]]) },
+      makeStreams([[streamB.url, {}]]),
       { parkUnused: true },
     )
     expect(other.send).toHaveBeenCalledWith({ type: 'PAUSE' })
@@ -1349,12 +1364,13 @@ describe('StreamWindow parking pauses playback when pauseParkedViews is enabled 
       ['0', streamA],
       ['1', streamB],
     ])
-    sw.setViews(viewContentMap, {
-      byURL: new Map([
+    sw.setViews(
+      viewContentMap,
+      makeStreams([
         [streamA.url, {}],
         [streamB.url, {}],
       ]),
-    })
+    )
 
     expect(other.send).toHaveBeenCalledWith({ type: 'RESUME' })
   })
@@ -1373,13 +1389,11 @@ describe('StreamWindow parking pauses playback when pauseParkedViews is enabled 
       spaces: [0],
       running: true,
     })
-    sw.views = new Map([[1, actor.actor]])
+    sw.views = new Map([[asViewId(1), actor.actor]])
     sw.createView = vi.fn()
 
     // Ordinary re-display of an already-running, never-parked view.
-    sw.setViews(new Map([['0', streamA]]), {
-      byURL: new Map([[streamA.url, {}]]),
-    })
+    sw.setViews(new Map([['0', streamA]]), makeStreams([[streamA.url, {}]]))
 
     expect(actor.send).not.toHaveBeenCalledWith({ type: 'RESUME' })
   })
@@ -1426,7 +1440,7 @@ describe('StreamWindow view registration and disposal', () => {
     sw.win = {
       contentView: { removeChildView: removeChildViewOnWin },
     } as unknown as InstanceType<typeof StreamWindow>['win']
-    sw.viewsByWebContentsId = new Map([[7, {} as never]])
+    sw.viewsByWebContentsId = new Map([[asViewId(7), {} as never]])
     const close = vi.fn()
     const view = { webContents: { id: 7, close } }
     const removeChildViewOnOffscreen = vi.fn()
@@ -1733,7 +1747,7 @@ describe('StreamWindow constructor', () => {
       // Both land on the overlay: it is the only child the stream views are
       // never stacked over, so a notice on the background layer would be hidden
       // behind the wall's tiles.
-      expect(sw.overlayView.webContents.send.mock.calls).toEqual([
+      expect(vi.mocked(sw.overlayView.webContents.send).mock.calls).toEqual([
         ['layer:blocked-url', 'http://192.168.1.50/bg'],
         ['layer:blocked-url', 'http://169.254.169.254/meta'],
       ])
@@ -1751,7 +1765,7 @@ describe('StreamWindow constructor', () => {
 
       layerLoadHandler()({ sender: sw.overlayView.webContents })
 
-      expect(sw.overlayView.webContents.send.mock.calls).toEqual([
+      expect(vi.mocked(sw.overlayView.webContents.send).mock.calls).toEqual([
         ['layer:blocked-url', 'http://192.168.1.50/bg'],
       ])
     })
@@ -1768,7 +1782,7 @@ describe('StreamWindow constructor', () => {
       }
       layerLoadHandler()({ sender: sw.overlayView.webContents })
 
-      const replayed = sw.overlayView.webContents.send.mock.calls
+      const replayed = vi.mocked(sw.overlayView.webContents.send).mock.calls
       expect(replayed[0]).toEqual([
         'layer:blocked-url',
         'http://192.168.1.50/the-operators-link',
@@ -1853,7 +1867,7 @@ describe('StreamWindow constructor', () => {
 
       background('http://192.168.1.50/bg', 'private network')
 
-      expect(sw.overlayView.webContents.send.mock.calls).toEqual([
+      expect(vi.mocked(sw.overlayView.webContents.send).mock.calls).toEqual([
         ['layer:blocked-url', 'http://192.168.1.50/bg'],
       ])
     })
@@ -2185,15 +2199,15 @@ describe('StreamWindow mutes parked views (issue #740)', () => {
       desiredAudio,
     })
     sw.views = new Map([
-      [1, expanding.actor],
-      [2, other.actor],
+      [asViewId(1), expanding.actor],
+      [asViewId(2), other.actor],
     ])
     sw.createView = vi.fn()
 
     const expand = () =>
       sw.setViews(
         fullscreenViewContentMap(2, 2, streamB),
-        { byURL: new Map([[streamB.url, {}]]) },
+        makeStreams([[streamB.url, {}]]),
         { parkUnused: true },
       )
     const collapse = () =>
@@ -2202,12 +2216,10 @@ describe('StreamWindow mutes parked views (issue #740)', () => {
           ['0', streamA],
           ['1', streamB],
         ]),
-        {
-          byURL: new Map([
-            [streamA.url, {}],
-            [streamB.url, {}],
-          ]),
-        },
+        makeStreams([
+          [streamA.url, {}],
+          [streamB.url, {}],
+        ]),
       )
 
     return { sw, expanding, other, expand, collapse }
@@ -2218,7 +2230,7 @@ describe('StreamWindow mutes parked views (issue #740)', () => {
 
     expand()
 
-    expect(sw.parkedViews.has(2)).toBe(true)
+    expect(sw.parkedViews.has(asViewId(2))).toBe(true)
     expect(other.send).toHaveBeenCalledWith({ type: 'MUTE' })
   })
 
@@ -2267,14 +2279,14 @@ describe('StreamWindow mutes parked views (issue #740)', () => {
     expanding.send.mockClear()
     other.send.mockClear()
 
-    sw.setListeningView(2)
+    sw.setListeningView(asViewId(2))
 
     // The live view is muted as usual, proving the selection was applied at
     // all -- but the parked one is only recorded, never made audible while it
     // is invisible.
     expect(expanding.send).toHaveBeenCalledWith({ type: 'MUTE' })
     expect(other.send).not.toHaveBeenCalled()
-    expect(sw.parkedAudio.get(2)).toBe('listening')
+    expect(sw.parkedAudio.get(asViewId(2))).toBe('listening')
   })
 
   it('drops the recorded audio state of a parked view when another view is selected', () => {
@@ -2284,9 +2296,9 @@ describe('StreamWindow mutes parked views (issue #740)', () => {
 
     // The operator picks the expanded view instead: the parked one must not
     // come back audible and make two streams play at once.
-    sw.setListeningView(1)
+    sw.setListeningView(asViewId(1))
     expect(expanding.send).toHaveBeenCalledWith({ type: 'UNMUTE' })
-    expect(sw.parkedAudio.get(2)).toBe('muted')
+    expect(sw.parkedAudio.get(asViewId(2))).toBe('muted')
     other.send.mockClear()
     collapse()
 
@@ -2324,7 +2336,7 @@ describe('StreamWindow mutes parked views (issue #740)', () => {
     const { sw, other, expand, collapse } = setupExpansion('muted')
 
     expand()
-    sw.setListeningView(2)
+    sw.setListeningView(asViewId(2))
     expand()
     other.send.mockClear()
     collapse()
@@ -2336,7 +2348,7 @@ describe('StreamWindow mutes parked views (issue #740)', () => {
     const { sw, other, expand, collapse } = setupExpansion('muted')
     expand()
 
-    sw.setListeningView(2)
+    sw.setListeningView(asViewId(2))
     other.send.mockClear()
     collapse()
 

--- a/packages/streamwall/src/main/TwitchBot.test.ts
+++ b/packages/streamwall/src/main/TwitchBot.test.ts
@@ -25,7 +25,7 @@ let fakeClient: FakeChatClient
 let chatClientOptions: { channels?: string[] } | undefined
 let staticAuthProviderArgs: unknown[]
 let setColorForUser: ReturnType<typeof vi.fn>
-let getTokenInfo: ReturnType<typeof vi.fn>
+let getTokenInfo: ReturnType<typeof vi.fn<(...args: unknown[]) => unknown>>
 
 vi.mock('@twurple/chat', () => ({
   ChatClient: vi.fn().mockImplementation(function ChatClient(options: never) {

--- a/packages/streamwall/src/main/appUpdater.test.ts
+++ b/packages/streamwall/src/main/appUpdater.test.ts
@@ -15,7 +15,9 @@ class FakeElectronUpdater extends EventEmitter {
 
 function createUpdater(repository: string | null = 'NilsR0711/streamwall') {
   const backend = new FakeElectronUpdater()
-  const setIntervalImpl = vi.fn(() => 'timer-handle')
+  const setIntervalImpl = vi.fn(
+    (_fn: () => void, _ms: number) => 'timer-handle',
+  )
   const clearIntervalImpl = vi.fn()
   const updater = new AppUpdater(backend, repository, {
     setIntervalImpl,

--- a/packages/streamwall/src/main/blockedLayerURLs.test.ts
+++ b/packages/streamwall/src/main/blockedLayerURLs.test.ts
@@ -9,6 +9,7 @@ import { BlockedLayerURLTracker } from './blockedLayerURLs'
 function layers(...links: string[]): StreamData[] {
   return links.map((link, i) => ({
     _id: `id-${i}`,
+    _dataSource: 'test',
     link,
     kind: 'overlay' as const,
   }))
@@ -150,6 +151,7 @@ describe('BlockedLayerURLTracker', () => {
       const overlay = layers('https://example.com/o')
       const video: StreamData = {
         _id: 'v',
+        _dataSource: 'test',
         link: 'https://example.com/v1',
         kind: 'video',
       }

--- a/packages/streamwall/src/main/bootstrap.test.ts
+++ b/packages/streamwall/src/main/bootstrap.test.ts
@@ -37,7 +37,18 @@ function fakeStreamwallState(
 ): StreamwallState {
   return {
     ...createInitialClientState({
-      config: { width: 0, height: 0, x: 0, y: 0, cols: 2, rows: 2 },
+      config: {
+        width: 0,
+        height: 0,
+        x: 0,
+        y: 0,
+        cols: 2,
+        rows: 2,
+        frameless: false,
+        fullscreen: false,
+        activeColor: '#fff',
+        backgroundColor: '#000',
+      },
       layoutPresets: [],
       favorites: [],
     }),
@@ -108,7 +119,18 @@ describe('createPersistedLocalStreamData', () => {
 describe('createInitialClientState', () => {
   it('carries the persisted presets and favorites into a local identity', () => {
     const state = createInitialClientState({
-      config: { width: 1, height: 2, x: 3, y: 4, cols: 3, rows: 2 },
+      config: {
+        width: 1,
+        height: 2,
+        x: 3,
+        y: 4,
+        cols: 3,
+        rows: 2,
+        frameless: false,
+        fullscreen: false,
+        activeColor: '#fff',
+        backgroundColor: '#000',
+      },
       layoutPresets: [],
       favorites: [],
     })
@@ -448,8 +470,8 @@ describe('wireWindowLifecycle', () => {
     let resolveFlush: () => void = () => undefined
     const flushStorage = vi.fn(
       () =>
-        new Promise<void>((resolve) => {
-          resolveFlush = resolve
+        new Promise<undefined>((resolve) => {
+          resolveFlush = () => resolve(undefined)
         }),
     )
     const { app } = wire('linux', flushStorage)
@@ -588,14 +610,14 @@ describe('createDataSourceHealthReporter', () => {
     const updateState = vi.fn()
     const track = createDataSourceHealthReporter(updateState)
 
-    track('source-a', 'json')(false, 'timed out')
+    track('source-a', 'json-url')(false, 'timed out')
 
     expect(updateState).toHaveBeenCalledTimes(1)
     const health = updateState.mock.calls[0][0].dataSourceHealth
     expect(health).toEqual([
       expect.objectContaining({
         id: 'source-a',
-        type: 'json',
+        type: 'json-url',
         status: 'error',
         message: 'timed out',
       }),
@@ -618,6 +640,7 @@ describe('createBlockedLayerURLReporter', () => {
 
   const overlay = (link: string): StreamData => ({
     _id: link,
+    _dataSource: 'test',
     kind: 'overlay',
     link,
   })
@@ -716,7 +739,18 @@ describe('createBlockedLayerURLReporter', () => {
   it('starts the broadcast state at generation zero', () => {
     expect(
       createInitialClientState({
-        config: { width: 0, height: 0, x: 0, y: 0, cols: 2, rows: 2 },
+        config: {
+          width: 0,
+          height: 0,
+          x: 0,
+          y: 0,
+          cols: 2,
+          rows: 2,
+          frameless: false,
+          fullscreen: false,
+          activeColor: '#fff',
+          backgroundColor: '#000',
+        },
         layoutPresets: [],
         favorites: [],
       }).blockedLayerURLsGeneration,

--- a/packages/streamwall/src/main/commandDispatch.test.ts
+++ b/packages/streamwall/src/main/commandDispatch.test.ts
@@ -39,8 +39,8 @@ test('dispatchCommand logs and swallows a rejection instead of leaking an unhand
   await new Promise((resolve) => setImmediate(resolve))
 
   assert.equal(unhandledRejections.length, 0)
-  assert.equal(log.error.mock.calls.length, 1)
-  const [message, loggedErr] = log.error.mock.calls[0]
+  assert.equal(vi.mocked(log.error).mock.calls.length, 1)
+  const [message, loggedErr] = vi.mocked(log.error).mock.calls[0]
   assert.match(message, /uplink/)
   assert.equal(loggedErr, err)
 })
@@ -53,7 +53,7 @@ test('dispatchCommand tags the logged error with the local source', async () => 
   dispatchCommand(onCommand, { type: 'ping' }, 'local')
   await new Promise((resolve) => setImmediate(resolve))
 
-  const [message] = log.error.mock.calls[0]
+  const [message] = vi.mocked(log.error).mock.calls[0]
   assert.match(message, /local/)
 })
 
@@ -79,7 +79,7 @@ test('dispatchLocalCommand converts a rejection into an error result', async () 
   const result = await dispatchLocalCommand(onCommand, { type: 'ping' })
 
   assert.deepEqual(result, { error: 'boom' })
-  assert.equal(log.error.mock.calls.length, 1)
+  assert.equal(vi.mocked(log.error).mock.calls.length, 1)
 })
 
 test('dispatchLocalCommand returns undefined when onCommand succeeds', async () => {

--- a/packages/streamwall/src/main/commandHandlers.test.ts
+++ b/packages/streamwall/src/main/commandHandlers.test.ts
@@ -1,5 +1,6 @@
 import {
   asCellIdx,
+  type CellIdx,
   type ControlCommand,
   type StreamwallState,
 } from 'streamwall-shared'
@@ -18,8 +19,8 @@ function cmd(msg: Record<string, unknown>): ControlCommand {
 }
 
 function fakeBrowseWindow(): BrowseWindow & {
-  destroy: ReturnType<typeof vi.fn>
-  loadURL: ReturnType<typeof vi.fn>
+  destroy: ReturnType<typeof vi.fn<() => void>>
+  loadURL: ReturnType<typeof vi.fn<(url: string) => unknown>>
 } {
   return {
     isDestroyed: vi.fn(() => false),
@@ -47,7 +48,9 @@ function makeDeps(overrides: Partial<CommandHandlerDeps> = {}) {
     setGridSize: vi.fn(),
     openDevTools: vi.fn(),
     // Resolves a stable view id to the grid cell it currently occupies.
-    getViewAnchorIdx: vi.fn((viewId: number) => viewId + 3),
+    getViewAnchorIdx: vi.fn<(viewId: number) => CellIdx | null>((viewId) =>
+      asCellIdx(viewId + 3),
+    ),
   }
 
   const deps: CommandHandlerDeps = {
@@ -187,7 +190,7 @@ describe('createOnCommand — view controls', () => {
 
   it('does not expand a view that has no placement', async () => {
     const ctx = makeDeps()
-    ctx.streamWindow.getViewAnchorIdx.mockReturnValue(null as unknown as number)
+    ctx.streamWindow.getViewAnchorIdx.mockReturnValue(null)
     const onCommand = createOnCommand(ctx.deps)
 
     await onCommand(

--- a/packages/streamwall/src/main/data/combine.test.ts
+++ b/packages/streamwall/src/main/data/combine.test.ts
@@ -67,7 +67,10 @@ describe('data source fan-out', () => {
         res.setHeader('content-type', 'application/json')
         res.end(
           JSON.stringify([
-            { link: `https://example.invalid${req.url}`, kind: 'video' },
+            {
+              link: `https://example.invalid${req.url}`,
+              kind: 'video' as const,
+            },
           ]),
         )
       })
@@ -110,7 +113,9 @@ describe('data source fan-out', () => {
     server = createServer((_req, res) => {
       res.setHeader('content-type', 'application/json')
       res.end(
-        JSON.stringify([{ link: 'https://good.example/s', kind: 'video' }]),
+        JSON.stringify([
+          { link: 'https://good.example/s', kind: 'video' as const },
+        ]),
       )
     })
     await new Promise<void>((resolve) =>
@@ -147,12 +152,18 @@ describe('data source fan-out', () => {
 describe('combineDataSources', () => {
   test('merges entries from multiple sources by link, letting later sources override fields', async () => {
     async function* sourceA() {
-      yield [{ kind: 'video', link: 'https://a.example/s', label: 'From A' }]
+      yield [
+        {
+          kind: 'video' as const,
+          link: 'https://a.example/s',
+          label: 'From A',
+        },
+      ]
     }
     async function* sourceB() {
       yield [
         {
-          kind: 'video',
+          kind: 'video' as const,
           link: 'https://a.example/s',
           label: 'From B',
           notes: 'extra',
@@ -178,7 +189,7 @@ describe('combineDataSources', () => {
 
   test('attaches a byURL index to the yielded list for quick lookups', async () => {
     async function* sourceA() {
-      yield [{ kind: 'video', link: 'https://a.example/s' }]
+      yield [{ kind: 'video' as const, link: 'https://a.example/s' }]
     }
     const gen = combineDataSources([sourceA()], new StreamIDGenerator())
     try {
@@ -193,7 +204,13 @@ describe('combineDataSources', () => {
 
   test('attaches a byId index keyed by the assigned stream id', async () => {
     async function* sourceA() {
-      yield [{ kind: 'video', link: 'https://a.example/s', source: 'Example' }]
+      yield [
+        {
+          kind: 'video' as const,
+          link: 'https://a.example/s',
+          source: 'Example',
+        },
+      ]
     }
     const gen = combineDataSources([sourceA()], new StreamIDGenerator())
     try {
@@ -209,7 +226,13 @@ describe('combineDataSources', () => {
 
   test('assigns stream ids via the provided StreamIDGenerator', async () => {
     async function* sourceA() {
-      yield [{ kind: 'video', link: 'https://a.example/s', source: 'Example' }]
+      yield [
+        {
+          kind: 'video' as const,
+          link: 'https://a.example/s',
+          source: 'Example',
+        },
+      ]
     }
     const gen = combineDataSources([sourceA()], new StreamIDGenerator())
     try {
@@ -224,10 +247,10 @@ describe('combineDataSources', () => {
 describe('markDataSource', () => {
   test('tags every stream in every yielded batch with the data source name', async () => {
     async function* source() {
-      yield [{ kind: 'video', link: 'https://a.example/s' }]
+      yield [{ kind: 'video' as const, link: 'https://a.example/s' }]
       yield [
-        { kind: 'video', link: 'https://a.example/s' },
-        { kind: 'video', link: 'https://b.example/s' },
+        { kind: 'video' as const, link: 'https://a.example/s' },
+        { kind: 'video' as const, link: 'https://b.example/s' },
       ]
     }
     const marked = markDataSource(source(), 'my-source')
@@ -335,10 +358,10 @@ describe('combineDataSources', () => {
   // this point hung forever.
   test('return() resolves after a second value has been pulled from multiple live sources', async () => {
     const a = new LocalStreamData([
-      { kind: 'video', link: 'https://a.example/s' },
+      { kind: 'video' as const, link: 'https://a.example/s' },
     ])
     const b = new LocalStreamData([
-      { kind: 'video', link: 'https://b.example/s' },
+      { kind: 'video' as const, link: 'https://b.example/s' },
     ])
 
     const gen = combineDataSources(
@@ -363,7 +386,7 @@ describe('combineDataSources', () => {
     })
     const source = new Repeater<StreamDataContent[]>(async (push, stop) => {
       try {
-        await push([{ kind: 'video', link: 'https://a.example/s' }])
+        await push([{ kind: 'video' as const, link: 'https://a.example/s' }])
         await stop
       } finally {
         markClosed()
@@ -406,7 +429,7 @@ describe('combineDataSources', () => {
     test('delivers a healthy source while another source stays silent', async () => {
       const { source: silent } = deferredSource()
       const healthy = new Repeater<StreamDataContent[]>(async (push, stop) => {
-        await push([{ kind: 'video', link: 'https://good.example/s' }])
+        await push([{ kind: 'video' as const, link: 'https://good.example/s' }])
         await stop
       })
 
@@ -423,7 +446,11 @@ describe('combineDataSources', () => {
       const { source: slow, yieldBatch } = deferredSource()
       const healthy = new Repeater<StreamDataContent[]>(async (push, stop) => {
         await push([
-          { kind: 'video', link: 'https://good.example/s', label: 'from fast' },
+          {
+            kind: 'video' as const,
+            link: 'https://good.example/s',
+            label: 'from fast',
+          },
         ])
         await stop
       })
@@ -443,8 +470,12 @@ describe('combineDataSources', () => {
 
       const pending = gen.next()
       yieldBatch([
-        { kind: 'video', link: 'https://good.example/s', label: 'from slow' },
-        { kind: 'video', link: 'https://slow.example/s' },
+        {
+          kind: 'video' as const,
+          link: 'https://good.example/s',
+          label: 'from slow',
+        },
+        { kind: 'video' as const, link: 'https://slow.example/s' },
       ])
       const { value } = await pending
 
@@ -461,7 +492,7 @@ describe('combineDataSources', () => {
     test('tears down while a source has never yielded', async () => {
       const { source: silent } = deferredSource()
       const healthy = new Repeater<StreamDataContent[]>(async (push, stop) => {
-        await push([{ kind: 'video', link: 'https://good.example/s' }])
+        await push([{ kind: 'video' as const, link: 'https://good.example/s' }])
         await stop
       })
 

--- a/packages/streamwall/src/main/data/local.test.ts
+++ b/packages/streamwall/src/main/data/local.test.ts
@@ -1,3 +1,4 @@
+import type { StreamDataContent } from 'streamwall-shared'
 import { describe, expect, test, vi } from 'vitest'
 import type { PresetPack } from '../presets'
 import { combineDataSources, markDataSource } from './combine'
@@ -84,7 +85,9 @@ describe('LocalStreamData', () => {
     const iterator = data.gen()
     try {
       const first = await iterator.next()
-      expect(first.value?.map((s) => s.link)).toEqual(['https://a.example/s'])
+      expect(first.value?.map((s: StreamDataContent) => s.link)).toEqual([
+        'https://a.example/s',
+      ])
 
       // Starting the next pull is what lets the generator's buffered push()
       // resolve and reach the `this.on('update', push)` line (the Repeater's
@@ -93,7 +96,7 @@ describe('LocalStreamData', () => {
       await waitForListener(data, 'update')
       data.update('https://b.example/s', { kind: 'video' })
       const second = await pending
-      expect(second.value?.map((s) => s.link)).toEqual([
+      expect(second.value?.map((s: StreamDataContent) => s.link)).toEqual([
         'https://a.example/s',
         'https://b.example/s',
       ])

--- a/packages/streamwall/src/main/data/watchFile.test.ts
+++ b/packages/streamwall/src/main/data/watchFile.test.ts
@@ -49,7 +49,7 @@ link = "https://c.example/s"
         'https://c.example/s',
       ])
     } finally {
-      await gen.return(undefined)
+      await gen.return?.(undefined)
     }
   })
 
@@ -67,7 +67,7 @@ _dataSource = "attacker"
       expect(value?.[0]).not.toHaveProperty('_id')
       expect(value?.[0]).not.toHaveProperty('_dataSource')
     } finally {
-      await gen.return(undefined)
+      await gen.return?.(undefined)
     }
   })
 
@@ -78,7 +78,7 @@ _dataSource = "attacker"
       const { value } = await gen.next()
       expect(value).toEqual([])
     } finally {
-      await gen.return(undefined)
+      await gen.return?.(undefined)
     }
   })
 
@@ -113,7 +113,7 @@ link = "https://b.example/s"
         'https://b.example/s',
       ])
     } finally {
-      await gen.return(undefined)
+      await gen.return?.(undefined)
     }
   })
 
@@ -143,7 +143,7 @@ link = "https://b.example/s"
         'https://b.example/s',
       ])
     } finally {
-      await gen.return(undefined)
+      await gen.return?.(undefined)
     }
   })
 
@@ -172,7 +172,7 @@ link = "https://a.example/s"
         ),
       ).toHaveLength(1)
     } finally {
-      await gen.return(undefined)
+      await gen.return?.(undefined)
       warnSpy.mockRestore()
     }
   })
@@ -228,7 +228,7 @@ link = "https://b.example/s"
         'https://b.example/s',
       ])
     } finally {
-      await gen.return(undefined)
+      await gen.return?.(undefined)
     }
   })
 
@@ -243,7 +243,7 @@ link = "https://a.example/s"
       await gen.next()
       expect(onHealth).toHaveBeenCalledWith(true)
     } finally {
-      await gen.return(undefined)
+      await gen.return?.(undefined)
     }
   })
 
@@ -258,7 +258,7 @@ link = "https://a.example/s"
       await gen.next()
       expect(onHealth).toHaveBeenCalledWith(false, expect.any(String))
     } finally {
-      await gen.return(undefined)
+      await gen.return?.(undefined)
     }
   })
 
@@ -286,7 +286,7 @@ link = "https://a.example/s"
     // return() without waiting on one.
     await expect(
       Promise.race([
-        gen.return(undefined),
+        gen.return?.(undefined),
         new Promise((_, reject) =>
           setTimeout(() => reject(new Error('return() hung')), 500),
         ),

--- a/packages/streamwall/src/main/partitions.test.ts
+++ b/packages/streamwall/src/main/partitions.test.ts
@@ -46,7 +46,9 @@ function fakeSession() {
     },
     // Overridable per test; the default reports every hostname as public so
     // tests that don't care about DNS classification aren't forced to stub it.
-    resolveHost: async (): Promise<{
+    resolveHost: async (
+      _host: string,
+    ): Promise<{
       endpoints: { address: string; family: 'ipv4' | 'ipv6' }[]
     }> => ({ endpoints: [{ address: '93.184.216.34', family: 'ipv4' }] }),
     check(permission: string): boolean {
@@ -164,13 +166,13 @@ test('hardenSession registers a permission request handler', () => {
     registered = true
     original(handler)
   }
-  hardenSession(session)
+  hardenSession(session as unknown as Parameters<typeof hardenSession>[0])
   assert.ok(registered, 'hardenSession must register a permission handler')
 })
 
 test('hardened session rejects every permission request', () => {
   const session = fakeSession()
-  hardenSession(session)
+  hardenSession(session as unknown as Parameters<typeof hardenSession>[0])
   for (const permission of [
     'media',
     'geolocation',
@@ -188,7 +190,7 @@ test('hardened session rejects every permission request', () => {
 
 test('hardenSession also installs the network-layer SSRF guard', async () => {
   const session = fakeSession()
-  hardenSession(session)
+  hardenSession(session as unknown as Parameters<typeof hardenSession>[0])
   assert.equal(
     await session.requestURL('http://169.254.169.254/latest/meta-data/'),
     true,
@@ -344,7 +346,9 @@ test('installRequestSSRFGuard survives a reporter that throws', async () => {
 test('hardenSession passes the blocked-request reporter through', async () => {
   const blocked: string[] = []
   const session = fakeSession()
-  hardenSession(session, { onBlocked: (url) => blocked.push(url) })
+  hardenSession(session as unknown as Parameters<typeof hardenSession>[0], {
+    onBlocked: (url) => blocked.push(url),
+  })
 
   await session.requestURL('http://169.254.169.254/latest/meta-data/')
 
@@ -356,7 +360,7 @@ test('hardenSession passes the blocked-request reporter through', async () => {
 // other capability probes that never raise a prompt (#789).
 test('hardenSession registers a permission check handler', () => {
   const session = fakeSession()
-  hardenSession(session)
+  hardenSession(session as unknown as Parameters<typeof hardenSession>[0])
   assert.ok(
     session.hasCheckHandler(),
     'hardenSession must register a permission check handler',
@@ -369,7 +373,7 @@ test('hardened session answers no to every permission check', () => {
   // check-only, while `display-capture`, `keyboardLock`, `speaker-selection`
   // and `window-management` are request-only.
   const session = fakeSession()
-  hardenSession(session)
+  hardenSession(session as unknown as Parameters<typeof hardenSession>[0])
   for (const permission of [
     'media',
     'mediaKeySystem',

--- a/packages/streamwall/src/main/viewStateMachine.test.ts
+++ b/packages/streamwall/src/main/viewStateMachine.test.ts
@@ -1,4 +1,4 @@
-import { MAX_VIEW_ERROR_LENGTH } from 'streamwall-shared'
+import { asCellIdx, asViewId, MAX_VIEW_ERROR_LENGTH } from 'streamwall-shared'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import log from './logger'
 
@@ -69,7 +69,7 @@ function makeActor(retry: RetryConfig, loadPageImpl?: () => Promise<void>) {
   })
   return createActor(machine, {
     input: {
-      id: 1,
+      id: asViewId(1),
       view: {} as never,
       win: {} as never,
       offscreenWin: {} as never,
@@ -87,7 +87,7 @@ const OTHER_CONTENT = {
   url: 'https://example.com/other-stream',
   kind: 'video' as const,
 }
-const POS = { x: 0, y: 0, width: 100, height: 100, spaces: [0] }
+const POS = { x: 0, y: 0, width: 100, height: 100, spaces: [asCellIdx(0)] }
 
 function display(actor: ReturnType<typeof makeActor>) {
   actor.send({ type: 'DISPLAY', pos: POS, content: CONTENT })
@@ -542,7 +542,7 @@ describe('viewStateMachine volume control', () => {
     })
     const actor = createActor(machine, {
       input: {
-        id: 1,
+        id: asViewId(1),
         view: {} as never,
         win: {} as never,
         offscreenWin: {} as never,
@@ -610,12 +610,24 @@ describe('viewStateMachine content swap while running (seamless preload)', () =>
     url: 'https://example.com/other-stream',
     kind: 'video' as const,
   }
-  const OTHER_POS = { x: 10, y: 10, width: 50, height: 50, spaces: [1] }
+  const OTHER_POS = {
+    x: 10,
+    y: 10,
+    width: 50,
+    height: 50,
+    spaces: [asCellIdx(1)],
+  }
   const THIRD_CONTENT = {
     url: 'https://example.com/third-stream',
     kind: 'video' as const,
   }
-  const THIRD_POS = { x: 20, y: 20, width: 30, height: 30, spaces: [2] }
+  const THIRD_POS = {
+    x: 20,
+    y: 20,
+    width: 30,
+    height: 30,
+    spaces: [asCellIdx(2)],
+  }
 
   // Same setup as makeActor, but with spies on the placement/swap actions and
   // a fake createNextView/disposeView pair so tests can assert exactly when a
@@ -653,7 +665,7 @@ describe('viewStateMachine content swap while running (seamless preload)', () =>
     })
     const actor = createActor(machine, {
       input: {
-        id: 1,
+        id: asViewId(1),
         view: {} as never,
         win: {} as never,
         offscreenWin: {} as never,
@@ -910,7 +922,7 @@ describe('viewStateMachine loadPage navigation', () => {
     })
     const actor = createActor(machine, {
       input: {
-        id: 1,
+        id: asViewId(1),
         view: view as never,
         win: {} as never,
         offscreenWin: {} as never,
@@ -1538,7 +1550,7 @@ describe('viewStateMachine pause/resume IPC (issue #374)', () => {
     })
     const actor = createActor(machine, {
       input: {
-        id: 1,
+        id: asViewId(1),
         view: {} as never,
         win: {} as never,
         offscreenWin: {} as never,
@@ -1695,7 +1707,7 @@ describe('viewStateMachine resyncSwappedView pause re-send (issue #621)', () => 
     })
     const actor = createActor(machine, {
       input: {
-        id: 1,
+        id: asViewId(1),
         view: {} as never,
         win: {} as never,
         offscreenWin: {} as never,
@@ -1810,7 +1822,13 @@ describe('viewStateMachine performSwap while the cell is parked (issue #741)', (
     }
   }
 
-  const NEW_POS = { x: 10, y: 20, width: 50, height: 60, spaces: [1] }
+  const NEW_POS = {
+    x: 10,
+    y: 20,
+    width: 50,
+    height: 60,
+    spaces: [asCellIdx(1)],
+  }
 
   /**
    * Runs the *real* `performSwap`, `positionView` and `offscreenView` (the
@@ -1850,7 +1868,7 @@ describe('viewStateMachine performSwap while the cell is parked (issue #741)', (
     })
     const actor = createActor(machine, {
       input: {
-        id: 1,
+        id: asViewId(1),
         view: view as never,
         win: win as never,
         offscreenWin: offscreenWin as never,

--- a/packages/streamwall/src/renderer/OverlayRoot.test.tsx
+++ b/packages/streamwall/src/renderer/OverlayRoot.test.tsx
@@ -1,10 +1,12 @@
 // @vitest-environment happy-dom
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
-import type {
-  StreamData,
-  StreamWindowConfig,
-  ViewState,
+import {
+  asCellIdx,
+  asViewId,
+  type StreamData,
+  type StreamWindowConfig,
+  type ViewState,
 } from 'streamwall-shared'
 import { afterEach, describe, expect, test } from 'vitest'
 import { Overlay } from './OverlayRoot'
@@ -36,14 +38,26 @@ function makeView(idx: number, label: string): ViewState {
   return {
     state: {
       displaying: {
-        running: { playback: 'playing', video: 'normal', audio: 'muted' },
+        running: {
+          playback: 'playing',
+          video: 'normal',
+          audio: 'muted',
+          pause: 'unpaused',
+          swap: 'idle',
+        },
       },
     },
     context: {
-      id: idx,
+      id: asViewId(idx),
       content: { url: `https://example.com/${label}`, kind: 'video' },
       info: null,
-      pos: { x: idx * 100, y: 0, width: 100, height: 100, spaces: [idx] },
+      pos: {
+        x: idx * 100,
+        y: 0,
+        width: 100,
+        height: 100,
+        spaces: [asCellIdx(idx)],
+      },
       error: null,
       volume: 1,
     },

--- a/packages/streamwall/src/renderer/playHLS.test.ts
+++ b/packages/streamwall/src/renderer/playHLS.test.ts
@@ -242,11 +242,11 @@ describe('playHLS', () => {
 
     const realCreateElement = document.createElement.bind(document)
     let createdVideo: HTMLVideoElement | undefined
-    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+    vi.spyOn(document, 'createElement').mockImplementation(((tag: string) => {
       const el = realCreateElement(tag)
       if (tag === 'video') createdVideo = el as HTMLVideoElement
       return el
-    })
+    }) as typeof document.createElement)
 
     setSrc('https://stream.example/live.m3u8')
     await import('./playHLS')

--- a/packages/streamwall/tsconfig.json
+++ b/packages/streamwall/tsconfig.json
@@ -23,5 +23,5 @@
     "allowImportingTsExtensions": true,
     "noEmit": true
   },
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/test/tsconfig-test-coverage.test.mjs
+++ b/test/tsconfig-test-coverage.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)))
+
+function readPackageJson(relativePath) {
+  return JSON.parse(readFileSync(join(rootDir, relativePath), 'utf8'))
+}
+
+function workspaceDirs() {
+  const rootPackageJson = readPackageJson('package.json')
+  return rootPackageJson.workspaces
+}
+
+// tsconfig.json is allowed a small amount of JSONC (`//` line comments) in
+// this repo - strip them before parsing so this guard does not have to take
+// on a full JSONC dependency for one feature.
+function readTsconfig(relativePath) {
+  const raw = readFileSync(join(rootDir, relativePath), 'utf8')
+  const withoutComments = raw.replace(/^\s*\/\/.*$/gm, '')
+  return JSON.parse(withoutComments)
+}
+
+// `npm run typecheck` runs `tsc --noEmit -p tsconfig.json` per workspace, and
+// `vitest run`/`node --test` do no type checking of their own - so a workspace
+// tsconfig that excludes its own test files is never type-checked by any CI
+// job. That gap let `packages/streamwall`'s test files go uncovered until
+// issue #748 fixed it; this guard keeps it from silently reappearing there or
+// in any newly added package.
+test('no workspace tsconfig.json excludes its own test files from typechecking', () => {
+  for (const workspace of workspaceDirs()) {
+    const tsconfigPath = join(workspace, 'tsconfig.json')
+    if (!existsSync(join(rootDir, tsconfigPath))) {
+      continue
+    }
+
+    const { exclude = [] } = readTsconfig(tsconfigPath)
+    const testExcludes = exclude.filter((pattern) =>
+      /\.test\.(ts|tsx)/.test(pattern),
+    )
+
+    assert.deepEqual(
+      testExcludes,
+      [],
+      `${tsconfigPath} excludes test files from typechecking via ` +
+        `${JSON.stringify(testExcludes)} - this package's own tests would ` +
+        'never be type-checked by any CI job',
+    )
+  }
+})


### PR DESCRIPTION
## Problem

`packages/streamwall`'s `tsconfig.json` excluded `**/*.test.ts`/`**/*.test.tsx` from `tsc`, unlike every sibling package. Since `npm run typecheck` runs `tsc --noEmit -p tsconfig.json` per workspace and `vitest run` performs no type checking, this package's ~1100 test cases were the only ones in the monorepo never type-checked by any CI job.

## Solution

- Dropped `"**/*.test.ts", "**/*.test.tsx"` from `packages/streamwall/tsconfig.json`'s `exclude` (matching `streamwall-control-ui`, which has no exclude at all).
- Fixed every type error this surfaced across 16 test files:
  - `ViewId`/`CellIdx` branded-type fixtures now go through `asViewId`/`asCellIdx` from `streamwall-shared` instead of raw numbers (`StreamWindow.test.ts`, `viewStateMachine.test.ts`, `OverlayRoot.test.tsx`, `commandHandlers.test.ts`).
  - A `makeStreams()` helper in `StreamWindow.test.ts` replaces ad hoc `{ byURL: new Map(...) }` literals with a properly-typed `StreamList` stand-in (`setViews`/`displayPlannedViews` only ever read `.byURL`, never the array itself).
  - Missing `StreamData`/`StreamWindowConfig` fixture fields added (`_dataSource`, `frameless`/`fullscreen`/`activeColor`/`backgroundColor`).
  - `vi.fn()` mocks given explicit signatures where the untyped/implementation-inferred type didn't match the real function they stand in for (`ipcMain.handle`, `webContents.send` access via `vi.mocked(...)`, forge's `spawnSync`, `setIntervalImpl`, `resolveHost`, `registerPackagingTmpdirFallbackCleanup`, `getTokenInfo`).
  - A couple of implicit-any callback params and a `DataSourceType`/`ContentKind` literal typo (`'json'` → `'json-url'`).
  - `hardenSession`'s test double cast to its real parameter type at each call site, since the hand-rolled fake session's simplified handler types don't structurally match Electron's `Session`.
- Added `test/tsconfig-test-coverage.test.mjs`, mirroring the existing `test/*.test.mjs` config guards, asserting no workspace `tsconfig.json` excludes test files from typechecking — so this gap cannot silently regress or reappear in a newly added package.

## Build safety

Verified the Vite/Electron Forge build is unaffected: `vite.main.config.ts`/`vite.preload.config.ts`/`vite.renderer.config.ts` bundle from explicit entry points and never read `tsconfig.json`'s `include`/`exclude`. `packages/streamwall` has no `build` script — packaging goes through `electron-forge package/make/publish`, gated by a `prePackage` hook (`forge.typecheck.ts`) that just shells out to `npm run typecheck`, unaffected by which files that command now covers.

## Testing performed

- `npm run typecheck` (all workspaces) — clean.
- `npm run lint` — clean.
- `npm run format` — no changes beyond what was already committed.
- `npm run test` (full repo) — 2398 tests passed across all 6 suites, including the new guard test.
- Manually verified the guard test fails against the regression (temporarily reintroduced the old `exclude` entries, confirmed `node --test test/tsconfig-test-coverage.test.mjs` fails, then reverted).

## Risks / breaking changes

None expected — this is a type-checking coverage change plus type-only fixes to test files. No production source file was touched, and no test's exercised behavior or assertions changed.

## Pre-PR review

One independent review round (fresh subagent with no prior context) returned `NO FINDINGS`.

Closes #748