### PR TITLE
fix(control-ui): validate a stream link's scheme before rendering it as an anchor

### DIFF
--- a/packages/streamwall-control-ui/src/Sidebar.test.tsx
+++ b/packages/streamwall-control-ui/src/Sidebar.test.tsx
@@ -583,3 +583,132 @@ describe('stream links open away from the control UI', () => {
     expect(link.getAttribute('rel')).toBe('noopener noreferrer')
   })
 })
+
+// `link` arrives from an untrusted data source (a TOML file or a polled JSON
+// URL, per `streamDataInputSchema`'s own doc comment) and was rendered
+// straight into `href` with no scheme check, unlike `releaseUrl` (issue
+// #773/PR #793). A compromised or misconfigured data source could put an
+// arbitrary scheme there and get an operator to activate it (issue #822).
+describe("validating a stream link's scheme before rendering it as an anchor (issue #822)", () => {
+  test('still renders a normal http(s) stream link as a clickable anchor', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      render(
+        <StreamList
+          rows={[baseRow({ link: 'https://example.com/stream' })]}
+          disabled={false}
+          onClickId={() => {}}
+          favorites={new Set()}
+        />,
+        container!,
+      )
+    })
+
+    const link = container.querySelector('a')
+    expect(link).not.toBeNull()
+    expect(link!.getAttribute('href')).toBe('https://example.com/stream')
+    expect(container.textContent).toContain('https://example.com/stream')
+  })
+
+  test('renders a javascript: stream link as plain text, not an anchor', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      render(
+        <StreamList
+          rows={[baseRow({ link: 'javascript:alert(1)' })]}
+          disabled={false}
+          onClickId={() => {}}
+          favorites={new Set()}
+        />,
+        container!,
+      )
+    })
+
+    expect(container.querySelector('a')).toBeNull()
+    expect(container.textContent).toContain('javascript:alert(1)')
+  })
+
+  test('renders a data: stream link as plain text, not an anchor', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      render(
+        <StreamList
+          rows={[baseRow({ link: 'data:text/html,<script>alert(1)</script>' })]}
+          disabled={false}
+          onClickId={() => {}}
+          favorites={new Set()}
+        />,
+        container!,
+      )
+    })
+
+    expect(container.querySelector('a')).toBeNull()
+    expect(container.textContent).toContain(
+      'data:text/html,<script>alert(1)</script>',
+    )
+  })
+
+  test('still truncates a non-http(s) stream link the same way a rendered anchor would be', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    const longJsLink = `javascript:${'a'.repeat(80)}`
+    act(() => {
+      render(
+        <StreamList
+          rows={[baseRow({ link: longJsLink })]}
+          disabled={false}
+          onClickId={() => {}}
+          favorites={new Set()}
+        />,
+        container!,
+      )
+    })
+
+    expect(container.querySelector('a')).toBeNull()
+    expect(container.textContent).not.toContain(longJsLink)
+    expect(container.textContent).toContain('javascript:')
+  })
+
+  test('renders a javascript: custom stream link as plain text, not an anchor', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      render(
+        <CustomStreamInput
+          link="javascript:alert(1)"
+          kind="video"
+          onChange={() => {}}
+          onDelete={() => {}}
+        />,
+        container!,
+      )
+    })
+
+    expect(container.querySelector('a')).toBeNull()
+    expect(container.textContent).toContain('javascript:alert(1)')
+  })
+
+  test('renders a data: custom stream link as plain text, not an anchor', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      render(
+        <CustomStreamInput
+          link="data:text/html,<script>alert(1)</script>"
+          kind="video"
+          onChange={() => {}}
+          onDelete={() => {}}
+        />,
+        container!,
+      )
+    })
+
+    expect(container.querySelector('a')).toBeNull()
+    expect(container.textContent).toContain(
+      'data:text/html,<script>alert(1)</script>',
+    )
+  })
+})

