### PR TITLE
fix(control-server): share one scrypt rate-limit bucket across deriving routes

### DIFF
--- a/packages/streamwall-control-server/src/index.ts
+++ b/packages/streamwall-control-server/src/index.ts
@@ -29,6 +29,7 @@ import {
 import { registerInviteRoutes } from './inviteExchange/invite.ts'
 import { getLoggerOptions, type LogLevel } from './logger.ts'
 import type { Clock } from './rateLimiter.ts'
+import { createScryptRateLimit } from './scryptRateLimit.ts'
 import {
   captureException,
   initSentry,
@@ -244,13 +245,16 @@ export async function initApp({
     },
   })
 
+  // One limiter instance, hence one store, for every route that verifies a
+  // credential. A per-route `config.rateLimit` object would have given each of
+  // them a private store and therefore a private budget — four times the
+  // ceiling this limit is documented to enforce (issue #821).
+  const scryptRateLimit = createScryptRateLimit(app, rateLimitConfig)
+
   await registerInviteRoutes(app, {
     auth,
     isSecure,
-    authRateLimit: {
-      max: rateLimitConfig.authMax,
-      timeWindow: rateLimitConfig.timeWindow,
-    },
+    scryptRateLimit,
   })
   // One cache for both routes: a credential verified for the uplink or for a
   // browser session is the same derivation either way, and a single instance
@@ -262,12 +266,12 @@ export async function initApp({
   })
 
   registerUplinkRoute(app, ctx, {
-    rateLimit: rateLimitConfig,
+    scryptRateLimit,
     verifiedTokens,
   })
   registerClientRoutes(app, ctx, {
     clientStaticPath,
-    rateLimit: rateLimitConfig,
+    scryptRateLimit,
     verifiedTokens,
   })
 

--- a/packages/streamwall-control-server/src/inviteExchange/invite.ts
+++ b/packages/streamwall-control-server/src/inviteExchange/invite.ts
@@ -1,4 +1,4 @@
-import type { FastifyInstance } from 'fastify'
+import type { FastifyInstance, onRequestAsyncHookHandler } from 'fastify'
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
@@ -34,8 +34,8 @@ export interface InviteRouteOptions {
   auth: Auth
   /** Whether the server is reached over TLS, gating the `Secure` cookie flag. */
   isSecure: boolean
-  /** Per-IP budget for the scrypt-bearing redemption route. */
-  authRateLimit: { max: number; timeWindow: string }
+  /** The limiter shared by every scrypt-deriving route. */
+  scryptRateLimit: onRequestAsyncHookHandler
 }
 
 /**
@@ -46,7 +46,7 @@ export interface InviteRouteOptions {
  */
 export async function registerInviteRoutes(
   app: FastifyInstance,
-  { auth, isSecure, authRateLimit }: InviteRouteOptions,
+  { auth, isSecure, scryptRateLimit }: InviteRouteOptions,
 ): Promise<void> {
   const pageHtml = await invitePageHtml()
   const exchangeScript = await inviteExchangeScript()
@@ -70,16 +70,16 @@ export async function registerInviteRoutes(
 
   // Redeems an invite. The secret arrives in the request body (not the URL),
   // and this route runs the expensive scrypt verification, so it carries the
-  // strict auth rate limit.
+  // strict auth rate limit — the one shared across every deriving route, which
+  // is why the budget is spent through the hook rather than a per-route config
+  // (issue #821). A redemption is unconditionally charged: the body is not
+  // parsed yet when the limiter runs, so there is nothing to classify on, and
+  // a redemption that carries no token has no legitimate caller anyway.
   app.post<{ Params: { id: string }; Body: { token?: string } }>(
     '/invite/:id',
     {
-      config: {
-        rateLimit: {
-          max: authRateLimit.max,
-          timeWindow: authRateLimit.timeWindow,
-        },
-      },
+      onRequest: scryptRateLimit,
+      config: { rateLimit: false, scryptDerives: () => true },
     },
     async (request, reply) => {
       const { id } = request.params

--- a/packages/streamwall-control-server/src/scryptRateLimit.test.ts
+++ b/packages/streamwall-control-server/src/scryptRateLimit.test.ts
@@ -484,4 +484,105 @@ describe('scrypt-bearing routes', () => {
       'a throttled handshake must be refused before any scrypt work',
     )
   })
+
+  test('the strict budget is one bucket per IP, not one per route', async () => {
+    // `@fastify/rate-limit` hands every route carrying its own `config.rateLimit`
+    // object a fresh store, so four scrypt-deriving routes used to mean four
+    // independent budgets — four times the ceiling this limit documents
+    // (issue #821). One IP gets one budget for scrypt work, whichever route it
+    // spends it on.
+    setEnvForTest({
+      STREAMWALL_RATE_LIMIT_MAX: '100',
+      STREAMWALL_AUTH_RATE_LIMIT_MAX: '2',
+    })
+    const { app, auth } = await buildTestApp()
+    after(() => app.close())
+    const invite = await auth.createToken({
+      kind: 'invite',
+      role: 'admin',
+      name: 'client',
+    })
+
+    for (let i = 0; i < 2; i++) {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/admin/status',
+        headers: { cookie: `${SESSION_COOKIE_NAME}=aaaaaaaa:bbbb${i}` },
+      })
+      assert.equal(res.statusCode, 403, 'the budget must be spent, not refused')
+    }
+    const spent = await app.inject({
+      method: 'GET',
+      url: '/admin/status',
+      headers: { cookie: `${SESSION_COOKIE_NAME}=aaaaaaaa:cccc` },
+    })
+    assert.equal(
+      spent.statusCode,
+      429,
+      'the strict budget must be spent for this spec to mean anything',
+    )
+
+    const derivations = countDerivations(auth)
+    const redeem = await app.inject({
+      method: 'POST',
+      url: `/invite/${invite.tokenId}`,
+      headers: { 'content-type': 'application/json' },
+      payload: { token: invite.secret },
+    })
+    assert.equal(
+      redeem.statusCode,
+      429,
+      'the invite route must share the strict budget, not hold its own',
+    )
+    assert.equal(
+      derivations.calls,
+      0,
+      'a throttled redemption must be refused before any scrypt work',
+    )
+  })
+
+  test('a spent strict budget also refuses the uplink handshake', async () => {
+    // Same shared bucket seen from the other end: the desktop uplink route is
+    // the fourth scrypt-deriving route and must not hand out a fresh budget
+    // after the browser-facing ones have spent theirs (issue #821).
+    setEnvForTest({
+      STREAMWALL_RATE_LIMIT_MAX: '100',
+      STREAMWALL_AUTH_RATE_LIMIT_MAX: '2',
+    })
+    const { app, auth } = await buildTestApp()
+    after(() => app.close())
+    const port = await listenTestApp(app)
+    const { base } = await mintUplinkToken(auth, port)
+
+    for (let i = 0; i < 3; i++) {
+      await app.inject({
+        method: 'GET',
+        url: '/admin/status',
+        headers: { cookie: `${SESSION_COOKIE_NAME}=aaaaaaaa:bbbb${i}` },
+      })
+    }
+
+    const derivations = countDerivations(auth)
+    const ws = new WebSocket(base, {
+      headers: { authorization: 'Bearer wrong-secret' },
+    })
+    ws.on('error', () => {})
+    after(() => ws.terminate())
+    const outcome = await Promise.race([
+      once(ws, 'open').then(() => 'open'),
+      once(ws, 'unexpected-response').then(
+        (args) => `http-${(args[1] as { statusCode: number }).statusCode}`,
+      ),
+    ])
+    assert.equal(
+      outcome,
+      'http-429',
+      'the uplink handshake must share the strict budget, not hold its own',
+    )
+    assert.equal(
+      derivations.calls,
+      0,
+      'a throttled handshake must be refused before any scrypt work',
+    )
+  })
 })

