### PR TITLE
fix(electron): re-attach a parked view when the fullscreen expansion collapses

### DIFF
--- a/packages/streamwall/src/main/StreamWindow.test.ts
+++ b/packages/streamwall/src/main/StreamWindow.test.ts
@@ -721,8 +721,6 @@ function makeReuseTestActor(opts: {
     stop,
     disposeView,
     setBounds,
-    removeChildViewOnWin,
-    addChildViewOnOffscreen,
   }
 }
 
@@ -1119,9 +1117,10 @@ describe('StreamWindow.setViews parking unused views during a fullscreen expansi
     expect(other.stop).not.toHaveBeenCalled()
     expect(other.disposeView).not.toHaveBeenCalled()
     // ...but is moved off the visible wall onto its own offscreen host so it
-    // does not render on top of (or behind) the expanded view.
-    expect(other.removeChildViewOnWin).toHaveBeenCalled()
-    expect(other.addChildViewOnOffscreen).toHaveBeenCalled()
+    // does not render on top of (or behind) the expanded view. The actor does
+    // the re-parenting itself, via PARK, so it can remember that it is
+    // detached -- see viewStateMachine's `parked` context flag (issue #816).
+    expect(other.send).toHaveBeenCalledWith({ type: 'PARK' })
     // It no longer appears in the emitted view states (only the expanded
     // view is visible, matching the pre-#369 behavior)...
     expect(sw.views.size).toBe(1)
@@ -1192,6 +1191,15 @@ describe('StreamWindow.setViews parking unused views during a fullscreen expansi
     expect(sw.createView).not.toHaveBeenCalled()
     expect(other.send).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'DISPLAY', content: streamA }),
+    )
+    // The parked view is re-attached to the wall explicitly: that DISPLAY
+    // re-sends the pos/content the cell already had, so the machine's
+    // `contentPosUnchanged` branch runs no actions and cannot put the view
+    // back by itself (issue #816).
+    expect(other.send).toHaveBeenCalledWith({ type: 'UNPARK' })
+    const sentTypes = other.send.mock.calls.map(([event]) => event.type)
+    expect(sentTypes.indexOf('UNPARK')).toBeGreaterThan(
+      sentTypes.indexOf('PARK'),
     )
     expect(sw.views.size).toBe(2)
     expect(sw.views.get(asViewId(2))).toBe(other.actor)

