### PR TITLE
fix(control-server): measure the shutdown force-exit from the signal

### DIFF
--- a/packages/streamwall-control-server/src/bootstrap.ts
+++ b/packages/streamwall-control-server/src/bootstrap.ts
@@ -1,4 +1,5 @@
 import process from 'node:process'
+import { setTimeout as delay } from 'node:timers/promises'
 import { inviteLink } from 'streamwall-shared'
 import type { Auth } from './auth.ts'
 import { resolveListenPort } from './config.ts'
@@ -265,6 +266,8 @@ export default async function runServer({
   logStream,
   updateChecker: injectedUpdateChecker,
   process: proc = process,
+  forceExitAfterMs = DEFAULT_FORCE_EXIT_MS,
+  initDelayMs,
 }: AppOptions & {
   hostname?: string
   port?: string
@@ -278,6 +281,16 @@ export default async function runServer({
   logStream?: { write(line: string): void }
   /** Test-only override so specs can exercise the real listen() path without reaching GitHub. */
   updateChecker?: UpdateChecker
+  /**
+   * Test-only override for the force-exit budget. Bounds the init-window
+   * listener below and, once a signal replays into it, the shutdown timer
+   * `registerShutdownHandlers` arms further down -- the same single deadline,
+   * measured from whenever the signal actually arrived (issue #823), not two
+   * budgets armed one after the other.
+   */
+  forceExitAfterMs?: number
+  /** Test-only delay inserted before `initApp`, so a spec can land a signal deterministically inside the init window. */
+  initDelayMs?: number
 }) {
   const url = new URL(baseURL)
   const hostname = overrideHostname ?? url.hostname
@@ -293,8 +306,12 @@ export default async function runServer({
   // else, so this one arms a deadline of its own: a `mkdir` or first write
   // wedged on an unresponsive volume must not leave the process unkillable,
   // and a second signal in that window gives up immediately — nothing has been
-  // built yet that could be flushed.
+  // built yet that could be flushed. The timestamp of that first signal is
+  // recorded so the deadline below can be measured from it rather than from
+  // whenever `registerShutdownHandlers` happens to take over -- otherwise the
+  // budget effectively gets armed twice in series (issue #823).
   let signalDuringInit: 'SIGTERM' | 'SIGINT' | null = null
+  let signalledDuringInitAt: number | undefined
   let initDeadline: ReturnType<typeof setTimeout> | undefined
   const initListeners = (['SIGTERM', 'SIGINT'] as const).map((signal) => {
     const listener = () => {
@@ -303,11 +320,18 @@ export default async function runServer({
         return
       }
       signalDuringInit = signal
-      initDeadline = setTimeout(() => proc.exit(1), DEFAULT_FORCE_EXIT_MS)
+      signalledDuringInitAt = Date.now()
+      initDeadline = setTimeout(() => proc.exit(1), forceExitAfterMs)
     }
     proc.on(signal, listener)
     return { signal, listener }
   })
+
+  // Test-only: lets a spec land a signal deterministically inside the window
+  // above, simulating a slow `mkdir`/first write without actually needing one.
+  if (initDelayMs) {
+    await delay(initDelayMs)
+  }
 
   // The startup diagnostics below run *after* `initApp` purely so they can go
   // through `app.log`: they belong in the structured stream like every other
@@ -364,9 +388,21 @@ export default async function runServer({
     await app.listen({ port, host: hostname })
   })()
 
+  // A signal that arrived during init already spent part of the force-exit
+  // budget waiting for init itself to finish; the shutdown timer below gets
+  // whatever is left of that one budget, not a fresh one, so the two stages
+  // together never take longer than `forceExitAfterMs` measured from the
+  // signal (issue #823). The floor keeps a signal that arrived right at the
+  // edge of the budget from arming an effectively-zero deadline.
+  const remainingForceExitMs =
+    signalledDuringInitAt !== undefined
+      ? Math.max(500, forceExitAfterMs - (Date.now() - signalledDuringInitAt))
+      : forceExitAfterMs
+
   const { isShuttingDown, shutdown } = registerShutdownHandlers({
     app,
     process: proc,
+    forceExitAfterMs: remainingForceExitMs,
     beforeClose: () => boot,
     flush: flushStorage,
   })

--- a/packages/streamwall-control-server/src/gracefulShutdown.test.ts
+++ b/packages/streamwall-control-server/src/gracefulShutdown.test.ts
@@ -226,7 +226,7 @@ describe('runServer shutdown wiring', () => {
     // (Fastify setup, route registration) actually takes on a loaded CI
     // runner, well clear of the 500ms floor `remainingForceExitMs` applies.
     const forceExitAfterMs = 3000
-    const initDelayMs = 500
+    const initDelayMs = 1500
     const exitTimes: number[] = []
     proc.exit = () => {
       exitTimes.push(Date.now())

--- a/packages/streamwall-control-server/src/gracefulShutdown.test.ts
+++ b/packages/streamwall-control-server/src/gracefulShutdown.test.ts
@@ -204,6 +204,63 @@ describe('runServer shutdown wiring', () => {
     assert.deepEqual(exitCodes, [0])
   })
 
+  test('a signal during a slow init force-exits within one budget of the signal, not two', async () => {
+    // Issue #823: the force-exit budget used to be armed twice in series
+    // for exactly this path -- once by the init-window listener above, then
+    // again from scratch once `registerShutdownHandlers` took over -- so a
+    // signal landing during a slow `initApp` (a `mkdir` or first write
+    // wedged on an unresponsive volume) could take up to roughly double the
+    // documented budget before the process gave up, well past Docker's stop
+    // grace period.
+    const db = inMemoryDb() as StorageDB
+    // The boot mints the uplink token via `db.update`, which this hangs
+    // forever, so `beforeClose` (the boot) never settles and the shutdown's
+    // own force-exit timer is what has to fire -- the wedged-shutdown case
+    // the budget exists for.
+    db.write = () => new Promise<void>(() => {})
+
+    const { proc } = fakeProcess()
+    const forceExitAfterMs = 1200
+    const initDelayMs = 500
+    const exitTimes: number[] = []
+    proc.exit = () => {
+      exitTimes.push(Date.now())
+    }
+
+    const signalledAt = Date.now()
+    void runServer({
+      baseURL: 'http://127.0.0.1:0',
+      clientStaticPath: import.meta.dirname,
+      db,
+      logLevel: 'silent',
+      updateChecker: fakeUpdateChecker(),
+      process: proc,
+      forceExitAfterMs,
+      initDelayMs,
+    })
+    // `runServer` runs synchronously up to the init delay, so the signal
+    // listeners are already attached by the time this line runs -- still
+    // well inside the delayed init window.
+    proc.emit('SIGTERM')
+
+    // Long enough to observe the force-exit even under the old, doubled
+    // budget (initDelayMs + forceExitAfterMs, roughly).
+    await delay(initDelayMs + forceExitAfterMs + 500)
+
+    assert.equal(
+      exitTimes.length,
+      1,
+      'the process must force-exit exactly once',
+    )
+    const elapsedFromSignal = exitTimes[0] - signalledAt
+    assert.ok(
+      elapsedFromSignal < forceExitAfterMs + 150,
+      `expected a single ~${forceExitAfterMs}ms budget measured from the ` +
+        `signal, took ${elapsedFromSignal}ms (a doubled budget would take ` +
+        `roughly ${initDelayMs + forceExitAfterMs}ms)`,
+    )
+  })
+
   test('a signal during the boot waits for the boot to finish writing', async () => {
     // Minting the uplink token is a scrypt derivation plus persisted writes,
     // so a container stop can easily land inside the boot. Exiting on top of

--- a/packages/streamwall-control-server/src/gracefulShutdown.test.ts
+++ b/packages/streamwall-control-server/src/gracefulShutdown.test.ts
@@ -220,7 +220,12 @@ describe('runServer shutdown wiring', () => {
     db.write = () => new Promise<void>(() => {})
 
     const { proc } = fakeProcess()
-    const forceExitAfterMs = 1200
+    // Wide margins on purpose: `initDelayMs` only needs to land the signal
+    // before `initApp` resolves, and the gap between it and
+    // `forceExitAfterMs` has to comfortably outlast whatever `initApp`
+    // (Fastify setup, route registration) actually takes on a loaded CI
+    // runner, well clear of the 500ms floor `remainingForceExitMs` applies.
+    const forceExitAfterMs = 3000
     const initDelayMs = 500
     const exitTimes: number[] = []
     proc.exit = () => {
@@ -254,7 +259,7 @@ describe('runServer shutdown wiring', () => {
     )
     const elapsedFromSignal = exitTimes[0] - signalledAt
     assert.ok(
-      elapsedFromSignal < forceExitAfterMs + 150,
+      elapsedFromSignal < forceExitAfterMs + 400,
       `expected a single ~${forceExitAfterMs}ms budget measured from the ` +
         `signal, took ${elapsedFromSignal}ms (a doubled budget would take ` +
         `roughly ${initDelayMs + forceExitAfterMs}ms)`,


### PR DESCRIPTION
## Problem

When a shutdown signal (`SIGTERM`/`SIGINT`) arrived during server init, the force-exit deadline was armed twice in series: once by the init-window listener (which exists because, as PID 1 in a container, an unhandled signal is dropped rather than terminating the process), and again from scratch once `registerShutdownHandlers` took over after `initApp` resolved. Nothing carried the elapsed time across, so the combined wait could run to roughly double `DEFAULT_FORCE_EXIT_MS` (8s) — past Docker's default ten-second stop grace period, resulting in exactly the unannounced `SIGKILL` the budget exists to avoid, and cutting the storage flush the shutdown was running short.

## Technical solution

- Record the timestamp of the first signal (`signalledDuringInitAt`) when the init-window listener fires.
- Once `initApp` resolves and the real shutdown handlers take over, compute `remainingForceExitMs = Math.max(500, forceExitAfterMs - (Date.now() - signalledDuringInitAt))` and pass that (not a fresh `forceExitAfterMs`) into `registerShutdownHandlers`. When no signal arrived during init, this falls back to the original `forceExitAfterMs`, so the normal path is unaffected.
- The 500ms floor keeps a signal that arrives right at the edge of the budget from arming an effectively-zero deadline.
- Added test-only `forceExitAfterMs`/`initDelayMs` overrides to `runServer` so a spec can land a signal deterministically inside the init window without needing a genuinely slow `initApp`.

## Testing performed

- `packages/streamwall-control-server/src/gracefulShutdown.test.ts`: added a regression test that stalls the boot's storage write forever (forcing the real force-exit path to fire), lands a signal during a delayed init, and asserts the process exits within one `forceExitAfterMs` budget of the signal — not the roughly-doubled wait the bug produced. Verified by hand that this test fails against the pre-fix code (observed ~1.65x the intended budget) and passes against the fix.
- Full package suite (`npm run test` in `packages/streamwall-control-server`): 262/262 passing.
- Full repo suite, `npm run format`, `npm run lint`, `npm run typecheck`: all clean.

## Risks / breaking changes

None expected. The normal (no signal during init) path is untouched. The only behavior change is that a signal landing during a slow init now gives up sooner in the pathological case this issue is about — strictly safer, not a regression.

## Pre-PR review

Three independent review rounds (fresh subagent each round, no access to this session's context), all about the new regression test's timing robustness:
- Round 1: margins too tight relative to CI jitter — widened.
- Round 2: the fixed/buggy outcomes were only 500ms apart, too easily hidden by jitter or a partial regression — widened further to a 1500ms separation.
- Round 3: `NO FINDINGS`.

No findings were dismissed as invalid; all were addressed.

Closes #823