--- a/packages/streamwall-control-server/src/scryptRateLimit.ts
+++ b/packages/streamwall-control-server/src/scryptRateLimit.ts
@@ -1,0 +1,74 @@
+import type {
+  FastifyInstance,
+  FastifyRequest,
+  onRequestAsyncHookHandler,
+} from 'fastify'
+
+import type { RateLimitConfig } from './config.ts'
+
+/** Where a request remembers whether it was charged for a derivation. */
+const DERIVES = Symbol('streamwall.derivesToken')
+
+/**
+ * Decides whether serving this request will have to run a scrypt derivation.
+ * Each deriving route supplies its own — the browser surface reads the session
+ * cookie, the uplink its bearer token — and declares it in the route's config
+ * so the one shared limiter can ask without knowing the routes.
+ */
+export type DerivationClassifier = (request: FastifyRequest) => boolean
+
+declare module 'fastify' {
+  interface FastifyContextConfig {
+    /**
+     * Set on every route guarded by the shared scrypt limiter. Its absence
+     * means the route never derives, so it stays on the global budget.
+     */
+    scryptDerives?: DerivationClassifier
+  }
+}
+
+/**
+ * Builds the single limiter shared by every scrypt-deriving route.
+ *
+ * `@fastify/rate-limit` gives each route carrying its own `config.rateLimit`
+ * object a private store (`store.child()` returns a fresh LRU), so per-route
+ * configs meant one independent budget per route — four times the ceiling the
+ * strict limit documents (issue #821). One limiter instance built here holds
+ * one store, and the routes attach it as their `onRequest` hook, so the whole
+ * scrypt-deriving surface spends a single per-IP budget.
+ *
+ * The bucket separation introduced with the strict limit (issue #735) is
+ * unchanged: only a request that will actually derive is charged to
+ * `<ip>:derive`; a request riding a credential the server already verified —
+ * or carrying none at all — stays on `<ip>:verified` at the global budget, so
+ * an attacker spraying unknown credentials can never lock a known operator out
+ * of their own socket.
+ */
+export function createScryptRateLimit(
+  app: FastifyInstance,
+  rateLimit: RateLimitConfig,
+): onRequestAsyncHookHandler {
+  /**
+   * `keyGenerator` and `max` both run per request and must agree, so the
+   * classification is computed once and remembered on the request rather than
+   * re-derived from a cache that may have changed in between.
+   */
+  const derivesOnce = (request: FastifyRequest): boolean => {
+    const memo = request as unknown as Record<symbol, boolean | undefined>
+    memo[DERIVES] ??=
+      request.routeOptions.config?.scryptDerives?.(request) ?? false
+    return memo[DERIVES]
+  }
+
+  // Typed as a `preHandler` handler by the plugin's declarations, but the
+  // handler it builds only ever takes `(request, reply)` and its own default
+  // hook is `onRequest` — which is where this has to run, so a handshake or a
+  // request body is refused before anything parses it.
+  return app.rateLimit({
+    keyGenerator: (request: FastifyRequest) =>
+      `${request.ip}:${derivesOnce(request) ? 'derive' : 'verified'}`,
+    max: (request: FastifyRequest) =>
+      derivesOnce(request) ? rateLimit.authMax : rateLimit.globalMax,
+    timeWindow: rateLimit.timeWindow,
+  }) as unknown as onRequestAsyncHookHandler
+}