--- a/packages/streamwall/src/main/StreamWindow.ts
+++ b/packages/streamwall/src/main/StreamWindow.ts
@@ -578,25 +578,24 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
 
   /**
    * Moves a running actor's view off the visible wall onto its own offscreen
-   * host window, without touching the actor's state. Used to keep a
-   * non-focused view alive (rather than torn down) across a fullscreen
-   * expansion: `setViews`' own matchers can then find and reposition it again
-   * on collapse -- via a normal `DISPLAY` event -- instead of recreating it
-   * from scratch (issue #369). Mirrors `viewStateMachine`'s `offscreenView`
-   * action, which the actor itself uses while a fresh view is loading.
+   * host window. Used to keep a non-focused view alive (rather than torn
+   * down) across a fullscreen expansion: `setViews`' own matchers can then
+   * find it again on collapse and `displayPlannedViews` un-parks it, instead
+   * of recreating it from scratch (issue #369).
+   *
+   * The re-parenting is done by the actor itself, via PARK, rather than
+   * behind its back: parking leaves `pos` and `content` untouched, so the
+   * collapse's DISPLAY re-sends exactly what the cell already had and its
+   * `contentPosUnchanged` branch is a noop. Only the actor's own `parked`
+   * flag can tell a detached view apart from an attached one, which is what
+   * both the un-parking UNPARK and `performSwap` rely on (issue #816).
    */
   private hideView(
     actor: ViewActor,
     previouslyParkedAudio: Map<ViewId, DesiredAudio>,
   ) {
-    const { id, view, win, offscreenWin } = actor.getSnapshot().context
-    // Taking a running view out of the wall window happens here and nowhere
-    // else, which is how viewStateMachine's `performSwap` recognizes a parked
-    // cell (issue #741) -- keep the two in step.
-    win.contentView.removeChildView(view)
-    offscreenWin.contentView.addChildView(view)
-    const { width, height } = offscreenWin.getBounds()
-    view.setBounds({ x: 0, y: 0, width, height })
+    const { id } = actor.getSnapshot().context
+    actor.send({ type: 'PARK' })
     // A parked view is entirely invisible, so it must be inaudible too:
     // before #369 these views were destroyed, which silenced them as a side
     // effect, and leaving one audible means a stream the operator cannot see
@@ -763,6 +762,12 @@ export default class StreamWindow extends EventEmitter<StreamWindowEventMap> {
       }
 
       view.send({ type: 'DISPLAY', pos, content })
+      // Put a parked view back on the wall. The DISPLAY above cannot do it:
+      // on a collapse it carries the pos/content the cell already had, so the
+      // machine's `contentPosUnchanged` branch runs no actions (issue #816).
+      // Harmless for a view that was never parked -- the machine ignores
+      // UNPARK unless it is actually parked.
+      view.send({ type: 'UNPARK' })
       view.send({ type: 'OPTIONS', options: getDisplayOptions(stream) })
       const viewId = view.getSnapshot().context.id
       if (previouslyParkedAudio.has(viewId)) {

--- a/packages/streamwall/src/main/viewStateMachine.test.ts
+++ b/packages/streamwall/src/main/viewStateMachine.test.ts
@@ -1989,6 +1989,35 @@ describe('viewStateMachine performSwap while the cell is parked (issue #741)', (
       matchesState('displaying.running', ctx.actor.getSnapshot().value),
     ).toBe(true)
   })
+
+  it('never puts the retiring view on the wall when a content-changing DISPLAY is immediately followed by UNPARK', async () => {
+    // Exactly what `StreamWindow.displayPlannedViews` does on every layout
+    // pass: DISPLAY, then unconditionally UNPARK right after, in the same
+    // synchronous call -- long before any preload has a chance to finish.
+    const ctx = setup()
+    ctx.actor.start()
+    await reachRunning(ctx.actor)
+    ctx.park()
+
+    ctx.actor.send({ type: 'DISPLAY', pos: NEW_POS, content: OTHER_CONTENT })
+    ctx.actor.send({ type: 'UNPARK' })
+
+    // Nothing may appear on the wall yet: the old view is stale and about to
+    // be retired, and the new one has not loaded. Popping the old view up at
+    // this point is exactly the "stale content flashes on the wall" failure
+    // the parked-swap handling (issue #741) exists to prevent.
+    expect(ctx.win.contentView.children).toEqual([ctx.overlay])
+    expect(ctx.actor.getSnapshot().context.parked).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(0)
+    ctx.actor.send({ type: 'NEXT_VIEW_INIT' })
+    ctx.actor.send({ type: 'NEXT_VIEW_LOADED' })
+
+    // Only once the preload finishes does the promoted view take the cell.
+    expect(ctx.win.contentView.children).toEqual([ctx.nextView, ctx.overlay])
+    expect(ctx.nextView.setBounds).toHaveBeenLastCalledWith(NEW_POS)
+    expect(ctx.win.contentView.children).not.toContain(ctx.view)
+  })
 })
 
 /**

--- a/packages/streamwall/src/main/viewStateMachine.test.ts
+++ b/packages/streamwall/src/main/viewStateMachine.test.ts
@@ -2235,4 +2235,25 @@ describe('viewStateMachine PARK/UNPARK (issue #816)', () => {
 
     expect(ctx.win.contentView.children).toEqual([ctx.view, ctx.overlay])
   })
+
+  it('un-parks a view that was parked while recovering from an error', async () => {
+    const ctx = setup()
+    ctx.actor.start()
+    await reachRunning(ctx.actor)
+    ctx.actor.send({ type: 'VIEW_ERROR', error: new Error('boom') })
+    expect(
+      matchesState('displaying.error', ctx.actor.getSnapshot().value),
+    ).toBe(true)
+
+    ctx.actor.send({ type: 'PARK' })
+    expect(ctx.actor.getSnapshot().context.parked).toBe(true)
+
+    // Collapse while still recovering: same as the loading case, the park
+    // must not outlive the error state, or the view stays off the wall once
+    // it eventually reloads and reaches running again.
+    ctx.actor.send({ type: 'DISPLAY', pos: POS, content: CONTENT })
+    ctx.actor.send({ type: 'UNPARK' })
+    expect(ctx.actor.getSnapshot().context.parked).toBe(false)
+    expect(ctx.win.contentView.children).toEqual([ctx.overlay])
+  })
 })

--- a/packages/streamwall/src/main/viewStateMachine.test.ts
+++ b/packages/streamwall/src/main/viewStateMachine.test.ts
@@ -1883,8 +1883,7 @@ describe('viewStateMachine performSwap while the cell is parked (issue #741)', (
 
     /** Exactly what `StreamWindow.hideView` does to park a running view. */
     const park = () => {
-      win.contentView.removeChildView(view)
-      offscreenWin.contentView.addChildView(view)
+      actor.send({ type: 'PARK' })
     }
 
     /** Drives the running actor through a content swap to its promotion. */
