### PR TITLE
fix(control-client): fire evicted response callbacks instead of dropping them

### DIFF
--- a/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.test.tsx
+++ b/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.test.tsx
@@ -280,9 +280,9 @@ describe('useStreamwallWebsocketConnection', () => {
         vi.advanceTimersByTime(60_000)
       })
 
-      // If any of the 500 callbacks were still pending, a late close would
-      // still invoke them. None should fire, because they were already
-      // evicted by the timeout, not by this close.
+      // Each is evicted with a synthetic error exactly once (issue #819) - if
+      // any were still pending, a later close would invoke them a second
+      // time.
       const lateCallbacks = Array.from({ length: 500 }, () => vi.fn())
       for (const cb of lateCallbacks) {
         act(() => {
@@ -292,12 +292,16 @@ describe('useStreamwallWebsocketConnection', () => {
       act(() => {
         vi.advanceTimersByTime(60_000)
       })
+      for (const cb of lateCallbacks) {
+        expect(cb).toHaveBeenCalledTimes(1)
+      }
+
       act(() => {
         socket.dispatch('close')
       })
 
       for (const cb of lateCallbacks) {
-        expect(cb).not.toHaveBeenCalled()
+        expect(cb).toHaveBeenCalledTimes(1)
       }
     })
 
@@ -321,6 +325,128 @@ describe('useStreamwallWebsocketConnection', () => {
       expect(cb).toHaveBeenCalledTimes(1)
       expect(cb).toHaveBeenCalledWith(
         expect.objectContaining({ response: true, id: 0, tokenId: 't' }),
+      )
+    })
+  })
+
+  // PR #759 / issue #745 introduced the eviction above but deleted the
+  // callback without ever invoking it, so a reply that genuinely takes
+  // longer than RESPONSE_TIMEOUT_MS to arrive was dropped on the floor: the
+  // operator saw neither success nor an error (issue #819, a regression of
+  // the silent-failure fix from issue #35).
+  describe('firing the evicted response callback instead of dropping it (issue #819)', () => {
+    const setViewVolumeCommand: ControlCommand = {
+      type: 'set-view-volume',
+      viewId: asViewId(0),
+      volume: 0.5,
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('invokes the callback with an error once the eviction window elapses, instead of dropping it', () => {
+      const { getConnection } = mount()
+      const cb = vi.fn()
+
+      act(() => {
+        getConnection().send(setViewVolumeCommand, cb)
+      })
+      act(() => {
+        vi.advanceTimersByTime(5000)
+      })
+
+      expect(cb).toHaveBeenCalledTimes(1)
+      expect(cb).toHaveBeenCalledWith(
+        expect.objectContaining({ error: expect.any(String) }),
+      )
+    })
+
+    it('logs a late reply that arrives after eviction instead of silently dropping it', () => {
+      const { getConnection } = mount()
+      const socket = instances[0]!
+      const cb = vi.fn()
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      act(() => {
+        getConnection().send(setViewVolumeCommand, cb)
+      })
+      act(() => {
+        vi.advanceTimersByTime(5000)
+      })
+      expect(cb).toHaveBeenCalledTimes(1)
+
+      act(() => {
+        socket.dispatch('message', {
+          data: JSON.stringify({ response: true, id: 0, ok: true }),
+        })
+      })
+
+      // The already-evicted callback must not be invoked a second time...
+      expect(cb).toHaveBeenCalledTimes(1)
+      // ...but the late reply is logged rather than silently dropped.
+      expect(warn).toHaveBeenCalled()
+      warn.mockRestore()
+    })
+
+    it('clears the eviction timer once a reply arrives, so it never later fires a synthetic error too', () => {
+      const { getConnection } = mount()
+      const socket = instances[0]!
+      const cb = vi.fn()
+
+      act(() => {
+        getConnection().send(createInviteCommand, cb)
+      })
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+      act(() => {
+        socket.dispatch('message', {
+          data: JSON.stringify({ response: true, id: 0, tokenId: 't' }),
+        })
+      })
+      expect(cb).toHaveBeenCalledTimes(1)
+
+      // Advance well past every eviction window this codebase uses. If the
+      // timer were not cleared, the callback would fire a second time with a
+      // synthetic timeout error.
+      act(() => {
+        vi.advanceTimersByTime(60_000)
+      })
+
+      expect(cb).toHaveBeenCalledTimes(1)
+    })
+
+    it('gives the scrypt-backed create-invite/delete-token commands a longer eviction window than other commands', () => {
+      const { getConnection } = mount()
+      const volumeCb = vi.fn()
+      const inviteCb = vi.fn()
+
+      act(() => {
+        getConnection().send(setViewVolumeCommand, volumeCb)
+      })
+      act(() => {
+        getConnection().send(createInviteCommand, inviteCb)
+      })
+
+      // Past the plain 5s window: the non-scrypt command is evicted...
+      act(() => {
+        vi.advanceTimersByTime(5000)
+      })
+      expect(volumeCb).toHaveBeenCalledTimes(1)
+      // ...but create-invite is still waiting.
+      expect(inviteCb).not.toHaveBeenCalled()
+
+      act(() => {
+        vi.advanceTimersByTime(60_000)
+      })
+      expect(inviteCb).toHaveBeenCalledTimes(1)
+      expect(inviteCb).toHaveBeenCalledWith(
+        expect.objectContaining({ error: expect.any(String) }),
       )
     })
   })

--- a/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.ts
+++ b/packages/streamwall-control-client/src/useStreamwallWebsocketConnection.ts
@@ -65,10 +65,17 @@ function patchState(
   return patched as StreamwallState
 }
 
+/** A callback awaiting a response, plus the eviction timer guarding it. */
+interface PendingResponse {
+  cb: (msg: object) => void
+  /** Cleared once the reply arrives, so eviction never fires afterward. */
+  timeoutId: ReturnType<typeof setTimeout>
+}
+
 interface WsRef {
   ws: ReconnectingWebSocket
   msgId: number
-  responseMap: Map<number, (msg: object) => void>
+  responseMap: Map<number, PendingResponse>
 }
 
 /**
@@ -80,6 +87,22 @@ interface WsRef {
  * server to answer the commands that do reply.
  */
 const RESPONSE_TIMEOUT_MS = 5000
+
+/**
+ * Eviction window for the two commands the server answers by deriving a
+ * scrypt hash (`create-invite`, `delete-token`): tens of milliseconds of
+ * libuv-threadpool work each (issues #735/#799) that can queue behind other
+ * derivations on a loaded or modest self-hosted box. `RESPONSE_TIMEOUT_MS` is
+ * comfortably enough for every other command, which the control server never
+ * derives anything for (issue #819).
+ */
+const CRYPTO_RESPONSE_TIMEOUT_MS = 15000
+
+function responseTimeoutMsFor(commandType: string): number {
+  return commandType === 'create-invite' || commandType === 'delete-token'
+    ? CRYPTO_RESPONSE_TIMEOUT_MS
+    : RESPONSE_TIMEOUT_MS
+}
 
 /**
  * WebSocket adapter: the transport-specific half of the collab wiring the
@@ -111,19 +134,30 @@ function useWebsocketCollabTransport(wsEndpoint: string): CollabTransport {
         }
         ws.send(JSON.stringify({ ...msg, id: msgId }))
         if (cb) {
-          responseMap.set(msgId, cb)
           // The control server only ever answers a handful of commands
           // (create-invite, delete-token); every other command is forwarded
           // to the uplink with no reply. createErrorSurfacingSend always
           // supplies a callback (to surface `{ error }` responses), so
           // without this eviction a forwarded command's entry - and the
           // closure it holds - would sit in responseMap for the lifetime of
-          // the socket instead of just until the next close (issue #745). A
-          // reply that does arrive after eviction is simply ignored, same as
-          // any other late reply for an id no longer in the map.
-          setTimeout(() => {
-            responseMap.delete(msgId)
-          }, RESPONSE_TIMEOUT_MS)
+          // the socket instead of just until the next close (issue #745).
+          //
+          // Eviction fires the callback with a synthetic error rather than
+          // just deleting the entry: PR #759 introduced this timer but left
+          // the callback uninvoked, so a reply that genuinely took longer
+          // than the window arrived to no callback and was silently dropped
+          // - the operator saw neither success nor an error (issue #819).
+          const timeoutId = setTimeout(() => {
+            const pending = responseMap.get(msgId)
+            if (pending) {
+              responseMap.delete(msgId)
+              pending.cb({
+                response: true,
+                error: 'No response from the server',
+              })
+            }
+          }, responseTimeoutMsFor(msg.type))
+          responseMap.set(msgId, { cb, timeoutId })
         }
         wsRef.current.msgId++
       },
@@ -181,7 +215,8 @@ function useWebsocketCollabTransport(wsEndpoint: string): CollabTransport {
           events.onClose()
           const { responseMap } = wsRef.current ?? {}
           if (responseMap) {
-            for (const responseCb of responseMap.values()) {
+            for (const { cb: responseCb, timeoutId } of responseMap.values()) {
+              clearTimeout(timeoutId)
               responseCb({ response: true, error: 'Connection closed' })
             }
             responseMap.clear()
@@ -204,10 +239,20 @@ function useWebsocketCollabTransport(wsEndpoint: string): CollabTransport {
           const msg = JSON.parse(ev.data)
           if (msg.response && wsRef.current != null) {
             const { responseMap } = wsRef.current
-            const responseCb = responseMap.get(msg.id)
-            if (responseCb) {
+            const pending = responseMap.get(msg.id)
+            if (pending) {
               responseMap.delete(msg.id)
-              responseCb(msg)
+              clearTimeout(pending.timeoutId)
+              pending.cb(msg)
+            } else {
+              // No pending callback for this id: either it was already
+              // evicted with a synthetic timeout error (issue #819) and the
+              // caller has moved on, or the id is otherwise stale. Either
+              // way, log the late reply instead of silently dropping it.
+              console.warn(
+                'Ignored a Streamwall response with no pending callback:',
+                msg,
+              )
             }
           } else if (msg.type === 'state') {
             desynced = false


### PR DESCRIPTION
## Problem

`useStreamwallWebsocketConnection`'s 5s `responseMap` eviction timer (added by PR #759 / issue #745) deleted a pending response callback without ever invoking it. A reply that genuinely took longer than the window to arrive - realistic for the scrypt-backed `create-invite`/`delete-token` commands under load - was silently dropped: the operator saw neither success nor an error, regressing the silent-failure fix from issue #35.

## Solution

- `responseMap` now stores `{ cb, timeoutId }` instead of a bare callback.
- The eviction timer invokes the callback with a synthetic `{ response: true, error: 'No response from the server' }` instead of just deleting the entry.
- The timer is cleared when a real reply arrives (and on socket close), so it can never also fire a synthetic error after the callback has already been resolved.
- A reply that still arrives with no matching entry (already evicted, or an otherwise stale id) is logged via `console.warn` instead of being silently dropped.
- `create-invite` and `delete-token` - the only two commands the control server answers by deriving a scrypt hash - get a longer eviction window (`CRYPTO_RESPONSE_TIMEOUT_MS`, 15s) than every other command (`RESPONSE_TIMEOUT_MS`, 5s), since their reply can queue behind other derivations on a loaded box.

## Testing

All new behavior is covered by `useStreamwallWebsocketConnection.test.tsx` (TDD: tests written first, confirmed failing against the pre-fix code, then made to pass):

- Eviction fires the callback with an error instead of dropping it.
- A late reply arriving after eviction is logged and does not double-invoke the callback.
- A reply arriving before eviction clears the timer, so no synthetic error fires afterward.
- `create-invite` gets the longer, scrypt-aware eviction window while a plain command still evicts at 5s.

One pre-existing test (`does not grow responseMap forever for a forwarded command that never gets a reply`) asserted the old, buggy behavior (late callbacks never firing); it now asserts the corrected behavior (each fires exactly once, from eviction, not a second time from a later close).

Full quality gate (`format`, `lint`, `typecheck`, `test`) is green across the whole monorepo (2425 tests).

## Pre-PR review

One independent review round (fresh subagent, no session context) returned `NO FINDINGS`. It additionally verified, by temporarily reverting to the pre-fix implementation, that the new tests genuinely fail without the fix.

## Risks / breaking changes

None. Purely additive behavior on an internal client hook; the public `send(msg, cb)` API is unchanged.

Closes #819