--- a/packages/streamwall-control-server/src/ws/client.ts
+++ b/packages/streamwall-control-server/src/ws/client.ts
@@ -1,5 +1,9 @@
 import fastifyStatic from '@fastify/static'
-import type { FastifyInstance, FastifyRequest } from 'fastify'
+import type {
+  FastifyInstance,
+  FastifyRequest,
+  onRequestAsyncHookHandler,
+} from 'fastify'
 import WebSocket from 'ws'
 import * as Y from 'yjs'
 
@@ -9,7 +13,7 @@ import {
   type StreamwallRole,
 } from 'streamwall-shared'
 import { uniqueRand62 } from '../auth.ts'
-import { SESSION_COOKIE_NAME, type RateLimitConfig } from '../config.ts'
+import { SESSION_COOKIE_NAME } from '../config.ts'
 import { type AppContext, type Client } from '../context.ts'
 import { identityDebugFields, identityFields } from '../logger.ts'
 import { applyValidatedDocUpdate } from '../stateDocGuard.ts'
@@ -23,14 +27,11 @@ import {
 export interface ClientRouteOptions {
   /** Filesystem root of the built control client served at `/`. */
   clientStaticPath: string
-  /** Per-IP budgets: the strict one guards routes that derive a token hash. */
-  rateLimit: RateLimitConfig
+  /** The limiter shared by every scrypt-deriving route. */
+  scryptRateLimit: onRequestAsyncHookHandler
   /** Shared cache of recently verified credentials. */
   verifiedTokens: VerifiedTokenCache
 }
-
-/** Where a request remembers whether it was charged for a derivation. */
-const DERIVES = Symbol('streamwall.derivesToken')
 
 /** Splits an `s` cookie into its token id and secret, or null if malformed. */
 function parseSessionCookie(
@@ -62,7 +63,7 @@ function parseSessionCookie(
 export function registerClientRoutes(
   app: FastifyInstance,
   ctx: AppContext,
-  { clientStaticPath, rateLimit, verifiedTokens }: ClientRouteOptions,
+  { clientStaticPath, scryptRateLimit, verifiedTokens }: ClientRouteOptions,
 ): void {
   /**
    * Whether serving this request will have to derive a token hash. Evaluated
@@ -88,28 +89,16 @@ export function registerClientRoutes(
   }
 
   /**
-   * `keyGenerator` and `max` both run per request and must agree, so the
-   * classification is computed once and remembered on the request rather than
-   * re-derived from a cache that may have changed in between.
-   */
-  const derivesOnce = (request: FastifyRequest): boolean => {
-    const memo = request as unknown as Record<symbol, boolean | undefined>
-    memo[DERIVES] ??= derives(request)
-    return memo[DERIVES]
-  }
-
-  /**
    * Only a request that actually has to derive is charged against the strict
    * budget; everything else stays on the global one. The two live in separate
    * buckets, so a browser reconnecting on a known session can never be locked
-   * out by an attacker spraying unknown cookies from the same IP.
+   * out by an attacker spraying unknown cookies from the same IP. Both buckets
+   * are held by the one limiter shared with the other deriving routes, so the
+   * strict budget bounds scrypt work per IP rather than per route (issue #821).
    */
-  const derivationRateLimit = {
-    keyGenerator: (request: FastifyRequest) =>
-      `${request.ip}:${derivesOnce(request) ? 'derive' : 'verified'}`,
-    max: (request: FastifyRequest) =>
-      derivesOnce(request) ? rateLimit.authMax : rateLimit.globalMax,
-    timeWindow: rateLimit.timeWindow,
+  const derivationRouteConfig = {
+    onRequest: scryptRateLimit,
+    config: { rateLimit: false as const, scryptDerives: derives },
   }
 
   const authenticate = async (request: FastifyRequest) => {
@@ -141,7 +130,7 @@ export function registerClientRoutes(
       '/admin/status',
       {
         preHandler: authenticate,
-        config: { rateLimit: derivationRateLimit },
+        ...derivationRouteConfig,
       },
       async (request, reply) => {
         if (!roleCan(request.identity?.role ?? null, 'view-server-status')) {
@@ -164,7 +153,7 @@ export function registerClientRoutes(
       {
         websocket: true,
         preHandler: authenticate,
-        config: { rateLimit: derivationRateLimit },
+        ...derivationRouteConfig,
       },
       async (ws, request) => {
         ws.binaryType = 'arraybuffer'

--- a/packages/streamwall-control-server/src/ws/uplink.ts
+++ b/packages/streamwall-control-server/src/ws/uplink.ts
@@ -1,4 +1,8 @@
-import type { FastifyInstance, FastifyRequest } from 'fastify'
+import type {
+  FastifyInstance,
+  FastifyRequest,
+  onRequestAsyncHookHandler,
+} from 'fastify'
 import * as Y from 'yjs'
 
 import {
@@ -6,7 +10,6 @@ import {
   streamwallStateSchema,
 } from 'streamwall-shared'
 import { StateWrapper } from '../auth.ts'
-import type { RateLimitConfig } from '../config.ts'
 import type { AppContext } from '../context.ts'
 import { identityDebugFields, identityFields } from '../logger.ts'
 import type { VerifiedTokenCache } from '../verifiedTokenCache.ts'
@@ -17,12 +20,9 @@ import {
   startHeartbeat,
 } from '../wsSupport.ts'
 
-/** Where a request remembers whether it was charged for a derivation. */
-const DERIVES = Symbol('streamwall.derivesToken')
-
 export interface UplinkRouteOptions {
-  /** Per-IP budgets: the strict one guards routes that derive a token hash. */
-  rateLimit: RateLimitConfig
+  /** The limiter shared by every scrypt-deriving route. */
+  scryptRateLimit: onRequestAsyncHookHandler
   /** Shared cache of recently verified credentials. */
   verifiedTokens: VerifiedTokenCache
 }
@@ -36,7 +36,7 @@ export interface UplinkRouteOptions {
 export function registerUplinkRoute(
   app: FastifyInstance,
   ctx: AppContext,
-  { rateLimit, verifiedTokens }: UplinkRouteOptions,
+  { scryptRateLimit, verifiedTokens }: UplinkRouteOptions,
 ): void {
   /** Whether this handshake will have to derive the bearer token's hash. */
   // Typed against the bare request the rate-limit hooks are handed, which does
@@ -51,17 +51,6 @@ export function registerUplinkRoute(
     )
   }
 
-  /**
-   * `keyGenerator` and `max` both run per request and must agree, so the
-   * classification is computed once and remembered on the request rather than
-   * re-derived from a cache that may have changed in between.
-   */
-  const derivesOnce = (request: FastifyRequest): boolean => {
-    const memo = request as unknown as Record<symbol, boolean | undefined>
-    memo[DERIVES] ??= derives(request)
-    return memo[DERIVES]
-  }
-
   app.get<{ Params: { id: string } }>(
     '/streamwall/:id/ws',
     {
@@ -73,16 +62,11 @@ export function registerUplinkRoute(
       // against the strict budget: a desktop reconnecting through a flapping
       // link presents a token the server verified moments ago, and must not be
       // locked out of its own uplink by its own retries — nor by anyone else
-      // spraying bogus tokens from the same address.
-      config: {
-        rateLimit: {
-          keyGenerator: (request: FastifyRequest) =>
-            `${request.ip}:${derivesOnce(request) ? 'derive' : 'verified'}`,
-          max: (request: FastifyRequest) =>
-            derivesOnce(request) ? rateLimit.authMax : rateLimit.globalMax,
-          timeWindow: rateLimit.timeWindow,
-        },
-      },
+      // spraying bogus tokens from the same address. The budget is the one
+      // shared with the other deriving routes rather than a per-route config,
+      // so it bounds scrypt work per IP rather than per route (issue #821).
+      onRequest: scryptRateLimit,
+      config: { rateLimit: false, scryptDerives: derives },
     },
     async (ws, request) => {
       ws.binaryType = 'arraybuffer'


### PR DESCRIPTION
## Summary

`@fastify/rate-limit` hands every route carrying its own `config.rateLimit` object a private store — `pluginComponent.store.child(...)`, and `LocalStore.child()` returns a fresh LRU. The strict scrypt budget added in #799 was therefore enforced once *per route* rather than once per IP. With four deriving routes (`POST /invite/:id`, `GET /admin/status`, `GET /client/ws`, `GET /streamwall/:id/ws`) one address could spend a full `authMax` on each, holding four times the intended share of the libuv thread pool that scrypt derivations run on.

**Technical solution.** A new `src/scryptRateLimit.ts` builds the limiter exactly once via `app.rateLimit()` — one instance, hence one store — and every deriving route attaches that same instance as its `onRequest` hook with `config.rateLimit: false`, so the plugin does not add a second per-route hook on top. Each route declares its own derivation classifier in `config.scryptDerives`, which the shared limiter reads through `request.routeOptions.config`; the memoisation of that classification (so `keyGenerator` and `max` can never disagree) moved out of `ws/client.ts` and `ws/uplink.ts` into the one shared module.

**Architecture decisions.**

- `groupId` was evaluated and rejected: the plugin appends it to the key *inside the route's own store*, which does nothing about the per-route store itself.
- A custom plugin-level `store` was rejected too — it would mean reimplementing `incr`/`read` including window expiry, `continueExceeding` and `exponentialBackoff`, duplicating upstream logic for no benefit.
- The bucket separation from #799 is deliberately unchanged: only a request that will actually derive is charged to `<ip>:derive`; a request riding an already-verified credential or carrying none at all stays on `<ip>:verified` at the global budget, so an attacker spraying unknown credentials from a shared NAT address still cannot lock a known operator out of their own socket.
- `POST /invite/:id` is charged unconditionally. Its classifier is `() => true` because the limiter runs at `onRequest`, before the body is parsed, so there is nothing to classify on — and a redemption carrying no token has no legitimate caller. This matches the route's pre-existing behaviour.
- The hook stays at `onRequest` (the plugin's own default), so a refusal still lands before body parsing and before the WebSocket upgrade — no scrypt work, and no parsing, on a throttled request.

## How was this tested?

Two new specs in `src/scryptRateLimit.test.ts`, both of which fail on `main` and pass here:

- *the strict budget is one bucket per IP, not one per route* — spends `authMax` on `/admin/status`, confirms the next probe is `429`, then asserts `POST /invite/:id` is also refused with `429` from the same IP in the same window and that no derivation ran. Without the fix the redemption succeeds with `204`.
- *a spent strict budget also refuses the uplink handshake* — same setup against `GET /streamwall/:id/ws`, asserting the handshake gets `http-429` instead of upgrading. Without the fix it opens.

The eleven pre-existing specs in that file are the regression guard for the #799 separation (known session keeps its socket, reconnecting herd is not throttled, cookieless request never spends the budget, static assets never derive) and all still pass unchanged.

Full gate green locally: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test` (2423 tests across 6 suites).

**Risks / breaking changes.** None for configuration — `STREAMWALL_AUTH_RATE_LIMIT_MAX` and `STREAMWALL_RATE_LIMIT_MAX` keep their meaning. The observable change is the intended one: the strict budget is now genuinely `authMax` per IP across the whole deriving surface instead of `authMax` per route, so an operator who was relying on the accidental 4× headroom will hit the documented ceiling sooner. The `<ip>:verified` buckets of the client and uplink routes also merge into one, which shares the global budget across those routes rather than granting each its own — the stricter and more correct reading of a per-IP limit.

## Pre-PR review

One round with an independent reviewer that had none of the implementing session's context. It re-derived the plugin's store semantics from `node_modules`, reverted the four production files while keeping the new test file to confirm both new specs genuinely fail without the fix (`204 !== 429`, `'open' !== 'http-429'`), restored the branch, and re-ran typecheck, lint, prettier and the full control-server suite. Result: **NO FINDINGS**. Nothing was dismissed.

No out-of-scope findings surfaced, so no follow-up issues were filed.

Closes #821

## Checklist

- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` pass locally
- [x] New behavior is covered by tests (or this PR explains why none apply)
- [x] PR title follows Conventional Commits
- [x] No AI-tool attribution in commits, PR body, or comments