@@ -1989,5 +1988,190 @@ describe('viewStateMachine performSwap while the cell is parked (issue #741)', (
     expect(
       matchesState('displaying.running', ctx.actor.getSnapshot().value),
     ).toBe(true)
+  })
+})
+
+/**
+ * Parking is a state the actor itself tracks (`context.parked`), not an
+ * invisible re-parenting done behind its back: a parked view's `pos` and
+ * `content` are exactly what they were before the expansion, so the collapse
+ * `DISPLAY` matches `contentPosUnchanged` and cannot be what puts the view
+ * back on the wall (issue #816).
+ */
+describe('viewStateMachine PARK/UNPARK (issue #816)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function makeFakeContentView() {
+    const children: unknown[] = []
+    return {
+      children,
+      addChildView: vi.fn((child: unknown, index?: number) => {
+        const existing = children.indexOf(child)
+        if (existing !== -1) {
+          children.splice(existing, 1)
+        }
+        if (index === undefined) {
+          children.push(child)
+        } else {
+          children.splice(index, 0, child)
+        }
+      }),
+      removeChildView: vi.fn((child: unknown) => {
+        const idx = children.indexOf(child)
+        if (idx !== -1) {
+          children.splice(idx, 1)
+        }
+      }),
+    }
+  }
+
+  function makeFakeWindow(width: number, height: number) {
+    return {
+      contentView: makeFakeContentView(),
+      getBounds: () => ({ width, height }),
+    }
+  }
+
+  /**
+   * Runs the *real* `positionView`/`offscreenView` against fake windows, so
+   * park/un-park is asserted on the same child-list bookkeeping production
+   * uses rather than on a hand-rolled fake actor.
+   */
+  function setup() {
+    const win = makeFakeWindow(1920, 1080)
+    const overlay = { setBounds: vi.fn() }
+    const view = { setBounds: vi.fn() }
+    const offscreenWin = makeFakeWindow(100, 100)
+
+    win.contentView.children.push(overlay)
+
+    const machine = viewStateMachine.provide({
+      actions: {
+        offscreenNextView: noop,
+        performSwap: noop,
+        resyncSwappedView: noop,
+        muteAudio: noop,
+        unmuteAudio: noop,
+        openDevTools: noop,
+        sendViewOptions: noop,
+        sendViewVolume: noop,
+        sendViewPause: noop,
+        sendViewResume: noop,
+        logError: noop,
+      },
+      actors: {
+        loadPage: fromPromise(async () => {}),
+      },
+    })
+    const actor = createActor(machine, {
+      input: {
+        id: asViewId(1),
+        view: view as never,
+        win: win as never,
+        offscreenWin: offscreenWin as never,
+        retry: makeRetry(),
+        createNextView: () => ({
+          view: {} as never,
+          offscreenWin: {} as never,
+        }),
+        disposeView: noop,
+      },
+    })
+
+    return { actor, win, overlay, view, offscreenWin }
+  }
+
+  it('takes the view off the wall and records the park on PARK', async () => {
+    const ctx = setup()
+    ctx.actor.start()
+    await reachRunning(ctx.actor)
+    expect(ctx.win.contentView.children).toContain(ctx.view)
+
+    ctx.actor.send({ type: 'PARK' })
+
+    expect(ctx.win.contentView.children).toEqual([ctx.overlay])
+    expect(ctx.offscreenWin.contentView.children).toContain(ctx.view)
+    expect(ctx.view.setBounds).toHaveBeenLastCalledWith({
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+    })
+    expect(ctx.actor.getSnapshot().context.parked).toBe(true)
+  })
+
+  it('re-attaches the view on UNPARK after a DISPLAY that changed nothing', async () => {
+    const ctx = setup()
+    ctx.actor.start()
+    await reachRunning(ctx.actor)
+    ctx.actor.send({ type: 'PARK' })
+
+    // What the collapse `setViews` sends: freshly-built but structurally
+    // equal pos/content objects, so `contentPosUnchanged` matches and the
+    // DISPLAY alone is a noop.
+    ctx.actor.send({
+      type: 'DISPLAY',
+      pos: { ...POS, spaces: [...POS.spaces] },
+      content: { ...CONTENT },
+    })
+    expect(ctx.win.contentView.children).toEqual([ctx.overlay])
+
+    ctx.actor.send({ type: 'UNPARK' })
+
+    // Back on the wall, below the overlay, at its cell rectangle.
+    expect(ctx.win.contentView.children).toEqual([ctx.view, ctx.overlay])
+    expect(ctx.offscreenWin.contentView.children).not.toContain(ctx.view)
+    expect(ctx.view.setBounds).toHaveBeenLastCalledWith(POS)
+    expect(ctx.actor.getSnapshot().context.parked).toBe(false)
+    // Un-parking must never restart the load.
+    expect(
+      matchesState('displaying.running', ctx.actor.getSnapshot().value),
+    ).toBe(true)
+  })
+
+  it('ignores UNPARK for a view that is not parked', async () => {
+    const ctx = setup()
+    ctx.actor.start()
+    await reachRunning(ctx.actor)
+    const childrenBefore = [...ctx.win.contentView.children]
+    ctx.win.contentView.addChildView.mockClear()
+
+    ctx.actor.send({ type: 'UNPARK' })
+
+    expect(ctx.win.contentView.addChildView).not.toHaveBeenCalled()
+    expect(ctx.win.contentView.children).toEqual(childrenBefore)
+  })
+
+  it('clears the park when a repositioning DISPLAY already re-attached the view', async () => {
+    const ctx = setup()
+    ctx.actor.start()
+    await reachRunning(ctx.actor)
+    ctx.actor.send({ type: 'PARK' })
+
+    const newPos = { ...POS, x: 400, spaces: [asCellIdx(1)] }
+    ctx.actor.send({ type: 'DISPLAY', pos: newPos, content: CONTENT })
+
+    expect(ctx.win.contentView.children).toEqual([ctx.view, ctx.overlay])
+    expect(ctx.actor.getSnapshot().context.parked).toBe(false)
+  })
+
+  it('clears the park when a parked view is reloaded back into running', async () => {
+    const ctx = setup()
+    ctx.actor.start()
+    await reachRunning(ctx.actor)
+    ctx.actor.send({ type: 'PARK' })
+
+    ctx.actor.send({ type: 'RELOAD' })
+    await vi.advanceTimersByTimeAsync(0)
+    ctx.actor.send({ type: 'VIEW_INIT' })
+    ctx.actor.send({ type: 'VIEW_LOADED' })
+
+    expect(ctx.actor.getSnapshot().context.parked).toBe(false)
+    expect(ctx.win.contentView.children).toEqual([ctx.view, ctx.overlay])
   })
 })