--- a/packages/streamwall-control-ui/src/Sidebar.tsx
+++ b/packages/streamwall-control-ui/src/Sidebar.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from 'preact/hooks'
 import {
   Color,
   idColor,
+  isHttpUrl,
   type ContentKind,
   type LocalStreamData,
   type StreamData,
@@ -157,9 +158,18 @@ function StreamLine({
             <strong>{source}</strong>{' '}
             <OrientationIndicator orientation={orientation} />{' '}
             {city ? `(${city} ${state}) ` : ''}
-            <a href={link} target="_blank" rel="noopener noreferrer">
-              {truncate(link, { length: 55 })}
-            </a>{' '}
+            {/* `link` arrives from an untrusted data source (a TOML file or
+             * a polled JSON URL); only render it as a clickable anchor for
+             * an http(s) URL, the same guard applied to `releaseUrl`
+             * (issue #773/PR #793), otherwise fall back to the same
+             * truncated plain text (issue #822). */}
+            {isHttpUrl(link) ? (
+              <a href={link} target="_blank" rel="noopener noreferrer">
+                {truncate(link, { length: 55 })}
+              </a>
+            ) : (
+              truncate(link, { length: 55 })
+            )}{' '}
             {notes}
           </>
         )}
@@ -221,9 +231,14 @@ export function CustomStreamInput({
         onChange={handleChangeLabel}
         placeholder="Label (optional)"
       />{' '}
-      <a href={props.link} target="_blank" rel="noopener noreferrer">
-        {props.link}
-      </a>{' '}
+      {/* Same untrusted-scheme guard as StreamLine above (issue #822). */}
+      {isHttpUrl(props.link) ? (
+        <a href={props.link} target="_blank" rel="noopener noreferrer">
+          {props.link}
+        </a>
+      ) : (
+        props.link
+      )}{' '}
       <span>({props.kind})</span>{' '}
       <button
         aria-label={`Delete custom stream ${props.label || props.link}`}


### PR DESCRIPTION
## Problem

`Sidebar.tsx`'s `StreamLine` and `CustomStreamInput` render a stream's `link` straight into `<a href>` with no scheme validation. `link` arrives from an untrusted data source per `streamDataInputSchema`'s own doc comment (a TOML file or a polled JSON URL), and `nonEmptyUrlSchema` performs no scheme check. PR #793 added `isHttpUrl`/`nullableHttpUrlSchema` for exactly this hazard on `releaseUrl`, and touched these same two anchors (adding `rel="noopener noreferrer"`), but left their `href` unvalidated - so a compromised or misconfigured data source can inject an arbitrary scheme into an anchor an operator is likely to click.

## Solution

Reuse the already-exported `isHttpUrl` guard (`streamwall-shared`), the same pattern already used in `ServerUpdateBanner.tsx` for `releaseUrl`:

- `StreamLine`: renders the `<a>` only when `isHttpUrl(link)`; otherwise falls back to the same 55-char truncated plain text the anchor case already used.
- `CustomStreamInput`: renders the `<a>` only when `isHttpUrl(props.link)`; otherwise falls back to the raw (untruncated) plain text it already rendered.
- `target="_blank" rel="noopener noreferrer"` is unchanged for the anchor case.

Left the schema boundary alone (the issue's "better still" alternative) - narrowing at the schema layer would coerce a non-http(s) `link` to something else for every consumer (it doubles as the stream's id elsewhere), which is a larger, separate change than this rendering-only fix calls for.

## Testing

TDD: tests written first, confirmed failing against the pre-fix code, then made to pass, in `Sidebar.test.tsx`:

- A normal `https:` stream link still renders as a clickable anchor (regression check).
- A `javascript:` stream link renders as plain text, not an anchor (`StreamList` and `CustomStreamInput`).
- A `data:` stream link renders as plain text, not an anchor (`StreamList` and `CustomStreamInput`).
- A non-http(s) link is still truncated the same way the anchor case would have truncated it.

Full quality gate (`format`, `lint`, `typecheck`, `test`) is green across the whole monorepo (2431 tests). Checked `packages/streamwall-control-e2e` for selectors touching this markup: `custom-stream.spec.ts` and `invite-management.spec.ts` both use `getByRole('link', ...)` against fixture links that are valid `https:` URLs, so they still render as anchors and need no change.

## Pre-PR review

One independent review round (fresh subagent, no session context) returned `NO FINDINGS`. It additionally verified the new tests fail against the pre-fix `Sidebar.tsx` and confirmed via grep that no other unguarded `href={link}` anchor remains in the file.

## Risks / breaking changes

None. A non-http(s) `link` (which should not occur from a well-behaved data source) now renders as plain text instead of a clickable anchor; every legitimate http(s) link is unaffected.

Closes #822