### PR TITLE
fix(electron): bound the data-source health message before it enters the broadcast state

### DIFF
--- a/packages/streamwall-shared/src/schemas.test.ts
+++ b/packages/streamwall-shared/src/schemas.test.ts
@@ -6,6 +6,7 @@ import {
   localStreamDataSchema,
   MAX_BLOCKED_LAYER_URL_LENGTH,
   MAX_BLOCKED_LAYER_URLS,
+  MAX_DATA_SOURCE_MESSAGE_LENGTH,
   MAX_URL_LENGTH,
   MAX_VIEW_ERROR_LENGTH,
   MAX_VIEW_IDX,
@@ -890,6 +891,43 @@ describe('streamwallStateSchema', () => {
             error: 'x'.repeat(MAX_VIEW_ERROR_LENGTH),
             volume: 1,
           },
+        },
+      ],
+    }
+    expect(streamwallStateSchema.safeParse(atLimit).success).toBe(true)
+  })
+
+  // Issue #817: a data source's health message forwards whatever the polled
+  // endpoint said back (including its raw HTTP reason phrase), which is
+  // entirely controlled by that endpoint and re-broadcast on every state
+  // update -- the same denial-of-service vector #734 fixed for
+  // `document.title`.
+  test('rejects a data source health message longer than the allowed length', () => {
+    const tooLong = {
+      ...VALID_STATE,
+      dataSourceHealth: [
+        {
+          id: 'https://source.example/data.json',
+          type: 'json-url',
+          status: 'error',
+          message: 'x'.repeat(MAX_DATA_SOURCE_MESSAGE_LENGTH + 1),
+          updatedAt: 1700000000000,
+        },
+      ],
+    }
+    expect(streamwallStateSchema.safeParse(tooLong).success).toBe(false)
+  })
+
+  test('accepts a data source health message at exactly the allowed length', () => {
+    const atLimit = {
+      ...VALID_STATE,
+      dataSourceHealth: [
+        {
+          id: 'https://source.example/data.json',
+          type: 'json-url',
+          status: 'error',
+          message: 'x'.repeat(MAX_DATA_SOURCE_MESSAGE_LENGTH),
+          updatedAt: 1700000000000,
         },
       ],
     }

--- a/packages/streamwall-shared/src/schemas.ts
+++ b/packages/streamwall-shared/src/schemas.ts
@@ -537,11 +537,24 @@ const blockedLayerURLsGenerationSchema = z
   // than the one dismissal edge this counter fixes.
   .default(0)
 
+/**
+ * A data source's health message reports whatever the polled endpoint said
+ * back - including its raw HTTP reason phrase, entirely controlled by that
+ * endpoint - and flows unbounded into the broadcast `StreamwallState`. Left
+ * unbounded, a hostile or misbehaving data source is the same
+ * denial-of-service vector #734 fixed for `document.title`: it can grow
+ * every state frame the desktop pushes over the uplink without limit. The
+ * producer (`DataSourceHealthTracker.report`) truncates to this length
+ * before the message ever reaches this schema; the bound here is the
+ * server-side backstop in case that truncation is ever bypassed.
+ */
+export const MAX_DATA_SOURCE_MESSAGE_LENGTH = 500
+
 const dataSourceHealthSchema = z.object({
   id: z.string(),
   type: z.enum(['json-url', 'toml-file']),
   status: z.enum(['ok', 'error']),
-  message: z.string().nullable(),
+  message: z.string().max(MAX_DATA_SOURCE_MESSAGE_LENGTH).nullable(),
   updatedAt: z.number(),
 })
 

--- a/packages/streamwall/src/main/data/poll.test.ts
+++ b/packages/streamwall/src/main/data/poll.test.ts
@@ -134,6 +134,41 @@ describe('pollDataURL', () => {
     }
   })
 
+  // Issue #817: the HTTP reason phrase is entirely controlled by the polled
+  // endpoint and flows unbounded into the health message re-broadcast in
+  // every state update -- the same denial-of-service vector #734 fixed for
+  // `document.title`. The status code and URL are enough to diagnose a
+  // failure without it.
+  test('does not forward the endpoint-controlled status text into the health message', async () => {
+    server = createServer((_req, res) => {
+      res.statusCode = 503
+      res.statusMessage = 'attacker-controlled reason phrase'
+      res.setHeader('content-type', 'application/json')
+      res.end('[]')
+    })
+    await new Promise<void>((resolve) =>
+      server!.listen(0, '127.0.0.1', resolve),
+    )
+    const { port } = server.address() as AddressInfo
+    const url = `http://127.0.0.1:${port}/`
+
+    const onHealth = vi.fn()
+    const gen = pollDataURL(url, 999, onHealth)
+    try {
+      await gen.next()
+      expect(onHealth).toHaveBeenCalledWith(
+        false,
+        expect.not.stringContaining('attacker-controlled reason phrase'),
+      )
+      expect(onHealth).toHaveBeenCalledWith(
+        false,
+        expect.stringContaining('503'),
+      )
+    } finally {
+      await gen.return(undefined)
+    }
+  })
+
   // This test (and the next) used to pace itself with real setTimeout races
   // (a 100ms poll interval plus a 150ms "still pending" probe window). That
   // real-time budget stacks with a real timer *inside* pollDataURL itself:

--- a/packages/streamwall/src/main/data/poll.ts
+++ b/packages/streamwall/src/main/data/poll.ts
@@ -86,8 +86,9 @@ export async function* pollDataURL(
       const resp = await fetchWithTimeout(url, fetchTimeout)
       if (!resp.ok) {
         // Drain and discard the unread body instead of leaving it dangling:
-        // undici otherwise holds the connection open until GC reclaims it,
-        // on every failing poll (issue #817).
+        // node-fetch's `body` is a `PassThrough` piped from the raw socket,
+        // which otherwise backpressures and holds the connection open until
+        // GC reclaims it, on every failing poll (issue #817).
         resp.body?.resume()
         // `statusText` is the HTTP reason phrase, entirely controlled by the
         // polled endpoint - forwarding it unbounded into the health message

--- a/packages/streamwall/src/main/data/poll.ts
+++ b/packages/streamwall/src/main/data/poll.ts
@@ -85,9 +85,16 @@ export async function* pollDataURL(
     try {
       const resp = await fetchWithTimeout(url, fetchTimeout)
       if (!resp.ok) {
-        throw new Error(
-          `received HTTP ${resp.status} ${resp.statusText} from ${url}`,
-        )
+        // Drain and discard the unread body instead of leaving it dangling:
+        // undici otherwise holds the connection open until GC reclaims it,
+        // on every failing poll (issue #817).
+        resp.body?.resume()
+        // `statusText` is the HTTP reason phrase, entirely controlled by the
+        // polled endpoint - forwarding it unbounded into the health message
+        // that gets re-broadcast in every state update is the same
+        // denial-of-service vector #734 fixed for `document.title` (issue
+        // #817). The status code and URL are enough to diagnose the failure.
+        throw new Error(`received HTTP ${resp.status} from ${url}`)
       }
       data = parseStreamEntries(await resp.json(), `from ${url}`)
       onHealth?.(true)

--- a/packages/streamwall/src/main/data/pollDrain.test.ts
+++ b/packages/streamwall/src/main/data/pollDrain.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test, vi } from 'vitest'
+
+// `node-fetch` is mocked at the module level (rather than driving a real
+// server, as `poll.test.ts` does) so this test can assert on the exact
+// `resp.body.resume()` call `pollDataURL` is supposed to make, without
+// picking up any of the several unrelated internal `resume()` calls Node's
+// own HTTP client/server machinery makes while a real request is in flight.
+const resume = vi.fn()
+
+vi.mock('node-fetch', () => ({
+  default: vi.fn(async () => ({
+    ok: false,
+    status: 503,
+    statusText: 'Service Unavailable',
+    body: { resume },
+    json: vi.fn(async () => {
+      throw new Error('body should never be read on a non-2xx response')
+    }),
+  })),
+}))
+
+const { pollDataURL } = await import('./poll')
+
+describe('pollDataURL non-2xx body draining (issue #817)', () => {
+  // Leaving a non-2xx response's body unread holds its connection open
+  // until GC reclaims it, on every failing poll. Draining it immediately
+  // instead releases the connection back to the pool.
+  test('drains the unread body of a non-2xx response instead of leaving it dangling', async () => {
+    const onHealth = vi.fn()
+    const gen = pollDataURL('http://example.invalid/', 999, onHealth)
+    try {
+      await gen.next()
+      expect(resume).toHaveBeenCalledTimes(1)
+      expect(onHealth).toHaveBeenCalledWith(
+        false,
+        expect.stringContaining('503'),
+      )
+    } finally {
+      await gen.return(undefined)
+    }
+  })
+})

--- a/packages/streamwall/src/main/dataSourceHealth.test.ts
+++ b/packages/streamwall/src/main/dataSourceHealth.test.ts
@@ -1,3 +1,4 @@
+import { MAX_DATA_SOURCE_MESSAGE_LENGTH } from 'streamwall-shared'
 import { describe, expect, test } from 'vitest'
 import { DataSourceHealthTracker } from './dataSourceHealth'
 
@@ -67,6 +68,31 @@ describe('DataSourceHealthTracker', () => {
     const result = tracker.report('url-b', 'toml-file', false, 'boom')
 
     expect(result.map((h) => h.id)).toEqual(['url-a', 'url-b'])
+  })
+
+  // Issue #817: a data source's message forwards whatever the polled
+  // endpoint said back, entirely under that endpoint's control, and flows
+  // unbounded into the broadcast state -- the same denial-of-service vector
+  // #734 fixed for `document.title`. Truncated at the producer, mirroring
+  // `formatError` for view errors, so the server-side schema bound is a
+  // backstop rather than the only thing standing between a hostile source
+  // and an oversized state frame.
+  test('truncates a message longer than the allowed length', () => {
+    const tracker = new DataSourceHealthTracker(() => 1000)
+    const oversized = 'x'.repeat(MAX_DATA_SOURCE_MESSAGE_LENGTH + 500)
+
+    const result = tracker.report('url', 'json-url', false, oversized)
+
+    expect(result[0].message).toBe('x'.repeat(MAX_DATA_SOURCE_MESSAGE_LENGTH))
+  })
+
+  test('does not truncate a message at exactly the allowed length', () => {
+    const tracker = new DataSourceHealthTracker(() => 1000)
+    const atLimit = 'x'.repeat(MAX_DATA_SOURCE_MESSAGE_LENGTH)
+
+    const result = tracker.report('url', 'json-url', false, atLimit)
+
+    expect(result[0].message).toBe(atLimit)
   })
 
   test('updates an existing entry in place rather than duplicating it', () => {

--- a/packages/streamwall/src/main/dataSourceHealth.ts
+++ b/packages/streamwall/src/main/dataSourceHealth.ts
@@ -1,4 +1,8 @@
-import { DataSourceHealth, DataSourceType } from 'streamwall-shared'
+import {
+  DataSourceHealth,
+  DataSourceType,
+  MAX_DATA_SOURCE_MESSAGE_LENGTH,
+} from 'streamwall-shared'
 
 /**
  * Aggregates the latest health of each configured stream data source, keyed
@@ -20,7 +24,13 @@ export class DataSourceHealthTracker {
       id,
       type,
       status: ok ? 'ok' : 'error',
-      message: ok ? null : (message ?? null),
+      // `message` forwards whatever the data source said back (issue #817),
+      // entirely under that source's control -- truncate here, the same way
+      // `formatError` does for view errors, so the schema's own bound is a
+      // backstop rather than the only limit.
+      message: ok
+        ? null
+        : (message?.slice(0, MAX_DATA_SOURCE_MESSAGE_LENGTH) ?? null),
       updatedAt: this.now(),
     })
     return [...this.byId.values()]


### PR DESCRIPTION
## Problem

`packages/streamwall/src/main/data/poll.ts` forwarded the polled endpoint's raw HTTP reason phrase (`statusText`) unbounded into the data-source health message, which `DataSourceHealthTracker.report` stores unmodified into `StreamwallState.dataSourceHealth[].message` and is re-broadcast on every state update. `dataSourceHealthSchema.message` had no length bound. `statusText` is entirely controlled by the polled endpoint and can be several KB long, so a hostile or misbehaving JSON data source could grow every state frame the desktop pushes over the uplink without limit — the same `maxPayload`-overrun denial-of-service class issue #734 fixed for `document.title`. Secondarily, the non-2xx response body was never read or cancelled, holding the connection open until GC.

## Solution

Mirrors `MAX_VIEW_ERROR_LENGTH`/`formatError`:

- `streamwall-shared/src/schemas.ts`: added `MAX_DATA_SOURCE_MESSAGE_LENGTH = 500` and applied `.max(...)` to `dataSourceHealthSchema.message` — the server-side backstop.
- `dataSourceHealth.ts`: `DataSourceHealthTracker.report` truncates the message to that length before it enters the tracked state.
- `poll.ts`: dropped `statusText` from the thrown error (status code + URL are enough to diagnose the failure); on a non-2xx response, drains the unread body via `resp.body?.resume()` instead of leaving it dangling. This codebase uses the `node-fetch` package, not the global `undici` fetch — `node-fetch`'s `Response.body` is a real Node `PassThrough` piped from the socket via `stream.pipeline`, so `.resume()` (not the WHATWG `.cancel()`) is the correct way to drain it and release the backpressured connection.

## Testing

- `schemas.test.ts`: rejects a message over the bound, accepts one at exactly the bound.
- `dataSourceHealth.test.ts`: truncates an oversized message, leaves one at the bound untouched.
- `poll.test.ts`: a non-2xx response's health message no longer contains the endpoint-controlled reason phrase, while the status code is still present.
- `pollDrain.test.ts`: a new file mocking `node-fetch` at the module level (rather than a real server, to isolate the exact call without picking up Node's own internal `resume()` calls elsewhere in the HTTP stack) asserts `resp.body.resume()` is called on a non-2xx response.
- Full quality gate green locally: format, lint, typecheck, full test suite (2447 tests).

## Pre-PR review

Two independent reviewer rounds ran against fresh diffs, each with no memory of the other:

- Round 1 found one minor issue: a code comment in `poll.ts` incorrectly attributed the connection-holding mechanism to "undici" (this codebase uses `node-fetch`, whose body is a `PassThrough`, not a WHATWG stream). Fixed in a follow-up commit.
- Round 2 re-verified the whole branch fresh, including re-checking the corrected comment against `node-fetch`'s actual source, and reported no findings.

No findings were dismissed as invalid; the one reported issue was fixed.

Closes #817