--- a/packages/streamwall/src/main/viewStateMachine.test.ts
+++ b/packages/streamwall/src/main/viewStateMachine.test.ts
@@ -2160,18 +2160,50 @@ describe('viewStateMachine PARK/UNPARK (issue #816)', () => {
     expect(ctx.actor.getSnapshot().context.parked).toBe(false)
   })
 
-  it('clears the park when a parked view is reloaded back into running', async () => {
+  it('keeps a parked view offscreen when it reaches running again', async () => {
     const ctx = setup()
     ctx.actor.start()
     await reachRunning(ctx.actor)
     ctx.actor.send({ type: 'PARK' })
 
+    // A parked cell whose view reloads must not pop up on top of the
+    // expansion that is still covering it.
     ctx.actor.send({ type: 'RELOAD' })
     await vi.advanceTimersByTimeAsync(0)
     ctx.actor.send({ type: 'VIEW_INIT' })
     ctx.actor.send({ type: 'VIEW_LOADED' })
 
+    expect(
+      matchesState('displaying.running', ctx.actor.getSnapshot().value),
+    ).toBe(true)
+    expect(ctx.win.contentView.children).toEqual([ctx.overlay])
+    expect(ctx.actor.getSnapshot().context.parked).toBe(true)
+
+    // The collapse still gets it back.
+    ctx.actor.send({ type: 'UNPARK' })
+    expect(ctx.win.contentView.children).toEqual([ctx.view, ctx.overlay])
     expect(ctx.actor.getSnapshot().context.parked).toBe(false)
+  })
+
+  it('un-parks a view that was parked before it finished loading', async () => {
+    const ctx = setup()
+    ctx.actor.start()
+    // Still in `displaying.loading`: never sent VIEW_INIT/VIEW_LOADED.
+    ctx.actor.send({ type: 'DISPLAY', pos: POS, content: CONTENT })
+    await vi.advanceTimersByTimeAsync(0)
+    ctx.actor.send({ type: 'PARK' })
+    expect(ctx.actor.getSnapshot().context.parked).toBe(true)
+
+    // Collapse while the view is still loading: nothing to place yet, but the
+    // park must not outlive it, or the view would stay off the wall for good.
+    ctx.actor.send({ type: 'DISPLAY', pos: POS, content: CONTENT })
+    ctx.actor.send({ type: 'UNPARK' })
+    expect(ctx.actor.getSnapshot().context.parked).toBe(false)
+    expect(ctx.win.contentView.children).toEqual([ctx.overlay])
+
+    ctx.actor.send({ type: 'VIEW_INIT' })
+    ctx.actor.send({ type: 'VIEW_LOADED' })
+
     expect(ctx.win.contentView.children).toEqual([ctx.view, ctx.overlay])
   })
 })

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -16,7 +16,7 @@ import {
   ContentDisplayOptions,
   ContentViewInfo,
 } from 'streamwall-shared/src/types'
-import { Actor, assign, fromPromise, setup } from 'xstate'
+import { Actor, assign, enqueueActions, fromPromise, setup } from 'xstate'
 import { createSessionHostResolver, ensureValidURL } from '../util'
 import { loadHTML } from './loadHTML'
 import log from './logger'
@@ -360,7 +360,6 @@ const viewStateMachine = setup({
       // `promoteNextView` adopts as this actor's offscreen window -- and let
       // the UNPARK that follows the collapse's DISPLAY position it via
       // `positionView` (issue #816).
-      //
       const existingIdx = win.contentView.children.indexOf(oldView)
       if (context.parked) {
         const { width, height } = next.offscreenWin.getBounds()
@@ -534,6 +533,16 @@ const viewStateMachine = setup({
   on: {
     PARK: {
       actions: ['offscreenView', 'markParked'],
+    },
+    // Fallback for a view that is parked while not `running` (it was still
+    // loading, or is recovering from an error, when the expansion started).
+    // Such a view is offscreen for its own reasons and is placed on the wall
+    // by `running`'s entry once it gets there, so un-parking it is purely a
+    // bookkeeping change -- but the flag has to be cleared, or it would stay
+    // "parked" forever. `displaying.running`'s own UNPARK handler takes
+    // precedence over this one.
+    UNPARK: {
+      actions: 'clearParked',
     },
     DISPLAY: {
       target: '.displaying',
@@ -721,7 +730,17 @@ const viewStateMachine = setup({
           // its backoff (issue #645). The streak is instead cleared once the
           // view has stayed healthy for retry.healthyDuration -- see
           // `playback.playing` below.
-          entry: ['positionView', 'clearParked'],
+          // Placing the view on the wall is what makes a cell visible, so a
+          // parked cell must not do it: a view that finishes loading (or
+          // recovers from an error) while an expansion covers its cell would
+          // otherwise pop up on top of that expansion. It stays on its
+          // offscreen host until the collapse's UNPARK, exactly like a view
+          // that was already `running` when it was parked.
+          entry: enqueueActions(({ context, enqueue }) => {
+            if (!context.parked) {
+              enqueue('positionView')
+            }
+          }),
           // Leaving `running` for any reason (manual RELOAD, a renderer-
           // reported VIEW_ERROR, or a stalled-view auto-reload) abandons any
           // preload that was in flight for this cell, so its WebContentsView

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -172,6 +172,15 @@ const viewStateMachine = setup({
       // parked (hidden) view instead of keeping it fully live while it's
       // hidden behind a fullscreen expansion (issue #374).
       desiredPaused: boolean
+      // Whether `StreamWindow` has parked this view: taken off the wall
+      // window onto its own offscreen host to survive a fullscreen expansion
+      // (issue #369) without being torn down. Parking leaves `pos` and
+      // `content` untouched, so the collapse's `DISPLAY` re-sends exactly
+      // what the cell already had and is a noop -- the actor has to remember
+      // that it is detached, or nothing would ever put it back on the wall
+      // (issue #816). Also tells `performSwap` where a promoted view belongs
+      // (issue #741).
+      parked: boolean
     },
 
     events: {} as
@@ -193,6 +202,12 @@ const viewStateMachine = setup({
       | { type: 'NEXT_VIEW_INIT' }
       | { type: 'NEXT_VIEW_LOADED' }
       | { type: 'NEXT_VIEW_ERROR'; error: unknown }
+      // Sent by `StreamWindow.hideView`/`displayPlannedViews` to take this
+      // view off the wall while a fullscreen expansion covers it, and to put
+      // it back afterwards (issues #369, #816). UNPARK is ignored unless the
+      // view is actually parked and running.
+      | { type: 'PARK' }
+      | { type: 'UNPARK' }
       | { type: 'MUTE' }
       | { type: 'UNMUTE' }
       | { type: 'BACKGROUND' }
@@ -276,6 +291,13 @@ const viewStateMachine = setup({
       view.setBounds({ x: 0, y: 0, width, height })
     },
 
+    markParked: assign({ parked: true }),
+
+    // Every path that (re-)attaches the view to the wall window clears the
+    // park, so `context.parked` always answers "is this view detached from
+    // the wall?" -- see the `parked` context field.
+    clearParked: assign({ parked: false }),
+
     positionView: ({ context }) => {
       const { pos, view, win, offscreenWin } = context
 
@@ -336,13 +358,11 @@ const viewStateMachine = setup({
       // nothing to remove it until the next layout change (issue #741). Leave
       // it on the offscreen host it already lives on -- the one
       // `promoteNextView` adopts as this actor's offscreen window -- and let
-      // the DISPLAY that un-parks the cell position it via `positionView`.
+      // the UNPARK that follows the collapse's DISPLAY position it via
+      // `positionView` (issue #816).
       //
-      // `StreamWindow.hideView` is the only thing that takes a *running*
-      // view out of the wall window, so a missing child means exactly that:
-      // parked. Keep the two in step if that ever changes.
       const existingIdx = win.contentView.children.indexOf(oldView)
-      if (existingIdx === -1) {
+      if (context.parked) {
         const { width, height } = next.offscreenWin.getBounds()
         next.view.setBounds({ x: 0, y: 0, width, height })
       } else {
@@ -412,6 +432,8 @@ const viewStateMachine = setup({
     volumeChanged: ({ context }, params: { volume: number }) => {
       return context.volume !== params.volume
     },
+
+    isParked: ({ context }) => context.parked,
 
     // Whether the view is still allowed to reload itself automatically.
     canRetry: ({ context }) =>
@@ -507,8 +529,12 @@ const viewStateMachine = setup({
     desiredAudio: 'muted',
     desiredBlurred: false,
     desiredPaused: false,
+    parked: false,
   }),
   on: {
+    PARK: {
+      actions: ['offscreenView', 'markParked'],
+    },
     DISPLAY: {
       target: '.displaying',
       actions: assign({
@@ -695,13 +721,20 @@ const viewStateMachine = setup({
           // its backoff (issue #645). The streak is instead cleared once the
           // view has stayed healthy for retry.healthyDuration -- see
           // `playback.playing` below.
-          entry: 'positionView',
+          entry: ['positionView', 'clearParked'],
           // Leaving `running` for any reason (manual RELOAD, a renderer-
           // reported VIEW_ERROR, or a stalled-view auto-reload) abandons any
           // preload that was in flight for this cell, so its WebContentsView
           // and offscreen window don't leak.
           exit: 'disposeStaleNextView',
           on: {
+            // Puts a parked view back on the wall. The collapse's DISPLAY
+            // cannot do it: it re-sends the pos/content the cell already has,
+            // so `contentPosUnchanged` matches and no action runs (#816).
+            UNPARK: {
+              guard: 'isParked',
+              actions: ['positionView', 'clearParked'],
+            },
             DISPLAY: [
               // Noop if nothing changed.
               {
@@ -716,6 +749,7 @@ const viewStateMachine = setup({
                     pos: ({ event }) => event.pos,
                   }),
                   'positionView',
+                  'clearParked',
                 ],
                 guard: {
                   type: 'contentUnchanged',

--- a/packages/streamwall/src/main/viewStateMachine.ts
+++ b/packages/streamwall/src/main/viewStateMachine.ts
@@ -357,16 +357,28 @@ const viewStateMachine = setup({
       // of the expansion at the parked cell's stale rectangle, playing, with
       // nothing to remove it until the next layout change (issue #741). Leave
       // it on the offscreen host it already lives on -- the one
-      // `promoteNextView` adopts as this actor's offscreen window -- and let
-      // the UNPARK that follows the collapse's DISPLAY position it via
-      // `positionView` (issue #816).
+      // `promoteNextView` adopts as this actor's offscreen window -- until
+      // `context.parked` actually clears (issue #816).
+      //
+      // A collapse that also changes the cell's content unparks it (via
+      // `preloading`'s own UNPARK handler) before this swap finishes, so
+      // `context.parked` is often already false by the time this runs and
+      // `oldView` never made it back onto the wall -- `existingIdx` is then
+      // -1. Fall back to the same "below the overlay" slot `positionView`
+      // uses in that case, rather than handing `addChildView` an invalid
+      // index.
       const existingIdx = win.contentView.children.indexOf(oldView)
       if (context.parked) {
         const { width, height } = next.offscreenWin.getBounds()
         next.view.setBounds({ x: 0, y: 0, width, height })
       } else {
         next.offscreenWin.contentView.removeChildView(next.view)
-        win.contentView.addChildView(next.view, existingIdx)
+        win.contentView.addChildView(
+          next.view,
+          existingIdx !== -1
+            ? existingIdx
+            : win.contentView.children.length - 1,
+        )
         if (pos) {
           next.view.setBounds(pos)
         }
@@ -991,6 +1003,21 @@ const viewStateMachine = setup({
                         type: 'logError',
                         params: ({ event: { error } }) => ({ error }),
                       },
+                    },
+                    // `running`'s own UNPARK (below) runs `positionView` on
+                    // `context.view` -- but while a swap is preloading,
+                    // that's the *retiring* view, not the one about to take
+                    // the cell. `StreamWindow.displayPlannedViews` sends
+                    // UNPARK right after every DISPLAY, including one that
+                    // just changed the content and started this preload, so
+                    // reaching this state still parked is routine, not rare.
+                    // Only clear the flag here: `performSwap` already reads
+                    // `context.parked` to decide where the *promoted* view
+                    // belongs once the preload actually finishes (issue
+                    // #816).
+                    UNPARK: {
+                      guard: 'isParked',
+                      actions: 'clearParked',
                     },
                     // Content changed again while a preload was already in
                     // flight for a since-superseded target (rapid successive


### PR DESCRIPTION
## Problem

`StreamWindow.hideView` parked a running view by re-parenting it onto an offscreen `BrowserWindow` outside the actor: the actor's `context.pos`/`context.content` were left untouched and no event recorded the park. Un-parking relied entirely on the collapse's `DISPLAY` re-attaching the view via `positionView`, but a collapse resends the exact same pos/content the cell already had, so the `contentPosUnchanged` guard matched and no action ran. Every parked tile stayed attached to its hidden offscreen window after a fullscreen expansion collapsed, defeating issue #369 and the muting work in #740/#775.

## Solution

Parking is now a state the actor itself tracks via an explicit `PARK`/`UNPARK` event pair instead of an invisible re-parenting side effect:

- `PARK` moves the view offscreen and sets `context.parked = true`.
- `running`'s own `UNPARK` handler re-attaches the view via `positionView` and clears the flag.
- A top-level fallback `UNPARK` handler clears the flag for a view parked while `loading` or recovering from an `error` — it has nothing to place yet, but the park must not outlive that state or the view would stay off the wall once it eventually reaches `running`.
- `running`'s entry only calls `positionView` when the view is not parked, so a view that finishes loading (or recovers) while still parked stays offscreen instead of popping onto the wall on top of the expansion.
- `StreamWindow.displayPlannedViews` now sends `UNPARK` right after every `DISPLAY`; harmless for a view that was never parked.

While extending the tests, a further bug surfaced: `displayPlannedViews` sends `DISPLAY` then `UNPARK` unconditionally, including when the same `DISPLAY` also changed the cell's content and kicked off an async preload (`running.swap.preloading`). `running`'s `UNPARK` handler ran `positionView` on `context.view`, which at that point is still the *retiring* view, popping stale content onto the wall for the whole preload duration instead of staying hidden until the promoted view took over. Fixed by giving `swap.preloading` its own `UNPARK` handler that only clears the `parked` flag (never repositions the retiring view), and letting `performSwap` — which already reads `context.parked` — decide where the *promoted* view belongs once the preload actually finishes. `performSwap`'s non-parked branch also needed the same "insert below the overlay" fallback `positionView` uses, since the retiring view may never have made it back onto the wall in this path.

## Testing

- Regression tests drive the real `viewStateMachine` (not hand-rolled fakes) through: display → park → identical DISPLAY → UNPARK, a view parked before it finished loading, a view parked while recovering from an error, a view whose reload finishes while still parked, and a content-changing DISPLAY immediately followed by UNPARK while the swap is still preloading.
- Full quality gate green locally: format, lint, typecheck, full test suite (2429 tests).

## Pre-PR review

Three independent reviewer rounds ran against fresh diffs of this branch, each with no memory of the others:

- Round 1 found a major bug: `UNPARK` sent immediately after a content-changing `DISPLAY` could reposition the stale, retiring view onto the wall while an async content swap was still preloading. Fixed via a dedicated `swap.preloading` `UNPARK` handler plus a `performSwap` insertion-index fallback, with a regression test that fails on the pre-fix code.
- Round 2 confirmed the fix by hand-tracing the state hierarchy and by running the new regression test against the pre-fix commit (it failed as expected). It suggested adding a test for parking while recovering from an error (previously only `loading` was covered); that test was added.
- Round 3 re-verified the whole branch from scratch, confirming no view can end up double-attached, permanently parked, or desynced between `context.parked` and physical attachment across all covered scenarios. It noted the new error-state test exercises the same top-level fallback handler as the loading-state test (no new state-machine branch), which is accurate — it is included anyway for direct scenario coverage of the case the issue's evidence called out, at negligible cost.

No findings were dismissed as invalid; every reported issue was fixed.

Closes #816